### PR TITLE
Full keyboard navigation for tabs, checklist, and suggestions log

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -112,6 +112,17 @@ h3 {
     letter-spacing: 0.01em;
 }
 
+/* Global focus-visible outline: a high-contrast oxblood ring so
+   keyboard users always know where they are. Applied via the
+   :focus-visible pseudo-class so mouse clicks don't trigger it.
+   Components that already use `focus-visible:ring-*` classes
+   compose with this outline — both show together. */
+*:focus-visible {
+    outline: 3px solid var(--color-accent);
+    outline-offset: 2px;
+    border-radius: 3px;
+}
+
 @keyframes banner-in {
     from {
         opacity: 0;

--- a/messages/en.json
+++ b/messages/en.json
@@ -5,26 +5,31 @@
     },
     "tabs": {
         "setup": "Setup",
-        "play": "Play"
+        "play": "Play",
+        "setupWithShortcut": "Setup (⌘H)",
+        "playWithShortcut": "Play (⌘K)"
     },
     "bottomNav": {
         "ariaLabel": "Primary navigation",
         "checklist": "Checklist",
+        "checklistWithShortcut": "Checklist (⌘J)",
         "suggest": "Suggest",
+        "suggestWithShortcut": "Suggest (⌘K)",
         "more": "More",
-        "gameSetup": "Game setup"
+        "gameSetup": "Game setup",
+        "gameSetupWithShortcut": "Game setup (⌘H)"
     },
     "toolbar": {
-        "undo": "↶ Undo",
+        "undo": "↶ Undo (⌘Z)",
         "undoAria": "Undo",
         "undoTitle": "Undo (⌘Z / Ctrl+Z)",
-        "redo": "↷ Redo",
+        "redo": "↷ Redo (⌘⇧Z)",
         "redoAria": "Redo",
         "redoTitle": "Redo (⌘⇧Z / Ctrl+Shift+Z)",
         "share": "Share link",
         "shareCopied": "Copied!",
         "copyFallback": "Copy this URL:",
-        "newGame": "New game",
+        "newGame": "New game (⌘N)",
         "newGameConfirm": "Start a new game? This will clear all players, cards, known hands, and suggestions."
     },
     "history": {
@@ -85,7 +90,9 @@
         "addCategory": "+ add category",
         "knownCardCheckboxAria": "{player} owns {card}",
         "startPlaying": "Start playing →",
-        "continuePlaying": "Continue playing →"
+        "startPlayingWithShortcut": "Start playing → (⌘;)",
+        "continuePlaying": "Continue playing →",
+        "continuePlayingWithShortcut": "Continue playing → (⌘;)"
     },
     "deduce": {
         "title": "Deduction grid",
@@ -147,6 +154,8 @@
         "addPlayersFirst": "Add players to see recommendations.",
         "nothingUseful": "Nothing useful to ask — you've already narrowed everything down.",
         "priorTitle": "{count, plural, =0 {Prior suggestions} other {Prior suggestions (#)}}",
+        "priorTitleWithShortcut": "{count, plural, =0 {Prior suggestions (⌘L)} other {Prior suggestions (⌘L) (#)}}",
+        "priorKeyboardHint": "↑↓ navigate · Enter edit · ⌫ remove · Esc exit",
         "priorEmpty": "No suggestions yet. Add one above.",
         "suggestedLine": "<strong>{suggester}</strong> suggested {cards}",
         "refutationLine": "{status, select, refutedSeenPassed {refuted by <strong>{refuter}</strong> (showed {seen}) · passed: {passers}} refutedSeen {refuted by <strong>{refuter}</strong> (showed {seen})} refutedPassed {refuted by <strong>{refuter}</strong> · passed: {passers}} refuted {refuted by <strong>{refuter}</strong>} nobodyPassed {nobody could refute · passed: {passers}} other {nobody could refute}}",

--- a/src/ui/Clue.tsx
+++ b/src/ui/Clue.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { useTranslations } from "next-intl";
 import { BottomNav } from "./components/BottomNav";
 import { Checklist } from "./components/Checklist";
@@ -65,12 +66,39 @@ export function Clue() {
                 <div className="flex min-h-0 flex-1 flex-col">
                     <TabContent />
                 </div>
+                <NewGameShortcut />
             </main>
             <BottomNav />
            </HoverProvider>
           </ClueProvider>
         </TooltipProvider>
     );
+}
+
+/**
+ * Cmd/Ctrl+N handler for starting a new game. Mounts once inside
+ * `ClueProvider` so `useClue` + i18n are available. Some browsers
+ * (Safari, Chrome on macOS) reserve Cmd+N for "new window" and do
+ * not let web pages preempt it — the binding still works in browsers
+ * that allow it (Firefox, packaged web views) and as Ctrl+N on
+ * Windows/Linux.
+ */
+function NewGameShortcut() {
+    const t = useTranslations("toolbar");
+    const { dispatch } = useClue();
+    useEffect(() => {
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (!(e.metaKey || e.ctrlKey)) return;
+            if (e.key !== "n" && e.key !== "N") return;
+            e.preventDefault();
+            if (window.confirm(t("newGameConfirm"))) {
+                dispatch({ type: "newGame" });
+            }
+        };
+        window.addEventListener("keydown", onKeyDown);
+        return () => window.removeEventListener("keydown", onKeyDown);
+    }, [dispatch, t]);
+    return null;
 }
 
 /**
@@ -146,7 +174,7 @@ function TabBar() {
                 className={tabClass(state.uiMode === "setup")}
                 onClick={() => dispatch({ type: "setUiMode", mode: "setup" })}
             >
-                {tTabs("setup")}
+                {tTabs("setupWithShortcut")}
             </button>
             <button
                 type="button"
@@ -155,7 +183,7 @@ function TabBar() {
                 className={tabClass(playActive)}
                 onClick={() => dispatch({ type: "setUiMode", mode: "checklist" })}
             >
-                {tTabs("play")}
+                {tTabs("playWithShortcut")}
             </button>
         </div>
     );

--- a/src/ui/checklistFocus.ts
+++ b/src/ui/checklistFocus.ts
@@ -1,0 +1,32 @@
+/**
+ * Cross-component signal for the Cmd/Ctrl+J shortcut. The global
+ * keyboard listener lives in `ClueProvider`, but the focus action has
+ * to land on a cell inside `Checklist`. A module-scoped bus with a
+ * last-focused memo bridges the gap — pressing ⌘J returns the user to
+ * wherever they last were in the grid, or to the first interactive
+ * cell if they've never been there.
+ *
+ * Parallels `suggestionFormFocus.ts`.
+ */
+
+type Target = { row: number; col: number } | "last" | "first";
+type Handler = (target: Target) => void;
+
+let current: Handler | null = null;
+let lastFocused: { row: number; col: number } | null = null;
+
+export function rememberChecklistCell(row: number, col: number): void {
+    lastFocused = { row, col };
+}
+
+export function registerChecklistFocusHandler(h: Handler): () => void {
+    current = h;
+    return () => {
+        if (current === h) current = null;
+    };
+}
+
+export function requestFocusChecklistCell(): void {
+    if (!current) return;
+    current(lastFocused ?? "first");
+}

