### PR TITLE
Desaturate checklist category header rows

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -35,6 +35,11 @@
     --color-accent: #7a1c1c;
     --color-accent-hover: #5e1414;
 
+    /* Category header strip on the checklist — a muted cousin of the
+     * accent so "why this value" popovers (which use --color-accent)
+     * read as a distinct layer stacked over these rows. */
+    --color-category-header: #8e4545;
+
     /* --- Y = claimed / confirmed (detective's green tick). */
     --color-yes: #2f5e1f;
     --color-yes-bg: #d7e4bf;

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -370,7 +370,7 @@ export function Checklist() {
                             <tr key={`h-${String(category.id)}`}>
                                 <th
                                     colSpan={cardSpan}
-                                    className="border border-border bg-accent px-2 py-1.5 text-left text-[11px] uppercase tracking-[0.05em] text-white"
+                                    className="border border-border bg-category-header px-2 py-1.5 text-left text-[11px] uppercase tracking-[0.05em] text-white"
                                 >
                                     {inSetup ? (
                                         <div className="flex items-center justify-between gap-2">


### PR DESCRIPTION
## Summary
- Category header rows (SUSPECT/WEAPON/ROOM) and the \"why this value\" InfoPopover both used `bg-accent`, so an open popover blended into the row beneath it.
- New `--color-category-header` token (`#8e4545`) in [app/globals.css](app/globals.css); [Checklist.tsx:373](src/ui/components/Checklist.tsx:373) now uses `bg-category-header`. InfoPopover keeps `bg-accent` and reads as a distinct layer.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm knip`
- [x] `pnpm i18n:check`
- [x] Visual check in dev server: SUSPECT/WEAPON/ROOM rows render in softer red, white text legible

🤖 Generated with [Claude Code](https://claude.com/claude-code)