### PR TITLE
Make ⌘J leave the Setup view

### DIFF
--- a/src/ui/state.tsx
+++ b/src/ui/state.tsx
@@ -638,12 +638,13 @@ export function ClueProvider({ children }: { children: ReactNode }) {
     );
 
     // Cmd/Ctrl+J: jump to the Checklist. On desktop Play already
-    // shows the checklist; on mobile Play-suggest hides it, so
-    // flip to the "checklist" sub-mode first.
+    // shows the checklist; on mobile Play-suggest hides it, and Setup
+    // renders its own Checklist variant — in both cases flip to the
+    // "checklist" sub-mode so the user lands in the Play view.
     useGlobalShortcut(
         "global.gotoChecklist",
         useCallback(() => {
-            if (uiModeRef.current === "suggest") {
+            if (uiModeRef.current !== "checklist") {
                 dispatchRaw({ type: "setUiMode", mode: "checklist" });
             }
             requestFocusChecklistCell();


### PR DESCRIPTION
## Summary
- ⌘J only dispatched `setUiMode: "checklist"` when coming from `suggest`, so pressing it from Setup did nothing visible. The Setup view also renders a Checklist, so `requestFocusChecklistCell` silently focused a cell without any view transition.
- Broaden the guard from `=== "suggest"` to `!== "checklist"` so ⌘J consistently lands the user in the Play checklist, matching how ⌘L handles the setup case.

## Test plan
- [x] `pnpm typecheck` / `pnpm test` / `pnpm knip` / `pnpm i18n:check`
- [x] Setup → ⌘J: switches to Play checklist, first cell focused
- [x] Checklist → ⌘J: stays in checklist (no redundant dispatch)
- [x] Setup → ⌘H / ⌘K / ⌘L: unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)