### PR TITLE
Consolidate keyboard shortcuts into a KeyMapping module

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -93,6 +93,13 @@ export default [
                             "indexOf",
                             "endsWith",
                             "startsWith",
+                            // keyMap module — first arg is a binding ID,
+                            // an internal type-system token (not user copy).
+                            "matches",
+                            "label",
+                            "allLabels",
+                            "getBinding",
+                            "useGlobalShortcut",
                             // Translator namespaces / namespace hooks.
                             // Matches `t`, `tReasons`, `tDeduce`, etc.
                             // Any local variable that's a translator

--- a/messages/en.json
+++ b/messages/en.json
@@ -12,32 +12,27 @@
         "infoGlyph": "ⓘ"
     },
     "tabs": {
-        "setup": "Setup",
-        "play": "Play",
-        "setupWithShortcut": "Setup (⌘H)",
-        "playWithShortcut": "Play (⌘K)"
+        "setup": "Setup ({shortcut})",
+        "play": "Play ({shortcut})"
     },
     "bottomNav": {
         "ariaLabel": "Primary navigation",
-        "checklist": "Checklist",
-        "checklistWithShortcut": "Checklist (⌘J)",
-        "suggest": "Suggest",
-        "suggestWithShortcut": "Suggest (⌘K)",
+        "checklist": "Checklist ({shortcut})",
+        "suggest": "Suggest ({shortcut})",
         "more": "More",
-        "gameSetup": "Game setup",
-        "gameSetupWithShortcut": "Game setup (⌘H)"
+        "gameSetup": "Game setup ({shortcut})"
     },
     "toolbar": {
-        "undo": "↶ Undo (⌘Z)",
+        "undo": "↶ Undo ({shortcut})",
         "undoAria": "Undo",
         "undoTitle": "Undo (⌘Z / Ctrl+Z)",
-        "redo": "↷ Redo (⌘⇧Z)",
+        "redo": "↷ Redo ({shortcut})",
         "redoAria": "Redo",
         "redoTitle": "Redo (⌘⇧Z / Ctrl+Shift+Z)",
         "share": "Share link",
         "shareCopied": "Copied!",
         "copyFallback": "Copy this URL:",
-        "newGame": "New game (⌘N)",
+        "newGame": "New game ({shortcut})",
         "newGameConfirm": "Start a new game? This will clear all players, cards, known hands, and suggestions."
     },
     "history": {
@@ -97,10 +92,8 @@
         "addCard": "+ add card",
         "addCategory": "+ add category",
         "knownCardCheckboxAria": "{player} owns {card}",
-        "startPlaying": "Start playing →",
-        "startPlayingWithShortcut": "Start playing → (⌘;)",
-        "continuePlaying": "Continue playing →",
-        "continuePlayingWithShortcut": "Continue playing → (⌘;)"
+        "startPlaying": "Start playing → ({shortcut})",
+        "continuePlaying": "Continue playing → ({shortcut})"
     },
     "deduce": {
         "title": "Deduction grid",
@@ -155,14 +148,13 @@
     },
     "suggestions": {
         "title": "Suggestion log",
-        "addTitle": "{platform, select, mac {Add a suggestion <shortcut>(⌘K)</shortcut>} other {Add a suggestion <shortcut>(Ctrl+K)</shortcut>}}",
+        "addTitle": "Add a suggestion <shortcut>({shortcutKey})</shortcut>",
         "recommendationsTitle": "Next-suggestion recommendations",
         "suggestingAs": "Suggesting as: ",
         "resolveContradictionFirst": "Resolve the contradiction to see recommendations.",
         "addPlayersFirst": "Add players to see recommendations.",
         "nothingUseful": "Nothing useful to ask — you've already narrowed everything down.",
-        "priorTitle": "{count, plural, =0 {Prior suggestions} other {Prior suggestions (#)}}",
-        "priorTitleWithShortcut": "{count, plural, =0 {Prior suggestions (⌘L)} other {Prior suggestions (⌘L) (#)}}",
+        "priorTitle": "{count, plural, =0 {Prior suggestions ({shortcut})} other {Prior suggestions ({shortcut}) (#)}}",
         "priorKeyboardHint": "↑↓ navigate · Enter edit · ⌫ remove · Esc exit",
         "priorEmpty": "No suggestions yet. Add one above.",
         "suggestedLine": "<strong>{suggester}</strong> suggested {cards}",
@@ -192,7 +184,7 @@
         "popoverNobodyRefuted": "Nobody refuted",
         "popoverNoShownCard": "Unknown / unseen",
         "popoverCommitHint": "Space toggles · Enter confirms",
-        "submit": "{platform, select, mac {Add (⌘↵)} other {Add (Ctrl+Enter)}}",
+        "submit": "Add ({shortcut})",
         "clearInputs": "Clear inputs",
         "pillValueNobody": "nobody",
         "pillValueUnknown": "unknown"

--- a/src/ui/Clue.tsx
+++ b/src/ui/Clue.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useCallback } from "react";
 import { useTranslations } from "next-intl";
 import { BottomNav } from "./components/BottomNav";
 import { Checklist } from "./components/Checklist";
@@ -10,6 +10,7 @@ import { Toolbar } from "./components/Toolbar";
 import { TooltipProvider } from "./components/Tooltip";
 import { ConfirmProvider, useConfirm } from "./hooks/useConfirm";
 import { SelectionProvider } from "./SelectionContext";
