### PR TITLE
Mobile bottom nav + app-shell sticky checklist header + bigger pill tap targets

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -7,6 +7,13 @@
         "setup": "Setup",
         "play": "Play"
     },
+    "bottomNav": {
+        "ariaLabel": "Primary navigation",
+        "checklist": "Checklist",
+        "suggest": "Suggest",
+        "more": "More",
+        "gameSetup": "Game setup"
+    },
     "toolbar": {
         "undo": "↶ Undo",
         "undoAria": "Undo",

--- a/src/logic/ClueState.ts
+++ b/src/logic/ClueState.ts
@@ -30,7 +30,7 @@ export interface DraftSuggestion {
  * Lives in ClueState (not component-local useState) so the shared-URL
  * encoder and localStorage persistence can round-trip it.
  */
-export type UiMode = "setup" | "play";
+export type UiMode = "setup" | "checklist" | "suggest";
 
 /**
  * Everything dispatch-able from the UI. One concrete action per

--- a/src/ui/Clue.tsx
+++ b/src/ui/Clue.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import { BottomNav } from "./components/BottomNav";
 import { Checklist } from "./components/Checklist";
 import { GlobalContradictionBanner } from "./components/GlobalContradictionBanner";
 import { SuggestionLogPanel } from "./components/SuggestionLogPanel";
@@ -10,22 +11,35 @@ import { HoverProvider } from "./HoverContext";
 import { ClueProvider, useClue } from "./state";
 
 /**
- * Top-level Clue solver app. The tab bar gates the whole page: the
- * Setup tab shows just the Checklist (deck / roster / hand sizes);
- * the Deduce tab shows the Checklist as a left column and the
- * SuggestionLogPanel as a right column on wide screens, stacking
- * below 800px. A single global contradiction banner is pinned to
- * the top of the viewport (`position: fixed` inside
- * GlobalContradictionBanner) whenever the deducer is stuck; it
- * measures its own height and publishes
- * `--contradiction-banner-offset`, which `<main>` adds to its top
- * padding so the header isn't hidden underneath.
+ * Top-level Clue solver app.
+ *
+ * **Desktop (≥ 800px)** shows a top `TabBar` (Setup / Play) and a
+ * top-right `Toolbar` (undo / redo / share / new game). The Play
+ * tab lays the `Checklist` next to a sticky `SuggestionLogPanel`
+ * in a 2-column grid.
+ *
+ * **Mobile (< 800px)** hides the top tab bar and toolbar entirely.
+ * A fixed `BottomNav` takes their place, with Checklist / Suggest
+ * tabs that split what desktop packs into a single Play grid, plus
+ * inline Undo/Redo and an overflow menu for Game setup, Share link,
+ * and New game. `<main>`'s bottom padding is bumped up to keep page
+ * content clear of the fixed nav.
+ *
+ * A single global contradiction banner is pinned to the top of the
+ * viewport (`position: fixed` inside `GlobalContradictionBanner`)
+ * whenever the deducer is stuck; it measures its own height and
+ * publishes `--contradiction-banner-offset`, which `<main>` adds to
+ * its top padding so the header isn't hidden underneath.
  *
  * The unified Checklist is the single surface for both Setup and
  * Play modes — the tab bar drives the `uiMode` slice and the
  * component gates its Setup-mode affordances (inline renames, add/
  * remove, hand-size row, "+ add card" / "+ add category") on that
- * flag.
+ * flag. `uiMode` has three values: `setup`, `checklist`, `suggest`.
+ * On desktop `checklist` and `suggest` both render the Play grid
+ * (the tab doesn't visually distinguish them); on mobile each routes
+ * to its own pane. This means resizing across the breakpoint never
+ * jumps tabs — the URL (`?tab=…`) stays coherent on both sides.
  */
 export function Clue() {
     const t = useTranslations("app");
@@ -33,19 +47,26 @@ export function Clue() {
         <TooltipProvider delayDuration={150} skipDelayDuration={50}>
           <ClueProvider>
            <HoverProvider>
-            <main className="mx-auto flex max-w-[1400px] flex-col gap-5 px-5 pb-15 [padding-top:calc(var(--contradiction-banner-offset,0px)+1.5rem)]">
-                <header className="flex flex-wrap items-center justify-between gap-4">
+            <main className="mx-auto flex h-[100dvh] max-w-[1400px] flex-col gap-5 px-5 pb-24 [@media(min-width:800px)]:pb-5 [padding-top:calc(var(--contradiction-banner-offset,0px)+1.5rem)]">
+                <header className="flex shrink-0 flex-wrap items-center justify-between gap-4">
                     <h1 className="m-0 text-[36px] uppercase tracking-[0.08em] text-accent drop-shadow-sm">
                         {t("title")}
                     </h1>
-                    <Toolbar />
+                    <div className="hidden [@media(min-width:800px)]:block">
+                        <Toolbar />
+                    </div>
                 </header>
 
                 <GlobalContradictionBanner />
 
-                <TabBar />
-                <TabContent />
+                <div className="hidden shrink-0 [@media(min-width:800px)]:block">
+                    <TabBar />
+                </div>
+                <div className="flex min-h-0 flex-1 flex-col">
+                    <TabContent />
+                </div>
             </main>
+            <BottomNav />
            </HoverProvider>
           </ClueProvider>
         </TooltipProvider>
@@ -53,23 +74,45 @@ export function Clue() {
 }
 
 /**
- * Tab-body router. Setup shows the Checklist at full width; Deduce
- * lays out Checklist + SuggestionLogPanel side by side on wide
- * screens and stacks them below the 800px breakpoint. `min-w-0` on
- * both children lets long card names / suggestion lines shrink
- * instead of breaking the grid.
+ * Tab-body router. Always fills the app-shell content slot (`h-full`)
+ * so that only one scroll container exists — whichever child elects
+ * to scroll (Checklist's table wrapper, SuggestionLogPanel's card).
+ *
+ * - `setup` → Checklist full width (setup affordances unlocked).
+ * - `checklist` / `suggest` → on desktop both render the Play grid
+ *   (Checklist + SuggestionLogPanel side by side); on mobile the grid
+ *   collapses to a single visible pane chosen by `uiMode`, using
+ *   `hidden` / `block` toggles rather than remounting. That keeps a
+ *   single React tree across the breakpoint — the active tab never
+ *   jumps when resizing.
+ *
+ * `min-w-0` lets long card names / suggestion lines shrink instead of
+ * breaking the grid. Each panel owns its own internal scroll so the
+ * Checklist's sticky header row anchors to its own scrollport; the
+ * outer page never scrolls.
  */
 function TabContent() {
     const { state } = useClue();
-    if (state.uiMode === "setup") {
+    const mode = state.uiMode;
+    if (mode === "setup") {
         return <Checklist />;
     }
+    // `hidden` / `block` classes keep both children mounted on desktop
+    // and hide the off-tab one on mobile.
+    const hideOnMobileIfSuggest =
+        mode === "suggest" ? "hidden [@media(min-width:800px)]:block" : "block";
+    const hideOnMobileIfChecklist =
+        mode === "checklist" ? "hidden [@media(min-width:800px)]:block" : "block";
     return (
-        <div className="grid gap-5 [@media(min-width:800px)]:grid-cols-[minmax(0,1fr)_minmax(320px,420px)]">
-            <div className="min-w-0">
+        <div className="grid h-full min-h-0 gap-5 [@media(min-width:800px)]:grid-cols-[minmax(0,1fr)_minmax(320px,420px)]">
+            <div className={`min-h-0 min-w-0 ${hideOnMobileIfSuggest}`}>
                 <Checklist />
             </div>
-            <div className="min-w-0">
+            <div
+                className={
+                    `min-h-0 min-w-0 overflow-y-auto ${hideOnMobileIfChecklist}`
+                }
+            >
                 <SuggestionLogPanel />
             </div>
         </div>
@@ -77,10 +120,12 @@ function TabContent() {
 }
 
 /**
- * Setup / Deduce tab switcher. Drives the `uiMode` reducer slice;
- * consumers (currently just GameSetupPanel's inline-edit gate and
- * the new Checklist's future affordances) read `state.uiMode` and
- * render accordingly.
+ * Setup / Play tab switcher (desktop only). Drives the `uiMode`
+ * reducer slice; consumers (Checklist's inline-edit gate and setup
+ * affordances) read `state.uiMode === "setup"` to decide what to
+ * render. The Play tab lights up for both `checklist` and `suggest`
+ * since desktop doesn't distinguish them. Clicking Play resolves to
+ * `checklist` — the more common landing.
  */
 function TabBar() {
     const { state, dispatch } = useClue();
@@ -91,6 +136,7 @@ function TabBar() {
                 ? "border-accent bg-transparent text-accent"
                 : "border-transparent bg-transparent text-muted hover:text-accent"
         }`;
+    const playActive = state.uiMode !== "setup";
     return (
         <div role="tablist" className="-mb-3 flex gap-2 border-b border-border">
             <button
@@ -105,9 +151,9 @@ function TabBar() {
             <button
                 type="button"
                 role="tab"
-                aria-selected={state.uiMode === "play"}
-                className={tabClass(state.uiMode === "play")}
-                onClick={() => dispatch({ type: "setUiMode", mode: "play" })}
+                aria-selected={playActive}
+                className={tabClass(playActive)}
+                onClick={() => dispatch({ type: "setUiMode", mode: "checklist" })}
             >
                 {tTabs("play")}
             </button>

--- a/src/ui/components/BottomNav.tsx
+++ b/src/ui/components/BottomNav.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import * as RadixPopover from "@radix-ui/react-popover";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import type { UiMode } from "../../logic/ClueState";
+import { useClue } from "../state";
+import { useToolbarActions } from "./Toolbar";
+
+/**
+ * Mobile-only fixed-bottom navigation. Shown only under 800px — the
+ * desktop header's `Toolbar` + `TabBar` cover the same affordances
+ * above that breakpoint. Five slots, left to right:
+ *
+ *   [Checklist] [Suggest] [Undo] [Redo] [⋯]
+ *
+ * The first two mirror the desktop Play grid split: on mobile the
+ * grid collapses to a single visible pane, chosen by `uiMode`. The
+ * overflow menu exposes everything else from the desktop Toolbar —
+ * Game setup (the Setup tab), Share link, and New game.
+ */
+export function BottomNav() {
+    const { state, dispatch, canUndo, canRedo, undo, redo } = useClue();
+    const t = useTranslations("bottomNav");
+    const tToolbar = useTranslations("toolbar");
+    const mode = state.uiMode;
+
+    const setMode = (next: UiMode) =>
+        dispatch({ type: "setUiMode", mode: next });
+
+    return (
+        <nav
+            aria-label={t("ariaLabel")}
+            className={
+                "fixed inset-x-0 bottom-0 z-40 border-t border-border bg-panel " +
+                "[padding-bottom:env(safe-area-inset-bottom,0px)] " +
+                "[@media(min-width:800px)]:hidden"
+            }
+        >
+            <ul className="m-0 flex list-none items-stretch justify-between gap-1 p-1">
+                <NavTabItem
+                    label={t("checklist")}
+                    active={mode === "checklist"}
+                    onClick={() => setMode("checklist")}
+                />
+                <NavTabItem
+                    label={t("suggest")}
+                    active={mode === "suggest"}
+                    onClick={() => setMode("suggest")}
+                />
+                <NavIconItem
+                    label={tToolbar("undoAria")}
+                    glyph="↶"
+                    onClick={undo}
+                    disabled={!canUndo}
+                />
+                <NavIconItem
+                    label={tToolbar("redoAria")}
+                    glyph="↷"
+                    onClick={redo}
+                    disabled={!canRedo}
+                />
+                <OverflowMenu setupActive={mode === "setup"} onSetup={() => setMode("setup")} />
+            </ul>
+        </nav>
+    );
+}
+
+/**
+ * Text-labelled tab slot (Checklist / Suggest). Active styling matches
+ * the desktop TabBar's accent underline — the bottom border lights up
+ * in red so the active tab reads at a glance against the panel
+ * background.
+ */
+function NavTabItem({
+    label,
+    active,
+    onClick,
+}: {
+    readonly label: string;
+    readonly active: boolean;
+    readonly onClick: () => void;
+}) {
+    return (
+        <li className="flex-1">
+            <button
+                type="button"
+                role="tab"
+                aria-selected={active}
+                onClick={onClick}
+                className={
+                    "flex h-12 w-full cursor-pointer items-center justify-center rounded-[var(--radius)] border-0 border-b-2 bg-transparent px-2 text-[13px] font-semibold " +
+                    (active
+                        ? "border-accent text-accent"
+                        : "border-transparent text-muted hover:text-accent")
+                }
+            >
+                {label}
+            </button>
+        </li>
+    );
+}
+
+/**
+ * Icon-only slot (Undo / Redo). Glyph matches the toolbar strings
+ * (↶ / ↷); `aria-label` carries the real name for screen readers.
+ */
+function NavIconItem({
+    label,
+    glyph,
+    onClick,
+    disabled,
+}: {
+    readonly label: string;
+    readonly glyph: string;
+    readonly onClick: () => void;
+    readonly disabled: boolean;
+}) {
+    return (
+        <li>
+            <button
+                type="button"
+                aria-label={label}
+                title={label}
+                onClick={onClick}
+                disabled={disabled}
+                className="flex h-12 w-12 cursor-pointer items-center justify-center rounded-[var(--radius)] border-none bg-transparent text-[20px] text-muted hover:text-accent disabled:cursor-not-allowed disabled:opacity-40"
+            >
+                {glyph}
+            </button>
+        </li>
+    );
+}
+
+/**
+ * Trailing overflow slot. A small Radix popover that opens *upward*
+ * (`side="top"`) above the fixed nav and hosts the three less-common
+ * actions: Game setup (switches to the Setup tab), Share link, and
+ * New game. Share + New game reuse `useToolbarActions` so the mobile
+ * flow is identical to the desktop Toolbar.
+ */
+function OverflowMenu({
+    setupActive,
+    onSetup,
+}: {
+    readonly setupActive: boolean;
+    readonly onSetup: () => void;
+}) {
+    const t = useTranslations("bottomNav");
+    const tToolbar = useTranslations("toolbar");
+    const [open, setOpen] = useState(false);
+    const { onShare, onNewGame, copied } = useToolbarActions();
+
+    const closeThen = (fn: () => void | Promise<void>) => () => {
+        setOpen(false);
+        void fn();
+    };
+
+    return (
+        <li>
+            <RadixPopover.Root open={open} onOpenChange={setOpen}>
+                <RadixPopover.Trigger
+                    aria-label={t("more")}
+                    title={t("more")}
+                    className="flex h-12 w-12 cursor-pointer items-center justify-center rounded-[var(--radius)] border-none bg-transparent text-[20px] text-muted hover:text-accent"
+                >
+                    ⋯
+                </RadixPopover.Trigger>
+                <RadixPopover.Portal>
+                    <RadixPopover.Content
+                        side="top"
+                        align="end"
+                        sideOffset={6}
+                        collisionPadding={8}
+                        className="z-50 min-w-[200px] rounded-[var(--radius)] border border-border bg-panel p-1 text-[13px] shadow-[0_6px_16px_rgba(0,0,0,0.18)]"
+                    >
+                        <MenuItem
+                            label={t("gameSetup")}
+                            active={setupActive}
+                            onClick={closeThen(onSetup)}
+                        />
+                        <MenuItem
+                            label={copied ? tToolbar("shareCopied") : tToolbar("share")}
+                            onClick={closeThen(onShare)}
+                        />
+                        <MenuItem
+                            label={tToolbar("newGame")}
+                            onClick={closeThen(onNewGame)}
+                        />
+                    </RadixPopover.Content>
+                </RadixPopover.Portal>
+            </RadixPopover.Root>
+        </li>
+    );
+}
+
+function MenuItem({
+    label,
+    active,
+    onClick,
+}: {
+    readonly label: string;
+    readonly active?: boolean;
+    readonly onClick: () => void;
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className={
+                "block w-full cursor-pointer rounded-[var(--radius)] border-none bg-transparent px-3 py-2 text-left text-[13px] hover:bg-hover " +
+                (active ? "text-accent font-semibold" : "text-inherit")
+            }
+        >
+            {label}
+        </button>
+    );
+}

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -77,7 +77,7 @@ export function Checklist() {
     const addPlayerHeaderCell = (
         <th
             key="add-player-col"
-            className="sticky top-0 z-10 w-px whitespace-nowrap border border-border bg-row-header px-1.5 py-1 text-center"
+            className="w-px whitespace-nowrap border border-border bg-row-header px-1.5 py-1 text-center"
         >
             <button
                 type="button"
@@ -168,14 +168,14 @@ export function Checklist() {
     const cardSpan = 1 + owners.length + (inSetup ? 1 : 0);
 
     return (
-        <section className="min-w-0 rounded-[var(--radius)] border border-border bg-panel p-4">
+        <section className="flex h-full min-w-0 flex-col rounded-[var(--radius)] border border-border bg-panel p-4">
             {inSetup && (
-                <div className="mb-3 flex justify-end">
+                <div className="mb-3 flex shrink-0 justify-end">
                     <button
                         type="button"
                         className="cursor-pointer rounded-[var(--radius)] border-none bg-accent px-4 py-2 text-[14px] font-semibold text-white hover:bg-accent-hover"
                         onClick={() =>
-                            dispatch({ type: "setUiMode", mode: "play" })
+                            dispatch({ type: "setUiMode", mode: "checklist" })
                         }
                     >
                         {suggestions.length > 0
@@ -184,9 +184,11 @@ export function Checklist() {
                     </button>
                 </div>
             )}
-            {inSetup ? <CardPackRow /> : <CaseFileHeader knowledge={knowledge} />}
+            <div className="shrink-0">
+                {inSetup ? <CardPackRow /> : <CaseFileHeader knowledge={knowledge} />}
+            </div>
             {inSetup && handSizeMismatch && (
-                <div className="mb-3 rounded-[var(--radius)] border border-warning-border bg-warning-bg px-3 py-2 text-[13px] text-warning">
+                <div className="mb-3 shrink-0 rounded-[var(--radius)] border border-warning-border bg-warning-bg px-3 py-2 text-[13px] text-warning">
                     {tSetup("handSizeMismatch", {
                         total: handSizesTotal,
                         expected: totalDealt,
@@ -194,15 +196,16 @@ export function Checklist() {
                     })}
                 </div>
             )}
+            <div className="-mx-4 min-h-0 flex-1 overflow-auto px-4">
             <table className="w-full border-collapse text-[13px]">
-                <thead>
+                <thead className="sticky top-0 z-20 bg-row-header">
                     <tr>
-                        <th className="sticky top-0 z-10 border border-border bg-row-header px-2 py-1 text-center font-semibold"></th>
+                        <th className="border border-border bg-row-header px-2 py-1 text-center font-semibold"></th>
                         {owners.flatMap(owner => {
                             const cell = (
                                 <th
                                     key={ownerKey(owner)}
-                                    className="sticky top-0 z-10 border border-border bg-row-header px-2 py-1 text-center align-top font-semibold"
+                                    className="border border-border bg-row-header px-2 py-1 text-center align-top font-semibold"
                                 >
                                     {inSetup && owner._tag === "Player" ? (
                                         <PlayerNameInput
@@ -571,6 +574,7 @@ export function Checklist() {
                     )}
                 </tbody>
             </table>
+            </div>
         </section>
     );
 }

--- a/src/ui/components/SuggestionForm.tsx
+++ b/src/ui/components/SuggestionForm.tsx
@@ -476,7 +476,7 @@ export function SuggestionForm({
                 {/*
                   * Add button lives inline with the pills so the whole
                   * form reads as a single row. Matches the pill height
-                  * (px-2 py-0.5 text-[12px]) but keeps the default
+                  * (px-3 py-2 text-[13px]) but keeps the default
                   * `rounded` radius instead of `rounded-full`, so it
                   * reads as a squared-off primary action distinct from
                   * the round pills.
@@ -484,7 +484,7 @@ export function SuggestionForm({
                 <button
                     type="button"
                     ref={submitBtnRef}
-                    className="cursor-pointer rounded border-none bg-accent px-2 py-0.5 text-[12px] text-white disabled:cursor-not-allowed disabled:bg-unknown"
+                    className="cursor-pointer rounded border-none bg-accent px-3 py-2 text-[13px] text-white disabled:cursor-not-allowed disabled:bg-unknown"
                     disabled={!canSubmit}
                     onClick={doSubmit}
                 >
@@ -493,7 +493,7 @@ export function SuggestionForm({
                 {onCancel !== undefined && (
                     <button
                         type="button"
-                        className="cursor-pointer rounded border border-border bg-white px-2 py-0.5 text-[12px]"
+                        className="cursor-pointer rounded border border-border bg-white px-3 py-2 text-[13px]"
                         onClick={onCancel}
                     >
                         {t("cancelAction")}

--- a/src/ui/components/SuggestionLogPanel.tsx
+++ b/src/ui/components/SuggestionLogPanel.tsx
@@ -323,7 +323,7 @@ function PriorSuggestions() {
                     {t("priorEmpty")}
                 </div>
             ) : (
-                <ol className="m-0 flex max-h-[300px] list-none flex-col gap-2 overflow-y-auto p-0">
+                <ol className="m-0 flex list-none flex-col gap-2 p-0">
                     {suggestions.map((s, idx) => (
                         <PriorSuggestionItem
                             key={s.id}

--- a/src/ui/components/SuggestionPills.tsx
+++ b/src/ui/components/SuggestionPills.tsx
@@ -231,7 +231,7 @@ export function PillPopover({
     const pillBody = (
         <span
             className={
-                "inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[12px] " +
+                "inline-flex items-center gap-1.5 rounded-full border px-3 py-2 text-[13px] " +
                 tone
             }
         >
@@ -461,7 +461,7 @@ export function SingleSelectList<T>({
                         role="option"
                         aria-selected={isSelected}
                         className={
-                            "flex cursor-pointer items-center gap-1.5 rounded px-2 py-1 text-[13px]" +
+                            "flex cursor-pointer items-center gap-1.5 rounded px-3 py-2 text-[13px]" +
                             (highlighted ? " bg-accent/15" : "") +
                             (row.kind === "nobody"
                                 ? " border-t border-border/60 text-muted"
@@ -619,7 +619,7 @@ export function MultiSelectList({
                             role="option"
                             aria-selected={checked}
                             className={
-                                "flex cursor-pointer items-center gap-1.5 rounded px-2 py-1 text-[13px]" +
+                                "flex cursor-pointer items-center gap-1.5 rounded px-3 py-2 text-[13px]" +
                                 (highlighted ? " bg-accent/15" : "")
                             }
                             onMouseEnter={() => setFocusedIdx(i)}
@@ -647,7 +647,7 @@ export function MultiSelectList({
                     role="option"
                     aria-selected={nobodyChosen}
                     className={
-                        "flex cursor-pointer items-center gap-1.5 rounded border-t border-border/60 px-2 py-1 text-[13px] text-muted" +
+                        "flex cursor-pointer items-center gap-1.5 rounded border-t border-border/60 px-3 py-2 text-[13px] text-muted" +
                         (focusedIdx === options.length
                             ? " bg-accent/15"
                             : "")

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -13,42 +13,15 @@ const buttonClass =
     "focus-visible:ring-offset-1 focus-visible:ring-offset-bg";
 
 /**
- * Top-of-page controls: undo/redo, start a fresh game, and copy a
- * shareable URL encoding the current state.
+ * Shared handlers for the Share-link and New-game actions. Keeps the
+ * clipboard fallback + transient "Copied!" state + confirm-and-dispatch
+ * flow in one place so both the desktop Toolbar and the mobile
+ * BottomNav overflow menu behave identically.
  */
-export function Toolbar() {
+export function useToolbarActions() {
     const t = useTranslations("toolbar");
-    const tHistory = useTranslations("history");
-    const {
-        dispatch,
-        currentShareUrl,
-        canUndo,
-        canRedo,
-        undo,
-        redo,
-        nextUndo,
-        nextRedo,
-    } = useClue();
+    const { dispatch, currentShareUrl } = useClue();
     const [copied, setCopied] = useState(false);
-
-    const undoTooltip = nextUndo
-        ? tHistory("undoTooltip", {
-              description: describeAction(
-                  nextUndo.action,
-                  nextUndo.previousState,
-                  tHistory,
-              ),
-          })
-        : undefined;
-    const redoTooltip = nextRedo
-        ? tHistory("redoTooltip", {
-              description: describeAction(
-                  nextRedo.action,
-                  nextRedo.previousState,
-                  tHistory,
-              ),
-          })
-        : undefined;
 
     const onShare = async () => {
         const url = currentShareUrl();
@@ -71,6 +44,39 @@ export function Toolbar() {
             dispatch({ type: "newGame" });
         }
     };
+
+    return { onShare, onNewGame, copied };
+}
+
+/**
+ * Top-of-page controls (desktop only): undo/redo, start a fresh game,
+ * and copy a shareable URL encoding the current state. Mobile uses
+ * `BottomNav` instead.
+ */
+export function Toolbar() {
+    const t = useTranslations("toolbar");
+    const tHistory = useTranslations("history");
+    const { canUndo, canRedo, undo, redo, nextUndo, nextRedo } = useClue();
+    const { onShare, onNewGame, copied } = useToolbarActions();
+
+    const undoTooltip = nextUndo
+        ? tHistory("undoTooltip", {
+              description: describeAction(
+                  nextUndo.action,
+                  nextUndo.previousState,
+                  tHistory,
+              ),
+          })
+        : undefined;
+    const redoTooltip = nextRedo
+        ? tHistory("redoTooltip", {
+              description: describeAction(
+                  nextRedo.action,
+                  nextRedo.previousState,
+                  tHistory,
+              ),
+          })
+        : undefined;
 
     return (
         <div className="flex flex-wrap items-center gap-3">

--- a/src/ui/state.tsx
+++ b/src/ui/state.tsx
@@ -609,7 +609,7 @@ export function ClueProvider({ children }: { children: ReactNode }) {
             const now = Date.now();
             const clear = now - lastPressAt < DOUBLE_TAP_MS;
             lastPressAt = clear ? 0 : now;
-            dispatchRaw({ type: "setUiMode", mode: "play" });
+            dispatchRaw({ type: "setUiMode", mode: "suggest" });
             requestFocusSuggestionForm({ clear });
         };
         window.addEventListener("keydown", onKeyDown);
@@ -703,9 +703,11 @@ export function ClueProvider({ children }: { children: ReactNode }) {
     const didHydrate = useRef(false);
 
     // One-shot hydration on mount: URL first, then localStorage. The
-    // `?tab=setup|play` param overrides the smart default; with no
-    // explicit tab we land on Play if the hydrated session has any
-    // suggestions, else Setup (the reducer's default).
+    // `?tab=setup|checklist|suggest` param overrides the smart default;
+    // with no explicit tab we land on the Checklist (play mode) if the
+    // hydrated session has any suggestions, else Setup (the reducer's
+    // default). On desktop `checklist` and `suggest` both render the
+    // same Play grid; on mobile they route to their own pane.
     useEffect(() => {
         if (didHydrate.current) return;
         didHydrate.current = true;
@@ -721,12 +723,14 @@ export function ClueProvider({ children }: { children: ReactNode }) {
         // Tab precedence: explicit `?tab=` wins; otherwise pick based on
         // hydrated suggestions. The default state.uiMode is "setup", so
         // only dispatch when we actually need to change it.
-        if (tabParam === "play") {
-            dispatch({ type: "setUiMode", mode: "play" });
+        if (tabParam === "checklist") {
+            dispatch({ type: "setUiMode", mode: "checklist" });
+        } else if (tabParam === "suggest") {
+            dispatch({ type: "setUiMode", mode: "suggest" });
         } else if (tabParam === "setup") {
             // No-op: default is already "setup".
         } else if (hydrated && hydrated.suggestions.length > 0) {
-            dispatch({ type: "setUiMode", mode: "play" });
+            dispatch({ type: "setUiMode", mode: "checklist" });
         }
     }, []);
 


### PR DESCRIPTION
## Summary
- **Mobile bottom nav** (< 800px): Checklist / Suggest tabs, inline undo/redo, and an overflow popover with Game setup / Share link / New game. Desktop Toolbar + TabBar hidden at this breakpoint.
- **URL-driven tabs**: `?tab=setup|checklist|suggest`. Desktop renders `checklist`/`suggest` as the same Play grid; mobile routes each value to its own pane via `hidden`/`block` toggles so resizing across the breakpoint never jumps tabs.
- **App-shell layout**: `<main>` fills `100dvh` with header / tabs / banner as `shrink-0` flex items; the content slot gets the remaining height. The Checklist panel is a flex column whose internal table wrapper owns both-axis scroll; `<thead>` is sticky so Player + Hand-size rows pin to the top while the body scrolls. Page itself never scrolls.
- **Tap targets**: pills, Add / Cancel buttons, and dropdown option rows bumped from ~22px to ~36px (`px-3 py-2 text-[13px]`).

## Test plan
- [x] Desktop (≥ 800px), all three `?tab` values: Play grid shows both Checklist + Suggestion log; Setup shows just the Checklist.
- [x] Mobile (< 800px): bottom nav visible, top Toolbar/TabBar hidden; Checklist / Suggest tabs swap the pane; overflow menu items route correctly.
- [x] Resize across 800px breakpoint on each of `checklist` / `suggest` / `setup` — no tab jumping.
- [x] Sticky thead covers Player + Hand-size rows in setup, Player row only in play, while scrolling the Checklist body.
- [x] Horizontal overflow (many players) scrolls inside the panel; background stays fixed.
- [x] `bun test` (76 tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)