--- a/src/ui/components/BottomNav.tsx
+++ b/src/ui/components/BottomNav.tsx
@@ -35,14 +35,14 @@ export function BottomNav() {
         >
             <ul className="m-0 flex list-none items-stretch justify-between gap-1 p-1">
                 <NavTabItem
-                    label={t("checklist")}
+                    label={t("checklistWithShortcut")}
                     active={mode === "checklist"}
                     onClick={() =>
                         dispatch({ type: "setUiMode", mode: "checklist" })
                     }
                 />
                 <NavTabItem
-                    label={t("suggest")}
+                    label={t("suggestWithShortcut")}
                     active={mode === "suggest"}
                     onClick={() =>
                         dispatch({ type: "setUiMode", mode: "suggest" })
@@ -180,7 +180,7 @@ function OverflowMenu({
                         className="z-50 min-w-[200px] rounded-[var(--radius)] border border-border bg-panel p-1 text-[13px] shadow-[0_6px_16px_rgba(0,0,0,0.18)]"
                     >
                         <MenuItem
-                            label={t("gameSetup")}
+                            label={t("gameSetupWithShortcut")}
                             active={setupActive}
                             onClick={closeThen(onSetup)}
                         />

--- a/src/ui/components/CardPackRow.tsx
+++ b/src/ui/components/CardPackRow.tsx
@@ -77,12 +77,13 @@ export function CardPackRow() {
                 {t("cardPack")}
             </div>
             <div className="flex flex-wrap items-center gap-2">
-                {CARD_SETS.map(choice => (
+                {CARD_SETS.map((choice, i) => (
                     <button
                         key={choice.id}
                         type="button"
                         className="cursor-pointer rounded border border-border bg-white px-3 py-1 text-[13px] hover:bg-hover"
                         onClick={() => onCardSet(choice)}
+                        {...(i === 0 ? { "data-setup-first-target": "card-pack" } : {})}
                     >
                         {choice.label}
                     </button>

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -2,7 +2,7 @@
 
 import { Result } from "effect";
 import { useTranslations } from "next-intl";
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { Card, Owner, Player, ownerLabel } from "../../logic/GameObjects";
 import {
     allCardIds,
@@ -36,6 +36,10 @@ import {
 import { Suggestion } from "../../logic/Suggestion";
 import { useHover } from "../HoverContext";
 import { useClue } from "../state";
+import {
+    registerChecklistFocusHandler,
+    rememberChecklistCell,
+} from "../checklistFocus";
 import { CardPackRow } from "./CardPackRow";
 import { Envelope } from "./Icons";
 import { Tooltip } from "./Tooltip";
@@ -67,6 +71,59 @@ export function Checklist() {
     const suggestions = derived.suggestionsAsData;
 
     const owners: ReadonlyArray<Owner> = allOwners(setup);
+
+    // Flat (card → row) index used for arrow-key grid navigation.
+    // Row 0 is the first card in the first category; rows run
+    // contiguously across all categories. Cells publish their
+    // row/col via data attrs so neighbors can be queried by
+    // `[data-cell-row="N"][data-cell-col="M"]`.
+    const rowIdxByCard = useMemo(() => {
+        const m = new Map<Card, number>();
+        let i = 0;
+        for (const cat of setup.categories) {
+            for (const entry of cat.cards) m.set(entry.id, i++);
+        }
+        return m;
+    }, [setup.categories]);
+    const totalRows = rowIdxByCard.size;
+    const totalCols = owners.length;
+
+    // Handle ⌘J focus requests: locate a cell by (row,col) and
+    // focus it. "first" falls back to the first interactive cell.
+    useEffect(() => {
+        const unregister = registerChecklistFocusHandler(target => {
+            const findAt = (row: number, col: number): HTMLElement | null => {
+                const el = document.querySelector<HTMLElement>(
+                    `[data-cell-row="${row}"][data-cell-col="${col}"]`,
+                );
+                return el;
+            };
+            const findFirst = (): HTMLElement | null => {
+                for (let r = 0; r < totalRows; r++) {
+                    for (let c = 0; c < totalCols; c++) {
+                        const el = findAt(r, c);
+                        if (el) return el;
+                    }
+                }
+                return null;
+            };
+            queueMicrotask(() => {
+                let el: HTMLElement | null = null;
+                if (target === "first") {
+                    el = findFirst();
+                } else if (target === "last") {
+                    el = findFirst();
+                } else {
+                    el = findAt(target.row, target.col) ?? findFirst();
+                }
+                if (el) {
+                    el.scrollIntoView({ block: "nearest", inline: "nearest" });
+                    el.focus({ preventScroll: false });
+                }
+            });
+        });
+        return unregister;
+    }, [totalRows, totalCols]);
 
     // In Setup mode the add-player column sits between the players and
     // the case file — clicking + spawns the new player where its column
@@ -168,19 +225,23 @@ export function Checklist() {
     const cardSpan = 1 + owners.length + (inSetup ? 1 : 0);
 
     return (
-        <section className="flex h-full min-w-0 flex-col rounded-[var(--radius)] border border-border bg-panel p-4">
+        <section
+            id="checklist"
+            className="flex h-full min-w-0 flex-col rounded-[var(--radius)] border border-border bg-panel p-4"
+        >
             {inSetup && (
                 <div className="mb-3 flex shrink-0 justify-end">
                     <button
                         type="button"
+                        data-setup-cta
                         className="cursor-pointer rounded-[var(--radius)] border-none bg-accent px-4 py-2 text-[14px] font-semibold text-white hover:bg-accent-hover"
                         onClick={() =>
                             dispatch({ type: "setUiMode", mode: "checklist" })
                         }
                     >
                         {suggestions.length > 0
-                            ? tSetup("continuePlaying")
-                            : tSetup("startPlaying")}
+                            ? tSetup("continuePlayingWithShortcut")
+                            : tSetup("startPlayingWithShortcut")}
                     </button>
                 </div>
             )}
@@ -200,7 +261,9 @@ export function Checklist() {
             <table className="w-full border-collapse text-[13px]">
                 <thead className="sticky top-0 z-20 bg-row-header">
                     <tr>
-                        <th className="border border-border bg-row-header px-2 py-1 text-center font-semibold"></th>
+                        <th className="border border-border bg-row-header px-2 py-1 text-center text-[10px] font-semibold uppercase tracking-[0.05em] text-muted">
+                            {inSetup ? null : "⌘J"}
+                        </th>
                         {owners.flatMap(owner => {
                             const cell = (
                                 <th
@@ -414,7 +477,9 @@ export function Checklist() {
                                             entry.name
                                         )}
                                     </th>
-                                    {owners.flatMap(owner => {
+                                    {owners.flatMap((owner, colIdx) => {
+                                        const rowIdx =
+                                            rowIdxByCard.get(entry.id) ?? -1;
                                         const value = getCellByOwnerCard(
                                             knowledge,
                                             owner,
@@ -475,7 +540,7 @@ export function Checklist() {
                                                         // In Setup mode the checkbox
                                                         // is the click target — no
                                                         // cell-wide button chrome.
-                                                        isPlayerCell && !setupCheckbox,
+                                                        isPlayerCell,
                                                         isHighlighted,
                                                     )}
                                                     onMouseEnter={() =>
@@ -487,7 +552,7 @@ export function Checklist() {
                                                         setHoveredCell(null)
                                                     }
                                                     onClick={
-                                                        isPlayerCell && !setupCheckbox
+                                                        isPlayerCell
                                                             ? () =>
                                                                   toggleKnownCard(
                                                                       owner,
@@ -496,17 +561,57 @@ export function Checklist() {
                                                             : undefined
                                                     }
                                                     role={
-                                                        isPlayerCell && !setupCheckbox
+                                                        isPlayerCell
                                                             ? "button"
                                                             : undefined
                                                     }
+                                                    aria-label={
+                                                        setupCheckbox
+                                                            ? tSetup(
+                                                                  "knownCardCheckboxAria",
+                                                                  {
+                                                                      player: String(
+                                                                          owner._tag ===
+                                                                              "Player"
+                                                                              ? owner.player
+                                                                              : "",
+                                                                      ),
+                                                                      card: entry.name,
+                                                                  },
+                                                              )
+                                                            : undefined
+                                                    }
+                                                    aria-pressed={
+                                                        setupCheckbox
+                                                            ? isKnownY
+                                                            : undefined
+                                                    }
                                                     tabIndex={
-                                                        isPlayerCell && !setupCheckbox
+                                                        isPlayerCell
                                                             ? 0
                                                             : undefined
                                                     }
+                                                    data-cell-row={
+                                                        isPlayerCell
+                                                            ? rowIdx
+                                                            : undefined
+                                                    }
+                                                    data-cell-col={
+                                                        isPlayerCell
+                                                            ? colIdx
+                                                            : undefined
+                                                    }
+                                                    onFocus={
+                                                        isPlayerCell
+                                                            ? () =>
+                                                                  rememberChecklistCell(
+                                                                      rowIdx,
+                                                                      colIdx,
+                                                                  )
+                                                            : undefined
+                                                    }
                                                     onKeyDown={
-                                                        isPlayerCell && !setupCheckbox
+                                                        isPlayerCell
                                                             ? e => {
                                                                   if (
                                                                       e.key === "Enter" ||
@@ -517,7 +622,49 @@ export function Checklist() {
                                                                           owner,
                                                                           entry.id,
                                                                       );
+                                                                      return;
                                                                   }
+                                                                  const deltaMap: Record<
+                                                                      string,
+                                                                      [number, number]
+                                                                  > = {
+                                                                      ArrowUp: [-1, 0],
+                                                                      ArrowDown: [1, 0],
+                                                                      ArrowLeft: [0, -1],
+                                                                      ArrowRight: [0, 1],
+                                                                  };
+                                                                  const delta =
+                                                                      deltaMap[e.key];
+                                                                  if (!delta) return;
+                                                                  e.preventDefault();
+                                                                  const [dr, dc] = delta;
+                                                                  // Walk until we find
+                                                                  // another interactive
+                                                                  // cell, skipping
+                                                                  // non-player columns
+                                                                  // (e.g. CaseFile in
+                                                                  // play mode still has
+                                                                  // a cell but is not
+                                                                  // focusable).
+                                                                  let r = rowIdx + dr;
+                                                                  let c = colIdx + dc;
+                                                                  let next: HTMLElement | null =
+                                                                      null;
+                                                                  while (
+                                                                      r >= 0 &&
+                                                                      r < totalRows &&
+                                                                      c >= 0 &&
+                                                                      c < totalCols
+                                                                  ) {
+                                                                      next =
+                                                                          document.querySelector<HTMLElement>(
+                                                                              `[data-cell-row="${r}"][data-cell-col="${c}"]`,
+                                                                          );
+                                                                      if (next) break;
+                                                                      r += dr;
+                                                                      c += dc;
+                                                                  }
+                                                                  if (next) next.focus();
                                                               }
                                                             : undefined
                                                     }
@@ -525,26 +672,11 @@ export function Checklist() {
                                                     {setupCheckbox ? (
                                                         <input
                                                             type="checkbox"
-                                                            className="h-4 w-4 cursor-pointer accent-accent"
+                                                            className="pointer-events-none h-4 w-4 accent-accent"
                                                             checked={isKnownY}
-                                                            onChange={() =>
-                                                                toggleKnownCard(
-                                                                    owner,
-                                                                    entry.id,
-                                                                )
-                                                            }
-                                                            aria-label={tSetup(
-                                                                "knownCardCheckboxAria",
-                                                                {
-                                                                    player: String(
-                                                                        owner._tag ===
-                                                                            "Player"
-                                                                            ? owner.player
-                                                                            : "",
-                                                                    ),
-                                                                    card: entry.name,
-                                                                },
-                                                            )}
+                                                            readOnly
+                                                            tabIndex={-1}
+                                                            aria-hidden
                                                         />
                                                     ) : (
                                                         <>

--- a/src/ui/components/SuggestionLogPanel.tsx
+++ b/src/ui/components/SuggestionLogPanel.tsx
@@ -345,23 +345,32 @@ function PriorSuggestions() {
     const suggestions = state.suggestions;
     return (
         <div className="mt-4 border-t border-border pt-4">
-            <h3 className={SECTION_TITLE}>
-                {t("priorTitle", { count: suggestions.length })}
+            <h3
+                id="prior-suggestions"
+                tabIndex={-1}
+                className={`${SECTION_TITLE} rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2`}
+            >
+                {t("priorTitleWithShortcut", { count: suggestions.length })}
             </h3>
             {suggestions.length === 0 ? (
                 <div className="text-[13px] text-muted">
                     {t("priorEmpty")}
                 </div>
             ) : (
-                <ol className="m-0 flex list-none flex-col gap-2 p-0">
-                    {suggestions.map((s, idx) => (
-                        <PriorSuggestionItem
-                            key={s.id}
-                            suggestion={s}
-                            idx={idx}
-                        />
-                    ))}
-                </ol>
+                <>
+                    <div className="mb-1 text-[11px] text-muted">
+                        {t("priorKeyboardHint")}
+                    </div>
+                    <ol className="m-0 flex list-none flex-col gap-2 p-0">
+                        {suggestions.map((s, idx) => (
+                            <PriorSuggestionItem
+                                key={s.id}
+                                suggestion={s}
+                                idx={idx}
+                            />
+                        ))}
+                    </ol>
+                </>
             )}
         </div>
     );
@@ -396,11 +405,16 @@ function PriorSuggestionItem({
 
     const [isSelfHovered, setIsSelfHovered] = useState(false);
     const [openPillId, setOpenPillId] = useState<string | null>(null);
+    // Keyboard-driven edit mode — set when the user presses Enter on
+    // a focused row. Promotes the row into pill-mode until Escape or
+    // focus leaves the row entirely.
+    const [isKeyboardEditing, setIsKeyboardEditing] = useState(false);
 
     // Pill-mode stays engaged while any popover is open, even if the
     // pointer has left the card (popovers render in a portal outside
     // our DOM subtree).
-    const isInPillMode = isSelfHovered || openPillId !== null;
+    const isInPillMode =
+        isSelfHovered || openPillId !== null || isKeyboardEditing;
 
     // Cell → suggestion hover (reverse of the Checklist's
     // `cellIsHighlighted`). Two ways a cell can reference a suggestion:
@@ -565,14 +579,77 @@ function PriorSuggestionItem({
 
     return (
         <li
+            tabIndex={0}
+            data-suggestion-row={idx}
             className={
-                "relative flex items-start gap-2 rounded-[var(--radius)] border px-3 py-2 text-[13px] transition-colors " +
+                "relative flex items-start gap-2 rounded-[var(--radius)] border px-3 py-2 text-[13px] transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 " +
                 (isHighlighted
                     ? "border-accent bg-accent text-white"
                     : "border-border")
             }
             onMouseEnter={onMouseEnter}
             onMouseLeave={onMouseLeave}
+            onFocus={e => {
+                // Row itself gained focus (not a descendant).
+                if (e.currentTarget === e.target) {
+                    setHoveredSuggestion(idx);
+                }
+            }}
+            onBlur={e => {
+                // Keep the cross-panel highlight while focus stays
+                // anywhere inside the row (pills / popovers / ×).
+                const next = e.relatedTarget as Node | null;
+                if (next && e.currentTarget.contains(next)) return;
+                setHoveredSuggestion(null);
+                setIsKeyboardEditing(false);
+            }}
+            onKeyDown={e => {
+                // Escape inside pills: bubble up here and exit edit mode.
+                if (e.currentTarget !== e.target) {
+                    if (
+                        e.key === "Escape" &&
+                        isKeyboardEditing &&
+                        openPillId === null
+                    ) {
+                        e.preventDefault();
+                        setIsKeyboardEditing(false);
+                        e.currentTarget.focus();
+                    }
+                    return;
+                }
+                if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+                    e.preventDefault();
+                    const dir = e.key === "ArrowDown" ? 1 : -1;
+                    let sib =
+                        dir === 1
+                            ? e.currentTarget.nextElementSibling
+                            : e.currentTarget.previousElementSibling;
+                    while (sib && !(sib instanceof HTMLLIElement)) {
+                        sib =
+                            dir === 1
+                                ? sib.nextElementSibling
+                                : sib.previousElementSibling;
+                    }
+                    if (sib instanceof HTMLElement) sib.focus();
+                } else if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    const row = e.currentTarget;
+                    setIsKeyboardEditing(true);
+                    queueMicrotask(() => {
+                        const first = row.querySelector<HTMLElement>(
+                            "[data-pill-id]",
+                        );
+                        first?.focus();
+                    });
+                } else if (e.key === "Delete" || e.key === "Backspace") {
+                    e.preventDefault();
+                    onRemove();
+                } else if (e.key === "Escape" && isKeyboardEditing) {
+                    e.preventDefault();
+                    setIsKeyboardEditing(false);
+                    e.currentTarget.focus();
+                }
+            }}
         >
             <span className="font-semibold">{idx + 1}.</span>
             <div className="min-w-0 flex-1 pr-5">

--- a/src/ui/components/Tooltip.tsx
+++ b/src/ui/components/Tooltip.tsx
@@ -33,9 +33,15 @@ export function Tooltip({
     delayMs?: number;
     variant?: "default" | "accent";
 }) {
-    if (content === undefined || content === null || content === "") {
-        return <>{children}</>;
-    }
+    // Always render the RadixTooltip.Root wrapper (even when empty) so
+    // that the children's DOM identity doesn't flip when content appears
+    // or disappears. Swapping between `<>{children}</>` and
+    // `<RadixTooltip.Root>…{children}…</RadixTooltip.Root>` remounts the
+    // child element and drops keyboard focus — e.g. toggling a setup
+    // cell would kick focus off the cell the moment a deduction
+    // produced a new tooltip for it.
+    const hasContent =
+        content !== undefined && content !== null && content !== "";
     const toneClasses =
         variant === "accent"
             ? "border-accent bg-accent text-white"
@@ -47,23 +53,25 @@ export function Tooltip({
     return (
         <RadixTooltip.Root delayDuration={delayMs}>
             <RadixTooltip.Trigger asChild>{children}</RadixTooltip.Trigger>
-            <RadixTooltip.Portal>
-                <RadixTooltip.Content
-                    side={side}
-                    sideOffset={6}
-                    collisionPadding={8}
-                    className={
-                        "z-50 max-w-[320px] rounded-[var(--radius)] border px-3 py-2 text-[12px] leading-snug shadow-[0_6px_16px_rgba(0,0,0,0.18)] " +
-                        toneClasses
-                    }
-                >
-                    {content}
-                    <RadixTooltip.Arrow
-                        className={arrowClasses}
-                        strokeWidth={0.5}
-                    />
-                </RadixTooltip.Content>
-            </RadixTooltip.Portal>
+            {hasContent && (
+                <RadixTooltip.Portal>
+                    <RadixTooltip.Content
+                        side={side}
+                        sideOffset={6}
+                        collisionPadding={8}
+                        className={
+                            "z-50 max-w-[320px] rounded-[var(--radius)] border px-3 py-2 text-[12px] leading-snug shadow-[0_6px_16px_rgba(0,0,0,0.18)] " +
+                            toneClasses
+                        }
+                    >
+                        {content}
+                        <RadixTooltip.Arrow
+                            className={arrowClasses}
+                            strokeWidth={0.5}
+                        />
+                    </RadixTooltip.Content>
+                </RadixTooltip.Portal>
+            )}
         </RadixTooltip.Root>
     );
 }

--- a/src/ui/state.tsx
+++ b/src/ui/state.tsx
@@ -64,6 +64,7 @@ import {
 } from "../logic/services";
 import { Layer } from "effect";
 import { requestFocusSuggestionForm } from "./suggestionFormFocus";
+import { requestFocusChecklistCell } from "./checklistFocus";
 
 type DeduceLayer = Layer.Layer<
     CardSetService | PlayerSetService | SuggestionsService
@@ -611,6 +612,117 @@ export function ClueProvider({ children }: { children: ReactNode }) {
             lastPressAt = clear ? 0 : now;
             dispatchRaw({ type: "setUiMode", mode: "suggest" });
             requestFocusSuggestionForm({ clear });
+        };
+        window.addEventListener("keydown", onKeyDown);
+        return () => window.removeEventListener("keydown", onKeyDown);
+    }, []);
+
+    // Refs shared by several shortcut handlers so their useEffect
+    // deps stay empty (no listener churn when state changes).
+    const uiModeRef = useRef(state.uiMode);
+    useEffect(() => {
+        uiModeRef.current = state.uiMode;
+    }, [state.uiMode]);
+    const gameStartedRef = useRef(false);
+    useEffect(() => {
+        gameStartedRef.current =
+            state.knownCards.length > 0 || state.suggestions.length > 0;
+    }, [state.knownCards, state.suggestions]);
+
+    // Cmd/Ctrl+H: switch to the Setup tab. (Overrides the Mac
+    // "hide app" default — explicit user choice.) Smart-landing:
+    //   - game started (any knownCards OR any suggestions) → focus
+    //     the last-focused checklist cell, or the first setup cell
+    //   - fresh game → focus the first card-pack preset button
+    useEffect(() => {
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (!(e.metaKey || e.ctrlKey)) return;
+            if (e.key !== "h" && e.key !== "H") return;
+            e.preventDefault();
+            dispatchRaw({ type: "setUiMode", mode: "setup" });
+            queueMicrotask(() => {
+                if (gameStartedRef.current) {
+                    requestFocusChecklistCell();
+                } else {
+                    const btn =
+                        document.querySelector<HTMLElement>(
+                            "[data-setup-first-target='card-pack']",
+                        );
+                    btn?.focus();
+                }
+            });
+        };
+        window.addEventListener("keydown", onKeyDown);
+        return () => window.removeEventListener("keydown", onKeyDown);
+    }, []);
+
+    // Cmd/Ctrl+; : jump to the Start / Continue playing CTA on the
+    // Setup tab (the primary exit action from setup).
+    useEffect(() => {
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (!(e.metaKey || e.ctrlKey)) return;
+            if (e.key !== ";") return;
+            e.preventDefault();
+            if (uiModeRef.current !== "setup") {
+                dispatchRaw({ type: "setUiMode", mode: "setup" });
+            }
+            queueMicrotask(() => {
+                const btn =
+                    document.querySelector<HTMLElement>("[data-setup-cta]");
+                btn?.focus();
+            });
+        };
+        window.addEventListener("keydown", onKeyDown);
+        return () => window.removeEventListener("keydown", onKeyDown);
+    }, []);
+
+    // Cmd/Ctrl+J: jump to the Checklist. On desktop Play already
+    // shows the checklist; on mobile Play-suggest hides it, so
+    // flip to the "checklist" sub-mode first. The focus request
+    // returns the user to whichever cell they were last on.
+    useEffect(() => {
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (!(e.metaKey || e.ctrlKey)) return;
+            if (e.key !== "j" && e.key !== "J") return;
+            e.preventDefault();
+            if (uiModeRef.current === "suggest") {
+                dispatchRaw({ type: "setUiMode", mode: "checklist" });
+            }
+            requestFocusChecklistCell();
+        };
+        window.addEventListener("keydown", onKeyDown);
+        return () => window.removeEventListener("keydown", onKeyDown);
+    }, []);
+
+    // Cmd/Ctrl+L: jump to the Prior suggestions log. If currently
+    // on Setup, flip to "suggest" first so the log is mounted.
+    // Focuses the first suggestion row if any exist so the user can
+    // immediately use ↑↓ — otherwise falls back to the section header
+    // (which has the empty-state message).
+    useEffect(() => {
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (!(e.metaKey || e.ctrlKey)) return;
+            if (e.key !== "l" && e.key !== "L") return;
+            e.preventDefault();
+            if (uiModeRef.current === "setup") {
+                dispatchRaw({ type: "setUiMode", mode: "suggest" });
+            }
+            queueMicrotask(() => {
+                const header = document.getElementById("prior-suggestions");
+                header?.scrollIntoView({
+                    behavior: "smooth",
+                    block: "start",
+                });
+                const firstRow =
+                    document.querySelector<HTMLElement>(
+                        "[data-suggestion-row='0']",
+                    );
+                if (firstRow) {
+                    firstRow.focus({ preventScroll: true });
+                } else if (header instanceof HTMLElement) {
+                    header.focus({ preventScroll: true });
+                }
+            });
         };
         window.addEventListener("keydown", onKeyDown);
         return () => window.removeEventListener("keydown", onKeyDown);


### PR DESCRIPTION
## Summary

Comprehensive keyboard navigation across the app. Every shortcut is discoverable inline — the UI advertises its own bindings.

**Global shortcuts (desktop + physical keyboards on mobile):**
- **⌘H** — Setup tab. Smart-lands on the last-focused checklist cell if a game is in progress; on the first card-pack preset (Classic) for a fresh game.
- **⌘J** — Checklist. Returns to the last-focused cell, or falls back to the first interactive cell.
- **⌘K** — Play + suggestion input (existing behavior preserved; double-tap still clears).
- **⌘L** — Prior suggestions log. Focuses the first row directly so arrow keys work immediately; falls back to the section header when the list is empty.
- **⌘;** — Start playing / Continue playing CTA on Setup.
- **⌘N** — New game with the same overwrite confirm as the button. *Note:* Safari/Chrome on macOS reserve ⌘N for "new window" so this is effective on browsers that allow preventDefault (Firefox, packaged web views) and as Ctrl+N on Windows/Linux.

**Within the checklist grid (both Setup and Play):**
- Arrow keys navigate between cells; Space/Enter toggles. Focus is preserved across toggles (fixed a `Tooltip` DOM-identity swap that was remounting cells).
- Setup-mode cells are now the focusable tap target (role=button, aria-pressed). Inner checkbox is visual-only — bigger hit target, cleaner keyboard model.

**Within the prior-suggestions log:**
- ↑↓ between rows, Enter to enter pill-edit mode (focuses first pill), Delete/Backspace to remove, Escape to leave edit mode.
- Keyboard focus drives the cross-panel checklist-cell halo, matching hover behavior.

**Discoverability:**
- Tabs: "Setup (⌘H)" / "Play (⌘K)"; mobile: "Checklist (⌘J)", "Suggest (⌘K)", "Game setup (⌘H)".
- Toolbar buttons: "Undo (⌘Z)", "Redo (⌘⇧Z)", "New game (⌘N)".
- Section headers: "Prior suggestions (⌘L)", "Add a suggestion (⌘K)".
- CTA: "Start playing → (⌘;)" / "Continue playing → (⌘;)".
- "⌘J" label in the top-left corner of the Play-tab checklist.

**Focus visibility:**
- Global `*:focus-visible` rule adds a 3px oxblood outline with 2px offset so keyboard users always know where they are. Composes cleanly with existing `focus-visible:ring-*` utilities.

## Test plan

- [x] 101/101 unit tests pass (`npm test`)
- [x] Typecheck clean (`npx tsc --noEmit`)
- [x] Verified end-to-end in browser preview:
  - Shortcut jumps land on the correct element for each of ⌘H/⌘J/⌘K/⌘L/⌘;/⌘N
  - ⌘H routes to first card pack on fresh game, last-focused cell on in-progress game
  - ⌘L focuses first suggestion row when list is non-empty, header when empty
  - Arrow keys move through grid in all 4 directions (both Setup and Play)
  - Space/Enter toggle setup cell AND keep focus on the cell
  - Delete/Backspace removes a focused suggestion row via confirm
  - Enter on a suggestion row promotes to pill-edit mode and focuses the first pill
  - All shortcut labels render correctly in desktop and mobile layouts
- [ ] Manual: test Ctrl+N on Windows/Linux (⌘N reserved on macOS browsers)
- [ ] Manual: verify the global focus ring looks right across light/dark preferences

🤖 Generated with [Claude Code](https://claude.com/claude-code)