### PR TITLE
Enable autoPort on next-dev / next-start launch configs

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,13 +5,15 @@
             "name": "next-dev",
             "runtimeExecutable": "pnpm",
             "runtimeArgs": ["dev"],
-            "port": 3000
+            "port": 3000,
+            "autoPort": true
         },
         {
             "name": "next-start",
             "runtimeExecutable": "pnpm",
             "runtimeArgs": ["start"],
-            "port": 3000
+            "port": 3000,
+            "autoPort": true
         },
         {
             "name": "out-serve",


### PR DESCRIPTION
## Summary
- Add `"autoPort": true` to the `next-dev` and `next-start` entries in [.claude/launch.json](.claude/launch.json).
- When port 3000 is already in use by another Claude Code session, the preview now picks the next free port instead of erroring out — concurrent worktrees can each run their own server.

## Test plan
- [x] Spawned a second preview while port 3000 was occupied: got port 59175 assigned and the dev server came up cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)