### PR TITLE
Tab-based layout, collapsible recommendations, and Setup polish

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -5,7 +5,7 @@
     },
     "tabs": {
         "setup": "Setup",
-        "play": "Deduce"
+        "play": "Play"
     },
     "toolbar": {
         "undo": "↶ Undo",
@@ -59,7 +59,9 @@
         "handSize": "Hand size",
         "handSizeMismatch": "Hand sizes total {total} {total, plural, one {card} other {cards}}; should total {expected} after the {caseFileCount} case-file cards.",
         "addPlayerTitle": "Add player",
+        "addPlayerLabel": "+ Player",
         "removePlayerTitle": "Remove {player}",
+        "removePlayerConfirm": "Remove {player}? They currently own known cards — those will also be cleared.",
         "duplicateName": "Duplicate name",
         "renameCategoryTitle": "Rename category",
         "removeCategoryTitle": "Remove {name}",
@@ -69,7 +71,9 @@
         "removeCardMin": "At least one card per category is required",
         "addCard": "+ add card",
         "addCategory": "+ add category",
-        "knownCardCheckboxAria": "{player} owns {card}"
+        "knownCardCheckboxAria": "{player} owns {card}",
+        "startPlaying": "Start playing →",
+        "continuePlaying": "Continue playing →"
     },
     "deduce": {
         "title": "Deduction grid",

--- a/src/ui/Clue.tsx
+++ b/src/ui/Clue.tsx
@@ -10,20 +10,22 @@ import { HoverProvider } from "./HoverContext";
 import { ClueProvider, useClue } from "./state";
 
 /**
- * Top-level Clue solver app. The suggestion log sits at the top because
- * it's where the user spends most of their time; the game-setup grid
- * and the deduction grid sit side-by-side below it on wide screens and
- * stack on mobile. A single global contradiction banner is pinned to the
- * top of the viewport (`position: fixed` inside GlobalContradictionBanner)
- * whenever the deducer is stuck; it measures its own height and publishes
- * `--contradiction-banner-offset`, which `<main>` adds to its top padding
- * so the header isn't hidden underneath.
+ * Top-level Clue solver app. The tab bar gates the whole page: the
+ * Setup tab shows just the Checklist (deck / roster / hand sizes);
+ * the Deduce tab shows the Checklist as a left column and the
+ * SuggestionLogPanel as a right column on wide screens, stacking
+ * below 800px. A single global contradiction banner is pinned to
+ * the top of the viewport (`position: fixed` inside
+ * GlobalContradictionBanner) whenever the deducer is stuck; it
+ * measures its own height and publishes
+ * `--contradiction-banner-offset`, which `<main>` adds to its top
+ * padding so the header isn't hidden underneath.
  *
- * The unified Checklist below the suggestion log is the single
- * surface for both Setup and Play modes — a tab bar drives the
- * `uiMode` slice and the component gates its Setup-mode affordances
- * (inline renames, add/remove, hand-size row, "+ add card" /
- * "+ add category") on that flag.
+ * The unified Checklist is the single surface for both Setup and
+ * Play modes — the tab bar drives the `uiMode` slice and the
+ * component gates its Setup-mode affordances (inline renames, add/
+ * remove, hand-size row, "+ add card" / "+ add category") on that
+ * flag.
  */
 export function Clue() {
     const t = useTranslations("app");
@@ -41,14 +43,36 @@ export function Clue() {
 
                 <GlobalContradictionBanner />
 
-                <SuggestionLogPanel />
-
                 <TabBar />
-                <Checklist />
+                <TabContent />
             </main>
            </HoverProvider>
           </ClueProvider>
         </TooltipProvider>
+    );
+}
+
+/**
+ * Tab-body router. Setup shows the Checklist at full width; Deduce
+ * lays out Checklist + SuggestionLogPanel side by side on wide
+ * screens and stacks them below the 800px breakpoint. `min-w-0` on
+ * both children lets long card names / suggestion lines shrink
+ * instead of breaking the grid.
+ */
+function TabContent() {
+    const { state } = useClue();
+    if (state.uiMode === "setup") {
+        return <Checklist />;
+    }
+    return (
+        <div className="grid gap-5 [@media(min-width:800px)]:grid-cols-[minmax(0,1fr)_minmax(320px,420px)]">
+            <div className="min-w-0">
+                <Checklist />
+            </div>
+            <div className="min-w-0">
+                <SuggestionLogPanel />
+            </div>
+        </div>
     );
 }
 

--- a/src/ui/components/CardPackRow.tsx
+++ b/src/ui/components/CardPackRow.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { CARD_SETS } from "../../logic/GameSetup";
 import {
     CustomCardSet,
@@ -22,9 +22,16 @@ export function CardPackRow() {
     const t = useTranslations("setup");
     const { state, dispatch, hasGameData } = useClue();
     const setup = state.setup;
+    // Initialise empty so server HTML and client's first render agree; the
+    // real list loads in a mount effect. Reading localStorage in the
+    // useState initialiser would produce 0 packs on SSR and N packs on
+    // the client's first render — a hydration mismatch.
     const [customPacks, setCustomPacks] = useState<ReadonlyArray<CustomCardSet>>(
-        () => loadCustomCardSets(),
+        [],
     );
+    useEffect(() => {
+        setCustomPacks(loadCustomCardSets());
+    }, []);
 
     const onCardSet = (choice: (typeof CARD_SETS)[number]) => {
         if (hasGameData() && !window.confirm(t("loadCardSetConfirm"))) return;

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -2,7 +2,7 @@
 
 import { Result } from "effect";
 import { useTranslations } from "next-intl";
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { Card, Owner, Player, ownerLabel } from "../../logic/GameObjects";
 import {
     allCardIds,
@@ -67,6 +67,31 @@ export function Checklist() {
     const suggestions = derived.suggestionsAsData;
 
     const owners: ReadonlyArray<Owner> = allOwners(setup);
+
+    // In Setup mode the add-player column sits between the players and
+    // the case file — clicking + spawns the new player where its column
+    // would naturally appear. Each of the three owner-axis rows below
+    // injects the matching header/cell right before the case-file
+    // column; Play mode skips the cell entirely (unchanged column
+    // count).
+    const addPlayerHeaderCell = (
+        <th
+            key="add-player-col"
+            className="sticky top-0 z-10 w-px whitespace-nowrap border border-border bg-row-header px-1.5 py-1 text-center"
+        >
+            <button
+                type="button"
+                className="cursor-pointer whitespace-nowrap rounded border-none bg-accent px-2 py-1 text-[12px] font-semibold leading-none text-white hover:bg-accent-hover"
+                title={tSetup("addPlayerTitle")}
+                onClick={() => dispatch({ type: "addPlayer" })}
+            >
+                {tSetup("addPlayerLabel")}
+            </button>
+        </th>
+    );
+    const addPlayerEmptyCell = (
+        <td key="add-player-col" className="border border-border" />
+    );
 
     const handSizeMap = new Map(state.handSizes);
     const defaults = new Map(defaultHandSizes(setup));
@@ -144,9 +169,21 @@ export function Checklist() {
 
     return (
         <section className="min-w-0 rounded-[var(--radius)] border border-border bg-panel p-4">
-            <h2 className="mb-3 text-[16px] uppercase tracking-[0.05em] text-accent">
-                {t("title")}
-            </h2>
+            {inSetup && (
+                <div className="mb-3 flex justify-end">
+                    <button
+                        type="button"
+                        className="cursor-pointer rounded-[var(--radius)] border-none bg-accent px-4 py-2 text-[14px] font-semibold text-white hover:bg-accent-hover"
+                        onClick={() =>
+                            dispatch({ type: "setUiMode", mode: "play" })
+                        }
+                    >
+                        {suggestions.length > 0
+                            ? tSetup("continuePlaying")
+                            : tSetup("startPlaying")}
+                    </button>
+                </div>
+            )}
             {inSetup ? <CardPackRow /> : <CaseFileHeader knowledge={knowledge} />}
             {inSetup && handSizeMismatch && (
                 <div className="mb-3 rounded-[var(--radius)] border border-warning-border bg-warning-bg px-3 py-2 text-[13px] text-warning">
@@ -161,83 +198,78 @@ export function Checklist() {
                 <thead>
                     <tr>
                         <th className="sticky top-0 z-10 border border-border bg-row-header px-2 py-1 text-center font-semibold"></th>
-                        {owners.map(owner => (
-                            <th
-                                key={ownerKey(owner)}
-                                className="sticky top-0 z-10 border border-border bg-row-header px-2 py-1 text-center align-top font-semibold"
-                            >
-                                {inSetup && owner._tag === "Player" ? (
-                                    <PlayerNameInput
-                                        player={owner.player}
-                                        allPlayers={setup.players}
-                                    />
-                                ) : (
-                                    ownerLabel(owner)
-                                )}
-                            </th>
-                        ))}
-                        {inSetup && (
-                            <th className="w-8 border border-border bg-row-header px-1.5 py-1 text-center">
-                                <button
-                                    type="button"
-                                    className="h-6 w-6 cursor-pointer rounded border-none bg-accent text-[16px] leading-none text-white hover:bg-accent-hover"
-                                    title={tSetup("addPlayerTitle")}
-                                    onClick={() =>
-                                        dispatch({ type: "addPlayer" })
-                                    }
+                        {owners.flatMap(owner => {
+                            const cell = (
+                                <th
+                                    key={ownerKey(owner)}
+                                    className="sticky top-0 z-10 border border-border bg-row-header px-2 py-1 text-center align-top font-semibold"
                                 >
-                                    +
-                                </button>
-                            </th>
-                        )}
+                                    {inSetup && owner._tag === "Player" ? (
+                                        <PlayerNameInput
+                                            player={owner.player}
+                                            allPlayers={setup.players}
+                                        />
+                                    ) : (
+                                        ownerLabel(owner)
+                                    )}
+                                </th>
+                            );
+                            return inSetup && owner._tag === "CaseFile"
+                                ? [addPlayerHeaderCell, cell]
+                                : [cell];
+                        })}
                     </tr>
                     {inSetup && (
                         <tr>
                             <th className="whitespace-nowrap border border-border bg-row-header px-1.5 py-1 text-left font-semibold">
                                 {tSetup("handSize")}
                             </th>
-                            {owners.map(owner => {
+                            {owners.flatMap(owner => {
+                                let cell: ReactNode;
                                 if (owner._tag !== "Player") {
-                                    return (
+                                    cell = (
                                         <td
                                             key={ownerKey(owner)}
                                             className="border border-border"
                                         />
                                     );
+                                } else {
+                                    const current = handSizeMap.get(owner.player);
+                                    const def = defaults.get(owner.player);
+                                    cell = (
+                                        <td
+                                            key={ownerKey(owner)}
+                                            className="border border-border px-1.5 py-1 text-center"
+                                        >
+                                            <input
+                                                type="number"
+                                                min={0}
+                                                max={allCardIds(setup).length}
+                                                className="w-14 rounded border border-border p-0.5 text-center text-[12px]"
+                                                value={
+                                                    current === undefined
+                                                        ? ""
+                                                        : String(current)
+                                                }
+                                                placeholder={
+                                                    def === undefined
+                                                        ? ""
+                                                        : String(def)
+                                                }
+                                                onChange={e =>
+                                                    onHandSizeChange(
+                                                        owner.player,
+                                                        e.currentTarget.value,
+                                                    )
+                                                }
+                                            />
+                                        </td>
+                                    );
                                 }
-                                const current = handSizeMap.get(owner.player);
-                                const def = defaults.get(owner.player);
-                                return (
-                                    <td
-                                        key={ownerKey(owner)}
-                                        className="border border-border px-1.5 py-1 text-center"
-                                    >
-                                        <input
-                                            type="number"
-                                            min={0}
-                                            max={allCardIds(setup).length}
-                                            className="w-14 rounded border border-border p-0.5 text-center text-[12px]"
-                                            value={
-                                                current === undefined
-                                                    ? ""
-                                                    : String(current)
-                                            }
-                                            placeholder={
-                                                def === undefined
-                                                    ? ""
-                                                    : String(def)
-                                            }
-                                            onChange={e =>
-                                                onHandSizeChange(
-                                                    owner.player,
-                                                    e.currentTarget.value,
-                                                )
-                                            }
-                                        />
-                                    </td>
-                                );
+                                return inSetup && owner._tag === "CaseFile"
+                                    ? [addPlayerEmptyCell, cell]
+                                    : [cell];
                             })}
-                            <td className="border border-border" />
                         </tr>
                     )}
                 </thead>
@@ -293,7 +325,7 @@ export function Checklist() {
                             </tr>,
                             ...category.cards.map(entry => (
                                 <tr key={String(entry.id)}>
-                                    <th className="border border-border px-2 py-1 text-left font-normal">
+                                    <th className="w-px whitespace-nowrap border border-border px-2 py-1 text-left font-normal">
                                         {inSetup ? (
                                             <div className="flex items-center justify-between gap-2">
                                                 <InlineTextEdit
@@ -333,7 +365,7 @@ export function Checklist() {
                                             entry.name
                                         )}
                                     </th>
-                                    {owners.map(owner => {
+                                    {owners.flatMap(owner => {
                                         const value = getCellByOwnerCard(
                                             knowledge,
                                             owner,
@@ -382,7 +414,7 @@ export function Checklist() {
                                                 {tooltipText}
                                             </div>
                                         ) : undefined;
-                                        return (
+                                        const cell = (
                                             <Tooltip
                                                 key={`${ownerKey(owner)}-${String(entry.id)}`}
                                                 content={tooltipContent}
@@ -473,10 +505,16 @@ export function Checklist() {
                                                 </td>
                                             </Tooltip>
                                         );
+                                        const emptyCell = (
+                                            <td
+                                                key={`add-player-col-${String(entry.id)}`}
+                                                className="border border-border"
+                                            />
+                                        );
+                                        return inSetup && owner._tag === "CaseFile"
+                                            ? [emptyCell, cell]
+                                            : [cell];
                                     })}
-                                    {inSetup && (
-                                        <td className="border border-border" />
-                                    )}
                                 </tr>
                             )),
                             ...(inSetup
@@ -589,7 +627,7 @@ function PlayerNameInput({
     allPlayers: ReadonlyArray<Player>;
 }) {
     const t = useTranslations("setup");
-    const { dispatch } = useClue();
+    const { state, dispatch } = useClue();
     const [editing, setEditing] = useState(String(player));
     const [error, setError] = useState("");
 
@@ -621,34 +659,53 @@ function PlayerNameInput({
         setError("");
     };
 
+    // Removing a player also drops their known cards (see the reducer's
+    // `removePlayer` branch). Prompt first when that's destructive — we
+    // skip the confirm otherwise so a freshly-added empty slot doesn't
+    // feel chatty.
+    const onRemove = () => {
+        const hasKnownCards = state.knownCards.some(
+            kc => kc.player === player,
+        );
+        if (hasKnownCards) {
+            const ok = window.confirm(
+                t("removePlayerConfirm", { player: String(player) }),
+            );
+            if (!ok) return;
+        }
+        dispatch({ type: "removePlayer", player });
+    };
+
     return (
         <div className="flex flex-col items-stretch gap-0.5">
-            <input
-                type="text"
-                className="box-border w-full rounded border border-border px-1.5 py-1 text-[12px]"
-                value={editing}
-                onChange={e => {
-                    setEditing(e.currentTarget.value);
-                    setError("");
-                }}
-                onBlur={commit}
-                onKeyDown={e => {
-                    if (e.key === "Enter") commit();
-                }}
-            />
+            <div className="flex items-center gap-1">
+                <input
+                    type="text"
+                    className="box-border min-w-0 flex-1 rounded border border-border px-1.5 py-1 text-[12px]"
+                    value={editing}
+                    onChange={e => {
+                        setEditing(e.currentTarget.value);
+                        setError("");
+                    }}
+                    onBlur={commit}
+                    onKeyDown={e => {
+                        if (e.key === "Enter") commit();
+                    }}
+                />
+                <button
+                    type="button"
+                    className="cursor-pointer rounded border-none bg-accent px-2 py-1 text-[12px] font-semibold leading-none text-white hover:bg-accent-hover"
+                    title={t("removePlayerTitle", { player: String(player) })}
+                    onClick={onRemove}
+                >
+                    &times;
+                </button>
+            </div>
             {error && (
                 <span className="whitespace-nowrap text-[11px] text-danger">
                     {error}
                 </span>
             )}
-            <button
-                type="button"
-                className="self-center border-none bg-transparent px-1 text-[14px] leading-none text-muted hover:text-danger"
-                title={t("removePlayerTitle", { player: String(player) })}
-                onClick={() => dispatch({ type: "removePlayer", player })}
-            >
-                &times;
-            </button>
         </div>
     );
 }

--- a/src/ui/components/SuggestionLogPanel.tsx
+++ b/src/ui/components/SuggestionLogPanel.tsx
@@ -44,10 +44,10 @@ export function SuggestionLogPanel() {
             <h2 className="m-0 mb-3 text-[16px] uppercase tracking-[0.05em] text-accent">
                 {t("title")}
             </h2>
-            <div className="grid gap-5 [@media(min-width:800px)]:grid-cols-[minmax(280px,1fr)_minmax(280px,1fr)]">
-                <AddSuggestion />
+            <div className="mb-5">
                 <Recommendations />
             </div>
+            <AddSuggestion />
             <PriorSuggestions />
         </section>
     );
@@ -351,6 +351,10 @@ function Recommendations() {
     const [asPlayer, setAsPlayer] = useState<string>(
         setup.players[0] ?? "",
     );
+    // Collapsed by default — the recommendation body runs a non-trivial
+    // Effect.runSync per render, so skipping it while closed keeps the
+    // suggestion-log panel snappy for users who don't need the hint.
+    const [expanded, setExpanded] = useState(false);
 
     useEffect(() => {
         if (asPlayer && setup.players.some(p => String(p) === asPlayer))
@@ -358,14 +362,41 @@ function Recommendations() {
         setAsPlayer(setup.players[0] ?? "");
     }, [setup.players, asPlayer]);
 
+    // Wrapping the button in an <h3> matches the sibling "Add a
+    // suggestion" header: globals.css applies the display font to all
+    // h1–h3 (and SECTION_TITLE sets shared size/weight), so the two
+    // headings render identically. The button owns aria-expanded and
+    // the click behaviour; the caret is trailing so every header in
+    // this pane starts at the same x.
+    const header = (
+        <h3 className={SECTION_TITLE}>
+            <button
+                type="button"
+                aria-expanded={expanded}
+                onClick={() => setExpanded(v => !v)}
+                className="flex w-full cursor-pointer items-center gap-1.5 border-none bg-transparent p-0 text-left font-[inherit] text-[inherit] hover:text-accent"
+            >
+                <span>{t("recommendationsTitle")}</span>
+                <span
+                    aria-hidden
+                    className="inline-block text-[16px] leading-none text-muted"
+                >
+                    {expanded ? "▾" : "▸"}
+                </span>
+            </button>
+        </h3>
+    );
+
+    if (!expanded) {
+        return <div>{header}</div>;
+    }
+
     const knowledge = Result.getOrUndefined(result);
     if (knowledge === undefined || !asPlayer) {
         return (
             <div>
-                <h3 className={SECTION_TITLE}>
-                    {t("recommendationsTitle")}
-                </h3>
-                <div className="text-[13px] text-muted">
+                {header}
+                <div className="mt-2 text-[13px] text-muted">
                     {knowledge === undefined
                         ? t("resolveContradictionFirst")
                         : t("addPlayersFirst")}
@@ -398,10 +429,8 @@ function Recommendations() {
 
     return (
         <div>
-            <h3 className={SECTION_TITLE}>
-                {t("recommendationsTitle")}
-            </h3>
-            <label className={LABEL_ROW}>
+            {header}
+            <label className={`${LABEL_ROW} mt-2`}>
                 {t("suggestingAs")}
                 <select
                     value={asPlayer}

--- a/src/ui/state.tsx
+++ b/src/ui/state.tsx
@@ -680,23 +680,49 @@ export function ClueProvider({ children }: { children: ReactNode }) {
 
     const didHydrate = useRef(false);
 
-    // One-shot hydration on mount: URL first, then localStorage.
+    // One-shot hydration on mount: URL first, then localStorage. The
+    // `?tab=setup|play` param overrides the smart default; with no
+    // explicit tab we land on Play if the hydrated session has any
+    // suggestions, else Setup (the reducer's default).
     useEffect(() => {
         if (didHydrate.current) return;
         didHydrate.current = true;
         if (typeof window === "undefined") return;
         const params = new URLSearchParams(window.location.search);
-        const state = params.get("state");
-        if (state) {
-            const session = decodeSessionFromUrl(state);
-            if (session) {
-                dispatch({ type: "replaceSession", session });
-                return;
-            }
+        const stateParam = params.get("state");
+        const tabParam = params.get("tab");
+        let hydrated: GameSession | undefined;
+        if (stateParam) hydrated = decodeSessionFromUrl(stateParam);
+        if (!hydrated) hydrated = loadFromLocalStorage();
+        if (hydrated) dispatch({ type: "replaceSession", session: hydrated });
+
+        // Tab precedence: explicit `?tab=` wins; otherwise pick based on
+        // hydrated suggestions. The default state.uiMode is "setup", so
+        // only dispatch when we actually need to change it.
+        if (tabParam === "play") {
+            dispatch({ type: "setUiMode", mode: "play" });
+        } else if (tabParam === "setup") {
+            // No-op: default is already "setup".
+        } else if (hydrated && hydrated.suggestions.length > 0) {
+            dispatch({ type: "setUiMode", mode: "play" });
         }
-        const session = loadFromLocalStorage();
-        if (session) dispatch({ type: "replaceSession", session });
     }, []);
+
+    // Mirror `uiMode` to the URL as `?tab=setup|play`. Uses
+    // replaceState (not pushState) because tab flips shouldn't clutter
+    // the back stack — same spirit as `setUiMode` bypassing undo/redo
+    // history. Gated on `didHydrate` so the initial reducer default
+    // doesn't stomp an unset URL before hydration has chosen the tab.
+    useEffect(() => {
+        if (!didHydrate.current) return;
+        if (typeof window === "undefined") return;
+        const params = new URLSearchParams(window.location.search);
+        const urlTab = state.uiMode;
+        if (params.get("tab") === urlTab) return;
+        params.set("tab", urlTab);
+        const newUrl = `${window.location.pathname}?${params.toString()}${window.location.hash}`;
+        window.history.replaceState(null, "", newUrl);
+    }, [state.uiMode]);
 
     // Save to localStorage whenever inputs change. Skip the first render
     // (before hydration) to avoid trampling a saved session with the


### PR DESCRIPTION
## What changed (by user-facing feature)

### Tab flow
- The Setup / Play tabs now gate the entire page, not just the checklist. Setup shows the deck-and-roster editor at full width; Play shows the Checklist on the left with the Suggestion log on the right.
- Below 800px the two Play columns stack vertically (Checklist first).
- The second tab was renamed from "Deduce" to "Play".

### Shareable / refresh-safe tab state
- The current tab persists to `?tab=setup|play`. Refreshing or sharing a link lands on the tab you were on.
- With no `?tab=` param: an empty game lands on Setup; a game with any logged suggestions lands on Play.
- The `?tab=` param is written with `history.replaceState`, so it doesn't pollute the browser back stack and it preserves any existing `?state=…` share payload.

### Setup page polish
- New "Start playing → / Continue playing →" pill in the top-right of Setup. The copy flips from "Start" to "Continue" as soon as there's at least one suggestion, and the button just switches to Play.
- The "Deduction grid" heading was removed, so Setup now leads directly with the card pack row.
- The add-player column moved: it now sits between the last player and the Case file, so clicking it spawns a column in the natural place. The button reads "+ Player" instead of a bare "+".
- Each player column header now has its × button inline with the name input, styled to match the "+ Player" pill (oxblood on cream instead of a faint ×). Removing a player who owns known cards now prompts "Remove {player}? They currently own known cards — those will also be cleared." before clearing them; empty players skip the prompt.
- The card-name column on the Checklist now hugs the longest card name rather than taking whatever width is left over.

### Suggestion log
- "Next-suggestion recommendations" moved above "Add a suggestion".
- That section is now collapsible and starts collapsed — clicking its heading toggles it. (The recommendation computation is skipped while collapsed.)
- Its heading was restyled to match "Add a suggestion" (same display font, size, weight) and the caret moved to the trailing edge so every heading in the pane has a flush-left start. The caret was also bumped up in size to be actually noticeable.

### Bug fix
- Custom card packs previously triggered a React hydration warning on refresh: the server rendered zero packs, then the client's first render pulled N packs from `localStorage`, and the two disagreed. The pack list now hydrates in a mount effect so both passes produce identical HTML.

## Verification performed

- `pnpm typecheck` and `pnpm i18n:check` both clean.
- Dev server (`next dev` via preview_start) verified across both tabs at 1280×900 and 600×800; no hydration warnings, no runtime errors.
- Hydration fix: saved a custom pack to `localStorage`, reloaded, confirmed no warning in the console and the pack renders.
- Tab URL: confirmed `?tab=setup|play` updates on click, `?state=…` is preserved, and no-param + saved suggestions lands on Play.
- Confirm prompt: verified it fires for a player with a known card (and declining keeps them), and does NOT fire for an empty player.

## Commit log

- `f2ae552` — **Tab-based layout, collapsible recommendations, and Setup polish.** Single commit covering the hydration fix, the tab-gated page layout + URL persistence, the Setup pill + column re-order + inline × + "+ Player" rename + confirm prompt, the card-name column width, and the collapsible / restyled recommendations pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)