### PR TITLE
Rename preset categories to singular (Suspect/Weapon/Room)

### DIFF
--- a/src/logic/CardSet.ts
+++ b/src/logic/CardSet.ts
@@ -16,7 +16,7 @@ export const CardEntry = (params: {
 }): CardEntry => new CardEntryImpl(params);
 
 /**
- * One category of cards (Suspects / Weapons / Rooms, or any custom
+ * One category of cards (Suspect / Weapon / Room, or any custom
  * deck). Carries its own opaque id so renames don't orphan references.
  */
 class CategoryImpl extends Data.Class<{

--- a/src/logic/Deducer.test.ts
+++ b/src/logic/Deducer.test.ts
@@ -18,11 +18,11 @@ import { runDeduce } from "./test-utils/RunDeduce";
 import "./test-utils/EffectExpectEquals";
 
 const setup = CLASSIC_SETUP_3P;
-// Suspects category id is the branded string "category-suspects" in the
+// Suspect category id is the branded string "category-suspects" in the
 // preset. Look up by the category's own id.
 const suspectsCategory = expectDefined(
-    setup.categories.find(c => c.name === "Suspects"),
-    "Suspects category",
+    setup.categories.find(c => c.name === "Suspect"),
+    "Suspect category",
 );
 const suspects = cardIdsInCategory(setup, suspectsCategory.id);
 const A = Player("Anisha");

--- a/src/logic/GameSetup.ts
+++ b/src/logic/GameSetup.ts
@@ -222,9 +222,9 @@ const CLASSIC_ROOMS: ReadonlyArray<CardEntry> = [
 ];
 
 const CLASSIC_CATEGORIES: ReadonlyArray<Category> = [
-    presetCategory("Suspects", "suspects", CLASSIC_SUSPECTS),
-    presetCategory("Weapons", "weapons", CLASSIC_WEAPONS),
-    presetCategory("Rooms", "rooms", CLASSIC_ROOMS),
+    presetCategory("Suspect", "suspects", CLASSIC_SUSPECTS),
+    presetCategory("Weapon", "weapons", CLASSIC_WEAPONS),
+    presetCategory("Room", "rooms", CLASSIC_ROOMS),
 ];
 
 /** The classic Clue deck packaged as a reusable CardSet. */
@@ -233,19 +233,19 @@ const CLASSIC_CARD_SET: CardSet = CardSet({
 });
 
 const MASTER_DETECTIVE_CATEGORIES: ReadonlyArray<Category> = [
-    presetCategory("Suspects", "md-suspects", [
+    presetCategory("Suspect", "md-suspects", [
         ...CLASSIC_SUSPECTS,
         presetCard("Miss Peach", "miss-peach"),
         presetCard("Mon. Brunette", "mon-brunette"),
         presetCard("Madame Rose", "madame-rose"),
         presetCard("Sgt. Gray", "sgt-gray"),
     ]),
-    presetCategory("Weapons", "md-weapons", [
+    presetCategory("Weapon", "md-weapons", [
         ...CLASSIC_WEAPONS,
         presetCard("Horseshoe", "horseshoe"),
         presetCard("Poison", "poison"),
     ]),
-    presetCategory("Rooms", "md-rooms", [
+    presetCategory("Room", "md-rooms", [
         ...CLASSIC_ROOMS,
         presetCard("Courtyard", "courtyard"),
         presetCard("Gazebo", "gazebo"),

--- a/src/logic/Recommender.test.ts
+++ b/src/logic/Recommender.test.ts
@@ -19,8 +19,8 @@ const B = Player("Bob");
 const C = Player("Cho");
 
 const suspectsCategory = expectDefined(
-    setup.categories.find(c => c.name === "Suspects"),
-    "Suspects category",
+    setup.categories.find(c => c.name === "Suspect"),
+    "Suspect category",
 );
 
 describe("recommendSuggestions", () => {

--- a/src/logic/Rules.test.ts
+++ b/src/logic/Rules.test.ts
@@ -31,16 +31,16 @@ import "./test-utils/EffectExpectEquals";
 
 const setup = CLASSIC_SETUP_3P;
 const suspectsCategory = expectDefined(
-    setup.categories.find(c => c.name === "Suspects"),
-    "Suspects category",
+    setup.categories.find(c => c.name === "Suspect"),
+    "Suspect category",
 );
 const weaponsCategory = expectDefined(
-    setup.categories.find(c => c.name === "Weapons"),
-    "Weapons category",
+    setup.categories.find(c => c.name === "Weapon"),
+    "Weapon category",
 );
 const roomsCategory = expectDefined(
-    setup.categories.find(c => c.name === "Rooms"),
-    "Rooms category",
+    setup.categories.find(c => c.name === "Room"),
+    "Room category",
 );
 const suspects = cardIdsInCategory(setup, suspectsCategory.id);
 const weapons = cardIdsInCategory(setup, weaponsCategory.id);

--- a/src/ui/components/SuggestionLogPanel.tsx
+++ b/src/ui/components/SuggestionLogPanel.tsx
@@ -266,22 +266,14 @@ function Recommendations() {
                                         const rawName =
                                             setup.categories[ci]?.name ??
                                             t("defaultCategorySingular");
-                                        // Category names are typically plural
-                                        // ("Weapons", "Rooms"); strip a trailing
-                                        // "s" so the collapsed label reads as
-                                        // "any weapon / room" rather than
-                                        // "any weapons / rooms".
-                                        const singular = rawName.replace(
-                                            /s$/,
-                                            "",
-                                        ).toLowerCase();
+                                        const categoryLabel = rawName.toLowerCase();
                                         return (
                                             <span key={ci}>
                                                 {ci > 0 && " + "}
                                                 {c === "any" ? (
                                                     <em className="text-muted">
                                                         {t("anyCategory", {
-                                                            category: singular,
+                                                            category: categoryLabel,
                                                         })}
                                                     </em>
                                                 ) : (


### PR DESCRIPTION
## Summary
- Renamed classic and Master Detective preset categories from plural (Suspects/Weapons/Rooms) to singular display names.
- Removed the now-obsolete trailing-`s` strip in the suggestion log's "any {category}" fallback — category names are already singular, so `rawName.toLowerCase()` is used directly.
- Updated test `find(c => c.name === ...)` lookups and the CardSet docstring to match.

## Test plan
- [x] `pnpm test` — all 76 tests pass
- [x] Verified in browser preview: case-file strip, checklist table section headers, and suggestion-form pills all render "Suspect" / "Weapon" / "Room"

🤖 Generated with [Claude Code](https://claude.com/claude-code)