### PR TITLE
Prevent focus outlines from being clipped by neighbor cells

### DIFF
--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -1248,10 +1248,10 @@ const CELL_BASE =
     "w-9 min-w-9 border border-border px-2 py-1 text-center font-semibold relative";
 
 const CELL_INTERACTIVE =
-    " cursor-pointer hover:ring-2 hover:ring-accent/40 focus:outline-none focus:ring-2 focus:ring-accent";
+    " cursor-pointer hover:z-10 hover:ring-2 hover:ring-accent/40 focus:z-10 focus:outline-none focus:ring-2 focus:ring-accent";
 
 const CELL_HIGHLIGHTED =
-    " ring-2 ring-accent ring-offset-1 ring-offset-panel";
+    " z-10 ring-2 ring-accent ring-offset-1 ring-offset-panel";
 
 const cellClass = (
     value: CellValue | undefined,


### PR DESCRIPTION
## Summary
- Checklist `<td>` cells share a stacking context, so the focus/hover/highlight ring was painted over by adjacent cells' backgrounds — the oxblood outline appeared as a broken rectangle.
- Added `focus:z-10`, `hover:z-10`, and `z-10` (on persistent highlight) to the cell class constants so the cell lifts above neighbors while its ring is visible.

## Test plan
- [ ] Tab through checklist cells; oxblood focus ring is a complete rectangle on all four sides, including next to colored (yes/no) cells
- [ ] Hover ring renders unclipped
- [ ] Persistent highlighted cell renders ring unclipped
- [ ] Sticky `<thead>` (z-20) still paints above focused body cells

🤖 Generated with [Claude Code](https://claude.com/claude-code)