### PR TITLE
Rewrite why-value tooltips to name specific players and cards

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -99,36 +99,36 @@
         "suggestionHeadline": "Suggestion #{number}",
         "initial-known-card": {
             "headline": "Given",
-            "detail": "You marked this cell in the known-cards grid."
+            "detail": "You marked that {cellPlayer} {value, select, Y {owns} other {doesn't own}} {cellCard}."
         },
         "initial-hand-size": {
             "headline": "Given",
-            "detail": "Known from the player's hand size."
+            "detail": "Known from {cellPlayer}'s hand size."
         },
         "card-ownership": {
             "headline": "Card ownership",
-            "detail": "Each card has exactly one owner. Once {card} was ruled in or out for other owners, this cell was forced."
+            "detail": "{value, select, Y {Each {card} has exactly one owner — every other owner was ruled out, so {cellPlayer} must own it.} other {{card} is already owned by someone else, so {cellPlayer} doesn't own it.}}"
         },
         "player-hand": {
             "headline": "Hand size",
-            "detail": "{player}'s hand holds a fixed number of cards. Counting the Ys and Ns in their row forced this cell."
+            "detail": "{value, select, Y {{player}'s hand is a fixed size and their other cards are all ruled out, so {player} must own {cellCard}.} other {{player}'s hand is a fixed size and already full, so {player} can't also hold {cellCard}.}}"
         },
         "case-file-category": {
             "headline": "Case file",
-            "detail": "The case file contains exactly one {category}. Narrowing the category forced this cell."
+            "detail": "{value, select, Y {The case file holds exactly one {category} — the others are ruled out, so the answer is {cellCard}.} other {The case file holds exactly one {category}; another card in that category is the answer, so it isn't {cellCard}.}}"
         },
         "non-refuters": {
-            "detailKnown": "The passer couldn't refute {suggester}'s suggestion, so they don't own any of the named cards.",
-            "detailUnknown": "A player who passed can't hold the named cards."
+            "detailKnown": "{cellPlayer} passed on {suggester}'s suggestion #{number}, so {cellPlayer} can't hold {cellCard}.",
+            "detailUnknown": "{cellPlayer} passed on suggestion #{number}, so {cellPlayer} can't hold {cellCard}."
         },
         "refuter-showed": {
-            "detailKnown": "{refuter} refuted and showed {seen}.",
-            "detailKnownNoCard": "{refuter} refuted and showed the refuting card.",
-            "detailUnknown": "Refuter showed the card."
+            "detailKnown": "{refuter} refuted suggestion #{number} by showing {seen}, so {cellPlayer} owns {cellCard}.",
+            "detailKnownNoCard": "{refuter} refuted suggestion #{number} by showing {cellCard}.",
+            "detailUnknown": "The refuter showed {cellCard} when refuting suggestion #{number}."
         },
         "refuter-owns-one-of": {
-            "detailKnown": "{refuter} refuted {suggester}'s suggestion ({cardLabels}) but we didn't see the card. Once the other two were ruled out, this one was forced.",
-            "detailUnknown": "Refuter had to own one of the three cards; the other two were already ruled out."
+            "detailKnown": "{refuter} refuted {suggester}'s suggestion #{number} ({cardLabels}); the other two were ruled out, so {refuter} must own {cellCard}.",
+            "detailUnknown": "The refuter of suggestion #{number} owned one of the three cards; the other two were ruled out, so it must be {cellCard}."
         }
     },
     "recommendations": {

--- a/src/logic/Provenance.ts
+++ b/src/logic/Provenance.ts
@@ -1,6 +1,6 @@
 import { Data, Effect, Equal, HashMap, Match, MutableHashMap, MutableHashSet, Option } from "effect";
 import type { ContradictionTrace } from "./Deducer";
-import { Card, CardCategory, Player } from "./GameObjects";
+import { Card, CardCategory, Player, ownerLabel } from "./GameObjects";
 import { Cell, CellValue, Contradiction, Knowledge } from "./Knowledge";
 import { applyConsistencyRules, applyDeductionRules } from "./Rules";
 import {
@@ -88,7 +88,7 @@ export const RefuterOwnsOneOf = (params: {
  *
  * - `iteration`: 0 for initial inputs, 1+ for rule passes.
  * - `kind`:      structured identity of the rule that set this cell.
- * - `detail`:    free-form human-readable detail.
+ * - `value`:     the Y / N value this reason forced into the output cell.
  * - `dependsOn`: cells whose values were consulted to derive this one.
  *                For initial inputs this is empty. For slice-based
  *                deductions it's the already-set cells in the slice.
@@ -99,7 +99,7 @@ export const RefuterOwnsOneOf = (params: {
 export interface Reason {
     readonly iteration: number;
     readonly kind: ReasonKind;
-    readonly detail: string;
+    readonly value: CellValue;
     readonly dependsOn: ReadonlyArray<Cell>;
 }
 
@@ -123,7 +123,6 @@ export interface SetCellRecord {
     readonly cell: Cell;
     readonly value: CellValue;
     readonly kind: ReasonKind;
-    readonly detail: string;
     readonly dependsOn: ReadonlyArray<Cell>;
 }
 
@@ -144,12 +143,17 @@ export type Tracer = (record: SetCellRecord) => void;
  * Dedup uses a HashSet keyed on Cell directly (structural Equal), so
  * no hash-surrogate string is needed.
  */
+export interface ChainEntry {
+    readonly cell: Cell;
+    readonly reason: Reason;
+}
+
 export const chainFor = (
     provenance: Provenance,
     cell: Cell,
-): ReadonlyArray<Reason> => {
+): ReadonlyArray<ChainEntry> => {
     const seen = MutableHashSet.empty<Cell>();
-    const out: Reason[] = [];
+    const out: ChainEntry[] = [];
     const stack: Cell[] = [cell];
     let next = stack.pop();
     while (next !== undefined) {
@@ -159,7 +163,7 @@ export const chainFor = (
                 MutableHashMap.get(provenance, next),
             );
             if (reason !== undefined) {
-                out.push(reason);
+                out.push({ cell: next, reason });
                 for (const dep of reason.dependsOn) stack.push(dep);
             }
         }
@@ -182,37 +186,48 @@ export const chainFor = (
  * (suggestion removed) fall back to the no-params branch of the
  * matching message.
  */
+/**
+ * Params every variant carries about the cell this reason set. The i18n
+ * templates interpolate these so lines read as concrete facts about a
+ * specific (player, card) rather than a generic "this cell".
+ */
+export interface CellParams {
+    readonly cellPlayer: string;
+    readonly cellCard: string;
+    readonly value: CellValue;
+}
+
 export type ReasonDescription =
     | {
           readonly kind: "initial-known-card";
-          readonly params: Record<string, never>;
+          readonly params: CellParams;
       }
     | {
           readonly kind: "initial-hand-size";
-          readonly params: Record<string, never>;
+          readonly params: CellParams;
       }
     | {
           readonly kind: "card-ownership";
-          readonly params: { readonly card: string };
+          readonly params: CellParams & { readonly card: string };
       }
     | {
           readonly kind: "player-hand";
-          readonly params: { readonly player: string };
+          readonly params: CellParams & { readonly player: string };
       }
     | {
           readonly kind: "case-file-category";
-          readonly params: { readonly category: string };
+          readonly params: CellParams & { readonly category: string };
       }
     | {
           readonly kind: "non-refuters";
-          readonly params: {
+          readonly params: CellParams & {
               readonly suggestionIndex: number;
               readonly suggester: string | undefined;
           };
       }
     | {
           readonly kind: "refuter-showed";
-          readonly params: {
+          readonly params: CellParams & {
               readonly suggestionIndex: number;
               readonly refuter: string | undefined;
               readonly seen: string | undefined;
@@ -220,7 +235,7 @@ export type ReasonDescription =
       }
     | {
           readonly kind: "refuter-owns-one-of";
-          readonly params: {
+          readonly params: CellParams & {
               readonly suggestionIndex: number;
               readonly suggester: string | undefined;
               readonly refuter: string | undefined;
@@ -230,34 +245,41 @@ export type ReasonDescription =
 
 export const describeReason = (
     reason: Reason,
+    cell: Cell,
     setup: GameSetup,
     suggestions: ReadonlyArray<Suggestion>,
-): ReasonDescription =>
-    Match.value(reason.kind).pipe(
+): ReasonDescription => {
+    const base: CellParams = {
+        cellPlayer: ownerLabel(cell.owner),
+        cellCard: cardName(setup, cell.card),
+        value: reason.value,
+    };
+    return Match.value(reason.kind).pipe(
         Match.tagsExhaustive({
             InitialKnownCard: (): ReasonDescription => ({
                 kind: "initial-known-card",
-                params: {},
+                params: base,
             }),
             InitialHandSize: (): ReasonDescription => ({
                 kind: "initial-hand-size",
-                params: {},
+                params: base,
             }),
             CardOwnership: ({ card }): ReasonDescription => ({
                 kind: "card-ownership",
-                params: { card: cardName(setup, card) },
+                params: { ...base, card: cardName(setup, card) },
             }),
             PlayerHand: ({ player }): ReasonDescription => ({
                 kind: "player-hand",
-                params: { player: String(player) },
+                params: { ...base, player: String(player) },
             }),
             CaseFileCategory: ({ category }): ReasonDescription => ({
                 kind: "case-file-category",
-                params: { category: categoryName(setup, category) },
+                params: { ...base, category: categoryName(setup, category) },
             }),
             NonRefuters: ({ suggestionIndex }): ReasonDescription => ({
                 kind: "non-refuters",
                 params: {
+                    ...base,
                     suggestionIndex,
                     suggester:
                         suggestions[suggestionIndex]?.suggester !== undefined
@@ -270,6 +292,7 @@ export const describeReason = (
                 return {
                     kind: "refuter-showed",
                     params: {
+                        ...base,
                         suggestionIndex,
                         refuter:
                             s?.refuter !== undefined
@@ -287,6 +310,7 @@ export const describeReason = (
                 return {
                     kind: "refuter-owns-one-of",
                     params: {
+                        ...base,
                         suggestionIndex,
                         suggester:
                             s?.suggester !== undefined
@@ -306,6 +330,7 @@ export const describeReason = (
             },
         }),
     );
+};
 
 /**
  * Run the deducer once and record, for every cell that was newly
@@ -336,11 +361,11 @@ export const deduceWithExplanations = (
 
         // Seed provenance with the initial inputs so the UI can explain
         // them as "you told us this".
-        HashMap.forEach(initial.checklist, (_value, cell) => {
+        HashMap.forEach(initial.checklist, (value, cell) => {
             MutableHashMap.set(provenance, cell, {
                 iteration: 0,
                 kind: InitialKnownCard(),
-                detail: "given from starting knowledge",
+                value,
                 dependsOn: [],
             });
         });
@@ -350,7 +375,7 @@ export const deduceWithExplanations = (
             MutableHashMap.set(provenance, record.cell, {
                 iteration: currentIteration,
                 kind: record.kind,
-                detail: record.detail,
+                value: record.value,
                 dependsOn: record.dependsOn,
             });
         };

--- a/src/logic/Rules.ts
+++ b/src/logic/Rules.ts
@@ -117,10 +117,6 @@ export const applySlice = (
                     cell,
                     value: N,
                     kind: slice.kind,
-                    detail:
-                        `${slice.label}: all ${slice.yCount} Y` +
-                        `${slice.yCount === 1 ? "" : "s"} accounted for, ` +
-                        `so this cell is N`,
                     dependsOn: yCells,
                 });
             }
@@ -137,10 +133,6 @@ export const applySlice = (
                     cell,
                     value: Y,
                     kind: slice.kind,
-                    detail:
-                        `${slice.label}: all ${nCount} N` +
-                        `${nCount === 1 ? "" : "s"} accounted for, ` +
-                        `so this cell is Y`,
                     dependsOn: nCells,
                 });
             }
@@ -261,9 +253,6 @@ export const nonRefutersDontHaveSuggestedCards = (
                         cell,
                         value: N,
                         kind: NonRefuters({ suggestionIndex }),
-                        detail:
-                            `${player} passed on suggestion #${suggestionIndex + 1}, ` +
-                            `so doesn't own ${card}`,
                         dependsOn: [],
                     });
                 }
@@ -306,9 +295,6 @@ export const refuterShowedCard = (
                 cell,
                 value: Y,
                 kind: RefuterShowed({ suggestionIndex }),
-                detail:
-                    `${suggestion.refuter} showed ${suggestion.seenCard} when ` +
-                    `refuting suggestion #${suggestionIndex + 1}`,
                 dependsOn: [],
             });
         }
@@ -369,10 +355,6 @@ export const refuterOwnsOneOf = (
                     cell,
                     value: Y,
                     kind: RefuterOwnsOneOf({ suggestionIndex }),
-                    detail:
-                        `${suggestion.refuter} refuted suggestion ` +
-                        `#${suggestionIndex + 1} and we've ruled out the ` +
-                        `other cards, so they must own this one`,
                     dependsOn: nCells,
                 });
             }

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -126,7 +126,7 @@ export function Checklist() {
         if (hoveredSuggestionIndex === null) return false;
         if (!provenance) return false;
         const chain = chainFor(provenance, Cell(owner, card));
-        for (const reason of chain) {
+        for (const { reason } of chain) {
             const tag = reason.kind._tag;
             const idx =
                 tag === "NonRefuters"
@@ -788,14 +788,14 @@ const resolveReasonCopy = (
         case "initial-hand-size":
             return {
                 headline: tReasons(`${desc.kind}.headline`),
-                detail: tReasons(`${desc.kind}.detail`),
+                detail: tReasons(`${desc.kind}.detail`, { ...desc.params }),
             };
         case "card-ownership":
         case "player-hand":
         case "case-file-category":
             return {
                 headline: tReasons(`${desc.kind}.headline`),
-                detail: tReasons(`${desc.kind}.detail`, desc.params),
+                detail: tReasons(`${desc.kind}.detail`, { ...desc.params }),
             };
         case "non-refuters": {
             const headline = tReasons("suggestionHeadline", {
@@ -804,9 +804,16 @@ const resolveReasonCopy = (
             const detail =
                 desc.params.suggester !== undefined
                     ? tReasons("non-refuters.detailKnown", {
+                          cellPlayer: desc.params.cellPlayer,
+                          cellCard: desc.params.cellCard,
                           suggester: desc.params.suggester,
+                          number: desc.params.suggestionIndex + 1,
                       })
-                    : tReasons("non-refuters.detailUnknown");
+                    : tReasons("non-refuters.detailUnknown", {
+                          cellPlayer: desc.params.cellPlayer,
+                          cellCard: desc.params.cellCard,
+                          number: desc.params.suggestionIndex + 1,
+                      });
             return { headline, detail };
         }
         case "refuter-showed": {
@@ -816,7 +823,11 @@ const resolveReasonCopy = (
             if (desc.params.refuter === undefined) {
                 return {
                     headline,
-                    detail: tReasons("refuter-showed.detailUnknown"),
+                    detail: tReasons("refuter-showed.detailUnknown", {
+                        cellPlayer: desc.params.cellPlayer,
+                        cellCard: desc.params.cellCard,
+                        number: desc.params.suggestionIndex + 1,
+                    }),
                 };
             }
             return {
@@ -824,11 +835,17 @@ const resolveReasonCopy = (
                 detail:
                     desc.params.seen !== undefined
                         ? tReasons("refuter-showed.detailKnown", {
+                              cellPlayer: desc.params.cellPlayer,
+                              cellCard: desc.params.cellCard,
                               refuter: desc.params.refuter,
                               seen: desc.params.seen,
+                              number: desc.params.suggestionIndex + 1,
                           })
                         : tReasons("refuter-showed.detailKnownNoCard", {
+                              cellPlayer: desc.params.cellPlayer,
+                              cellCard: desc.params.cellCard,
                               refuter: desc.params.refuter,
+                              number: desc.params.suggestionIndex + 1,
                           }),
             };
         }
@@ -843,15 +860,22 @@ const resolveReasonCopy = (
             ) {
                 return {
                     headline,
-                    detail: tReasons("refuter-owns-one-of.detailUnknown"),
+                    detail: tReasons("refuter-owns-one-of.detailUnknown", {
+                        cellPlayer: desc.params.cellPlayer,
+                        cellCard: desc.params.cellCard,
+                        number: desc.params.suggestionIndex + 1,
+                    }),
                 };
             }
             return {
                 headline,
                 detail: tReasons("refuter-owns-one-of.detailKnown", {
+                    cellPlayer: desc.params.cellPlayer,
+                    cellCard: desc.params.cellCard,
                     refuter: desc.params.refuter,
                     suggester: desc.params.suggester,
                     cardLabels: desc.params.cardLabels,
+                    number: desc.params.suggestionIndex + 1,
                 }),
             };
         }
@@ -889,8 +913,8 @@ const buildCellTitle = (args: {
     const chain = provenance
         ? chainFor(provenance, Cell(owner, card))
         : [];
-    const chainLines: string[] = chain.map((reason, i) => {
-        const desc = describeReason(reason, setup, suggestions);
+    const chainLines: string[] = chain.map(({ cell: entryCell, reason }, i) => {
+        const desc = describeReason(reason, entryCell, setup, suggestions);
         const { headline, detail } = resolveReasonCopy(desc, tReasons);
         return tDeduce("whyLine", {
             index: i + 1,

--- a/src/ui/components/SuggestionLogPanel.tsx
+++ b/src/ui/components/SuggestionLogPanel.tsx
@@ -375,7 +375,7 @@ function PriorSuggestionItem({
     const isHighlightedByCell = useMemo(() => {
         if (!hoveredCell) return false;
         if (derived.provenance) {
-            for (const reason of chainFor(derived.provenance, hoveredCell)) {
+            for (const { reason } of chainFor(derived.provenance, hoveredCell)) {
                 const tag = reason.kind._tag;
                 if (
                     tag === "NonRefuters" ||


### PR DESCRIPTION
## Summary
- Each reason line now includes the output cell's player + card + Y/N value, so previously-identical "You marked this cell in the known-cards grid" lines now read as distinct statements per (player, card).
- `chainFor` exposes the cell alongside each reason; `describeReason` uses it to populate `cellPlayer` / `cellCard` / `value` for every template.
- Message templates rewritten with Y- and N-branches so the copy reads naturally in both directions (e.g. "Kapil's hand is a fixed size and already full, so Kapil can't also hold Lead pipe").

## Test plan
- [x] `pnpm test` — 96/96 pass
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] Preview: marked 5 cards in a player column, hovered a hand-size-forced N cell; tooltip now reads 5 distinct "Given" lines naming each card, followed by a concrete hand-size explanation.
- [x] Preview: hovered a card-ownership-forced N cell; tooltip names the specific card and owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)