### PR TITLE
Flesh out keyboard nav for the setup grid and prior-suggestion edits

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -151,6 +151,8 @@
         "nothingUseful": "Nothing useful to ask — you've already narrowed everything down.",
         "priorTitle": "{count, plural, =0 {Prior suggestions ({shortcut})} other {Prior suggestions ({shortcut}) (#)}}",
         "priorKeyboardHint": "↑↓ navigate · Enter edit · ⌫ remove · Esc exit",
+        "priorRowHintDesktop": "Press Enter to edit",
+        "priorRowHintMobile": "Tap to edit",
         "priorEmpty": "No suggestions yet. Add one above.",
         "suggestedLine": "<strong>{suggester}</strong> suggested {cards}",
         "refutationLine": "{status, select, refutedSeenPassed {refuted by <strong>{refuter}</strong> (showed {seen}) · passed: {passers}} refutedSeen {refuted by <strong>{refuter}</strong> (showed {seen})} refutedPassed {refuted by <strong>{refuter}</strong> · passed: {passers}} refuted {refuted by <strong>{refuter}</strong>} nobodyPassed {nobody could refute · passed: {passers}} other {nobody could refute}}",

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -56,6 +56,135 @@ import { Envelope } from "./Icons";
 import { InfoPopover } from "./InfoPopover";
 
 /**
+ * Box around the grid nav ring. Setup mode extends the ring to
+ * include the player-name (row -2), hand-size (row -1), and
+ * card-name (col -1) input cells; Play mode collapses to the
+ * body-cell rectangle (0..rows-1, 0..cols-1).
+ */
+type GridBounds = {
+    readonly minRow: number;
+    readonly maxRow: number;
+    readonly minCol: number;
+    readonly maxCol: number;
+};
+
+function findNavCell(r: number, c: number): HTMLElement | null {
+    return document.querySelector<HTMLElement>(
+        `[data-cell-row="${r}"][data-cell-col="${c}"]`,
+    );
+}
+
+/**
+ * Arrow-key grid navigation. Up/Down/Left/Right walk to the nearest
+ * neighbour cell published with `data-cell-row` / `data-cell-col`.
+ * Cmd/Ctrl + Arrow jumps to the edge of the grid in that direction;
+ * if the exact edge cell is empty (e.g. Case File column has no
+ * player-name row), it walks back toward the origin and picks the
+ * first cell found.
+ *
+ * When `isTextInput` is true, Left/Right only navigate at the text
+ * boundary (cursor at pos 0 or end, no selection) so mid-string
+ * editing feels normal. Up/Down always navigate (single-line
+ * inputs). Cmd+Arrow always navigates (overrides browser Home/End).
+ */
+function navigateGrid(
+    e: React.KeyboardEvent<HTMLElement>,
+    rowIdx: number,
+    colIdx: number,
+    bounds: GridBounds,
+    opts: { readonly isTextInput?: boolean } = {},
+): void {
+    const native = e.nativeEvent;
+    // Shift/alt + arrow is reserved for browser selection / word-skip
+    // inside text inputs and has no existing grid-nav semantics.
+    if (native.shiftKey || native.altKey) return;
+    const isArrowKey =
+        native.key === "ArrowUp" ||
+        native.key === "ArrowDown" ||
+        native.key === "ArrowLeft" ||
+        native.key === "ArrowRight";
+    const isMod = (native.metaKey || native.ctrlKey) && isArrowKey;
+    // Text inputs restrict nav to actual arrow keys (+ Cmd+Arrow).
+    // WASD / IJKL alternates would hijack typing otherwise.
+    const allowAlt = !opts.isTextInput;
+    const up =
+        (allowAlt && matches("nav.up", native)) ||
+        native.key === "ArrowUp";
+    const down =
+        (allowAlt && matches("nav.down", native)) ||
+        native.key === "ArrowDown";
+    const left =
+        (allowAlt && matches("nav.left", native)) ||
+        native.key === "ArrowLeft";
+    const right =
+        (allowAlt && matches("nav.right", native)) ||
+        native.key === "ArrowRight";
+    if (!up && !down && !left && !right) return;
+
+    const dr = up ? -1 : down ? 1 : 0;
+    const dc = left ? -1 : right ? 1 : 0;
+
+    if (opts.isTextInput && !isMod && (left || right)) {
+        const el = e.currentTarget as HTMLInputElement;
+        const selStart = el.selectionStart ?? 0;
+        const selEnd = el.selectionEnd ?? 0;
+        const len = el.value.length;
+        if (selStart !== selEnd) return;
+        if (left && selStart > 0) return;
+        if (right && selEnd < len) return;
+    }
+
+    const current = e.currentTarget as HTMLElement;
+    let target: HTMLElement | null = null;
+    if (isMod) {
+        // Start at the far edge along each active axis; walk back
+        // toward origin by (-dr, -dc).
+        let r = dr !== 0 ? (dr > 0 ? bounds.maxRow : bounds.minRow) : rowIdx;
+        let c = dc !== 0 ? (dc > 0 ? bounds.maxCol : bounds.minCol) : colIdx;
+        while (
+            r >= bounds.minRow &&
+            r <= bounds.maxRow &&
+            c >= bounds.minCol &&
+            c <= bounds.maxCol
+        ) {
+            const found = findNavCell(r, c);
+            if (found && found !== current) {
+                target = found;
+                break;
+            }
+            if (dr < 0 && r >= rowIdx) break;
+            if (dr > 0 && r <= rowIdx) break;
+            if (dc < 0 && c >= colIdx) break;
+            if (dc > 0 && c <= colIdx) break;
+            r -= dr;
+            c -= dc;
+        }
+    } else {
+        let r = rowIdx + dr;
+        let c = colIdx + dc;
+        while (
+            r >= bounds.minRow &&
+            r <= bounds.maxRow &&
+            c >= bounds.minCol &&
+            c <= bounds.maxCol
+        ) {
+            const found = findNavCell(r, c);
+            if (found) {
+                target = found;
+                break;
+            }
+            r += dr;
+            c += dc;
+        }
+    }
+
+    if (target) {
+        e.preventDefault();
+        target.focus();
+    }
+}
+
+/**
  * Unified tabbed checklist: the single surface for both editing the
  * deck / roster (Setup mode) and tracking deductions (Play mode).
  * State-slice ownership is one tab-gate deep: `inSetup` controls
@@ -103,21 +232,23 @@ export function Checklist() {
     }, [setup.categories]);
     const totalRows = rowIdxByCard.size;
     const totalCols = owners.length;
+    // Setup mode extends the nav ring up (player-name row -2,
+    // hand-size row -1) and left (card-name col -1).
+    const bounds: GridBounds = {
+        minRow: inSetup ? -2 : 0,
+        maxRow: totalRows - 1,
+        minCol: inSetup ? -1 : 0,
+        maxCol: totalCols - 1,
+    };
 
     // Handle ⌘J focus requests: locate a cell by (row,col) and
     // focus it. "first" falls back to the first interactive cell.
     useEffect(() => {
         const unregister = registerChecklistFocusHandler(target => {
-            const findAt = (row: number, col: number): HTMLElement | null => {
-                const el = document.querySelector<HTMLElement>(
-                    `[data-cell-row="${row}"][data-cell-col="${col}"]`,
-                );
-                return el;
-            };
             const findFirst = (): HTMLElement | null => {
-                for (let r = 0; r < totalRows; r++) {
-                    for (let c = 0; c < totalCols; c++) {
-                        const el = findAt(r, c);
+                for (let r = bounds.minRow; r <= bounds.maxRow; r++) {
+                    for (let c = bounds.minCol; c <= bounds.maxCol; c++) {
+                        const el = findNavCell(r, c);
                         if (el) return el;
                     }
                 }
@@ -130,7 +261,7 @@ export function Checklist() {
                 } else if (target === "last") {
                     el = findFirst();
                 } else {
-                    el = findAt(target.row, target.col) ?? findFirst();
+                    el = findNavCell(target.row, target.col) ?? findFirst();
                 }
                 if (el) {
                     el.scrollIntoView(
@@ -142,7 +273,7 @@ export function Checklist() {
             });
         });
         return unregister;
-    }, [totalRows, totalCols]);
+    }, [bounds.minRow, bounds.maxRow, bounds.minCol, bounds.maxCol]);
 
     // In Setup mode the add-player column sits between the players and
     // the case file — clicking + spawns the new player where its column
@@ -287,7 +418,7 @@ export function Checklist() {
                         <th className="border-r border-b border-border bg-row-header px-2 py-1 text-center text-[10px] font-semibold uppercase tracking-[0.05em] text-muted">
                             {inSetup ? null : label("global.gotoChecklist")}
                         </th>
-                        {owners.flatMap(owner => {
+                        {owners.flatMap((owner, ownerIdx) => {
                             const cell = (
                                 <th
                                     key={ownerKey(owner)}
@@ -297,6 +428,8 @@ export function Checklist() {
                                         <PlayerNameInput
                                             player={owner.player}
                                             allPlayers={setup.players}
+                                            colIdx={ownerIdx}
+                                            bounds={bounds}
                                         />
                                     ) : (
                                         ownerLabel(owner)
@@ -313,7 +446,7 @@ export function Checklist() {
                             <th className="whitespace-nowrap border-r border-b border-border bg-row-header px-1.5 py-1 text-left font-semibold">
                                 {tSetup("handSize")}
                             </th>
-                            {owners.flatMap(owner => {
+                            {owners.flatMap((owner, ownerIdx) => {
                                 let cell: ReactNode;
                                 if (owner._tag !== "Player") {
                                     cell = (
@@ -344,6 +477,23 @@ export function Checklist() {
                                                     def === undefined
                                                         ? ""
                                                         : String(def)
+                                                }
+                                                data-cell-row={-1}
+                                                data-cell-col={ownerIdx}
+                                                onFocus={() =>
+                                                    rememberChecklistCell(
+                                                        -1,
+                                                        ownerIdx,
+                                                    )
+                                                }
+                                                onKeyDown={e =>
+                                                    navigateGrid(
+                                                        e,
+                                                        -1,
+                                                        ownerIdx,
+                                                        bounds,
+                                                        { isTextInput: true },
+                                                    )
                                                 }
                                                 onChange={e =>
                                                     onHandSizeChange(
@@ -441,7 +591,10 @@ export function Checklist() {
                                     )}
                                 </th>
                             </tr>,
-                            ...category.cards.map(entry => (
+                            ...category.cards.map(entry => {
+                                const cardRowIdx =
+                                    rowIdxByCard.get(entry.id) ?? -1;
+                                return (
                                 <tr key={String(entry.id)}>
                                     <th className="w-px whitespace-nowrap border-r border-b border-border px-2 py-1 text-left font-normal">
                                         {inSetup ? (
@@ -457,6 +610,11 @@ export function Checklist() {
                                                             name: next,
                                                         })
                                                     }
+                                                    navCell={{
+                                                        rowIdx: cardRowIdx,
+                                                        colIdx: -1,
+                                                        bounds,
+                                                    }}
                                                 />
                                                 <button
                                                     type="button"
@@ -622,38 +780,7 @@ export function Checklist() {
                                         // through the whole grid.
                                         const onGridArrowKey = (
                                             e: React.KeyboardEvent<HTMLTableCellElement>,
-                                        ) => {
-                                            const native = e.nativeEvent;
-                                            const dr = matches("nav.up", native)
-                                                ? -1
-                                                : matches("nav.down", native)
-                                                  ? 1
-                                                  : 0;
-                                            const dc = matches("nav.left", native)
-                                                ? -1
-                                                : matches("nav.right", native)
-                                                  ? 1
-                                                  : 0;
-                                            if (dr === 0 && dc === 0) return;
-                                            e.preventDefault();
-                                            let r = rowIdx + dr;
-                                            let c = colIdx + dc;
-                                            let next: HTMLElement | null = null;
-                                            while (
-                                                r >= 0 &&
-                                                r < totalRows &&
-                                                c >= 0 &&
-                                                c < totalCols
-                                            ) {
-                                                next = document.querySelector<HTMLElement>(
-                                                    `[data-cell-row="${r}"][data-cell-col="${c}"]`,
-                                                );
-                                                if (next) break;
-                                                r += dr;
-                                                c += dc;
-                                            }
-                                            if (next) next.focus();
-                                        };
+                                        ) => navigateGrid(e, rowIdx, colIdx, bounds);
                                         const onCellFocus = () =>
                                             rememberChecklistCell(
                                                 rowIdx,
@@ -807,7 +934,8 @@ export function Checklist() {
                                             : [cell];
                                     })}
                                 </tr>
-                            )),
+                                );
+                            }),
                             ...(inSetup
                                 ? [
                                       <tr key={`add-card-${String(category.id)}`}>
@@ -861,17 +989,28 @@ export function Checklist() {
 /**
  * Editable text cell. Commits the new value on blur or Enter; resets
  * to the external value on Escape or if the input is cleared.
+ *
+ * If `navCell` is provided the input joins the Checklist grid nav
+ * ring at that (row, col): arrow keys walk to neighbour cells
+ * (Left/Right only at the text boundary), Cmd/Ctrl+Arrow jumps to
+ * the edge.
  */
 function InlineTextEdit({
     value,
     onCommit,
     className,
     title,
+    navCell,
 }: {
     value: string;
     onCommit: (next: string) => void;
     className?: string;
     title?: string;
+    navCell?: {
+        readonly rowIdx: number;
+        readonly colIdx: number;
+        readonly bounds: GridBounds;
+    };
 }) {
     const [local, setLocal] = useState(value);
     useEffect(() => {
@@ -893,9 +1032,34 @@ function InlineTextEdit({
             value={local}
             className={className}
             title={title}
+            {...(navCell
+                ? {
+                      "data-cell-row": navCell.rowIdx,
+                      "data-cell-col": navCell.colIdx,
+                  }
+                : {})}
+            onFocus={
+                navCell
+                    ? () =>
+                          rememberChecklistCell(
+                              navCell.rowIdx,
+                              navCell.colIdx,
+                          )
+                    : undefined
+            }
             onChange={e => setLocal(e.currentTarget.value)}
             onBlur={commit}
             onKeyDown={e => {
+                if (navCell) {
+                    navigateGrid(
+                        e,
+                        navCell.rowIdx,
+                        navCell.colIdx,
+                        navCell.bounds,
+                        { isTextInput: true },
+                    );
+                    if (e.defaultPrevented) return;
+                }
                 if (e.key === "Enter") {
                     (e.currentTarget as HTMLInputElement).blur();
                 } else if (e.key === "Escape") {
@@ -910,13 +1074,21 @@ function InlineTextEdit({
 /**
  * Editable player-name header with remove-× button. Handles the
  * duplicate-name check locally so the reducer doesn't have to.
+ *
+ * The input joins the Checklist grid nav ring at row -2 so arrow
+ * keys sweep between player-name inputs and down into the hand-size
+ * and card cells; Cmd/Ctrl+Arrow jumps to the grid edge.
  */
 function PlayerNameInput({
     player,
     allPlayers,
+    colIdx,
+    bounds,
 }: {
     player: Player;
     allPlayers: ReadonlyArray<Player>;
+    colIdx: number;
+    bounds: GridBounds;
 }) {
     const t = useTranslations("setup");
     const { state, dispatch } = useClue();
@@ -984,12 +1156,19 @@ function PlayerNameInput({
                     type="text"
                     className="box-border min-w-0 flex-1 rounded border border-border px-1.5 py-1 text-[12px]"
                     value={editing}
+                    data-cell-row={-2}
+                    data-cell-col={colIdx}
+                    onFocus={() => rememberChecklistCell(-2, colIdx)}
                     onChange={e => {
                         setEditing(e.currentTarget.value);
                         setError("");
                     }}
                     onBlur={commit}
                     onKeyDown={e => {
+                        navigateGrid(e, -2, colIdx, bounds, {
+                            isTextInput: true,
+                        });
+                        if (e.defaultPrevented) return;
                         if (e.key === "Enter") commit();
                     }}
                 />

--- a/src/ui/components/SuggestionForm.tsx
+++ b/src/ui/components/SuggestionForm.tsx
@@ -384,7 +384,15 @@ export function SuggestionForm({
             const onPillTrigger =
                 root.contains(active) &&
                 active.closest("[data-pill-id]") !== null;
-            const inPopover = isInsideSuggestionPopover(active);
+            // `isInsideSuggestionPopover` matches ANY pill popover
+            // (the Add form, Edit-prior-suggestion rows, …). Restrict
+            // to popovers whose trigger lives in *this* form's root —
+            // otherwise we'd steal arrow-nav from the prior-suggestion
+            // rows whose popovers happen to share the attribute.
+            const inPopover =
+                isInsideSuggestionPopover(active) &&
+                root.querySelector('[data-pill-id][data-state="open"]') !==
+                    null;
             if (!onPillTrigger && !inPopover && !onSubmitBtn) return;
 
             // Resolve the "current" pill we're navigating from.

--- a/src/ui/components/SuggestionLogPanel.tsx
+++ b/src/ui/components/SuggestionLogPanel.tsx
@@ -3,7 +3,7 @@
 import { Effect, Layer, Result } from "effect";
 import { AnimatePresence, motion } from "motion/react";
 import { useTranslations } from "next-intl";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Card, Player } from "../../logic/GameObjects";
 import { footnotesForCell } from "../../logic/Footnotes";
 import { cardName } from "../../logic/GameSetup";
@@ -20,6 +20,7 @@ import {
     makeSetupLayer,
 } from "../../logic/services";
 import { useConfirm } from "../hooks/useConfirm";
+import { useIsDesktop } from "../hooks/useIsDesktop";
 import { useListFormatter } from "../hooks/useListFormatter";
 import { useSelection } from "../SelectionContext";
 import { InfoPopover } from "./InfoPopover";
@@ -40,6 +41,7 @@ import {
     displayPassers,
     displayPlayer,
     displayPlayerOpt,
+    isInsideSuggestionPopover,
     isNobody,
     MultiSelectList,
     NOBODY,
@@ -422,6 +424,7 @@ function RecommendationsBody({
 function PriorSuggestions() {
     const t = useTranslations("suggestions");
     const { state } = useClue();
+    const isDesktop = useIsDesktop();
     const suggestions = state.suggestions;
     return (
         <div className="mt-4 border-t border-border pt-4">
@@ -441,9 +444,11 @@ function PriorSuggestions() {
                 </div>
             ) : (
                 <>
-                    <div className="mb-1 text-[11px] text-muted">
-                        {t("priorKeyboardHint")}
-                    </div>
+                    {isDesktop && (
+                        <div className="mb-1 text-[11px] text-muted">
+                            {t("priorKeyboardHint")}
+                        </div>
+                    )}
                     <ol className="m-0 flex list-none flex-col gap-2 p-0">
                         <AnimatePresence initial={false}>
                             {suggestions
@@ -496,6 +501,7 @@ function PriorSuggestionItem({
         activeSuggestionIndex,
     } = useSelection();
     const confirm = useConfirm();
+    const isDesktop = useIsDesktop();
     const setup = state.setup;
     const listFormatter = useListFormatter();
 
@@ -504,6 +510,10 @@ function PriorSuggestionItem({
     // a focused row. Promotes the row into pill-mode until Escape or
     // focus leaves the row entirely.
     const [isKeyboardEditing, setIsKeyboardEditing] = useState(false);
+    // Row-level keyboard focus tracker. Only true while focus is on
+    // the <li> itself (not descendant pills / ×) — drives the
+    // "Press Enter to edit" cue on desktop.
+    const [isRowFocused, setIsRowFocused] = useState(false);
 
     const isSelected = selectedSuggestionIndex === idx;
     const isActive = activeSuggestionIndex === idx;
@@ -675,6 +685,122 @@ function PriorSuggestionItem({
     // the Add form uses: can't pick a shown card if nobody refuted).
     const seenDisabled = s.refuter === undefined;
 
+    // Pill IDs for this row, in visual order. Used by the arrow-key
+    // nav and the advance-on-commit logic that mirror SuggestionForm's
+    // behaviour. The seenCard pill is skipped when disabled (no
+    // refuter).
+    const pillIds = useMemo<ReadonlyArray<string>>(() => {
+        const ids = [`suggester-${s.id}`];
+        setup.categories.forEach((_, i) => {
+            ids.push(`card-${s.id}-${i}`);
+        });
+        ids.push(`passers-${s.id}`);
+        ids.push(`refuter-${s.id}`);
+        ids.push(`seenCard-${s.id}`);
+        return ids;
+    }, [s.id, setup.categories]);
+
+    // `next` defaults to the *current* `s` — callers pass a post-commit
+    // snapshot when a commit just swapped `refuter` so the advance
+    // skips an unreachable shown-card pill immediately.
+    const advanceFrom = (
+        fromId: string,
+        nextSuggestion: DraftSuggestion = s,
+    ) => {
+        const idx = pillIds.indexOf(fromId);
+        if (idx < 0) {
+            setOpenPillId(null);
+            return;
+        }
+        for (let i = idx + 1; i < pillIds.length; i++) {
+            const id = pillIds[i];
+            if (id === undefined) continue;
+            if (
+                id.startsWith("seenCard-") &&
+                nextSuggestion.refuter === undefined
+            ) {
+                continue;
+            }
+            setOpenPillId(id);
+            return;
+        }
+        setOpenPillId(null);
+    };
+
+    // Row ref for scoping the arrow-key nav listener to this row's
+    // pills + popovers (popovers live in a Radix portal, so the row
+    // can't own the keydown directly).
+    const rowRef = useRef<HTMLLIElement>(null);
+
+    // ArrowLeft / ArrowRight between pills — matches SuggestionForm's
+    // behaviour for the Add-a-suggestion flow. Active when focus is on
+    // one of this row's pill triggers, or inside one of its popovers.
+    useEffect(() => {
+        const onKeyDown = (e: KeyboardEvent) => {
+            if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
+            const isLeft = matches("nav.left", e);
+            const isRight = matches("nav.right", e);
+            if (!isLeft && !isRight) return;
+
+            const rowEl = rowRef.current;
+            const active = document.activeElement as Element | null;
+            if (!rowEl || !active) return;
+
+            // Determine which pill the user is currently on. Either
+            // focus is on a trigger inside this row, or a popover
+            // (portalled outside the row) is open for one of our
+            // pills.
+            let currentPillId: string | null = null;
+            if (rowEl.contains(active)) {
+                const trig = active.closest("[data-pill-id]");
+                if (trig) {
+                    currentPillId = trig.getAttribute("data-pill-id");
+                }
+            }
+            if (
+                currentPillId === null &&
+                openPillId !== null &&
+                pillIds.includes(openPillId) &&
+                isInsideSuggestionPopover(active) &&
+                rowEl.querySelector(
+                    '[data-pill-id][data-state="open"]',
+                ) !== null
+            ) {
+                currentPillId = openPillId;
+            }
+            if (currentPillId === null || !pillIds.includes(currentPillId)) {
+                return;
+            }
+
+            const dir = isRight ? 1 : -1;
+            let targetId: string | null = null;
+            for (
+                let i = pillIds.indexOf(currentPillId) + dir;
+                i >= 0 && i < pillIds.length;
+                i += dir
+            ) {
+                const id = pillIds[i];
+                if (id === undefined) continue;
+                if (
+                    id.startsWith("seenCard-") &&
+                    s.refuter === undefined
+                ) {
+                    continue;
+                }
+                targetId = id;
+                break;
+            }
+            if (targetId === null) {
+                if (isLeft) e.preventDefault();
+                return;
+            }
+            e.preventDefault();
+            setOpenPillId(targetId);
+        };
+        document.addEventListener("keydown", onKeyDown);
+        return () => document.removeEventListener("keydown", onKeyDown);
+    }, [pillIds, openPillId, s.refuter]);
+
     // Internal-consistency validation: unlike the Add form (where
     // option-builders prevent most paradoxes at input time and pill
     // ordering gates PILL_SEEN behind the refuter), the inline edit
@@ -729,6 +855,7 @@ function PriorSuggestionItem({
 
     return (
         <motion.li
+            ref={rowRef}
             layout
             // Larger initial y offset so a newly-added suggestion
             // visually "drops in" from the Add-a-suggestion form
@@ -758,9 +885,16 @@ function PriorSuggestionItem({
                 // Row itself gained focus (not a descendant).
                 if (e.currentTarget === e.target) {
                     setHoveredSuggestion(idx);
+                    setIsRowFocused(true);
                 }
             }}
             onBlur={e => {
+                // Row-level focus left (whether or not focus stays
+                // inside the row via pills/×, the row itself is no
+                // longer the focused element).
+                if (e.target === e.currentTarget) {
+                    setIsRowFocused(false);
+                }
                 // Keep the cross-panel highlight while focus stays
                 // anywhere inside the row (pills / popovers / ×).
                 const next = e.relatedTarget as Node | null;
@@ -854,9 +988,15 @@ function PriorSuggestionItem({
                                 options={suggesterOpts}
                                 selected={s.suggester}
                                 onCommit={value => {
-                                    if (!isNobody(value))
+                                    if (!isNobody(value)) {
                                         commit({ suggester: value });
-                                    setOpenPillId(null);
+                                        advanceFrom(`suggester-${s.id}`, {
+                                            ...s,
+                                            suggester: value,
+                                        });
+                                    } else {
+                                        setOpenPillId(null);
+                                    }
                                 }}
                                 nobodyLabel={null}
                                 nobodyValue={null}
@@ -888,11 +1028,16 @@ function PriorSuggestionItem({
                                         selected={cardId}
                                         onCommit={value => {
                                             if (!isNobody(value)) {
-                                                const next = [...s.cards];
-                                                next[i] = value;
-                                                commit({ cards: next });
+                                                const nextCards = [...s.cards];
+                                                nextCards[i] = value;
+                                                commit({ cards: nextCards });
+                                                advanceFrom(pid, {
+                                                    ...s,
+                                                    cards: nextCards,
+                                                });
+                                            } else {
+                                                setOpenPillId(null);
                                             }
-                                            setOpenPillId(null);
                                         }}
                                         nobodyLabel={null}
                                         nobodyValue={null}
@@ -920,7 +1065,25 @@ function PriorSuggestionItem({
                                 nobodyChosen={false}
                                 nobodyLabel={t("popoverNobodyPassed")}
                                 commitHint={t("popoverCommitHint")}
-                                onCommit={commitPassers}
+                                onCommit={(value, opts) => {
+                                    commitPassers(value);
+                                    // MultiSelectList fires an
+                                    // `advance: false` commit from its
+                                    // unmount cleanup (to persist
+                                    // toggled state on outside-click /
+                                    // Esc / arrow-nav-away). Auto-
+                                    // advancing there would hijack the
+                                    // very nav that caused the unmount
+                                    // and open the wrong pill.
+                                    if (opts?.advance === false) return;
+                                    const nextNonRefuters = isNobody(value)
+                                        ? []
+                                        : Array.from(new Set(value));
+                                    advanceFrom(`passers-${s.id}`, {
+                                        ...s,
+                                        nonRefuters: nextNonRefuters,
+                                    });
+                                }}
                             />
                         </PillPopover>
 
@@ -948,7 +1111,24 @@ function PriorSuggestionItem({
                                 selected={s.refuter ?? null}
                                 onCommit={value => {
                                     commitRefuter(value);
-                                    setOpenPillId(null);
+                                    // Post-commit shape: nobody clears both
+                                    // refuter and seenCard; otherwise refuter
+                                    // is set (keep any existing seenCard —
+                                    // the error banner will surface a stale
+                                    // pairing if the user later fixes it).
+                                    const nextS: DraftSuggestion = isNobody(
+                                        value,
+                                    )
+                                        ? (() => {
+                                              const {
+                                                  refuter: _r,
+                                                  seenCard: _sc,
+                                                  ...rest
+                                              } = s;
+                                              return rest;
+                                          })()
+                                        : { ...s, refuter: value };
+                                    advanceFrom(`refuter-${s.id}`, nextS);
                                 }}
                                 nobodyLabel={t("popoverNobodyRefuted")}
                                 nobodyValue={NOBODY}
@@ -984,6 +1164,9 @@ function PriorSuggestionItem({
                                 selected={s.seenCard ?? null}
                                 onCommit={value => {
                                     commitSeenCard(value);
+                                    // seenCard is the last pill — no
+                                    // advance target; just close the
+                                    // popover.
                                     setOpenPillId(null);
                                 }}
                                 nobodyLabel={t("popoverNoShownCard")}
@@ -1025,14 +1208,39 @@ function PriorSuggestionItem({
                                 ),
                             })}
                         </div>
+                        {!isDesktop && (
+                            <div
+                                className={
+                                    "mt-0.5 text-[11px] " +
+                                    (isHighlighted
+                                        ? "text-white/70"
+                                        : "text-muted")
+                                }
+                            >
+                                {t("priorRowHintMobile")}
+                            </div>
+                        )}
                     </>
+                )}
+                {isDesktop && isRowFocused && !isKeyboardEditing && (
+                    <div
+                        className={
+                            "mt-0.5 text-[11px] " +
+                            (isHighlighted ? "text-white/70" : "text-muted")
+                        }
+                    >
+                        {t("priorRowHintDesktop")}
+                    </div>
                 )}
             </div>
             <button
                 type="button"
                 aria-label={t("removeAction")}
                 className={
-                    "absolute right-1.5 top-1 cursor-pointer rounded border-none bg-transparent px-1 text-[16px] leading-none " +
+                    "absolute cursor-pointer rounded border-none bg-transparent leading-none " +
+                    (isDesktop
+                        ? "right-1.5 top-1 px-1 text-[16px] "
+                        : "right-0.5 top-0.5 min-h-[32px] min-w-[32px] px-2 py-1 text-[22px] ") +
                     (isHighlighted
                         ? "text-white/70 hover:text-white"
                         : "text-muted hover:text-accent")

--- a/src/ui/state.tsx
+++ b/src/ui/state.tsx
@@ -652,8 +652,11 @@ export function ClueProvider({ children }: { children: ReactNode }) {
     );
 
     // Cmd/Ctrl+L: jump to the Prior suggestions log. Focuses the
-    // first suggestion row if any exist so the user can immediately
-    // use ↑↓ — otherwise falls back to the section header (empty state).
+    // first rendered row so the user can immediately use ↑↓ — "first"
+    // means first in DOM order, not `data-suggestion-row="0"`, since
+    // the list is rendered newest-first and could be reordered later
+    // without touching this shortcut. Falls back to the section
+    // header when the list is empty.
     useGlobalShortcut(
         "global.gotoPriorLog",
         useCallback(() => {
@@ -667,7 +670,7 @@ export function ClueProvider({ children }: { children: ReactNode }) {
                     block: "start",
                 });
                 const firstRow = document.querySelector<HTMLElement>(
-                    "[data-suggestion-row='0']",
+                    "[data-suggestion-row]",
                 );
                 if (firstRow) {
                     firstRow.focus({ preventScroll: true });


### PR DESCRIPTION
## Behavior changes

**Setup-mode checklist grid**
- Player-name header inputs, hand-size inputs, and card-name inputs now participate in arrow-key grid navigation alongside the Y/N cells — Up/Down/Left/Right walks between them naturally.
- Cmd/Ctrl + Arrow jumps to the edge of the grid in that direction (top / bottom / leftmost / rightmost). If the exact edge cell is empty for that row/column (e.g. Case File column has no player-name row), focus lands on the nearest cell in that direction.
- Inside text inputs, Left/Right only jumps cells at the text boundary — mid-string editing still moves the cursor normally. Shift/Alt+Arrow stays with the browser for selection / word-skip.

**Prior-suggestion row (edit + delete)**
- Row now shows a focus-scoped "Press Enter to edit" hint on desktop and a persistent "Tap to edit" hint on mobile.
- × delete button gets a ≥32px tap target on mobile; the keyboard-shortcut legend above the list is desktop-only.
- Inline pill row supports the same keyboard behavior as the Add form: ArrowLeft/Right walks between pills (works on the trigger and inside open popovers), and committing a value auto-advances to the next enabled pill.

**⌘L shortcut**
- Now focuses whichever row is first in DOM order (the top of the list) instead of `data-suggestion-row="0"`, so it always lands on the visually top row regardless of sort order. Empty-state still falls back to the section header.

## Commits

- `Extend keyboard nav in the checklist and prior-suggestion edit flow` — adds `GridBounds` / `navigateGrid` helper in `Checklist.tsx` and wires it into `PlayerNameInput`, the hand-size `<input>`, and `InlineTextEdit` (guarded by `data-cell-row` / `data-cell-col` attributes on each input). Adds `pillIds` + `advanceFrom` + a scoped document-level ArrowLeft/Right listener in `PriorSuggestionItem` and routes each `onCommit` through `advanceFrom`, respecting `MultiSelectList`'s `{ advance: false }` unmount callback. Scopes `SuggestionForm`'s popover detection to its own form root so prior-suggestion popovers don't trip it. Adds `priorRowHintDesktop` / `priorRowHintMobile` i18n keys and gates the header legend + row hint + enlarged × button on `useIsDesktop`.
- `Focus top-of-list row on Cmd/Ctrl+L instead of index 0` — swaps `[data-suggestion-row='0']` for `[data-suggestion-row]` in `state.tsx` so the shortcut picks the first DOM-rendered row.

## Verification

- `pnpm typecheck` · `pnpm lint` · `pnpm test` (128 passing) · `pnpm knip` · `pnpm i18n:check` — all green.
- Manual browser verification via `preview_start` / `preview_eval`: setup-mode arrow nav through player-name / hand-size / card-name cells (including Cmd+Arrow edge jumps and the text-boundary rule), prior-suggestion ArrowLeft/Right walk in both directions across all 7 pills, commit-advance on Enter, row-focus hint visibility, mobile resize (hint switches to "Tap to edit", × button measures 32×35), and ⌘L focusing the top row from both Suggest and Setup modes with an empty-state fallback to the header.