### PR TITLE
Replace desktop tab bar with shared overflow menu; rename ?tab= to ?view=

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -10,10 +10,6 @@
         "info": "More info",
         "infoGlyph": "ⓘ"
     },
-    "tabs": {
-        "setup": "Setup ({shortcut})",
-        "play": "Play ({shortcut})"
-    },
     "bottomNav": {
         "ariaLabel": "Primary navigation",
         "checklist": "Checklist ({shortcut})",

--- a/src/ui/Clue.tsx
+++ b/src/ui/Clue.tsx
@@ -10,23 +10,25 @@ import { Toolbar } from "./components/Toolbar";
 import { TooltipProvider } from "./components/Tooltip";
 import { ConfirmProvider, useConfirm } from "./hooks/useConfirm";
 import { SelectionProvider } from "./SelectionContext";
-import { label, useGlobalShortcut } from "./keyMap";
+import { useGlobalShortcut } from "./keyMap";
 import { ClueProvider, useClue } from "./state";
 
 /**
  * Top-level Clue solver app.
  *
- * **Desktop (≥ 800px)** shows a top `TabBar` (Setup / Play) and a
- * top-right `Toolbar` (undo / redo / share / new game). The Play
- * tab lays the `Checklist` next to a sticky `SuggestionLogPanel`
- * in a 2-column grid.
+ * **Desktop (≥ 800px)** shows the `Checklist` and `SuggestionLogPanel`
+ * side-by-side in a 2-column grid. A top-right `Toolbar` holds Undo
+ * and Redo as top-level buttons plus a `⋯` overflow menu for Game
+ * setup, Share link, and New game. Setup mode (entered via ⌘H or the
+ * overflow menu) swaps the grid for a full-width Checklist that
+ * unlocks inline-edit affordances.
  *
- * **Mobile (< 800px)** hides the top tab bar and toolbar entirely.
- * A fixed `BottomNav` takes their place, with Checklist / Suggest
- * tabs that split what desktop packs into a single Play grid, plus
- * inline Undo/Redo and an overflow menu for Game setup, Share link,
- * and New game. `<main>`'s bottom padding is bumped up to keep page
- * content clear of the fixed nav.
+ * **Mobile (< 800px)** hides the desktop Toolbar entirely. A fixed
+ * `BottomNav` takes its place, with Checklist / Suggest tabs that
+ * split what desktop packs into a single Play grid, plus inline
+ * Undo/Redo and a `⋯` overflow menu that mirrors the desktop one.
+ * `<main>`'s bottom padding is bumped up to keep page content clear
+ * of the fixed nav.
  *
  * A single global contradiction banner is pinned to the top of the
  * viewport (`position: fixed` inside `GlobalContradictionBanner`)
@@ -35,14 +37,14 @@ import { ClueProvider, useClue } from "./state";
  * its top padding so the header isn't hidden underneath.
  *
  * The unified Checklist is the single surface for both Setup and
- * Play modes — the tab bar drives the `uiMode` slice and the
- * component gates its Setup-mode affordances (inline renames, add/
- * remove, hand-size row, "+ add card" / "+ add category") on that
- * flag. `uiMode` has three values: `setup`, `checklist`, `suggest`.
- * On desktop `checklist` and `suggest` both render the Play grid
- * (the tab doesn't visually distinguish them); on mobile each routes
- * to its own pane. This means resizing across the breakpoint never
- * jumps tabs — the URL (`?tab=…`) stays coherent on both sides.
+ * Play modes — the overflow menu's Game setup item drives the
+ * `uiMode` slice and the component gates its Setup-mode affordances
+ * (inline renames, add/remove, hand-size row, "+ add card" / "+ add
+ * category") on that flag. `uiMode` has three values: `setup`,
+ * `checklist`, `suggest`. On desktop `checklist` and `suggest` both
+ * render the Play grid; on mobile each routes to its own pane. This
+ * means resizing across the breakpoint never jumps tabs — the URL
+ * (`?tab=…`) stays coherent on both sides.
  */
 export function Clue() {
     const t = useTranslations("app");
@@ -63,9 +65,6 @@ export function Clue() {
 
                 <GlobalContradictionBanner />
 
-                <div className="hidden shrink-0 [@media(min-width:800px)]:block">
-                    <TabBar />
-                </div>
                 <div className="flex min-h-0 flex-1 flex-col">
                     <TabContent />
                 </div>
@@ -144,44 +143,3 @@ function TabContent() {
     );
 }
 
-/**
- * Setup / Play tab switcher (desktop only). Drives the `uiMode`
- * reducer slice; consumers (Checklist's inline-edit gate and setup
- * affordances) read `state.uiMode === "setup"` to decide what to
- * render. The Play tab lights up for both `checklist` and `suggest`
- * since desktop doesn't distinguish them. Clicking Play resolves to
- * `checklist` — the more common landing.
- */
-function TabBar() {
-    const { state, dispatch } = useClue();
-    const tTabs = useTranslations("tabs");
-    const tabClass = (active: boolean) =>
-        `cursor-pointer border-0 border-b-2 px-3 py-1.5 text-[13px] font-semibold ${
-            active
-                ? "border-accent bg-transparent text-accent"
-                : "border-transparent bg-transparent text-muted hover:text-accent"
-        }`;
-    const playActive = state.uiMode !== "setup";
-    return (
-        <div role="tablist" className="-mb-3 flex gap-2 border-b border-border">
-            <button
-                type="button"
-                role="tab"
-                aria-selected={state.uiMode === "setup"}
-                className={tabClass(state.uiMode === "setup")}
-                onClick={() => dispatch({ type: "setUiMode", mode: "setup" })}
-            >
-                {tTabs("setup", { shortcut: label("global.gotoSetup") })}
-            </button>
-            <button
-                type="button"
-                role="tab"
-                aria-selected={playActive}
-                className={tabClass(playActive)}
-                onClick={() => dispatch({ type: "setUiMode", mode: "checklist" })}
-            >
-                {tTabs("play", { shortcut: label("global.gotoPlay") })}
-            </button>
-        </div>
-    );
-}

--- a/src/ui/Clue.tsx
+++ b/src/ui/Clue.tsx
@@ -44,7 +44,7 @@ import { ClueProvider, useClue } from "./state";
  * `checklist`, `suggest`. On desktop `checklist` and `suggest` both
  * render the Play grid; on mobile each routes to its own pane. This
  * means resizing across the breakpoint never jumps tabs — the URL
- * (`?tab=…`) stays coherent on both sides.
+ * (`?view=…`) stays coherent on both sides.
  */
 export function Clue() {
     const t = useTranslations("app");

--- a/src/ui/components/BottomNav.tsx
+++ b/src/ui/components/BottomNav.tsx
@@ -7,12 +7,13 @@ import { describeAction } from "../../logic/describeAction";
 import { useLongPress } from "../hooks/useLongPress";
 import { useClue } from "../state";
 import { label } from "../keyMap";
+import { OverflowMenu } from "./OverflowMenu";
 import { useToolbarActions } from "./Toolbar";
 
 /**
  * Mobile-only fixed-bottom navigation. Shown only under 800px — the
- * desktop header's `Toolbar` + `TabBar` cover the same affordances
- * above that breakpoint. Five slots, left to right:
+ * desktop header `Toolbar` covers the same affordances above that
+ * breakpoint. Five slots, left to right:
  *
  *   [Checklist] [Suggest] [Undo] [Redo] [⋯]
  *
@@ -90,7 +91,7 @@ export function BottomNav() {
                     disabled={!canRedo}
                     preview={redoPreview}
                 />
-                <OverflowMenu
+                <BottomOverflowMenu
                     setupActive={mode === "setup"}
                     onSetup={() =>
                         dispatch({ type: "setUiMode", mode: "setup" })
@@ -197,13 +198,14 @@ function NavIconItem({
 }
 
 /**
- * Trailing overflow slot. A small Radix popover that opens *upward*
- * (`side="top"`) above the fixed nav and hosts the three less-common
- * actions: Game setup (switches to the Setup tab), Share link, and
- * New game. Share + New game reuse `useToolbarActions` so the mobile
- * flow is identical to the desktop Toolbar.
+ * Trailing overflow slot — thin wrapper around the shared `OverflowMenu`
+ * with mobile-specific trigger styling (icon slot, ~12 tall/wide) and
+ * `side="top"` so the popover opens upward above the fixed nav. The
+ * menu items mirror the desktop Toolbar: Game setup (switches to Setup
+ * mode), Share link, and New game. Share + New game reuse
+ * `useToolbarActions` so the mobile flow is identical to the desktop.
  */
-function OverflowMenu({
+function BottomOverflowMenu({
     setupActive,
     onSetup,
 }: {
@@ -212,75 +214,36 @@ function OverflowMenu({
 }) {
     const t = useTranslations("bottomNav");
     const tToolbar = useTranslations("toolbar");
-    const [open, setOpen] = useState(false);
     const { onShare, onNewGame, copied } = useToolbarActions();
-
-    const closeThen = (fn: () => void | Promise<void>) => () => {
-        setOpen(false);
-        void fn();
-    };
-
     return (
         <li>
-            <RadixPopover.Root open={open} onOpenChange={setOpen}>
-                <RadixPopover.Trigger
-                    aria-label={t("more")}
-                    title={t("more")}
-                    className="flex h-12 w-12 cursor-pointer items-center justify-center rounded-[var(--radius)] border-none bg-transparent text-[20px] text-muted hover:text-accent"
-                >
-                    ⋯
-                </RadixPopover.Trigger>
-                <RadixPopover.Portal>
-                    <RadixPopover.Content
-                        side="top"
-                        align="end"
-                        sideOffset={6}
-                        collisionPadding={8}
-                        className="z-50 min-w-[200px] rounded-[var(--radius)] border border-border bg-panel p-1 text-[13px] shadow-[0_6px_16px_rgba(0,0,0,0.18)]"
-                    >
-                        <MenuItem
-                            label={t("gameSetup", {
-                                shortcut: label("global.gotoSetup"),
-                            })}
-                            active={setupActive}
-                            onClick={closeThen(onSetup)}
-                        />
-                        <MenuItem
-                            label={copied ? tToolbar("shareCopied") : tToolbar("share")}
-                            onClick={closeThen(onShare)}
-                        />
-                        <MenuItem
-                            label={tToolbar("newGame", {
-                                shortcut: label("global.newGame"),
-                            })}
-                            onClick={closeThen(onNewGame)}
-                        />
-                    </RadixPopover.Content>
-                </RadixPopover.Portal>
-            </RadixPopover.Root>
+            <OverflowMenu
+                triggerClassName="flex h-12 w-12 cursor-pointer items-center justify-center rounded-[var(--radius)] border-none bg-transparent text-[20px] text-muted hover:text-accent"
+                triggerLabel={t("more")}
+                side="top"
+                align="end"
+                items={[
+                    {
+                        label: t("gameSetup", {
+                            shortcut: label("global.gotoSetup"),
+                        }),
+                        active: setupActive,
+                        onClick: onSetup,
+                    },
+                    {
+                        label: copied
+                            ? tToolbar("shareCopied")
+                            : tToolbar("share"),
+                        onClick: onShare,
+                    },
+                    {
+                        label: tToolbar("newGame", {
+                            shortcut: label("global.newGame"),
+                        }),
+                        onClick: onNewGame,
+                    },
+                ]}
+            />
         </li>
-    );
-}
-
-function MenuItem({
-    label,
-    active,
-    onClick,
-}: {
-    readonly label: string;
-    readonly active?: boolean;
-    readonly onClick: () => void;
-}) {
-    return (
-        <button
-            type="button"
-            onClick={onClick}
-            className={
-                "block w-full cursor-pointer rounded-[var(--radius)] border-none bg-transparent px-3 py-2 text-left text-[13px] hover:bg-hover " +
-                (active ? "text-accent font-semibold" : "text-inherit")
-            }
-        >
-            {label}
-        </button>
     );
 }

--- a/src/ui/components/OverflowMenu.tsx
+++ b/src/ui/components/OverflowMenu.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import * as RadixPopover from "@radix-ui/react-popover";
+import { useState } from "react";
+
+interface OverflowMenuItem {
+    readonly label: string;
+    readonly active?: boolean;
+    readonly onClick: () => void | Promise<void>;
+}
+
+/**
+ * Shared `⋯` overflow menu. Used by the desktop header Toolbar and the
+ * mobile BottomNav. Internally a Radix Popover — each menu item closes
+ * the popover before firing its handler so confirms/dialogs don't fight
+ * with the open menu.
+ */
+export function OverflowMenu({
+    triggerClassName,
+    triggerLabel,
+    side,
+    align,
+    items,
+}: {
+    readonly triggerClassName: string;
+    readonly triggerLabel: string;
+    readonly side: "top" | "bottom";
+    readonly align: "start" | "end";
+    readonly items: ReadonlyArray<OverflowMenuItem>;
+}) {
+    const [open, setOpen] = useState(false);
+    const closeThen = (fn: () => void | Promise<void>) => () => {
+        setOpen(false);
+        void fn();
+    };
+    return (
+        <RadixPopover.Root open={open} onOpenChange={setOpen}>
+            <RadixPopover.Trigger
+                aria-label={triggerLabel}
+                title={triggerLabel}
+                className={triggerClassName}
+            >
+                ⋯
+            </RadixPopover.Trigger>
+            <RadixPopover.Portal>
+                <RadixPopover.Content
+                    side={side}
+                    align={align}
+                    sideOffset={6}
+                    collisionPadding={8}
+                    className="z-50 min-w-[200px] rounded-[var(--radius)] border border-border bg-panel p-1 text-[13px] shadow-[0_6px_16px_rgba(0,0,0,0.18)]"
+                >
+                    {items.map((item, i) => {
+                        const handleClick = closeThen(item.onClick);
+                        return item.active === undefined ? (
+                            <MenuItem
+                                key={i}
+                                label={item.label}
+                                onClick={handleClick}
+                            />
+                        ) : (
+                            <MenuItem
+                                key={i}
+                                label={item.label}
+                                active={item.active}
+                                onClick={handleClick}
+                            />
+                        );
+                    })}
+                </RadixPopover.Content>
+            </RadixPopover.Portal>
+        </RadixPopover.Root>
+    );
+}
+
+function MenuItem({
+    label,
+    active,
+    onClick,
+}: {
+    readonly label: string;
+    readonly active?: boolean;
+    readonly onClick: () => void;
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className={
+                "block w-full cursor-pointer rounded-[var(--radius)] border-none bg-transparent px-3 py-2 text-left text-[13px] hover:bg-hover " +
+                (active ? "text-accent font-semibold" : "text-inherit")
+            }
+        >
+            {label}
+        </button>
+    );
+}

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -6,6 +6,7 @@ import { describeAction } from "../../logic/describeAction";
 import { useConfirm } from "../hooks/useConfirm";
 import { useClue } from "../state";
 import { label } from "../keyMap";
+import { OverflowMenu } from "./OverflowMenu";
 import { Tooltip } from "./Tooltip";
 
 const buttonClass =
@@ -52,14 +53,25 @@ export function useToolbarActions() {
 }
 
 /**
- * Top-of-page controls (desktop only): undo/redo, start a fresh game,
- * and copy a shareable URL encoding the current state. Mobile uses
- * `BottomNav` instead.
+ * Top-of-page controls (desktop only): undo/redo as top-level buttons,
+ * plus a ⋯ overflow menu that hosts Game setup, Share link, and New
+ * game. Mirrors the mobile `BottomNav` overflow so both breakpoints
+ * share the same menu structure.
  */
 export function Toolbar() {
     const t = useTranslations("toolbar");
+    const tNav = useTranslations("bottomNav");
     const tHistory = useTranslations("history");
-    const { canUndo, canRedo, undo, redo, nextUndo, nextRedo } = useClue();
+    const {
+        state,
+        dispatch,
+        canUndo,
+        canRedo,
+        undo,
+        redo,
+        nextUndo,
+        nextRedo,
+    } = useClue();
     const { onShare, onNewGame, copied } = useToolbarActions();
 
     const undoTooltip = nextUndo
@@ -107,12 +119,32 @@ export function Toolbar() {
                     {t("redo", { shortcut: label("global.redo") })}
                 </button>
             </Tooltip>
-            <button type="button" className={buttonClass} onClick={onShare}>
-                {copied ? t("shareCopied") : t("share")}
-            </button>
-            <button type="button" className={buttonClass} onClick={onNewGame}>
-                {t("newGame", { shortcut: label("global.newGame") })}
-            </button>
+            <OverflowMenu
+                triggerClassName={buttonClass}
+                triggerLabel={tNav("more")}
+                side="bottom"
+                align="end"
+                items={[
+                    {
+                        label: tNav("gameSetup", {
+                            shortcut: label("global.gotoSetup"),
+                        }),
+                        active: state.uiMode === "setup",
+                        onClick: () =>
+                            dispatch({ type: "setUiMode", mode: "setup" }),
+                    },
+                    {
+                        label: copied ? t("shareCopied") : t("share"),
+                        onClick: onShare,
+                    },
+                    {
+                        label: t("newGame", {
+                            shortcut: label("global.newGame"),
+                        }),
+                        onClick: onNewGame,
+                    },
+                ]}
+            />
         </div>
     );
 }

--- a/src/ui/state.tsx
+++ b/src/ui/state.tsx
@@ -764,8 +764,8 @@ export function ClueProvider({ children }: { children: ReactNode }) {
     const didHydrate = useRef(false);
 
     // One-shot hydration on mount: URL first, then localStorage. The
-    // `?tab=setup|checklist|suggest` param overrides the smart default;
-    // with no explicit tab we land on the Checklist (play mode) if the
+    // `?view=setup|checklist|suggest` param overrides the smart default;
+    // with no explicit view we land on the Checklist (play mode) if the
     // hydrated session has any suggestions, else Setup (the reducer's
     // default). On desktop `checklist` and `suggest` both render the
     // same Play grid; on mobile they route to their own pane.
@@ -775,38 +775,39 @@ export function ClueProvider({ children }: { children: ReactNode }) {
         if (typeof window === "undefined") return;
         const params = new URLSearchParams(window.location.search);
         const stateParam = params.get("state");
-        const tabParam = params.get("tab");
+        const viewParam = params.get("view");
         let hydrated: GameSession | undefined;
         if (stateParam) hydrated = decodeSessionFromUrl(stateParam);
         if (!hydrated) hydrated = loadFromLocalStorage();
         if (hydrated) dispatch({ type: "replaceSession", session: hydrated });
 
-        // Tab precedence: explicit `?tab=` wins; otherwise pick based on
-        // hydrated suggestions. The default state.uiMode is "setup", so
-        // only dispatch when we actually need to change it.
-        if (tabParam === "checklist") {
+        // View precedence: explicit `?view=` wins; otherwise pick based
+        // on hydrated suggestions. The default state.uiMode is "setup",
+        // so only dispatch when we actually need to change it.
+        if (viewParam === "checklist") {
             dispatch({ type: "setUiMode", mode: "checklist" });
-        } else if (tabParam === "suggest") {
+        } else if (viewParam === "suggest") {
             dispatch({ type: "setUiMode", mode: "suggest" });
-        } else if (tabParam === "setup") {
+        } else if (viewParam === "setup") {
             // No-op: default is already "setup".
         } else if (hydrated && hydrated.suggestions.length > 0) {
             dispatch({ type: "setUiMode", mode: "checklist" });
         }
     }, []);
 
-    // Mirror `uiMode` to the URL as `?tab=setup|play`. Uses
-    // replaceState (not pushState) because tab flips shouldn't clutter
-    // the back stack — same spirit as `setUiMode` bypassing undo/redo
-    // history. Gated on `didHydrate` so the initial reducer default
-    // doesn't stomp an unset URL before hydration has chosen the tab.
+    // Mirror `uiMode` to the URL as `?view=setup|checklist|suggest`.
+    // Uses replaceState (not pushState) because view flips shouldn't
+    // clutter the back stack — same spirit as `setUiMode` bypassing
+    // undo/redo history. Gated on `didHydrate` so the initial reducer
+    // default doesn't stomp an unset URL before hydration has chosen
+    // the view.
     useEffect(() => {
         if (!didHydrate.current) return;
         if (typeof window === "undefined") return;
         const params = new URLSearchParams(window.location.search);
-        const urlTab = state.uiMode;
-        if (params.get("tab") === urlTab) return;
-        params.set("tab", urlTab);
+        const urlView = state.uiMode;
+        if (params.get("view") === urlView) return;
+        params.set("view", urlView);
         const newUrl = `${window.location.pathname}?${params.toString()}${window.location.hash}`;
         window.history.replaceState(null, "", newUrl);
     }, [state.uiMode]);


### PR DESCRIPTION
## Summary

- **Commit 1**: Remove the desktop Setup / Play tab bar. The header Toolbar now mirrors the mobile BottomNav pattern — Undo and Redo stay as top-level buttons; Game setup, Share link, and New game move into a ⋯ overflow menu. A new shared `OverflowMenu` component is consumed by both Toolbar (`side=bottom`) and BottomNav (`side=top`), collapsing the duplicated Radix Popover + MenuItem scaffolding into one place. `uiMode`, `TabContent`'s setup/play layout gate, and keyboard shortcuts are all unchanged.
- **Commit 2**: Rename the `?tab=` query param to `?view=`. No legacy support — previously-shared `?tab=…` URLs fall through to the default (Setup, or Checklist if the hydrated session has suggestions).

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm knip`
- [x] `pnpm test` (101 tests pass)
- [x] Desktop browser: header shows `[Undo] [Redo] [⋯]`; overflow menu opens with Game setup / Share / New game; Game setup highlights when `uiMode === "setup"`; 2-column Checklist + SuggestionLog grid renders in play modes; Setup mode renders Checklist full-width
- [x] Mobile browser: BottomNav unchanged, same overflow menu via the shared component
- [x] `?view=suggest` hydrates to Suggest tab; switching tabs updates URL via `replaceState`
- [x] Legacy `?tab=suggest` falls through to default without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)