### PR TITLE
Remove unused next-start and out-serve preview targets

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -7,19 +7,6 @@
             "runtimeArgs": ["dev"],
             "port": 3000,
             "autoPort": true
-        },
-        {
-            "name": "next-start",
-            "runtimeExecutable": "pnpm",
-            "runtimeArgs": ["start"],
-            "port": 3000,
-            "autoPort": true
-        },
-        {
-            "name": "out-serve",
-            "runtimeExecutable": "pnpm",
-            "runtimeArgs": ["dlx", "serve", "out", "-l", "4173"],
-            "port": 4173
         }
     ]
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -226,7 +226,6 @@ export default [
                             // Config keys used as string values.
                             "effect",
                             "next-dev",
-                            "next-start",
                         ],
                     },
                 },


### PR DESCRIPTION
## Summary
- `next start` doesn't work with `output: "export"` (static SPA), so the `next-start` launch target was non-functional.
- The `out-serve` static-export preview workflow isn't exercised in practice.
- Leave only `next-dev` in `.claude/launch.json`; drop the now-dead `next-start` entry from the ESLint i18n allow-list.

## Test plan
- [x] `pnpm install` and `preview_start next-dev` — boots Next 16.2.4 cleanly, app renders.
- [x] `Grep` confirms no remaining references to `out-serve` or `next-start`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)