### PR TITLE
Allow effect-docs MCP tools without permission prompt

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,7 +50,9 @@
       "mcp__Claude_Preview__preview_fill",
       "mcp__Claude_Preview__preview_resize",
       "mcp__Claude_Preview__preview_start",
-      "mcp__Claude_Preview__preview_stop"
+      "mcp__Claude_Preview__preview_stop",
+      "mcp__effect-docs__effect_docs_search",
+      "mcp__effect-docs__get_effect_doc"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Adds the two read-only `effect-docs` MCP tools (`effect_docs_search`, `get_effect_doc`) to `permissions.allow` in `.claude/settings.json` so Claude Code no longer prompts on every call.

## Commits
- **Allow effect-docs MCP tools without permission prompt** — appends `mcp__effect-docs__effect_docs_search` and `mcp__effect-docs__get_effect_doc` to the project allowlist, alongside the existing `mcp__Claude_Preview__*` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)