### PR TITLE
Note pnpm install in CLAUDE.md and tighten ESLint ignore globs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,23 @@
 
 Use `pnpm` for everything. Never `npm`, `yarn`, or `bun`.
 
+## Install dependencies
+
+Run `pnpm install` from the repo root before anything else — immediately after cloning, after switching branches, and whenever `package.json` or `pnpm-lock.yaml` changes. Every script in this repo reads from `node_modules` and will error out if it hasn't been populated.
+
+Scripts that require `pnpm install`:
+
+- `pnpm typecheck` — TypeScript (`tsc --noEmit`)
+- `pnpm lint` — ESLint (with `eslint-plugin-i18next`)
+- `pnpm test` / `pnpm test:debug` — Jest test runner
+- `pnpm knip` — unused-exports audit
+- `pnpm i18n:check` — orphan-key audit (`scripts/check-i18n-keys.mjs`)
+- `pnpm dev` — Next.js dev server (used by the `next-dev` preview)
+- `pnpm build` — static export
+- `pnpm start` — serve the static export
+
+The `next-dev` preview configured in `.claude/launch.json` runs `pnpm install && pnpm dev` itself, so previews are self-healing — but the pre-commit checks above are not. If any of them fails with a module-not-found error, run `pnpm install` first and retry.
+
 ## Verification checks
 
 All of these must pass green before every commit:

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -32,12 +32,13 @@ const pluginHtmlEntitiesRegex = require(
 export default [
     {
         ignores: [
-            ".next/**",
-            "node_modules/**",
-            "coverage/**",
-            "dist/**",
-            "out/**",
-            "messages/**",
+            "**/.next/**",
+            "**/node_modules/**",
+            "**/coverage/**",
+            "**/dist/**",
+            "**/out/**",
+            "**/messages/**",
+            "**/.claude/worktrees/**",
         ],
     },
     {


### PR DESCRIPTION
## Summary

Two small tidy-ups from a larger backlog:

- `CLAUDE.md` now tells future contributors (and agents) to run `pnpm install` before anything else. Every script in this repo reads from `node_modules`, so a fresh clone/worktree fails loudly on the pre-commit checks before CLAUDE.md's instructions can help — adding an "Install dependencies" section between "Package manager" and "Verification checks" enumerates the affected scripts exhaustively.
- ESLint's flat-config `ignores` list now uses `**/`-prefixed globs. Previously, running `pnpm lint` from inside one git worktree surfaced errors from *other* worktrees' `.next/` artifacts (the top-level `.next/**` pattern didn't match nested children). Also adds an explicit `**/.claude/worktrees/**` entry as belt-and-suspenders.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint` — still clean, no longer leaks sibling-worktree noise
- [x] `pnpm test` — 128 tests pass across 13 suites
- [x] `pnpm knip`
- [x] `pnpm i18n:check`

## Commits

- `Remind future contributors to run pnpm install` — CLAUDE.md section enumerating every script gated on `node_modules`.
- `Stop linting sibling worktrees under .claude/worktrees/` — prefix ignore globs with `**/` and add `**/.claude/worktrees/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)