### PR TITLE
Add CLAUDE.md with project conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,50 @@
+# Project conventions
+
+## Package manager
+
+Use `pnpm` for everything. Never `npm`, `yarn`, or `bun`.
+
+## Verification checks
+
+All of these must pass green before every commit:
+
+- `pnpm typecheck`
+- `pnpm lint`
+- `pnpm test`
+- `pnpm knip`
+- `pnpm i18n:check`
+
+If you amend or update a commit, re-run the full set — a previously-green commit can break after edits.
+
+## Manual verification in the preview
+
+For any change that's observable in the browser, use the `next-dev` preview (configured in `.claude/launch.json`) to exercise the change yourself before reporting the task done. Follow the `<verification_workflow>` from the system prompt: start/reload the preview, check console/network/logs, take a screenshot or snapshot as proof. Don't ask the user to verify manually.
+
+## Tests
+
+Write exhaustive tests for any code you add or modify.
+
+When modifying behavior:
+
+1. Read the existing tests covering that code first.
+2. Remove or update tests that assert outdated behavior.
+3. Add tests for any previously-uncovered cases the change introduces.
+4. Run `pnpm test` and make sure everything passes.
+
+Tests live next to source (`Foo.test.ts(x)` beside `Foo.ts(x)`) — match that pattern.
+
+## PR workflow
+
+- Always open a PR. Never merge directly to `main`.
+- Always merge with a **merge commit** — not squash, not rebase.
+- Only merge when I explicitly ask. Sometimes I'll ask you to open the PR and I'll merge it myself. If unsure whether to merge, ask.
+
+## Commit message format
+
+- **Title**: imperative mood, under ~70 chars.
+- **Body**: lead with a description of the change from the user's perspective. Then describe any technical details. Add any other useful context after that.
+
+## PR title and description format
+
+- **Title**: a cohesive, concise summary that covers all commits in the PR.
+- **Description**: lead with the behavior changes from the user's perspective. At the bottom, include a log of the commits with code-oriented technical descriptions of what each one does.


### PR DESCRIPTION
## Summary

Claude Code will now automatically pick up this project's conventions every session — no need to repeat them. The new `CLAUDE.md` covers:

- **Package manager** — always `pnpm`
- **Verification checks before every commit** — `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm knip`, `pnpm i18n:check` must all pass; re-run on amend
- **Manual verification** — use the `next-dev` preview for any browser-visible change
- **Tests** — write exhaustive tests; read/update/remove related tests when changing behavior
- **PR workflow** — always open a PR, never merge directly to `main`, use merge commits, only merge when explicitly asked
- **Commit messages** — user-perspective first, then technical details
- **PR titles & descriptions** — cohesive title; user-perspective behavior changes first, commit log with technical details at the bottom

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm knip`
- [x] `pnpm i18n:check`

## Commit log

- **Add CLAUDE.md with project conventions** — new root-level `CLAUDE.md` (50 lines) loaded into every Claude Code session's system context. References existing repo paths (`package.json` scripts, `.claude/launch.json` preview config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)