### PR TITLE
Fix pre-existing typecheck, lint, and knip warnings

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -141,6 +141,12 @@ export default [
                             "aria-hidden",
                             "aria-orientation",
                             "data-.*",
+                            // Positioning / variant tokens on
+                            // component props (Radix Popover's
+                            // `side` / `align`, our own `variant`).
+                            "side",
+                            "align",
+                            "variant",
                         ],
                     },
                     // Ignore object-property values on common setup
@@ -193,6 +199,11 @@ export default [
                             "✓",
                             "✕",
                             "·",
+                            // Undo / redo / overflow glyphs in the
+                            // mobile BottomNav.
+                            "↶",
+                            "↷",
+                            "⋯",
                             // ICU `select` branch keys — internal
                             // discriminator tags passed into the
                             // `refutationLine` template. Not user copy.

--- a/src/ui/Clue.tsx
+++ b/src/ui/Clue.tsx
@@ -100,9 +100,9 @@ function TabContent() {
     // `hidden` / `block` classes keep both children mounted on desktop
     // and hide the off-tab one on mobile.
     const hideOnMobileIfSuggest =
-        mode === "suggest" ? "hidden [@media(min-width:800px)]:block" : "block";
+        mode === "suggest" ? "hidden [@media(min-width:800px)]:block" : "";
     const hideOnMobileIfChecklist =
-        mode === "checklist" ? "hidden [@media(min-width:800px)]:block" : "block";
+        mode === "checklist" ? "hidden [@media(min-width:800px)]:block" : "";
     return (
         <div className="grid h-full min-h-0 gap-5 [@media(min-width:800px)]:grid-cols-[minmax(0,1fr)_minmax(320px,420px)]">
             <div className={`min-h-0 min-w-0 ${hideOnMobileIfSuggest}`}>

--- a/src/ui/components/BottomNav.tsx
+++ b/src/ui/components/BottomNav.tsx
@@ -3,7 +3,6 @@
 import * as RadixPopover from "@radix-ui/react-popover";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
-import type { UiMode } from "../../logic/ClueState";
 import { useClue } from "../state";
 import { useToolbarActions } from "./Toolbar";
 
@@ -25,9 +24,6 @@ export function BottomNav() {
     const tToolbar = useTranslations("toolbar");
     const mode = state.uiMode;
 
-    const setMode = (next: UiMode) =>
-        dispatch({ type: "setUiMode", mode: next });
-
     return (
         <nav
             aria-label={t("ariaLabel")}
@@ -41,12 +37,16 @@ export function BottomNav() {
                 <NavTabItem
                     label={t("checklist")}
                     active={mode === "checklist"}
-                    onClick={() => setMode("checklist")}
+                    onClick={() =>
+                        dispatch({ type: "setUiMode", mode: "checklist" })
+                    }
                 />
                 <NavTabItem
                     label={t("suggest")}
                     active={mode === "suggest"}
-                    onClick={() => setMode("suggest")}
+                    onClick={() =>
+                        dispatch({ type: "setUiMode", mode: "suggest" })
+                    }
                 />
                 <NavIconItem
                     label={tToolbar("undoAria")}
@@ -60,7 +60,12 @@ export function BottomNav() {
                     onClick={redo}
                     disabled={!canRedo}
                 />
-                <OverflowMenu setupActive={mode === "setup"} onSetup={() => setMode("setup")} />
+                <OverflowMenu
+                    setupActive={mode === "setup"}
+                    onSetup={() =>
+                        dispatch({ type: "setUiMode", mode: "setup" })
+                    }
+                />
             </ul>
         </nav>
     );

--- a/src/ui/components/SuggestionLogPanel.tsx
+++ b/src/ui/components/SuggestionLogPanel.tsx
@@ -405,6 +405,7 @@ function PriorSuggestionItem({
     }, [hoveredCell, derived.provenance, derived.footnotes, idx]);
 
     const isHighlighted = isInPillMode || isHighlightedByCell;
+    // eslint-disable-next-line i18next/no-literal-string
     const pillVariant = isHighlighted ? "onAccent" : "default";
 
     const commit = (patch: Partial<DraftSuggestion>) =>

--- a/src/ui/components/SuggestionLogPanel.tsx
+++ b/src/ui/components/SuggestionLogPanel.tsx
@@ -5,7 +5,7 @@ import { useTranslations } from "next-intl";
 import { useEffect, useMemo, useState } from "react";
 import { Card, Player } from "../../logic/GameObjects";
 import { footnotesForCell } from "../../logic/Footnotes";
-import { GameSetup, cardName } from "../../logic/GameSetup";
+import { cardName } from "../../logic/GameSetup";
 import { chainFor } from "../../logic/Provenance";
 import {
     consolidateRecommendations,
@@ -612,11 +612,9 @@ function PriorSuggestionItem({
                             variant={pillVariant}
                             open={openPillId === `passers-${s.id}`}
                             onOpenChange={onOpenChangeFor(`passers-${s.id}`)}
-                            onClear={
-                                s.nonRefuters.length > 0
-                                    ? clearPassers
-                                    : undefined
-                            }
+                            {...(s.nonRefuters.length > 0
+                                ? { onClear: clearPassers }
+                                : {})}
                         >
                             <MultiSelectList
                                 options={passersOpts}
@@ -642,9 +640,9 @@ function PriorSuggestionItem({
                             variant={pillVariant}
                             open={openPillId === `refuter-${s.id}`}
                             onOpenChange={onOpenChangeFor(`refuter-${s.id}`)}
-                            onClear={
-                                s.refuter !== undefined ? clearRefuter : undefined
-                            }
+                            {...(s.refuter !== undefined
+                                ? { onClear: clearRefuter }
+                                : {})}
                         >
                             <SingleSelectList<Player>
                                 options={refuterOpts}
@@ -677,11 +675,9 @@ function PriorSuggestionItem({
                             onOpenChange={onOpenChangeFor(
                                 `seenCard-${s.id}`,
                             )}
-                            onClear={
-                                s.seenCard !== undefined
-                                    ? clearSeenCard
-                                    : undefined
-                            }
+                            {...(s.seenCard !== undefined
+                                ? { onClear: clearSeenCard }
+                                : {})}
                         >
                             <SingleSelectList<Card>
                                 options={seenCardOpts}

--- a/src/ui/components/SuggestionPills.tsx
+++ b/src/ui/components/SuggestionPills.tsx
@@ -38,15 +38,15 @@ export const isNobody = (v: unknown): v is Nobody => v === NOBODY;
 
 // ---- Pill status ------------------------------------------------------
 
-export type PillStatus =
+type PillStatus =
     | "done"
     | "pendingRequired"
     | "pendingOptional"
     | "error";
 
-export const STATUS_DONE: PillStatus = "done";
-export const STATUS_PENDING_REQ: PillStatus = "pendingRequired";
-export const STATUS_PENDING_OPT: PillStatus = "pendingOptional";
+const STATUS_DONE: PillStatus = "done";
+const STATUS_PENDING_REQ: PillStatus = "pendingRequired";
+const STATUS_PENDING_OPT: PillStatus = "pendingOptional";
 
 export const pillStatusForPlayer = (
     value: Player | Nobody | null,


### PR DESCRIPTION
## Summary
Brings the `main` baseline to zero errors across the full check suite — `pnpm typecheck`, `pnpm lint`, `pnpm knip`, and `pnpm build` all now pass. No behavior changes.

- **TypeScript** (5 → 0): drop an unused `GameSetup` import in `SuggestionLogPanel.tsx`; convert three `onClear={cond ? fn : undefined}` props to conditional spreads so they stop tripping `exactOptionalPropertyTypes`.
- **Knip** (4 → 0): strip `export` from `PillStatus` / `STATUS_DONE` / `STATUS_PENDING_REQ` / `STATUS_PENDING_OPT` in `SuggestionPills.tsx` — they're only used internally.
- **ESLint `i18next/no-literal-string`** (13 → 0): refactor three call sites (drop a no-op `"block"` className fallback, inline `dispatch` in `BottomNav` in place of a `setMode` helper, suppress one legitimate variant-token line); extend the lint config to exempt `side` / `align` / `variant` jsx attributes and `↶` / `↷` / `⋯` glyphs.

## Test plan
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 errors
- [x] `pnpm knip` — clean
- [x] `pnpm build` — succeeds
- [x] `pnpm test` — 76/76 pass
- [x] `pnpm i18n:check` — clean
- [x] Smoke test in mobile preview: Checklist ↔ Suggest tab swap, overflow menu → Game setup all still work after inlining `dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)