### PR TITLE
Allowlist read-only and common pnpm/preview commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,32 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm install)",
+      "Bash(pnpm typecheck)",
+      "Bash(pnpm test)",
+      "Bash(pnpm test *)",
+      "Bash(pnpm knip)",
+      "Bash(pnpm lint)",
+      "Bash(pnpm i18n:check)",
+      "Bash(pnpm view *)",
+      "Bash(git commit)",
+      "Bash(git commit *)",
+      "Bash(git push)",
+      "Bash(git push -u *)",
+      "Bash(gh pr create)",
+      "Bash(gh pr create *)",
+      "Bash(gh pr edit)",
+      "Bash(gh pr edit *)",
+      "mcp__Claude_Preview__preview_screenshot",
+      "mcp__Claude_Preview__preview_console_logs",
+      "mcp__Claude_Preview__preview_snapshot",
+      "mcp__Claude_Preview__preview_list",
+      "mcp__Claude_Preview__preview_logs",
+      "mcp__Claude_Preview__preview_click",
+      "mcp__Claude_Preview__preview_fill",
+      "mcp__Claude_Preview__preview_resize",
+      "mcp__Claude_Preview__preview_start",
+      "mcp__Claude_Preview__preview_stop"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Cuts permission prompts for the commands Claude Code runs most often in this repo. The allowlist is scoped so any compound command containing something dangerous still prompts.

**What runs without prompting now:**
- The full pre-commit green-check chain: `pnpm typecheck`, `pnpm lint`, `pnpm test`, `pnpm knip`, `pnpm i18n:check`
- `pnpm install` (exact only — adding a package still prompts)
- `pnpm test <path>` for running a single test file
- `pnpm view <pkg>` for registry lookups
- `git commit` — agents can commit on their own branch
- `git push` (plain) and `git push -u origin <branch>` for initial feature-branch publish
- `gh pr create` — agents can open their own PRs
- `gh pr edit` — agents can update their PR's title/body post-open
- Claude Preview MCP tools for observing and driving the preview browser: `preview_screenshot`, `preview_console_logs`, `preview_snapshot`, `preview_list`, `preview_logs`, `preview_click`, `preview_fill`, `preview_resize`, `preview_start`, `preview_stop`

**What still prompts (by design):**
- `pnpm install <pkg>` — prevents silent package additions
- `pnpm build` — produces build artifacts
- Anything in `pnpm exec …` or raw interpreter invocations
- `git add`, `git rebase`, `git reset`, `git checkout`, and other mutating git commands
- Compound commands that include a non-allowlisted segment (e.g. `pnpm test && rm -rf dist`)

**Known limitation:** Claude Code's permission patterns are glob-prefix matches, so `Bash(git push -u *)` also matches `git push -u origin <branch> --force`. In practice Claude won't construct a force-push unless explicitly asked, but worth knowing.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `pnpm knip`
- [x] `pnpm i18n:check`

## Commits

- `Allowlist read-only and common pnpm/preview commands` — creates `.claude/settings.json` with `permissions.allow` covering the 5 pre-commit pnpm scripts, `pnpm install` (exact), `pnpm test *`, `pnpm view *`, `git commit`/`git push`/`gh pr create`/`gh pr edit` (so agents can self-publish PRs), and 10 Claude Preview MCP tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)