### PR TITLE
Unify Add and Edit suggestion forms behind one SuggestionForm

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -187,6 +187,8 @@
         "pillErrorRefuterInPassers": "Refuter cannot also have passed",
         "submitDisabledFillIn": "Fill in {fields} to add",
         "submitDisabledFixError": "Fix the {fields} before adding",
+        "submitDisabledFillInUpdate": "Fill in {fields} to update",
+        "submitDisabledFixErrorUpdate": "Fix the {fields} before updating",
         "popoverNobodyPassed": "Nobody passed",
         "popoverNobodyRefuted": "Nobody refuted",
         "popoverNoShownCard": "Unknown / unseen",

--- a/src/ui/components/SuggestionForm.tsx
+++ b/src/ui/components/SuggestionForm.tsx
@@ -2,8 +2,10 @@
 
 import { useTranslations } from "next-intl";
 import {
+    forwardRef,
     useCallback,
     useEffect,
+    useImperativeHandle,
     useMemo,
     useRef,
     useState,
@@ -13,7 +15,6 @@ import type { GameSetup } from "../../logic/GameSetup";
 import { categoryOfCard } from "../../logic/GameSetup";
 import type { Card, Player } from "../../logic/GameObjects";
 import { newSuggestionId } from "../../logic/Suggestion";
-import { registerSuggestionFormFocusHandler } from "../suggestionFormFocus";
 import { label, matches } from "../keyMap";
 import { Tooltip } from "./Tooltip";
 import {
@@ -34,6 +35,66 @@ import {
     pillStatusForPlayer,
     SingleSelectList,
 } from "./SuggestionPills";
+
+/**
+ * Imperative handle exposed via `ref` so callers can drive focus
+ * without baking global keyboard bindings into the form. Used by the
+ * Add-suggestion mount to honour the Cmd+K shortcut.
+ */
+export interface SuggestionFormHandle {
+    readonly focusFirstPill: (options?: { readonly clear?: boolean }) => void;
+}
+
+interface SuggestionFormProps {
+    readonly setup: GameSetup;
+    readonly suggestion?: DraftSuggestion;
+    readonly onSubmit: (draft: DraftSuggestion) => void;
+    readonly onCancel?: () => void;
+    /**
+     * `"onAccent"` flips the form's interior styling for use inside a
+     * red-bg edit row: pills render light-on-red, the submit button
+     * inverts to a light pill on accent, and the form's own outer
+     * spacing collapses (the row owns the chrome).
+     */
+    readonly variant?: "default" | "onAccent";
+    /** Hide the h3 title (used inline within an existing row). */
+    readonly showHeader?: boolean;
+    /** Hide the top-right "× Clear inputs" link. */
+    readonly showClearInputs?: boolean;
+    /**
+     * Per-pill clear (×) affordance for the optional pills. Each flag,
+     * when true AND the corresponding field has a value, renders a
+     * tiny × on the pill chip itself (see `PillPopover.onClear`).
+     */
+    readonly pillClearable?: {
+        readonly passers?: boolean;
+        readonly refuter?: boolean;
+        readonly seenCard?: boolean;
+    };
+    /**
+     * Drives the submit button label and the disabled-tooltip phrasing.
+     * Defaults to `"update"` when `suggestion` is provided, otherwise
+     * `"add"`.
+     */
+    readonly submitLabel?: "add" | "update";
+    /**
+     * Optional outer element whose focus also counts as "in the form"
+     * for Cmd+Enter. The inline-edit row passes its `<li>` ref here so
+     * Cmd+Enter from anywhere in the row (including the row itself)
+     * commits the draft. Each form keeps its own scope, so two forms
+     * mounted at once never both fire on the same shortcut.
+     */
+    readonly keyboardScopeRef?: React.RefObject<HTMLElement | null>;
+    /**
+     * Fired after a successful submit, deferred via `setTimeout(_, 0)`
+     * so the caller's `onSubmit` state changes (and any unmount they
+     * trigger) have flushed first. Lets the caller place focus on an
+     * element that survives the commit — e.g. the inline-edit row
+     * refocuses its `<li>` here so the just-edited row keeps keyboard
+     * context after the form unmounts.
+     */
+    readonly afterSubmit?: () => void;
+}
 
 /**
  * Pill-driven form for composing (or editing) a suggestion.
@@ -69,17 +130,29 @@ import {
  * "no card shown" state — distinct from "not decided yet" — and the
  * pill renders a checked `✓` instead of the dashed outline.
  */
-export function SuggestionForm({
-    setup,
-    suggestion,
-    onSubmit,
-    onCancel,
-}: {
-    readonly setup: GameSetup;
-    readonly suggestion?: DraftSuggestion;
-    readonly onSubmit: (draft: DraftSuggestion) => void;
-    readonly onCancel?: () => void;
-}): React.ReactElement {
+export const SuggestionForm = forwardRef<
+    SuggestionFormHandle,
+    SuggestionFormProps
+>(function SuggestionForm(
+    {
+        setup,
+        suggestion,
+        onSubmit,
+        onCancel,
+        variant = "default",
+        showHeader = true,
+        showClearInputs = true,
+        pillClearable,
+        submitLabel,
+        keyboardScopeRef,
+        afterSubmit,
+    },
+    ref,
+): React.ReactElement {
+    const effectiveSubmitLabel: "add" | "update" =
+        // eslint-disable-next-line i18next/no-literal-string -- internal mode discriminator
+        submitLabel ?? (suggestion !== undefined ? "update" : "add");
+    const onAccent = variant === "onAccent";
     const t = useTranslations("suggestions");
 
     // --- Form state ----------------------------------------------------
@@ -298,9 +371,12 @@ export function SuggestionForm({
         if (canSubmit) return undefined;
         if (errors.size > 0) {
             const fields = Array.from(errors.keys()).map(pillLabelFor);
-            return t("submitDisabledFixError", {
-                fields: formatFieldList(fields),
-            });
+            return t(
+                effectiveSubmitLabel === "update"
+                    ? "submitDisabledFixErrorUpdate"
+                    : "submitDisabledFixError",
+                { fields: formatFieldList(fields) },
+            );
         }
         const missing: Array<string> = [];
         if (form.suggester === null) missing.push(t("pillSuggester"));
@@ -310,10 +386,21 @@ export function SuggestionForm({
             }
         });
         if (missing.length === 0) return undefined;
-        return t("submitDisabledFillIn", {
-            fields: formatFieldList(missing),
-        });
-    }, [canSubmit, errors, form, setup.categories, pillLabelFor, t]);
+        return t(
+            effectiveSubmitLabel === "update"
+                ? "submitDisabledFillInUpdate"
+                : "submitDisabledFillIn",
+            { fields: formatFieldList(missing) },
+        );
+    }, [
+        canSubmit,
+        errors,
+        form,
+        setup.categories,
+        pillLabelFor,
+        t,
+        effectiveSubmitLabel,
+    ]);
 
     const doSubmit = useCallback(() => {
         if (!canSubmit || draft === null) return;
@@ -325,28 +412,37 @@ export function SuggestionForm({
             setForm(emptyFormState(setup));
             setOpenPillId(PILL_SUGGESTER);
         }
-    }, [canSubmit, draft, onSubmit, suggestion, setup]);
+        if (afterSubmit !== undefined) {
+            // Defer past React's commit (and any unmount the parent's
+            // onSubmit triggered). setTimeout puts this on the
+            // macrotask queue, so it always lands after the current
+            // task's microtasks — including React's batched flush.
+            setTimeout(afterSubmit, 0);
+        }
+    }, [canSubmit, draft, onSubmit, suggestion, setup, afterSubmit]);
 
     /**
      * Cmd/Ctrl+Enter submits from anywhere inside the form —
-     * including inside any open popover content. The popovers render
-     * in a Radix Portal, so we catch the event at the document level
-     * only while the form is mounted AND a popover is open OR focus
-     * is within the form root.
+     * including inside any open popover content, and (when the parent
+     * widens it via `keyboardScopeRef`) inside the wrapping container
+     * such as the inline-edit row's `<li>`. Each form keeps its own
+     * scope so two mounted forms never both fire.
      */
     const formRootRef = useRef<HTMLDivElement>(null);
     useEffect(() => {
         const onKeyDown = (e: KeyboardEvent) => {
             if (!matches("action.submit", e)) return;
-            // Only handle if focus is inside our form root or in any
-            // Radix portal popover owned by our form (we check by
-            // walking up from the focused element).
             const active = document.activeElement as Element | null;
             const root = formRootRef.current;
+            const scope = keyboardScopeRef?.current ?? null;
             if (
                 !root ||
                 !active ||
-                !(root.contains(active) || isInsideSuggestionPopover(active))
+                !(
+                    root.contains(active) ||
+                    isInsideSuggestionPopover(active) ||
+                    (scope !== null && scope.contains(active))
+                )
             ) {
                 return;
             }
@@ -355,7 +451,7 @@ export function SuggestionForm({
         };
         document.addEventListener("keydown", onKeyDown);
         return () => document.removeEventListener("keydown", onKeyDown);
-    }, [doSubmit]);
+    }, [doSubmit, keyboardScopeRef]);
 
     /**
      * Pill-to-pill navigation keys. ArrowLeft/Right and Tab/Shift+Tab
@@ -465,45 +561,87 @@ export function SuggestionForm({
         setOpenPillId(null);
     }, [setup]);
 
-    // Cmd/Ctrl+K shortcut: the global listener in ClueProvider calls
-    // `requestFocusSuggestionForm`; we register the actual focus/clear
-    // action here so it runs against our local state.
-    useEffect(() => {
-        return registerSuggestionFormFocusHandler(({ clear }) => {
-            if (clear) setForm(emptyFormState(setup));
-            setOpenPillId(PILL_SUGGESTER);
-        });
-    }, [setup]);
+    // Imperative handle: callers (e.g. AddSuggestion wiring up the
+    // global Cmd+K shortcut) drive focus through `focusFirstPill`. The
+    // form itself stays oblivious to global keyboard bindings.
+    useImperativeHandle(
+        ref,
+        () => ({
+            focusFirstPill: ({ clear } = {}) => {
+                if (clear === true) setForm(emptyFormState(setup));
+                setOpenPillId(PILL_SUGGESTER);
+            },
+        }),
+        [setup],
+    );
+
+    // Per-pill clear callbacks for the optional pills. Wired into the
+    // `pillClearable` prop — each callback resets that field (and any
+    // dependent fields, e.g. clearing refuter must also clear seenCard
+    // because PILL_SEEN becomes unreachable).
+    const onClearPassers = useCallback(
+        () => setForm(f => ({ ...f, nonRefuters: null })),
+        [],
+    );
+    const onClearRefuter = useCallback(
+        () => setForm(f => ({ ...f, refuter: null, seenCard: null })),
+        [],
+    );
+    const onClearSeenCard = useCallback(
+        () => setForm(f => ({ ...f, seenCard: null })),
+        [],
+    );
 
     // --- Render --------------------------------------------------------
+    const showHeaderBar = showHeader || showClearInputs;
+    // Submit button styling. On the default form: filled accent when
+    // active, muted-fill when blocked. On the onAccent variant (sitting
+    // inside a red-bg row): invert to a light pill on accent so the
+    // button reads as a distinct primary action against the same
+    // background colour.
+    const submitButtonClass =
+        "rounded border-none px-3 py-2 text-[13px] " +
+        (onAccent
+            ? canSubmit
+                ? "cursor-pointer bg-panel text-accent"
+                : "cursor-not-allowed bg-panel/40 text-accent/60"
+            : canSubmit
+              ? "cursor-pointer bg-accent text-white"
+              : "cursor-not-allowed bg-unknown-bg text-muted/70");
     return (
         <div ref={formRootRef}>
-            <div className="mb-2 flex items-center justify-between gap-2">
-                <h3 className="mt-0 mb-0 text-[14px] font-semibold">
-                    {suggestion !== undefined
-                        ? t("editTitle")
-                        : t.rich("addTitle", {
-                              shortcutKey: label("global.gotoPlay"),
-                              shortcut: chunks => (
-                                  <span className="font-normal text-muted">
-                                      {chunks}
-                                  </span>
-                              ),
-                          })}
-                </h3>
-                {hasAnyInput && (
-                    <button
-                        type="button"
-                        onClick={onClearInputs}
-                        className="inline-flex cursor-pointer items-center gap-1 border-none bg-transparent p-0 text-[12px] text-muted hover:text-accent"
-                    >
-                        <span aria-hidden className="text-[14px] leading-none">
-                            ×
-                        </span>
-                        {t("clearInputs")}
-                    </button>
-                )}
-            </div>
+            {showHeaderBar && (
+                <div className="mb-2 flex items-center justify-between gap-2">
+                    {showHeader ? (
+                        <h3 className="mt-0 mb-0 text-[14px] font-semibold">
+                            {suggestion !== undefined
+                                ? t("editTitle")
+                                : t.rich("addTitle", {
+                                      shortcutKey: label("global.gotoPlay"),
+                                      shortcut: chunks => (
+                                          <span className="font-normal text-muted">
+                                              {chunks}
+                                          </span>
+                                      ),
+                                  })}
+                        </h3>
+                    ) : (
+                        <span />
+                    )}
+                    {showClearInputs && hasAnyInput && (
+                        <button
+                            type="button"
+                            onClick={onClearInputs}
+                            className="inline-flex cursor-pointer items-center gap-1 border-none bg-transparent p-0 text-[12px] text-muted hover:text-accent"
+                        >
+                            <span aria-hidden className="text-[14px] leading-none">
+                                ×
+                            </span>
+                            {t("clearInputs")}
+                        </button>
+                    )}
+                </div>
+            )}
             <div className="flex flex-wrap items-center gap-1.5">
                 {/* Suggester pill */}
                 <PillPopover