+import { label, useGlobalShortcut } from "./keyMap";
 import { ClueProvider, useClue } from "./state";
 
 /**
@@ -90,21 +91,14 @@ function NewGameShortcut() {
     const t = useTranslations("toolbar");
     const { dispatch } = useClue();
     const confirm = useConfirm();
-    useEffect(() => {
-        const onKeyDown = async (e: KeyboardEvent) => {
-            if (!(e.metaKey || e.ctrlKey)) return;
-            if (e.key !== "n" && e.key !== "N") return;
-            e.preventDefault();
-            if (await confirm({ message: t("newGameConfirm") })) {
-                dispatch({ type: "newGame" });
-            }
-        };
-        const listener = (e: KeyboardEvent) => {
-            void onKeyDown(e);
-        };
-        window.addEventListener("keydown", listener);
-        return () => window.removeEventListener("keydown", listener);
-    }, [confirm, dispatch, t]);
+    useGlobalShortcut(
+        "global.newGame",
+        useCallback(() => {
+            void confirm({ message: t("newGameConfirm") }).then(ok => {
+                if (ok) dispatch({ type: "newGame" });
+            });
+        }, [confirm, dispatch, t]),
+    );
     return null;
 }
 
@@ -181,7 +175,7 @@ function TabBar() {
                 className={tabClass(state.uiMode === "setup")}
                 onClick={() => dispatch({ type: "setUiMode", mode: "setup" })}
             >
-                {tTabs("setupWithShortcut")}
+                {tTabs("setup", { shortcut: label("global.gotoSetup") })}
             </button>
             <button
                 type="button"
@@ -190,7 +184,7 @@ function TabBar() {
                 className={tabClass(playActive)}
                 onClick={() => dispatch({ type: "setUiMode", mode: "checklist" })}
             >
-                {tTabs("playWithShortcut")}
+                {tTabs("play", { shortcut: label("global.gotoPlay") })}
             </button>
         </div>
     );

--- a/src/ui/components/BottomNav.tsx
+++ b/src/ui/components/BottomNav.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 import { describeAction } from "../../logic/describeAction";
 import { useLongPress } from "../hooks/useLongPress";
 import { useClue } from "../state";
+import { label } from "../keyMap";
 import { useToolbarActions } from "./Toolbar";
 
 /**
@@ -58,14 +59,18 @@ export function BottomNav() {
         >
             <ul className="m-0 flex list-none items-stretch justify-between gap-1 p-1">
                 <NavTabItem
-                    label={t("checklistWithShortcut")}
+                    label={t("checklist", {
+                        shortcut: label("global.gotoChecklist"),
+                    })}
                     active={mode === "checklist"}
                     onClick={() =>
                         dispatch({ type: "setUiMode", mode: "checklist" })
                     }
                 />
                 <NavTabItem
-                    label={t("suggestWithShortcut")}
+                    label={t("suggest", {
+                        shortcut: label("global.gotoPlay"),
+                    })}
                     active={mode === "suggest"}
                     onClick={() =>
                         dispatch({ type: "setUiMode", mode: "suggest" })
@@ -234,7 +239,9 @@ function OverflowMenu({
                         className="z-50 min-w-[200px] rounded-[var(--radius)] border border-border bg-panel p-1 text-[13px] shadow-[0_6px_16px_rgba(0,0,0,0.18)]"
                     >
                         <MenuItem
-                            label={t("gameSetupWithShortcut")}
+                            label={t("gameSetup", {
+                                shortcut: label("global.gotoSetup"),
+                            })}
                             active={setupActive}
                             onClick={closeThen(onSetup)}
                         />
@@ -243,7 +250,9 @@ function OverflowMenu({
                             onClick={closeThen(onShare)}
                         />
                         <MenuItem
-                            label={tToolbar("newGame")}
+                            label={tToolbar("newGame", {
+                                shortcut: label("global.newGame"),
+                            })}
                             onClick={closeThen(onNewGame)}
                         />
                     </RadixPopover.Content>

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -41,6 +41,7 @@ import {
     registerChecklistFocusHandler,
     rememberChecklistCell,
 } from "../checklistFocus";
+import { label, matches } from "../keyMap";
 import { CardPackRow } from "./CardPackRow";
 import { Envelope } from "./Icons";
 import { InfoPopover } from "./InfoPopover";
@@ -249,8 +250,12 @@ export function Checklist() {
                         }
                     >
                         {suggestions.length > 0
-                            ? tSetup("continuePlayingWithShortcut")
-                            : tSetup("startPlayingWithShortcut")}
+                            ? tSetup("continuePlaying", {
+                                  shortcut: label("global.gotoSetupCta"),
+                              })
+                            : tSetup("startPlaying", {
+                                  shortcut: label("global.gotoSetupCta"),
+                              })}
                     </button>
                 </div>
             )}
@@ -271,8 +276,7 @@ export function Checklist() {
                 <thead className="sticky top-0 z-20 bg-row-header">
                     <tr>
                         <th className="border border-border bg-row-header px-2 py-1 text-center text-[10px] font-semibold uppercase tracking-[0.05em] text-muted">
-                            {/* eslint-disable-next-line i18next/no-literal-string -- platform-specific shortcut glyph */}
-                            {inSetup ? null : "⌘J"}
+                            {inSetup ? null : label("global.gotoChecklist")}
                         </th>
                         {owners.flatMap(owner => {
                             const cell = (
@@ -610,19 +614,19 @@ export function Checklist() {
                                         const onGridArrowKey = (
                                             e: React.KeyboardEvent<HTMLTableCellElement>,
                                         ) => {
-                                            const deltaMap: Record<
-                                                string,
-                                                [number, number]
-                                            > = {
-                                                ArrowUp: [-1, 0],
-                                                ArrowDown: [1, 0],
-                                                ArrowLeft: [0, -1],
-                                                ArrowRight: [0, 1],
-                                            };
-                                            const delta = deltaMap[e.key];
-                                            if (!delta) return;
+                                            const native = e.nativeEvent;
+                                            const dr = matches("nav.up", native)
+                                                ? -1
+                                                : matches("nav.down", native)
+                                                  ? 1
+                                                  : 0;
+                                            const dc = matches("nav.left", native)
+                                                ? -1
+                                                : matches("nav.right", native)
+                                                  ? 1
+                                                  : 0;
+                                            if (dr === 0 && dc === 0) return;
                                             e.preventDefault();
-                                            const [dr, dc] = delta;
                                             let r = rowIdx + dr;
                                             let c = colIdx + dc;
                                             let next: HTMLElement | null = null;
@@ -678,8 +682,10 @@ export function Checklist() {
                                                     }
                                                     onKeyDown={e => {
                                                         if (
-                                                            e.key === "Enter" ||
-                                                            e.key === " "
+                                                            matches(
+                                                                "action.toggle",
+                                                                e.nativeEvent,
+                                                            )
                                                         ) {
                                                             e.preventDefault();
                                                             toggleKnownCard(
@@ -730,8 +736,10 @@ export function Checklist() {
                                                             // click-to-toggle via asChild,
                                                             // so we synthesize a click.
                                                             if (
-                                                                e.key === "Enter" ||
-                                                                e.key === " "
+                                                                matches(
+                                                                    "action.toggle",
+                                                                    e.nativeEvent,
+                                                                )
                                                             ) {
                                                                 e.preventDefault();
                                                                 e.currentTarget.click();

--- a/src/ui/components/SuggestionForm.tsx
+++ b/src/ui/components/SuggestionForm.tsx
@@ -14,6 +14,7 @@ import { categoryOfCard } from "../../logic/GameSetup";
 import type { Card, Player } from "../../logic/GameObjects";
 import { newSuggestionId } from "../../logic/Suggestion";
 import { registerSuggestionFormFocusHandler } from "../suggestionFormFocus";
+import { label, matches } from "../keyMap";
 import {
     displayCard,
     displayCardOpt,
@@ -79,19 +80,6 @@ export function SuggestionForm({
     readonly onCancel?: () => void;
 }): React.ReactElement {
     const t = useTranslations("suggestions");
-
-    // --- Platform detection for submit modifier (SSR-safe) ---
-    //
-    // Mac uses ⌘ (metaKey), Windows / Linux use Ctrl (ctrlKey). The
-    // key handler accepts either modifier regardless of detected
-    // platform, so misconfigured machines aren't locked out —
-    // detection only drives display copy.
-    const [isMac, setIsMac] = useState(false);
-    useEffect(() => {
-        if (typeof navigator === "undefined") return;
-        setIsMac(/Mac|iPhone|iPad/.test(navigator.platform));
-    }, []);
-    const platformKey = isMac ? PLATFORM_MAC : PLATFORM_OTHER;
 
     // --- Form state ----------------------------------------------------
     const [form, setForm] = useState<FormState>(() =>
@@ -279,8 +267,7 @@ export function SuggestionForm({
     const formRootRef = useRef<HTMLDivElement>(null);
     useEffect(() => {
         const onKeyDown = (e: KeyboardEvent) => {
-            if (e.key !== "Enter") return;
-            if (!(e.metaKey || e.ctrlKey)) return;
+            if (!matches("action.submit", e)) return;
             // Only handle if focus is inside our form root or in any
             // Radix portal popover owned by our form (we check by
             // walking up from the focused element).
@@ -313,8 +300,8 @@ export function SuggestionForm({
     useEffect(() => {
         const onKeyDown = (e: KeyboardEvent) => {
             if (e.metaKey || e.ctrlKey || e.altKey) return;
-            const isLeft = e.key === "ArrowLeft";
-            const isRight = e.key === "ArrowRight";
+            const isLeft = matches("nav.left", e);
+            const isRight = matches("nav.right", e);
             const isShiftTab = e.key === "Tab" && e.shiftKey;
             const isTab = e.key === "Tab" && !e.shiftKey;
             if (!isLeft && !isRight && !isShiftTab && !isTab) return;
@@ -421,7 +408,7 @@ export function SuggestionForm({
                     {suggestion !== undefined
                         ? t("editTitle")
                         : t.rich("addTitle", {
-                              platform: platformKey,
+                              shortcutKey: label("global.gotoPlay"),
                               shortcut: chunks => (
                                   <span className="font-normal text-muted">
                                       {chunks}
@@ -573,7 +560,7 @@ export function SuggestionForm({
                     disabled={!canSubmit}
                     onClick={doSubmit}
                 >
-                    {t("submit", { platform: platformKey })}
+                    {t("submit", { shortcut: label("action.submit") })}
                 </button>
                 {onCancel !== undefined && (
                     <button
@@ -588,16 +575,6 @@ export function SuggestionForm({
         </div>
     );
 }
-
-// ---- Platform discriminators (not user copy) ---------------------------
-
- 
-// ICU `select` keys for the submit / addTitle templates in
-// messages/en.json. Must match the string literals in those messages
-// exactly.
-const PLATFORM_MAC = "mac";
-const PLATFORM_OTHER = "other";
- 
 
 // ---- Form state -------------------------------------------------------
 

--- a/src/ui/components/SuggestionLogPanel.tsx
+++ b/src/ui/components/SuggestionLogPanel.tsx
@@ -44,6 +44,7 @@ import {
     DraftSuggestion,
     useClue,
 } from "../state";
+import { label, matches } from "../keyMap";
 
 const SECTION_TITLE = "mt-0 mb-2 text-[14px] font-semibold";
 // Kept for the recommendations chooser below — the suggestion form
@@ -371,7 +372,10 @@ function PriorSuggestions() {
                 tabIndex={-1}
                 className={`${SECTION_TITLE} rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2`}
             >
-                {t("priorTitleWithShortcut", { count: suggestions.length })}
+                {t("priorTitle", {
+                    count: suggestions.length,
+                    shortcut: label("global.gotoPriorLog"),
+                })}
             </h3>
             {suggestions.length === 0 ? (
                 <div className="text-[13px] text-muted">
@@ -644,10 +648,11 @@ function PriorSuggestionItem({
                 setIsKeyboardEditing(false);
             }}
             onKeyDown={e => {
+                const native = e.nativeEvent;
                 // Escape inside pills: bubble up here and exit edit mode.
                 if (e.currentTarget !== e.target) {
                     if (
-                        e.key === "Escape" &&
+                        matches("action.cancel", native) &&
                         isKeyboardEditing &&
                         openPillId === null
                     ) {
@@ -657,9 +662,12 @@ function PriorSuggestionItem({
                     }
                     return;
                 }
-                if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+                if (
+                    matches("nav.down", native) ||
+                    matches("nav.up", native)
+                ) {
                     e.preventDefault();
-                    const dir = e.key === "ArrowDown" ? 1 : -1;
+                    const dir = matches("nav.down", native) ? 1 : -1;
                     let sib =
                         dir === 1
                             ? e.currentTarget.nextElementSibling
@@ -671,7 +679,7 @@ function PriorSuggestionItem({
                                 : sib.previousElementSibling;
                     }
                     if (sib instanceof HTMLElement) sib.focus();
-                } else if (e.key === "Enter" || e.key === " ") {
+                } else if (matches("action.toggle", native)) {
                     e.preventDefault();
                     const row = e.currentTarget;
                     setIsKeyboardEditing(true);
@@ -681,10 +689,13 @@ function PriorSuggestionItem({
                         );
                         first?.focus();
                     });
-                } else if (e.key === "Delete" || e.key === "Backspace") {
+                } else if (matches("action.remove", native)) {
                     e.preventDefault();
                     void onRemove();
-                } else if (e.key === "Escape" && isKeyboardEditing) {
+                } else if (
+                    matches("action.cancel", native) &&
+                    isKeyboardEditing
+                ) {
                     e.preventDefault();
                     setIsKeyboardEditing(false);
                     e.currentTarget.focus();

--- a/src/ui/components/SuggestionPills.tsx
+++ b/src/ui/components/SuggestionPills.tsx
@@ -11,6 +11,7 @@ import {
 import type { Card, Player } from "../../logic/GameObjects";
 import type { GameSetup } from "../../logic/GameSetup";
 import { Tooltip } from "./Tooltip";
+import { matches } from "../keyMap";
 
 /**
  * Shared pill primitives for both the Add-a-suggestion form and the
@@ -435,29 +436,30 @@ export function SingleSelectList<T>({
     );
 
     const onKeyDown = (e: React.KeyboardEvent<HTMLUListElement>) => {
-        if (e.key === "ArrowDown") {
+        const native = e.nativeEvent;
+        if (matches("nav.down", native)) {
             e.preventDefault();
             setFocusedIdx(i => (i + 1) % Math.max(rows.length, 1));
             return;
         }
-        if (e.key === "ArrowUp") {
+        if (matches("nav.up", native)) {
             e.preventDefault();
             setFocusedIdx(i =>
                 (i - 1 + rows.length) % Math.max(rows.length, 1),
             );
             return;
         }
-        if (e.key === "Home") {
+        if (matches("nav.home", native)) {
             e.preventDefault();
             setFocusedIdx(0);
             return;
         }
-        if (e.key === "End") {
+        if (matches("nav.end", native)) {
             e.preventDefault();
             setFocusedIdx(Math.max(rows.length - 1, 0));
             return;
         }
-        if (e.key === "Enter" || e.key === " ") {
+        if (matches("action.toggle", native)) {
             e.preventDefault();
             commitAt(focusedIdx);
             return;
@@ -582,27 +584,33 @@ export function MultiSelectList({
     };
 
     const onKeyDown = (e: React.KeyboardEvent<HTMLUListElement>) => {
-        if (e.key === "ArrowDown") {
+        const native = e.nativeEvent;
+        if (matches("nav.down", native)) {
             e.preventDefault();
             setFocusedIdx(i => (i + 1) % rowCount);
             return;
         }
-        if (e.key === "ArrowUp") {
+        if (matches("nav.up", native)) {
             e.preventDefault();
             setFocusedIdx(i => (i - 1 + rowCount) % rowCount);
             return;
         }
-        if (e.key === "Home") {
+        if (matches("nav.home", native)) {
             e.preventDefault();
             setFocusedIdx(0);
             return;
         }
-        if (e.key === "End") {
+        if (matches("nav.end", native)) {
             e.preventDefault();
             setFocusedIdx(rowCount - 1);
             return;
         }
-        if (e.key === " ") {
+        // Space toggles the focused row without advancing; Enter
+        // commits the whole set and advances to the next pill. We
+        // want those semantics to stay distinct, so check the raw
+        // keys directly rather than using the combined action.toggle
+        // binding.
+        if (e.key === " " && !e.metaKey && !e.ctrlKey && !e.altKey) {
             e.preventDefault();
             if (isNobodyRow(focusedIdx)) {
                 commitAdvance(NOBODY);
@@ -612,7 +620,7 @@ export function MultiSelectList({
             if (opt !== undefined) toggle(opt.value);
             return;
         }
-        if (e.key === "Enter") {
+        if (matches("action.commit", native)) {
             e.preventDefault();
             if (isNobodyRow(focusedIdx)) {
                 commitAdvance(NOBODY);

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { describeAction } from "../../logic/describeAction";
 import { useConfirm } from "../hooks/useConfirm";
 import { useClue } from "../state";
+import { label } from "../keyMap";
 import { Tooltip } from "./Tooltip";
 
 const buttonClass =
@@ -91,7 +92,7 @@ export function Toolbar() {
                     title={t("undoTitle")}
                     aria-label={t("undoAria")}
                 >
-                    {t("undo")}
+                    {t("undo", { shortcut: label("global.undo") })}
                 </button>
             </Tooltip>
             <Tooltip content={redoTooltip}>
@@ -103,14 +104,14 @@ export function Toolbar() {
                     title={t("redoTitle")}
                     aria-label={t("redoAria")}
                 >
-                    {t("redo")}
+                    {t("redo", { shortcut: label("global.redo") })}
                 </button>
             </Tooltip>
             <button type="button" className={buttonClass} onClick={onShare}>
                 {copied ? t("shareCopied") : t("share")}
             </button>
             <button type="button" className={buttonClass} onClick={onNewGame}>
-                {t("newGame")}
+                {t("newGame", { shortcut: label("global.newGame") })}
             </button>
         </div>
     );

--- a/src/ui/keyMap.ts
+++ b/src/ui/keyMap.ts
@@ -1,0 +1,292 @@
+"use client";
+
+/**
+ * Single source of truth for every keyboard shortcut in the app.
+ *
+ * Each binding owns both sides of the contract:
+ *   - `match(event)`: predicate used by handlers
+ *   - `label`: display string shown in the UI next to the action
+ *
+ * A binding can carry multiple combos. The first combo's label is
+ * canonical (what UI labels show by default); any combo may match the
+ * event. This lets alternate keys (e.g. W/A/S/D, I/J/K/L) share a
+ * binding with the arrow keys without duplicating handler logic.
+ *
+ * The active map is module-scoped and mutable so a future settings UI
+ * can swap it in place — call sites keep using `matches(id, e)` and
+ * `label(id)` and update automatically.
+ */
+
+import { useEffect } from "react";
+
+export type KeyCombo = {
+    readonly label: string;
+    readonly match: (e: KeyboardEvent) => boolean;
+};
+
+export type KeyBinding = {
+    readonly id: string;
+    readonly description: string;
+    readonly combos: ReadonlyArray<KeyCombo>;
+};
+
+// ---- Combo factories ---------------------------------------------------
+
+const hasMod = (e: KeyboardEvent): boolean => e.metaKey || e.ctrlKey;
+
+/** Cmd/Ctrl + key (exact; no Shift/Alt). Case-insensitive key. */
+function mod(key: string, label: string): KeyCombo {
+    const k = key.toLowerCase();
+    return {
+        label,
+        match: e =>
+            hasMod(e) &&
+            !e.shiftKey &&
+            !e.altKey &&
+            e.key.toLowerCase() === k,
+    };
+}
+
+/** Cmd/Ctrl + Shift + key. Case-insensitive key. */
+function modShift(key: string, label: string): KeyCombo {
+    const k = key.toLowerCase();
+    return {
+        label,
+        match: e =>
+            hasMod(e) &&
+            e.shiftKey &&
+            !e.altKey &&
+            e.key.toLowerCase() === k,
+    };
+}
+
+/** Bare key (no modifiers). Matches the exact key value. */
+function bare(key: string, label: string): KeyCombo {
+    return {
+        label,
+        match: e =>
+            !e.metaKey &&
+            !e.ctrlKey &&
+            !e.altKey &&
+            !e.shiftKey &&
+            e.key === key,
+    };
+}
+
+/** Bare key (no modifiers), case-insensitive. For A-Z letter keys. */
+function bareCI(key: string, label: string): KeyCombo {
+    const k = key.toLowerCase();
+    return {
+        label,
+        match: e =>
+            !e.metaKey &&
+            !e.ctrlKey &&
+            !e.altKey &&
+            !e.shiftKey &&
+            e.key.toLowerCase() === k,
+    };
+}
+
+/** Cmd/Ctrl+Enter — form submit. */
+function modEnter(label: string): KeyCombo {
+    return {
+        label,
+        match: e => hasMod(e) && e.key === "Enter",
+    };
+}
+
+export const combo = { mod, modShift, bare, bareCI, modEnter };
+
+// ---- Binding IDs -------------------------------------------------------
+
+export type BindingId =
+    // Global (window-level)
+    | "global.undo"
+    | "global.redo"
+    | "global.newGame"
+    | "global.gotoSetup"
+    | "global.gotoPlay"
+    | "global.gotoChecklist"
+    | "global.gotoPriorLog"
+    | "global.gotoSetupCta"
+    // Navigation primitives (scoped)
+    | "nav.up"
+    | "nav.down"
+    | "nav.left"
+    | "nav.right"
+    | "nav.home"
+    | "nav.end"
+    // Action primitives (scoped)
+    | "action.toggle"
+    | "action.commit"
+    | "action.remove"
+    | "action.cancel"
+    | "action.submit";
+
+// ---- Default keymap ----------------------------------------------------
+
+export const DEFAULT_KEY_MAP: Record<BindingId, KeyBinding> = {
+    "global.undo": {
+        id: "global.undo",
+        description: "Undo the last change",
+        combos: [combo.mod("z", "⌘Z")],
+    },
+    "global.redo": {
+        id: "global.redo",
+        description: "Redo the next change",
+        combos: [combo.modShift("z", "⌘⇧Z")],
+    },
+    "global.newGame": {
+        id: "global.newGame",
+        description: "Start a new game",
+        combos: [combo.mod("n", "⌘N")],
+    },
+    "global.gotoSetup": {
+        id: "global.gotoSetup",
+        description: "Jump to the Setup tab",
+        combos: [combo.mod("h", "⌘H")],
+    },
+    "global.gotoPlay": {
+        id: "global.gotoPlay",
+        description: "Jump to the suggestion form",
+        combos: [combo.mod("k", "⌘K")],
+    },
+    "global.gotoChecklist": {
+        id: "global.gotoChecklist",
+        description: "Jump to the checklist",
+        combos: [combo.mod("j", "⌘J")],
+    },
+    "global.gotoPriorLog": {
+        id: "global.gotoPriorLog",
+        description: "Jump to the prior suggestions log",
+        combos: [combo.mod("l", "⌘L")],
+    },
+    "global.gotoSetupCta": {
+        id: "global.gotoSetupCta",
+        description: "Focus the Start/Continue playing button",
+        combos: [combo.mod(";", "⌘;")],
+    },
+
+    "nav.up": {
+        id: "nav.up",
+        description: "Move up",
+        combos: [
+            combo.bare("ArrowUp", "↑"),
+            combo.bareCI("w", "W"),
+            combo.bareCI("i", "I"),
+        ],
+    },
+    "nav.down": {
+        id: "nav.down",
+        description: "Move down",
+        combos: [
+            combo.bare("ArrowDown", "↓"),
+            combo.bareCI("s", "S"),
+            combo.bareCI("k", "K"),
+        ],
+    },
+    "nav.left": {
+        id: "nav.left",
+        description: "Move left",
+        combos: [
+            combo.bare("ArrowLeft", "←"),
+            combo.bareCI("a", "A"),
+            combo.bareCI("j", "J"),
+        ],
+    },
+    "nav.right": {
+        id: "nav.right",
+        description: "Move right",
+        combos: [
+            combo.bare("ArrowRight", "→"),
+            combo.bareCI("d", "D"),
+            combo.bareCI("l", "L"),
+        ],
+    },
+    "nav.home": {
+        id: "nav.home",
+        description: "Jump to first",
+        combos: [combo.bare("Home", "Home")],
+    },
+    "nav.end": {
+        id: "nav.end",
+        description: "Jump to last",
+        combos: [combo.bare("End", "End")],
+    },
+
+    "action.toggle": {
+        id: "action.toggle",
+        description: "Toggle the focused item",
+        combos: [combo.bare(" ", "Space"), combo.bare("Enter", "Enter")],
+    },
+    "action.commit": {
+        id: "action.commit",
+        description: "Commit the current selection",
+        combos: [combo.bare("Enter", "Enter")],
+    },
+    "action.remove": {
+        id: "action.remove",
+        description: "Remove the focused item",
+        combos: [combo.bare("Delete", "Delete"), combo.bare("Backspace", "⌫")],
+    },
+    "action.cancel": {
+        id: "action.cancel",
+        description: "Cancel / exit",
+        combos: [combo.bare("Escape", "Esc")],
+    },
+    "action.submit": {
+        id: "action.submit",
+        description: "Submit the form",
+        combos: [combo.modEnter("⌘↵")],
+    },
+};
+
+// ---- Active map + accessors --------------------------------------------
+
+let activeKeyMap: Record<BindingId, KeyBinding> = DEFAULT_KEY_MAP;
+
+/** Replace the active map. Reserved for a future customization UI. */
+export function setKeyMap(next: Record<BindingId, KeyBinding>): void {
+    activeKeyMap = next;
+}
+
+export function getBinding(id: BindingId): KeyBinding {
+    return activeKeyMap[id];
+}
+
+/** True if the event matches any combo on the binding. */
+export function matches(id: BindingId, e: KeyboardEvent): boolean {
+    return activeKeyMap[id].combos.some(c => c.match(e));
+}
+
+/** Canonical display label (first combo). Safe on empty combos. */
+export function label(id: BindingId, index = 0): string {
+    return activeKeyMap[id].combos[index]?.label ?? "";
+}
+
+/** Every combo's label, in declaration order. */
+export function allLabels(id: BindingId): ReadonlyArray<string> {
+    return activeKeyMap[id].combos.map(c => c.label);
+}
+
+// ---- React hook --------------------------------------------------------
+
+/**
+ * Attach a window-level keydown listener that fires only when the event
+ * matches the binding. preventDefault is applied automatically on match.
+ * Pass the handler memoized (useCallback) to avoid re-registering.
+ */
+export function useGlobalShortcut(
+    id: BindingId,
+    handler: (e: KeyboardEvent) => void,
+): void {
+    useEffect(() => {
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (!matches(id, e)) return;
+            e.preventDefault();
+            handler(e);
+        };
+        window.addEventListener("keydown", onKeyDown);
+        return () => window.removeEventListener("keydown", onKeyDown);
+    }, [id, handler]);
+}

--- a/src/ui/state.tsx
+++ b/src/ui/state.tsx
@@ -65,6 +65,7 @@ import {
 import { Layer } from "effect";
 import { requestFocusSuggestionForm } from "./suggestionFormFocus";
 import { requestFocusChecklistCell } from "./checklistFocus";
+import { useGlobalShortcut } from "./keyMap";
 
 type DeduceLayer = Layer.Layer<
     CardSetService | PlayerSetService | SuggestionsService
@@ -578,47 +579,8 @@ export function ClueProvider({ children }: { children: ReactNode }) {
     const undo = useCallback(() => dispatchRaw({ type: "__undo" }), []);
     const redo = useCallback(() => dispatchRaw({ type: "__redo" }), []);
 
-    // Keyboard bindings: Cmd/Ctrl+Z for undo, Cmd/Ctrl+Shift+Z for redo.
-    // Swallow the event only when we're going to act on it, so typing
-    // Cmd+Z in an input field still triggers undo (the user intends it).
-    useEffect(() => {
-        const onKeyDown = (e: KeyboardEvent) => {
-            const mod = e.metaKey || e.ctrlKey;
-            if (!mod) return;
-            // Key comparison is case-insensitive: `e.key` is "Z" when
-            // Shift is held, "z" otherwise.
-            if (e.key !== "z" && e.key !== "Z") return;
-            e.preventDefault();
-            if (e.shiftKey) redo();
-            else undo();
-        };
-        window.addEventListener("keydown", onKeyDown);
-        return () => window.removeEventListener("keydown", onKeyDown);
-    }, [undo, redo]);
-
-    // Cmd/Ctrl+K: switch to Play tab and focus the suggestion form.
-    // Two presses within DOUBLE_TAP_MS also clear the form. The tab
-    // switch goes through `dispatchRaw` so it stays out of the undo
-    // history — matching how hydration flips the tab.
-    useEffect(() => {
-        let lastPressAt = 0;
-        const DOUBLE_TAP_MS = 400;
-        const onKeyDown = (e: KeyboardEvent) => {
-            if (!(e.metaKey || e.ctrlKey)) return;
-            if (e.key !== "k" && e.key !== "K") return;
-            e.preventDefault();
-            const now = Date.now();
-            const clear = now - lastPressAt < DOUBLE_TAP_MS;
-            lastPressAt = clear ? 0 : now;
-            dispatchRaw({ type: "setUiMode", mode: "suggest" });
-            requestFocusSuggestionForm({ clear });
-        };
-        window.addEventListener("keydown", onKeyDown);
-        return () => window.removeEventListener("keydown", onKeyDown);
-    }, []);
-
-    // Refs shared by several shortcut handlers so their useEffect
-    // deps stay empty (no listener churn when state changes).
+    // Refs shared by several shortcut handlers so their handler
+    // references stay stable (no listener churn when state changes).
     const uiModeRef = useRef(state.uiMode);
     useEffect(() => {
         uiModeRef.current = state.uiMode;
@@ -629,40 +591,57 @@ export function ClueProvider({ children }: { children: ReactNode }) {
             state.knownCards.length > 0 || state.suggestions.length > 0;
     }, [state.knownCards, state.suggestions]);
 
+    // Keyboard bindings wired via the central keyMap module. Each
+    // useGlobalShortcut installs one window keydown listener that only
+    // fires on a match; labels shown in the UI come from the same
+    // module so they stay in lockstep with the matcher.
+    useGlobalShortcut("global.undo", useCallback(() => undo(), [undo]));
+    useGlobalShortcut("global.redo", useCallback(() => redo(), [redo]));
+
+    // Cmd/Ctrl+K: switch to Play tab and focus the suggestion form.
+    // Two presses within DOUBLE_TAP_MS also clear the form. The tab
+    // switch goes through `dispatchRaw` so it stays out of the undo
+    // history — matching how hydration flips the tab.
+    const lastGotoPlayAtRef = useRef(0);
+    useGlobalShortcut(
+        "global.gotoPlay",
+        useCallback(() => {
+            const DOUBLE_TAP_MS = 400;
+            const now = Date.now();
+            const clear = now - lastGotoPlayAtRef.current < DOUBLE_TAP_MS;
+            lastGotoPlayAtRef.current = clear ? 0 : now;
+            dispatchRaw({ type: "setUiMode", mode: "suggest" });
+            requestFocusSuggestionForm({ clear });
+        }, []),
+    );
+
     // Cmd/Ctrl+H: switch to the Setup tab. (Overrides the Mac
-    // "hide app" default — explicit user choice.) Smart-landing:
-    //   - game started (any knownCards OR any suggestions) → focus
-    //     the last-focused checklist cell, or the first setup cell
+    // "hide app" default.) Smart-landing:
+    //   - game started → focus the last-focused checklist cell, else
+    //     the first setup cell
     //   - fresh game → focus the first card-pack preset button
-    useEffect(() => {
-        const onKeyDown = (e: KeyboardEvent) => {
-            if (!(e.metaKey || e.ctrlKey)) return;
-            if (e.key !== "h" && e.key !== "H") return;
-            e.preventDefault();
+    useGlobalShortcut(
+        "global.gotoSetup",
+        useCallback(() => {
             dispatchRaw({ type: "setUiMode", mode: "setup" });
             queueMicrotask(() => {
                 if (gameStartedRef.current) {
                     requestFocusChecklistCell();
                 } else {
-                    const btn =
-                        document.querySelector<HTMLElement>(
-                            "[data-setup-first-target='card-pack']",
-                        );
+                    const btn = document.querySelector<HTMLElement>(
+                        "[data-setup-first-target='card-pack']",
+                    );
                     btn?.focus();
                 }
             });
-        };
-        window.addEventListener("keydown", onKeyDown);
-        return () => window.removeEventListener("keydown", onKeyDown);
-    }, []);
+        }, []),
+    );
 
     // Cmd/Ctrl+; : jump to the Start / Continue playing CTA on the
     // Setup tab (the primary exit action from setup).
-    useEffect(() => {
-        const onKeyDown = (e: KeyboardEvent) => {
-            if (!(e.metaKey || e.ctrlKey)) return;
-            if (e.key !== ";") return;
-            e.preventDefault();
+    useGlobalShortcut(
+        "global.gotoSetupCta",
+        useCallback(() => {
             if (uiModeRef.current !== "setup") {
                 dispatchRaw({ type: "setUiMode", mode: "setup" });
             }
@@ -671,39 +650,28 @@ export function ClueProvider({ children }: { children: ReactNode }) {
                     document.querySelector<HTMLElement>("[data-setup-cta]");
                 btn?.focus();
             });
-        };
-        window.addEventListener("keydown", onKeyDown);
-        return () => window.removeEventListener("keydown", onKeyDown);
-    }, []);
+        }, []),
+    );
 
     // Cmd/Ctrl+J: jump to the Checklist. On desktop Play already
     // shows the checklist; on mobile Play-suggest hides it, so
-    // flip to the "checklist" sub-mode first. The focus request
-    // returns the user to whichever cell they were last on.
-    useEffect(() => {
-        const onKeyDown = (e: KeyboardEvent) => {
-            if (!(e.metaKey || e.ctrlKey)) return;
-            if (e.key !== "j" && e.key !== "J") return;
-            e.preventDefault();
+    // flip to the "checklist" sub-mode first.
+    useGlobalShortcut(
+        "global.gotoChecklist",
+        useCallback(() => {
             if (uiModeRef.current === "suggest") {
                 dispatchRaw({ type: "setUiMode", mode: "checklist" });
             }
             requestFocusChecklistCell();
-        };
-        window.addEventListener("keydown", onKeyDown);
-        return () => window.removeEventListener("keydown", onKeyDown);
-    }, []);
+        }, []),
+    );
 
-    // Cmd/Ctrl+L: jump to the Prior suggestions log. If currently
-    // on Setup, flip to "suggest" first so the log is mounted.
-    // Focuses the first suggestion row if any exist so the user can
-    // immediately use ↑↓ — otherwise falls back to the section header
-    // (which has the empty-state message).
-    useEffect(() => {
-        const onKeyDown = (e: KeyboardEvent) => {
-            if (!(e.metaKey || e.ctrlKey)) return;
-            if (e.key !== "l" && e.key !== "L") return;
-            e.preventDefault();
+    // Cmd/Ctrl+L: jump to the Prior suggestions log. Focuses the
+    // first suggestion row if any exist so the user can immediately
+    // use ↑↓ — otherwise falls back to the section header (empty state).
+    useGlobalShortcut(
+        "global.gotoPriorLog",
+        useCallback(() => {
             if (uiModeRef.current === "setup") {
                 dispatchRaw({ type: "setUiMode", mode: "suggest" });
             }
@@ -713,20 +681,17 @@ export function ClueProvider({ children }: { children: ReactNode }) {
                     behavior: "smooth",
                     block: "start",
                 });
-                const firstRow =
-                    document.querySelector<HTMLElement>(
-                        "[data-suggestion-row='0']",
-                    );
+                const firstRow = document.querySelector<HTMLElement>(
+                    "[data-suggestion-row='0']",
+                );
                 if (firstRow) {
                     firstRow.focus({ preventScroll: true });
                 } else if (header instanceof HTMLElement) {
                     header.focus({ preventScroll: true });
                 }
             });
-        };
-        window.addEventListener("keydown", onKeyDown);
-        return () => window.removeEventListener("keydown", onKeyDown);
-    }, []);
+        }, []),
+    );
 
     // Derive expensive values. The inner useMemos chain so each only
     // recomputes when its actual inputs change; React Compiler will


### PR DESCRIPTION
## Summary

Every keyboard handler in the app now routes through a single `src/ui/keyMap.ts` module. Each binding owns both the match predicate and the display label, so labels shown next to actions stay in lockstep with the keys that trigger them. A binding can carry multiple combos, which is how arrow keys and letter keys share the same behavior without duplicating handler logic.

The module ships with a mutable `activeKeyMap` so a future settings UI can swap bindings in place — every `matches(id, e)` / `label(id)` call updates automatically.

## Letter-key alternates

Per request, letter keys now mirror the arrow keys everywhere arrows are used. Arrows keep working as before.

- **Horizontal**: `A` / `D` and `J` / `L` → ←/→ (checklist grid, suggestion-form pill navigation)
- **Vertical**: `W` / `S` and `I` / `K` → ↑/↓ (checklist grid, suggestion-log rows, popover option lists)

Letter keys are only wired into scoped handlers (cells, rows, popover lists) — never global — so typing a letter in a text input still types.

## i18n changes

Shortcut suffixes on buttons / tabs / headers move from hard-coded strings (`"Setup (⌘H)"`) to ICU variables (`"Setup ({shortcut})"`) with the shortcut injected from the keymap. The `{platform, select, mac … other …}` templates for `addTitle` / `submit` collapse to a single label driven by the keymap.

## Public API surface (reserved for future settings UI)

`keyMap.ts` exports `KeyBinding` / `KeyCombo` / `BindingId` types, `combo` factories, `DEFAULT_KEY_MAP`, and mutator/accessor functions (`setKeyMap`, `getBinding`, `allLabels`). Knip correctly flags these as unused — they're the surface a customization UI will consume.

## Test plan

- [x] `npm test` — 101/101 passing
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean (added `matches` / `label` / `useGlobalShortcut` to the i18next callee exempt list)
- [x] `npm run i18n:check` — clean (one pre-existing orphan `common.close` is non-blocking)
- [x] Browser preview — verified end-to-end:
  - All 8 global shortcuts (⌘Z, ⌘⇧Z, ⌘N, ⌘H, ⌘J, ⌘K, ⌘L, ⌘;) fire the correct action
  - All tab / button labels render their shortcut suffix
  - Checklist grid: arrow keys AND A/D/J/L/W/S/I/K both navigate correctly, Space/Enter toggles, focus is preserved
  - Suggestion-log rows: ↑↓/W/S/I/K navigate between rows, Enter/Space enters edit mode, Delete/Backspace removes
  - ⌘H smart-lands on card-pack for fresh game
  - ⌘; focuses the Start playing CTA
- [ ] Manual: exercise the suggestion-form pill navigation (←→ and A/D/J/L) with real keystrokes
- [ ] Manual: popover-list navigation (↑↓ and W/S/I/K) and Home/End

## Rebase

Rebased on top of `main` after PR #20 (hover-mobile) merged. Conflicts were in `Clue.tsx`, `Checklist.tsx`, and `SuggestionLogPanel.tsx` — resolved by keeping upstream's structure (new `ConfirmProvider` / `SelectionProvider`, refactored Checklist cell rendering, `useConfirm` async New-game) and routing the keyboard-specific logic through the new keymap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)