@@ -512,6 +650,7 @@ export function SuggestionForm({
                     status={pillStatusForPlayer(form.suggester, false)}
                     valueDisplay={displayPlayer(form.suggester)}
                     errorReason={errorReasonFor(PILL_SUGGESTER)}
+                    variant={variant}
                     open={openPillId === PILL_SUGGESTER}
                     onOpenChange={onOpenChangeFor(PILL_SUGGESTER)}
                 >
@@ -536,6 +675,7 @@ export function SuggestionForm({
                             setup,
                         )}
                         errorReason={errorReasonFor(`card-${i}` as PillId)}
+                        variant={variant}
                         open={openPillId === (`card-${i}` as PillId)}
                         onOpenChange={onOpenChangeFor(
                             `card-${i}` as PillId,
@@ -561,8 +701,13 @@ export function SuggestionForm({
                     status={pillStatusForPassers(form.nonRefuters)}
                     valueDisplay={displayPassers(form.nonRefuters, t)}
                     errorReason={errorReasonFor(PILL_PASSERS)}
+                    variant={variant}
                     open={openPillId === PILL_PASSERS}
                     onOpenChange={onOpenChangeFor(PILL_PASSERS)}
+                    {...(pillClearable?.passers === true &&
+                    form.nonRefuters !== null
+                        ? { onClear: onClearPassers }
+                        : {})}
                 >
                     <MultiSelectList
                         options={passersOptions(setup, form)}
@@ -588,8 +733,12 @@ export function SuggestionForm({
                     status={pillStatusForPlayer(form.refuter, true)}
                     valueDisplay={displayPlayerOpt(form.refuter, t)}
                     errorReason={errorReasonFor(PILL_REFUTER)}
+                    variant={variant}
                     open={openPillId === PILL_REFUTER}
                     onOpenChange={onOpenChangeFor(PILL_REFUTER)}
+                    {...(pillClearable?.refuter === true && form.refuter !== null
+                        ? { onClear: onClearRefuter }
+                        : {})}
                 >
                     <SingleSelectList<Player>
                         options={refuterOptions(setup, form)}
@@ -611,8 +760,12 @@ export function SuggestionForm({
                     disabled={isPillDisabled(PILL_SEEN)}
                     disabledHint={t("pillSeenDisabledHint")}
                     errorReason={errorReasonFor(PILL_SEEN)}
+                    variant={variant}
                     open={openPillId === PILL_SEEN}
                     onOpenChange={onOpenChangeFor(PILL_SEEN)}
+                    {...(pillClearable?.seenCard === true && form.seenCard !== null
+                        ? { onClear: onClearSeenCard }
+                        : {})}
                 >
                     <SingleSelectList<Card>
                         options={suggestedCardOptions(form, setup)}
@@ -626,9 +779,9 @@ export function SuggestionForm({
                 </PillPopover>
 
                 {/*
-                  * Add button lives inline with the pills so the whole
-                  * form reads as a single row. Matches the pill height
-                  * (px-3 py-2 text-[13px]) but keeps the default
+                  * Add/Update button lives inline with the pills so the
+                  * whole form reads as a single row. Matches the pill
+                  * height (px-3 py-2 text-[13px]) but keeps the default
                   * `rounded` radius instead of `rounded-full`, so it
                   * reads as a squared-off primary action distinct from
                   * the round pills.
@@ -637,16 +790,16 @@ export function SuggestionForm({
                     <button
                         type="button"
                         ref={submitBtnRef}
-                        className={
-                            "rounded border-none px-3 py-2 text-[13px] " +
-                            (canSubmit
-                                ? "cursor-pointer bg-accent text-white"
-                                : "cursor-not-allowed bg-unknown-bg text-muted/70")
-                        }
+                        className={submitButtonClass}
                         aria-disabled={!canSubmit}
                         onClick={doSubmit}
                     >
-                        {t("submit", { shortcut: label("action.submit") })}
+                        {t(
+                            effectiveSubmitLabel === "update"
+                                ? "updateAction"
+                                : "submit",
+                            { shortcut: label("action.submit") },
+                        )}
                     </button>
                 </Tooltip>
                 {onCancel !== undefined && (
@@ -661,7 +814,7 @@ export function SuggestionForm({
             </div>
         </div>
     );
-}
+});
 
 // ---- Form state -------------------------------------------------------
 
@@ -777,7 +930,7 @@ export type PillId =
 type OpenTarget = PillId | "submit" | null;
 
 export const PILL_SUGGESTER: PillId = "suggester";
-export const PILL_PASSERS: PillId = "passers";
+const PILL_PASSERS: PillId = "passers";
 export const PILL_REFUTER: PillId = "refuter";
 export const PILL_SEEN: PillId = "seenCard";
 const TARGET_SUBMIT = "submit" as const;
@@ -853,7 +1006,7 @@ export const isPillDisabledFor = (
  * a single suggestion — not external contradictions caught by the
  * solver. `GlobalContradictionBanner` covers the latter.
  */
-export type PillErrorCode =
+type PillErrorCode =
     | "seenCardNotSuggested"
     | "seenCardWithoutRefuter"
     | "suggesterIsRefuter"

--- a/src/ui/components/SuggestionForm.tsx
+++ b/src/ui/components/SuggestionForm.tsx
@@ -50,13 +50,6 @@ interface SuggestionFormProps {
     readonly suggestion?: DraftSuggestion;
     readonly onSubmit: (draft: DraftSuggestion) => void;
     readonly onCancel?: () => void;
-    /**
-     * `"onAccent"` flips the form's interior styling for use inside a
-     * red-bg edit row: pills render light-on-red, the submit button
-     * inverts to a light pill on accent, and the form's own outer
-     * spacing collapses (the row owns the chrome).
-     */
-    readonly variant?: "default" | "onAccent";
     /** Hide the h3 title (used inline within an existing row). */
     readonly showHeader?: boolean;
     /** Hide the top-right "× Clear inputs" link. */
@@ -139,7 +132,6 @@ export const SuggestionForm = forwardRef<
         suggestion,
         onSubmit,
         onCancel,
-        variant = "default",
         showHeader = true,
         showClearInputs = true,
         pillClearable,
@@ -152,7 +144,6 @@ export const SuggestionForm = forwardRef<
     const effectiveSubmitLabel: "add" | "update" =
         // eslint-disable-next-line i18next/no-literal-string -- internal mode discriminator
         submitLabel ?? (suggestion !== undefined ? "update" : "add");
-    const onAccent = variant === "onAccent";
     const t = useTranslations("suggestions");
 
     // --- Form state ----------------------------------------------------
@@ -594,20 +585,11 @@ export const SuggestionForm = forwardRef<
 
     // --- Render --------------------------------------------------------
     const showHeaderBar = showHeader || showClearInputs;
-    // Submit button styling. On the default form: filled accent when
-    // active, muted-fill when blocked. On the onAccent variant (sitting
-    // inside a red-bg row): invert to a light pill on accent so the
-    // button reads as a distinct primary action against the same
-    // background colour.
     const submitButtonClass =
         "rounded border-none px-3 py-2 text-[13px] " +
-        (onAccent
-            ? canSubmit
-                ? "cursor-pointer bg-panel text-accent"
-                : "cursor-not-allowed bg-panel/40 text-accent/60"
-            : canSubmit
-              ? "cursor-pointer bg-accent text-white"
-              : "cursor-not-allowed bg-unknown-bg text-muted/70");
+        (canSubmit
+            ? "cursor-pointer bg-accent text-white"
+            : "cursor-not-allowed bg-unknown-bg text-muted/70");
     return (
         <div ref={formRootRef}>
             {showHeaderBar && (
@@ -650,7 +632,6 @@ export const SuggestionForm = forwardRef<
                     status={pillStatusForPlayer(form.suggester, false)}
                     valueDisplay={displayPlayer(form.suggester)}
                     errorReason={errorReasonFor(PILL_SUGGESTER)}
-                    variant={variant}
                     open={openPillId === PILL_SUGGESTER}
                     onOpenChange={onOpenChangeFor(PILL_SUGGESTER)}
                 >
@@ -675,7 +656,6 @@ export const SuggestionForm = forwardRef<
                             setup,
                         )}
                         errorReason={errorReasonFor(`card-${i}` as PillId)}
-                        variant={variant}
                         open={openPillId === (`card-${i}` as PillId)}
                         onOpenChange={onOpenChangeFor(
                             `card-${i}` as PillId,
@@ -701,7 +681,6 @@ export const SuggestionForm = forwardRef<
                     status={pillStatusForPassers(form.nonRefuters)}
                     valueDisplay={displayPassers(form.nonRefuters, t)}
                     errorReason={errorReasonFor(PILL_PASSERS)}
-                    variant={variant}
                     open={openPillId === PILL_PASSERS}
                     onOpenChange={onOpenChangeFor(PILL_PASSERS)}
                     {...(pillClearable?.passers === true &&
@@ -733,7 +712,6 @@ export const SuggestionForm = forwardRef<
                     status={pillStatusForPlayer(form.refuter, true)}
                     valueDisplay={displayPlayerOpt(form.refuter, t)}
                     errorReason={errorReasonFor(PILL_REFUTER)}
-                    variant={variant}
                     open={openPillId === PILL_REFUTER}
                     onOpenChange={onOpenChangeFor(PILL_REFUTER)}
                     {...(pillClearable?.refuter === true && form.refuter !== null
@@ -760,7 +738,6 @@ export const SuggestionForm = forwardRef<
                     disabled={isPillDisabled(PILL_SEEN)}
                     disabledHint={t("pillSeenDisabledHint")}
                     errorReason={errorReasonFor(PILL_SEEN)}
-                    variant={variant}
                     open={openPillId === PILL_SEEN}
                     onOpenChange={onOpenChangeFor(PILL_SEEN)}
                     {...(pillClearable?.seenCard === true && form.seenCard !== null

--- a/src/ui/components/SuggestionLogPanel.editMode.test.tsx
+++ b/src/ui/components/SuggestionLogPanel.editMode.test.tsx
@@ -13,31 +13,41 @@ vi.mock("next-intl", () => {
 });
 
 vi.mock("motion/react", () => {
+    // Memoize per tag — without this, every access to `motion.li` (etc.)
+    // returns a *new* forwardRef component, so React sees a new
+    // component type on every render and unmounts/remounts the DOM
+    // node. That breaks anything that depends on a stable element
+    // across renders, like keyboard focus on the row.
+    const motionCache: Record<string, React.ComponentType<unknown>> = {};
     const motion = new Proxy(
         {},
         {
-            get: (_t, tag: string) =>
-                forwardRef(
-                    (
-                        props: Record<string, unknown>,
-                        ref: React.Ref<HTMLElement>,
-                    ) => {
-                        const {
-                            layout: _layout,
-                            layoutId: _layoutId,
-                            initial: _initial,
-                            animate: _animate,
-                            exit: _exit,
-                            transition: _transition,
-                            variants: _variants,
-                            custom: _custom,
-                            whileHover: _whileHover,
-                            whileTap: _whileTap,
-                            ...rest
-                        } = props;
-                        return createElement(tag, { ...rest, ref });
-                    },
-                ),
+            get: (_t, tag: string) => {
+                if (motionCache[tag] === undefined) {
+                    motionCache[tag] = forwardRef(
+                        (
+                            props: Record<string, unknown>,
+                            ref: React.Ref<HTMLElement>,
+                        ) => {
+                            const {
+                                layout: _layout,
+                                layoutId: _layoutId,
+                                initial: _initial,
+                                animate: _animate,
+                                exit: _exit,
+                                transition: _transition,
+                                variants: _variants,
+                                custom: _custom,
+                                whileHover: _whileHover,
+                                whileTap: _whileTap,
+                                ...rest
+                            } = props;
+                            return createElement(tag, { ...rest, ref });
+                        },
+                    ) as React.ComponentType<unknown>;
+                }
+                return motionCache[tag];
+            },
         },
     );
     return {
@@ -213,6 +223,75 @@ describe("PriorSuggestionItem — exiting edit mode", () => {
         fireEvent.pointerDown(cell!);
         fireEvent.click(cell!);
         await waitPillsHidden();
+    });
+});
+
+describe("PriorSuggestionItem — focus restoration after edit ends", () => {
+    test("clicking Update returns focus to the row", async () => {
+        await seedOneSuggestionAndMount();
+        fireEvent.click(getRow());
+        await waitPillsVisible();
+        fireEvent.click(
+            within(getRow()).getByRole("button", { name: /updateAction/ }),
+        );
+        await waitPillsHidden();
+        await waitFor(() => {
+            expect(document.activeElement).toBe(getRow());
+        });
+    });
+
+    test("clicking the × cancel button returns focus to the row", async () => {
+        await seedOneSuggestionAndMount();
+        fireEvent.click(getRow());
+        await waitPillsVisible();
+        fireEvent.click(
+            within(getRow()).getByRole("button", { name: "cancelEditAria" }),
+        );
+        await waitPillsHidden();
+        await waitFor(() => {
+            expect(document.activeElement).toBe(getRow());
+        });
+    });
+});
+
+describe("PriorSuggestionItem — keyboard navigation across disabled pills", () => {
+    test("ArrowRight from refuter (no value) opens the disabled seenCard pill, then Update", async () => {
+        // Bug repro: edit a suggestion whose refuter is unset, so
+        // PILL_SEEN ("Shown card") is disabled. With the old bespoke
+        // nav handler, ArrowRight skipped the disabled pill and never
+        // landed on Update. Sharing SuggestionForm fixes both: the
+        // disabled pill IS focusable (its popover shows the "why
+        // disabled" hint), and Update is the terminal target.
+        await seedOneSuggestionAndMount();
+        fireEvent.click(getRow());
+        await waitPillsVisible();
+        const refuterTrigger = getRow().querySelector<HTMLElement>(
+            "[data-pill-id='refuter']",
+        );
+        expect(refuterTrigger).not.toBeNull();
+        refuterTrigger!.focus();
+        fireEvent.keyDown(document, {
+            key: "ArrowRight",
+            code: "ArrowRight",
+        });
+        const seenTrigger = getRow().querySelector<HTMLElement>(
+            "[data-pill-id='seenCard']",
+        );
+        expect(seenTrigger).not.toBeNull();
+        await waitFor(() => {
+            expect(seenTrigger!.getAttribute("data-state")).toBe("open");
+        });
+        // ArrowRight again → Update button.
+        fireEvent.keyDown(document, {
+            key: "ArrowRight",
+            code: "ArrowRight",
+        });
+        const updateBtn = within(getRow()).getByRole("button", {
+            name: /updateAction/,
+        });
+        await waitFor(() => {
+            expect(document.activeElement).toBe(updateBtn);
+        });
     });
 });
 

--- a/src/ui/components/SuggestionLogPanel.tsx
+++ b/src/ui/components/SuggestionLogPanel.tsx
@@ -661,16 +661,16 @@ function PriorSuggestionItem({
             aria-pressed={isSelected}
             data-suggestion-row={idx}
             className={
-                // Edit mode is a strong fill; cell-cross-highlight and
-                // hover are subtler outline rings. Keyboard focus is
-                // covered by the app-wide `:focus-visible` outline (see
-                // app/globals.css), so we don't add a ring there.
-                "relative flex items-start gap-2 rounded-[var(--radius)] border px-3 py-2 text-[13px] transition-colors cursor-pointer overflow-hidden " +
-                (isEditing
-                    ? "border-accent bg-accent text-white "
-                    : (isHighlightedByCell
-                          ? "border-border ring-2 ring-accent ring-offset-1 ring-offset-panel "
-                          : "border-border hover:ring-2 hover:ring-accent hover:ring-offset-1 hover:ring-offset-panel "))
+                // Edit mode and cell-cross-highlight share the same
+                // outline-ring treatment so the inline form's pill
+                // focus rings stay legible. Keyboard focus on the row
+                // itself is covered by the app-wide `:focus-visible`
+                // outline (see app/globals.css), so we don't add one
+                // here.
+                "relative flex items-start gap-2 rounded-[var(--radius)] border border-border px-3 py-2 text-[13px] transition-colors cursor-pointer overflow-hidden " +
+                (isEditing || isHighlightedByCell
+                    ? "ring-2 ring-accent ring-offset-1 ring-offset-panel "
+                    : "hover:ring-2 hover:ring-accent hover:ring-offset-1 hover:ring-offset-panel ")
             }
             onPointerEnter={onPointerEnter}
             onPointerLeave={onPointerLeave}
@@ -780,7 +780,6 @@ function PriorSuggestionItem({
                             suggestion={s}
                             onSubmit={onCommitEdit}
                             afterSubmit={refocusRow}
-                            variant="onAccent"
                             showHeader={false}
                             showClearInputs={false}
                             pillClearable={{
@@ -855,7 +854,7 @@ function PriorSuggestionItem({
                         exitEdit();
                         refocusRow();
                     }}
-                    className="absolute right-1 top-1 min-h-[44px] min-w-[44px] cursor-pointer rounded border-none bg-transparent px-2 py-1 text-[22px] leading-none text-white/80 hover:text-white"
+                    className="absolute right-1 top-1 min-h-[44px] min-w-[44px] cursor-pointer rounded border-none bg-transparent px-2 py-1 text-[22px] leading-none text-muted hover:text-accent"
                 >
                     ×
                 </button>

--- a/src/ui/components/SuggestionLogPanel.tsx
+++ b/src/ui/components/SuggestionLogPanel.tsx
@@ -4,7 +4,7 @@ import { Effect, Layer, Result } from "effect";
 import { AnimatePresence, motion } from "motion/react";
 import { useTranslations } from "next-intl";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Card, Player } from "../../logic/GameObjects";
+import { Player } from "../../logic/GameObjects";
 import { footnotesForCell } from "../../logic/Footnotes";
 import { cardName } from "../../logic/GameSetup";
 import { chainFor } from "../../logic/Provenance";
@@ -26,37 +26,14 @@ import { useSelection } from "../SelectionContext";
 import { InfoPopover } from "./InfoPopover";
 import {
     SuggestionForm,
-    type FormState,
-    type PillErrorCode,
-    type PillId,
-    PILL_PASSERS,
-    PILL_REFUTER,
-    PILL_SEEN,
-    PILL_SUGGESTER,
-    validateFormConsistency,
+    type SuggestionFormHandle,
 } from "./SuggestionForm";
-import {
-    displayCard,
-    displayCardOpt,
-    displayPassers,
-    displayPlayer,
-    displayPlayerOpt,
-    isInsideSuggestionPopover,
-    isNobody,
-    MultiSelectList,
-    NOBODY,
-    type Nobody,
-    type Option,
-    PillPopover,
-    pillStatusForCard,
-    pillStatusForPassers,
-    pillStatusForPlayer,
-    SingleSelectList,
-} from "./SuggestionPills";
+import { isInsideSuggestionPopover } from "./SuggestionPills";
 import {
     DraftSuggestion,
     useClue,
 } from "../state";
+import { registerSuggestionFormFocusHandler } from "../suggestionFormFocus";
 import {
     T_FAST,
     T_SPRING_SOFT,
@@ -100,12 +77,22 @@ export function SuggestionLogPanel() {
 /**
  * Top of the log: the pill-driven form for composing a new
  * suggestion. Delegates the entire UI to `<SuggestionForm>` — the
- * panel only wires the reducer dispatch.
+ * panel only wires the reducer dispatch and the global Cmd+K shortcut
+ * (the form itself is unaware of any global keybinding).
  */
 function AddSuggestion() {
     const { dispatch, state } = useClue();
+    const formRef = useRef<SuggestionFormHandle>(null);
+    useEffect(
+        () =>
+            registerSuggestionFormFocusHandler(({ clear }) =>
+                formRef.current?.focusFirstPill({ clear }),
+            ),
+        [],
+    );
     return (
         <SuggestionForm
+            ref={formRef}
             setup={state.setup}
             onSubmit={draft =>
                 dispatch({ type: "addSuggestion", suggestion: draft })
@@ -505,17 +492,11 @@ function PriorSuggestionItem({
     const setup = state.setup;
     const listFormatter = useListFormatter();
 
-    const [openPillId, setOpenPillId] = useState<string | null>(null);
     // Explicit edit-mode flag. Decoupled from hover/focus — only set
     // by an unambiguous user gesture (Enter, desktop click, or the
-    // mobile Edit button). Controls whether the row renders pills and
-    // the Update/× buttons.
+    // mobile Edit button). Controls whether the row swaps its idle
+    // sentence pair for the inline `<SuggestionForm>` editor.
     const [isEditing, setIsEditing] = useState(false);
-    // Local buffered edits. `null` when not editing. Pills render
-    // from `draft ?? s` so the display follows unsaved changes, while
-    // the canonical suggestion store is only mutated when the user
-    // clicks Update.
-    const [draft, setDraft] = useState<DraftSuggestion | null>(null);
     // Mobile-only two-step-to-edit state. First tap on a row flips
     // this on and reveals an Edit button; tapping the button is the
     // second step that actually enters edit mode. Irrelevant on
@@ -527,13 +508,6 @@ function PriorSuggestionItem({
     const [isRowFocused, setIsRowFocused] = useState(false);
 
     const isSelected = selectedSuggestionIndex === idx;
-    // Canonical "current values" for this row — buffered draft while
-    // editing, otherwise the stored suggestion.
-    const current: DraftSuggestion = draft ?? s;
-    // Pill-mode is strictly coupled to the edit-mode flag now (plus a
-    // grace window while a pill popover is closing, which lives in
-    // `openPillId`). Hover/focus never flips this on.
-    const isInPillMode = isEditing || openPillId !== null;
 
     // Cell → suggestion cross-highlight (reverse of the Checklist's
     // `cellIsHighlighted`). Two ways a cell can reference a suggestion:
@@ -567,64 +541,6 @@ function PriorSuggestionItem({
         return false;
     }, [activeCell, derived.provenance, derived.footnotes, idx]);
 
-    // Two visual modes, deliberately distinct:
-    //  - editing → filled red accent (strong "you're modifying this")
-    //  - cell-cross-highlight / hover / focus → outline ring only
-    // Pill variant flips to `onAccent` only for the red-bg mode so the
-    // pills remain readable against the filled background.
-    // eslint-disable-next-line i18next/no-literal-string
-    const pillVariant = isEditing ? "onAccent" : "default";
-
-    // Commit helpers now mutate the local draft instead of dispatching
-    // to the store. The store is only written when the user clicks
-    // Update (`commitEdit`), so partial edits and exploratory changes
-    // are cheap to discard.
-    const commit = (patch: Partial<DraftSuggestion>) =>
-        setDraft(d => ({ ...(d ?? s), ...patch }));
-
-    const commitRefuter = (value: Player | Nobody) =>
-        setDraft(d => {
-            const base = d ?? s;
-            if (isNobody(value)) {
-                // Use destructure-without-field trick: exactOptionalPropertyTypes
-                // requires absent key (not `undefined`) for the optional slot.
-                const { refuter: _r, seenCard: _sc, ...rest } = base;
-                return rest;
-            }
-            return { ...base, refuter: value };
-        });
-
-    const commitSeenCard = (value: Card | Nobody) =>
-        setDraft(d => {
-            const base = d ?? s;
-            if (isNobody(value)) {
-                const { seenCard: _sc, ...rest } = base;
-                return rest;
-            }
-            return { ...base, seenCard: value };
-        });
-
-    const commitPassers = (value: ReadonlyArray<Player> | Nobody) =>
-        setDraft(d => ({
-            ...(d ?? s),
-            nonRefuters: isNobody(value) ? [] : Array.from(new Set(value)),
-        }));
-
-    const clearRefuter = () =>
-        setDraft(d => {
-            const base = d ?? s;
-            const { refuter: _r, seenCard: _sc, ...rest } = base;
-            return rest;
-        });
-    const clearSeenCard = () =>
-        setDraft(d => {
-            const base = d ?? s;
-            const { seenCard: _sc, ...rest } = base;
-            return rest;
-        });
-    const clearPassers = () =>
-        setDraft(d => ({ ...(d ?? s), nonRefuters: [] }));
-
     const onRemove = async () => {
         if (await confirm({ message: t("removeConfirm") })) {
             dispatch({ type: "removeSuggestion", id: s.id });
@@ -633,7 +549,6 @@ function PriorSuggestionItem({
 
     const enterEdit = () => {
         setIsEditing(true);
-        setDraft({ ...s });
         setShowMobileEditButton(false);
         // Pin the selection while editing so the grid highlights the
         // cells this suggestion contributed to (via the existing
@@ -641,61 +556,35 @@ function PriorSuggestionItem({
         setSelectedSuggestion(idx);
     };
 
-    const cancelEdit = () => {
+    const exitEdit = () => {
         setIsEditing(false);
-        setDraft(null);
-        setOpenPillId(null);
         setShowMobileEditButton(false);
         if (selectedSuggestionIndex === idx) setSelectedSuggestion(null);
     };
 
-    const commitEdit = () => {
-        const next = draft;
-        setIsEditing(false);
-        setDraft(null);
-        setOpenPillId(null);
-        setShowMobileEditButton(false);
-        if (selectedSuggestionIndex === idx) setSelectedSuggestion(null);
-        if (next !== null) {
-            dispatch({ type: "updateSuggestion", suggestion: next });
-        }
+    // After the edit ends via commit (Update / Cmd+Enter) or the ×
+    // cancel button, the just-active element (Update btn, ×, or a
+    // pill) unmounts; without restoring focus, activeElement falls
+    // back to <body>. Deferring via setTimeout lets React's commit
+    // (and the form's own focus-restoration on unmount) settle first.
+    const refocusRow = () =>
+        setTimeout(() => rowRef.current?.focus(), 0);
+
+    const onCommitEdit = (draft: DraftSuggestion) => {
+        exitEdit();
+        dispatch({ type: "updateSuggestion", suggestion: draft });
     };
 
-    // Option builders mirror the exclusion logic in SuggestionForm:
-    // suggester ↔ refuter ↔ passers are pairwise disjoint in Clue.
-    const playerChoices = (
-        exclude: ReadonlyArray<Player | undefined>,
-    ): ReadonlyArray<Option<Player>> => {
-        const excl = new Set<Player>();
-        for (const p of exclude) if (p !== undefined) excl.add(p);
-        return setup.players
-            .filter(p => !excl.has(p))
-            .map(p => ({ value: p, label: String(p) }));
-    };
-    const suggesterOpts = useMemo(
-        () => playerChoices([current.refuter, ...current.nonRefuters]),
-        [current, setup.players],
-    );
-    const refuterOpts = useMemo(
-        () => playerChoices([current.suggester, ...current.nonRefuters]),
-        [current, setup.players],
-    );
-    const passersOpts = useMemo(
-        () => playerChoices([current.suggester, current.refuter]),
-        [current, setup.players],
-    );
-    const seenCardOpts = useMemo(
-        () =>
-            current.cards.flatMap((id): Array<Option<Card>> => {
-                for (const cat of setup.categories) {
-                    const entry = cat.cards.find(e => e.id === id);
-                    if (entry !== undefined)
-                        return [{ value: id, label: entry.name }];
-                }
-                return [];
-            }),
-        [current.cards, setup.categories],
-    );
+    // Row ref for scoping the outside-click-cancel listener and for
+    // querying open pill popovers (Radix triggers carry
+    // `data-state="open"` so we can detect "any pill popover open in
+    // this row" without subscribing to the form's internal state).
+    const rowRef = useRef<HTMLLIElement>(null);
+
+    const hasOpenPillPopover = (): boolean =>
+        rowRef.current?.querySelector(
+            '[data-pill-id][data-state="open"]',
+        ) !== null;
 
     // Desktop hover preview. Touch never fires these (pointer-type
     // filter) because on iOS Safari tap synthesizes a pointerenter
@@ -708,7 +597,10 @@ function PriorSuggestionItem({
     };
     const onPointerLeave = (e: React.PointerEvent) => {
         if (e.pointerType !== "mouse") return;
-        if (openPillId === null) setHoveredSuggestion(null);
+        // Keep the highlight while a popover (portalled outside the
+        // row) is open — the user is mid-edit and the mouse may be
+        // travelling through the portal back into the row.
+        if (!hasOpenPillPopover()) setHoveredSuggestion(null);
     };
 
     // Click / tap on the row itself. Desktop: one click → edit.
@@ -722,182 +614,6 @@ function PriorSuggestionItem({
             setSelectedSuggestion(idx);
         }
     };
-
-    // Pill open-state toggle shared by every pill on the row.
-    const onOpenChangeFor = (pillId: string) => (open: boolean) => {
-        setOpenPillId(prev =>
-            open ? pillId : prev === pillId ? null : prev,
-        );
-    };
-
-    // Refuter pill disables the Shown card pill when absent (same rule
-    // the Add form uses: can't pick a shown card if nobody refuted).
-    const seenDisabled = current.refuter === undefined;
-
-    // Pill IDs for this row, in visual order. Used by the arrow-key
-    // nav and the advance-on-commit logic that mirror SuggestionForm's
-    // behaviour. The seenCard pill is skipped when disabled (no
-    // refuter).
-    const pillIds = useMemo<ReadonlyArray<string>>(() => {
-        const ids = [`suggester-${s.id}`];
-        setup.categories.forEach((_, i) => {
-            ids.push(`card-${s.id}-${i}`);
-        });
-        ids.push(`passers-${s.id}`);
-        ids.push(`refuter-${s.id}`);
-        ids.push(`seenCard-${s.id}`);
-        return ids;
-    }, [s.id, setup.categories]);
-
-    // `next` defaults to the *current* buffered draft — callers pass a
-    // post-commit snapshot when a commit just swapped `refuter` so the
-    // advance skips an unreachable shown-card pill immediately.
-    const advanceFrom = (
-        fromId: string,
-        nextSuggestion: DraftSuggestion = current,
-    ) => {
-        const idx = pillIds.indexOf(fromId);
-        if (idx < 0) {
-            setOpenPillId(null);
-            return;
-        }
-        for (let i = idx + 1; i < pillIds.length; i++) {
-            const id = pillIds[i];
-            if (id === undefined) continue;
-            if (
-                id.startsWith("seenCard-") &&
-                nextSuggestion.refuter === undefined
-            ) {
-                continue;
-            }
-            setOpenPillId(id);
-            return;
-        }
-        setOpenPillId(null);
-    };
-
-    // Row ref for scoping the arrow-key nav listener to this row's
-    // pills + popovers (popovers live in a Radix portal, so the row
-    // can't own the keydown directly).
-    const rowRef = useRef<HTMLLIElement>(null);
-
-    // ArrowLeft / ArrowRight between pills — matches SuggestionForm's
-    // behaviour for the Add-a-suggestion flow. Active when focus is on
-    // one of this row's pill triggers, or inside one of its popovers.
-    useEffect(() => {
-        const onKeyDown = (e: KeyboardEvent) => {
-            if (e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
-            const isLeft = matches("nav.left", e);
-            const isRight = matches("nav.right", e);
-            if (!isLeft && !isRight) return;
-
-            const rowEl = rowRef.current;
-            const active = document.activeElement as Element | null;
-            if (!rowEl || !active) return;
-
-            // Determine which pill the user is currently on. Either
-            // focus is on a trigger inside this row, or a popover
-            // (portalled outside the row) is open for one of our
-            // pills.
-            let currentPillId: string | null = null;
-            if (rowEl.contains(active)) {
-                const trig = active.closest("[data-pill-id]");
-                if (trig) {
-                    currentPillId = trig.getAttribute("data-pill-id");
-                }
-            }
-            if (
-                currentPillId === null &&
-                openPillId !== null &&
-                pillIds.includes(openPillId) &&
-                isInsideSuggestionPopover(active) &&
-                rowEl.querySelector(
-                    '[data-pill-id][data-state="open"]',
-                ) !== null
-            ) {
-                currentPillId = openPillId;
-            }
-            if (currentPillId === null || !pillIds.includes(currentPillId)) {
-                return;
-            }
-
-            const dir = isRight ? 1 : -1;
-            let targetId: string | null = null;
-            for (
-                let i = pillIds.indexOf(currentPillId) + dir;
-                i >= 0 && i < pillIds.length;
-                i += dir
-            ) {
-                const id = pillIds[i];
-                if (id === undefined) continue;
-                if (
-                    id.startsWith("seenCard-") &&
-                    current.refuter === undefined
-                ) {
-                    continue;
-                }
-                targetId = id;
-                break;
-            }
-            if (targetId === null) {
-                if (isLeft) e.preventDefault();
-                return;
-            }
-            e.preventDefault();
-            setOpenPillId(targetId);
-        };
-        document.addEventListener("keydown", onKeyDown);
-        return () => document.removeEventListener("keydown", onKeyDown);
-    }, [pillIds, openPillId, current.refuter]);
-
-    // Internal-consistency validation: unlike the Add form (where
-    // option-builders prevent most paradoxes at input time and pill
-    // ordering gates PILL_SEEN behind the refuter), the inline edit
-    // lets the user change fields in any order. A later edit can
-    // strand an earlier choice — most commonly a `seenCard` whose
-    // category card was subsequently swapped. Surface that as a
-    // pill-level error instead of silently keeping the stale value.
-    const formLike: FormState = useMemo(
-        () => ({
-            id: String(s.id),
-            suggester: current.suggester,
-            cards: current.cards,
-            nonRefuters:
-                current.nonRefuters.length > 0 ? current.nonRefuters : null,
-            refuter: current.refuter ?? null,
-            seenCard: current.seenCard ?? null,
-        }),
-        [s.id, current],
-    );
-    const errors = useMemo(
-        () => validateFormConsistency(formLike),
-        [formLike],
-    );
-    const errorMessageFor = (code: PillErrorCode): string => {
-        switch (code) {
-            case "seenCardNotSuggested":
-                return t("pillErrorSeenCardNotSuggested");
-            case "seenCardWithoutRefuter":
-                return t("pillErrorSeenCardWithoutRefuter");
-            case "suggesterIsRefuter":
-                return t("pillErrorSuggesterIsRefuter");
-            case "suggesterInPassers":
-                return t("pillErrorSuggesterInPassers");
-            case "refuterInPassers":
-                return t("pillErrorRefuterInPassers");
-        }
-    };
-    const errorReasonFor = (id: PillId): string | undefined => {
-        const code = errors.get(id);
-        return code === undefined ? undefined : errorMessageFor(code);
-    };
-
-    // Passed-by value: map from DraftSuggestion's always-array shape
-    // to the pill-status-friendly null-when-empty shape. The underlying
-    // data can't distinguish "explicit nobody" from "not decided" —
-    // empty array collapses both.
-    const passersValue =
-        current.nonRefuters.length === 0 ? null : current.nonRefuters;
 
     // Outside-click cancel: while editing, any pointerdown outside
     // this row and outside any Radix pill popover portal discards the
@@ -916,40 +632,12 @@ function PriorSuggestionItem({
             ) {
                 return;
             }
-            cancelEdit();
+            exitEdit();
         };
         document.addEventListener("pointerdown", onPointerDown, true);
         return () =>
             document.removeEventListener("pointerdown", onPointerDown, true);
     }, [isEditing]);
-
-    // Cmd/Ctrl+Enter commits the draft from anywhere inside the row
-    // (or any of its pill popovers). Mirrors the SuggestionForm Add
-    // shortcut so the keyboard flow is consistent across the two
-    // editors.
-    useEffect(() => {
-        if (!isEditing) return;
-        const onKeyDown = (e: KeyboardEvent) => {
-            if (!matches("action.submit", e)) return;
-            const active = document.activeElement;
-            const row = rowRef.current;
-            const inRow = !!(
-                row &&
-                active instanceof Node &&
-                row.contains(active)
-            );
-            const inPopover =
-                active instanceof Element &&
-                isInsideSuggestionPopover(active) &&
-                row?.querySelector('[data-pill-id][data-state="open"]') !==
-                    null;
-            if (!inRow && !inPopover) return;
-            e.preventDefault();
-            commitEdit();
-        };
-        document.addEventListener("keydown", onKeyDown);
-        return () => document.removeEventListener("keydown", onKeyDown);
-    }, [isEditing, draft]);
 
     const rowTransition = useReducedTransition(T_SPRING_SOFT);
     const pillStaggerTransition = useReducedTransition(T_FAST);
@@ -1010,16 +698,20 @@ function PriorSuggestionItem({
             onKeyDown={e => {
                 const native = e.nativeEvent;
                 // Escape inside pills: bubble up here and cancel edit
-                // mode entirely (discards the draft).
+                // mode entirely (discards the draft). Skip when a
+                // popover was open — Radix's own dismiss-layer handles
+                // that Esc by closing the popover, but the keydown can
+                // still bubble; we don't want a second handler here
+                // tearing down the whole edit too.
                 if (e.currentTarget !== e.target) {
                     if (
                         matches("action.cancel", native) &&
                         isEditing &&
-                        openPillId === null
+                        !hasOpenPillPopover()
                     ) {
                         e.preventDefault();
                         const row = e.currentTarget;
-                        cancelEdit();
+                        exitEdit();
                         row.focus();
                     }
                     return;
@@ -1062,7 +754,7 @@ function PriorSuggestionItem({
                 ) {
                     e.preventDefault();
                     const row = e.currentTarget;
-                    cancelEdit();
+                    exitEdit();
                     row.focus();
                 }
             }}
@@ -1073,234 +765,31 @@ function PriorSuggestionItem({
                 onClick={e => {
                     // Pills and the remove × live here; don't let their
                     // clicks toggle the row's pin state.
-                    if (isInPillMode) e.stopPropagation();
+                    if (isEditing) e.stopPropagation();
                 }}
             >
-                {isInPillMode ? (
+                {isEditing ? (
                     <motion.div
                         key="pill-mode"
                         initial={{ opacity: 0 }}
                         animate={{ opacity: 1 }}
                         transition={pillStaggerTransition}
-                        className="flex flex-wrap items-center gap-1.5"
                     >
-                        <PillPopover
-                            pillId={`suggester-${s.id}`}
-                            label={t("pillSuggester")}
-                            status={pillStatusForPlayer(current.suggester, false)}
-                            valueDisplay={displayPlayer(current.suggester)}
-                            errorReason={errorReasonFor(PILL_SUGGESTER)}
-                            variant={pillVariant}
-                            open={openPillId === `suggester-${s.id}`}
-                            onOpenChange={onOpenChangeFor(`suggester-${s.id}`)}
-                        >
-                            <SingleSelectList<Player>
-                                options={suggesterOpts}
-                                selected={current.suggester}
-                                onCommit={value => {
-                                    if (!isNobody(value)) {
-                                        commit({ suggester: value });
-                                        advanceFrom(`suggester-${s.id}`, {
-                                            ...current,
-                                            suggester: value,
-                                        });
-                                    } else {
-                                        setOpenPillId(null);
-                                    }
-                                }}
-                                nobodyLabel={null}
-                                nobodyValue={null}
-                            />
-                        </PillPopover>
-
-                        {setup.categories.map((cat, i) => {
-                            const cardId = current.cards[i] ?? null;
-                            const pid = `card-${s.id}-${i}`;
-                            return (
-                                <PillPopover
-                                    key={cat.id}
-                                    pillId={pid}
-                                    label={cat.name}
-                                    status={pillStatusForCard(cardId, false)}
-                                    valueDisplay={displayCard(cardId, setup)}
-                                    errorReason={errorReasonFor(
-                                        `card-${i}` as PillId,
-                                    )}
-                                    variant={pillVariant}
-                                    open={openPillId === pid}
-                                    onOpenChange={onOpenChangeFor(pid)}
-                                >
-                                    <SingleSelectList<Card>
-                                        options={cat.cards.map(c => ({
-                                            value: c.id,
-                                            label: c.name,
-                                        }))}
-                                        selected={cardId}
-                                        onCommit={value => {
-                                            if (!isNobody(value)) {
-                                                const nextCards = [
-                                                    ...current.cards,
-                                                ];
-                                                nextCards[i] = value;
-                                                commit({ cards: nextCards });
-                                                advanceFrom(pid, {
-                                                    ...current,
-                                                    cards: nextCards,
-                                                });
-                                            } else {
-                                                setOpenPillId(null);
-                                            }
-                                        }}
-                                        nobodyLabel={null}
-                                        nobodyValue={null}
-                                    />
-                                </PillPopover>
-                            );
-                        })}
-
-                        <PillPopover
-                            pillId={`passers-${s.id}`}
-                            label={t("pillPassers")}
-                            status={pillStatusForPassers(passersValue)}
-                            valueDisplay={displayPassers(passersValue, t)}
-                            errorReason={errorReasonFor(PILL_PASSERS)}
-                            variant={pillVariant}
-                            open={openPillId === `passers-${s.id}`}
-                            onOpenChange={onOpenChangeFor(`passers-${s.id}`)}
-                            {...(current.nonRefuters.length > 0
-                                ? { onClear: clearPassers }
-                                : {})}
-                        >
-                            <MultiSelectList
-                                options={passersOpts}
-                                selected={current.nonRefuters}
-                                nobodyChosen={false}
-                                nobodyLabel={t("popoverNobodyPassed")}
-                                commitHint={t("popoverCommitHint")}
-                                onCommit={(value, opts) => {
-                                    commitPassers(value);
-                                    // MultiSelectList fires an
-                                    // `advance: false` commit from its
-                                    // unmount cleanup (to persist
-                                    // toggled state on outside-click /
-                                    // Esc / arrow-nav-away). Auto-
-                                    // advancing there would hijack the
-                                    // very nav that caused the unmount
-                                    // and open the wrong pill.
-                                    if (opts?.advance === false) return;
-                                    const nextNonRefuters = isNobody(value)
-                                        ? []
-                                        : Array.from(new Set(value));
-                                    advanceFrom(`passers-${s.id}`, {
-                                        ...current,
-                                        nonRefuters: nextNonRefuters,
-                                    });
-                                }}
-                            />
-                        </PillPopover>
-
-                        <PillPopover
-                            pillId={`refuter-${s.id}`}
-                            label={t("pillRefuter")}
-                            status={pillStatusForPlayer(
-                                current.refuter ?? null,
-                                true,
-                            )}
-                            valueDisplay={displayPlayerOpt(
-                                current.refuter ?? null,
-                                t,
-                            )}
-                            errorReason={errorReasonFor(PILL_REFUTER)}
-                            variant={pillVariant}
-                            open={openPillId === `refuter-${s.id}`}
-                            onOpenChange={onOpenChangeFor(`refuter-${s.id}`)}
-                            {...(current.refuter !== undefined
-                                ? { onClear: clearRefuter }
-                                : {})}
-                        >
-                            <SingleSelectList<Player>
-                                options={refuterOpts}
-                                selected={current.refuter ?? null}
-                                onCommit={value => {
-                                    commitRefuter(value);
-                                    // Post-commit shape: nobody clears both
-                                    // refuter and seenCard; otherwise refuter
-                                    // is set (keep any existing seenCard —
-                                    // the error banner will surface a stale
-                                    // pairing if the user later fixes it).
-                                    const nextS: DraftSuggestion = isNobody(
-                                        value,
-                                    )
-                                        ? (() => {
-                                              const {
-                                                  refuter: _r,
-                                                  seenCard: _sc,
-                                                  ...rest
-                                              } = current;
-                                              return rest;
-                                          })()
-                                        : { ...current, refuter: value };
-                                    advanceFrom(`refuter-${s.id}`, nextS);
-                                }}
-                                nobodyLabel={t("popoverNobodyRefuted")}
-                                nobodyValue={NOBODY}
-                            />
-                        </PillPopover>
-
-                        <PillPopover
-                            pillId={`seenCard-${s.id}`}
-                            label={t("pillSeen")}
-                            status={pillStatusForCard(
-                                current.seenCard ?? null,
-                                true,
-                            )}
-                            valueDisplay={displayCardOpt(
-                                current.seenCard ?? null,
-                                setup,
-                                t,
-                            )}
-                            disabled={seenDisabled}
-                            disabledHint={t("pillSeenDisabledHint")}
-                            errorReason={errorReasonFor(PILL_SEEN)}
-                            variant={pillVariant}
-                            open={openPillId === `seenCard-${s.id}`}
-                            onOpenChange={onOpenChangeFor(
-                                `seenCard-${s.id}`,
-                            )}
-                            {...(current.seenCard !== undefined
-                                ? { onClear: clearSeenCard }
-                                : {})}
-                        >
-                            <SingleSelectList<Card>
-                                options={seenCardOpts}
-                                selected={current.seenCard ?? null}
-                                onCommit={value => {
-                                    commitSeenCard(value);
-                                    // seenCard is the last pill — no
-                                    // advance target; just close the
-                                    // popover.
-                                    setOpenPillId(null);
-                                }}
-                                nobodyLabel={t("popoverNoShownCard")}
-                                nobodyValue={NOBODY}
-                            />
-                        </PillPopover>
-
-                        {/* Update lives inline with the pills (mirrors
-                            the Add button on the new-suggestion form)
-                            so the row reads as one cohesive editor. */}
-                        <button
-                            type="button"
-                            onClick={e => {
-                                e.stopPropagation();
-                                commitEdit();
+                        <SuggestionForm
+                            setup={setup}
+                            suggestion={s}
+                            onSubmit={onCommitEdit}
+                            afterSubmit={refocusRow}
+                            variant="onAccent"
+                            showHeader={false}
+                            showClearInputs={false}
+                            pillClearable={{
+                                passers: true,
+                                refuter: true,
+                                seenCard: true,
                             }}
-                            className="cursor-pointer rounded border-none bg-accent px-3 py-2 text-[13px] text-white"
-                        >
-                            {t("updateAction", {
-                                shortcut: label("action.submit"),
-                            })}
-                        </button>
+                            keyboardScopeRef={rowRef}
+                        />
                     </motion.div>
                 ) : (
                     <>
@@ -1363,7 +852,8 @@ function PriorSuggestionItem({
                     aria-label={t("cancelEditAria")}
                     onClick={e => {
                         e.stopPropagation();
-                        cancelEdit();
+                        exitEdit();
+                        refocusRow();
                     }}
                     className="absolute right-1 top-1 min-h-[44px] min-w-[44px] cursor-pointer rounded border-none bg-transparent px-2 py-1 text-[22px] leading-none text-white/80 hover:text-white"
                 >


### PR DESCRIPTION
## Summary

- When editing a prior suggestion, ArrowLeft/Right now traverses disabled pills (showing the "why disabled" hint), and the Update button is reachable via keyboard — matching the Add flow.
- After committing or cancelling an edit, focus restores to the row so the keyboard user keeps context.
- The edit row no longer flips to a solid red background — pill focus rings were getting lost against the fill. Edit mode now uses the same outline-ring treatment as the cell-cross-highlight.

## Why

`PriorSuggestionItem` had drifted from `<SuggestionForm>` and re-implemented the entire pill row from scratch, with subtle behavior bugs (skipped disabled pills in nav, never reached Update). It now mounts `<SuggestionForm suggestion={s} ...>` instead, so the bug disappears because both modes run the same code — and any future SuggestionForm improvements apply to both.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm knip && pnpm i18n:check` all green
- [x] Manual: edit a prior suggestion with no refuter — ArrowRight from Refuter opens the disabled Shown-card pill (showing "Add a refuter first"); ArrowRight again focuses Update; ArrowLeft from Update returns to last reachable pill.
- [x] Manual: clicking Update (or ⌘+Enter) commits and refocuses the row; × cancel does the same.
- [x] Manual: Cmd+K still focuses the Add form's first pill (no regression).
- [x] Manual: per-pill × on optional pills clears that field; outside-click and Esc still cancel the edit.

## Commits

- `dd35811` Unify Add and Edit suggestion forms behind one SuggestionForm — `PriorSuggestionItem` mounts `<SuggestionForm>` with new props (`showHeader`, `showClearInputs`, `pillClearable`, `submitLabel`, `keyboardScopeRef`, `afterSubmit`) instead of duplicating the pill row, commit helpers, option builders, auto-advance, validation, and Cmd+Enter handler. SuggestionForm exposes a `SuggestionFormHandle` via `forwardRef` + `useImperativeHandle`, and the Cmd+K bus registration moves out into `AddSuggestion`. The `motion/react` test mock is fixed to memoize per-tag (it previously returned a fresh `forwardRef` on every Proxy access, silently breaking focus across renders).
- `9964a0a` Drop red-accent edit-row treatment; reuse the default form styling — removes the now-dead `variant`/`onAccent` machinery from `SuggestionForm` and switches the edit row to an accent ring on the parchment background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)