### PR TITLE
Add splash modal and About page; redirect / to /play

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,16 @@ Use `pnpm` for everything. Never `npm`, `yarn`, or `bun`.
 
 Once per shell session, run `nvm use` from the repo root — it picks the version from `.nvmrc`. With `engine-strict=true` in `.npmrc`, every other script (`pnpm install`, `pnpm test`, etc.) will refuse to run on the wrong Node version, so getting this right once at the start of a session is what unblocks everything else. You don't need to re-run it before every command in the same shell.
 
-**Only `source ~/.nvm/nvm.sh` if `nvm use` actually fails with `command not found`.** Most shells load nvm through `.zshrc`/`.bashrc` already, and sourcing it preemptively triggers a permission prompt that slows every command. Try `nvm use` first; only fall back to sourcing if it isn't on PATH. Both are once-per-shell — once you've run `nvm use` (and `source` if it was needed), the correct Node version is locked in for the rest of that shell, and every subsequent `pnpm` / `node` / build command works without re-running either.
+**Once per session, not once per command.** Run `nvm use` (and the `source` fix below if it errors) once, then run every other `pnpm` / `node` / build command on its own. Don't keep prepending `export NVM_DIR=… && source … && nvm use && pnpm …` to every command — the active Node binary stays on PATH for subsequent commands in the same session, so re-running the env setup is just noise (and extra permission prompts).
+
+**`source ~/.nvm/nvm.sh` whenever `nvm use` fails for any reason.** The two failure modes both point at the same fix:
+
+- `nvm: command not found` — nvm isn't on PATH at all.
+- `version "vX.Y.Z" is not yet installed` even though `~/.nvm/versions/node/vX.Y.Z` exists — `NVM_DIR` is unset, so nvm can't see the installed versions. This happens in sandboxed / non-interactive shells where `.zshrc` / `.bashrc` didn't run.
+
+In both cases run `export NVM_DIR="$HOME/.nvm" && source "$HOME/.nvm/nvm.sh"` and retry `nvm use`. Don't try to `nvm install` your way out of the second one — the version is already there, the env is just blind to it.
+
+Most interactive shells load nvm through `.zshrc` / `.bashrc` already, so sourcing preemptively can trigger a permission prompt for no reason. Try `nvm use` first; source on any failure.
 
 ## Install dependencies
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,13 @@ The app is a client-only static SPA. There is no server, no API, and no account:
 ## Repository layout
 
 ```
-app/                    Next.js App Router entry — layout, providers, single page.
-  page.tsx              Renders <Clue/>; the entire app is one client boundary.
+app/                    Next.js App Router entry — layout, providers, three routes.
+  page.tsx              Server component; redirects / → /play (build-time meta refresh).
+  play/page.tsx         Renders <Clue/> + <SplashModal/>; the main game UI.
+  about/page.tsx        Renders shared <AboutContent/> (motivation copy + YouTube embed).
 
 src/
+  routes.ts             Single source of truth for in-app paths.
   logic/                Pure Effect game model (no React).
     GameSetup.ts          Players, card packs, dealt cards.
     Knowledge.ts          The (player × card) grid + cell values.
@@ -50,12 +53,14 @@ src/
     Recommender.ts        Suggests the next move.
     Provenance.ts         "Why does this cell have this value?" footnotes.
     Persistence.ts        localStorage round-trip via PersistenceSchema.
+    SplashState.ts        localStorage timestamps for the about-app splash modal.
     services/             Effect services injected as ambient context (CardSet, PlayerSet, …).
   ui/                   React 19 client components.
     Clue.tsx              Top-level shell, mobile/desktop layout switch.
     state.tsx             ClueProvider — wraps deducer in useMemo, owns undo/redo.
-    components/           Checklist, SuggestionForm, Toolbar, Tooltip, …
-    hooks/                useConfirm, useIsDesktop, …
+    components/           Checklist, SuggestionForm, Toolbar, AboutContent,
+                          SplashModal, YouTubeEmbed, …
+    hooks/                useConfirm, useIsDesktop, useSplashGate, …
   i18n/                 next-intl provider + flat message map.
   analytics/            PostHog client + typed event emitters + Web Vitals.
   observability/        Effect → OpenTelemetry → Honeycomb runtime.
@@ -64,7 +69,7 @@ messages/en.json        UI strings.
 scripts/check-i18n-keys.mjs   Audits orphan/missing translation keys.
 
 .github/workflows/ci.yml   typecheck / lint / test / knip / i18n-check / build
-renovate.json              Dependency PRs.
+renovate.json5             Dependency PRs.
 CODEOWNERS                 Review routing.
 ```
 

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { AboutContent } from "../../src/ui/components/AboutContent";
+
+export default function AboutPage() {
+    const t = useTranslations("about");
+    return (
+        <main className="mx-auto flex max-w-2xl flex-col gap-5 px-5 py-8">
+            <h1 className="m-0 font-display text-[28px] text-accent">
+                {t("pageHeading")}
+            </h1>
+            <AboutContent context="page" />
+        </main>
+    );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,12 @@
-"use client";
-
-import { Clue } from "@/ui/Clue";
+import { redirect } from "next/navigation";
+import { routes } from "../src/routes";
 
 /**
- * The entire app is client-only — no server rendering, no API routes.
- * We mark the page as a client boundary and let <Clue /> own the state.
+ * Root path is just a redirect into `/play`. Server component so it
+ * runs at build time under `output: "export"` — Next.js emits a
+ * static `out/index.html` whose only content is a meta-refresh, so
+ * the redirect happens before any of our app JS loads.
  */
-export default function Page() {
-    return <Clue />;
+export default function RootRedirect(): never {
+    redirect(routes.play);
 }

--- a/app/play/page.tsx
+++ b/app/play/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { Clue } from "../../src/ui/Clue";
+import { SplashModal } from "../../src/ui/components/SplashModal";
+import { useSplashGate } from "../../src/ui/hooks/useSplashGate";
+
+export default function PlayPage() {
+    const { showSplash, dismiss } = useSplashGate();
+    return (
+        <>
+            <Clue />
+            <SplashModal open={showSplash} onDismiss={dismiss} />
+        </>
+    );
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -130,6 +130,14 @@ export default [
                             // Effect services register themselves with a
                             // string key; that's a type-system token.
                             "Context\\.Service",
+                            // `Effect.fn("module.operation")` names a
+                            // tracing span — internal observability key,
+                            // never user copy.
+                            "Effect\\.fn",
+                            // `window.open(url, targetName, features)`
+                            // takes the route, the named-tab target, and
+                            // a features list — none of them user copy.
+                            "window\\.open",
                         ],
                     },
                     // Exempt attributes that carry non-copy values
@@ -155,6 +163,10 @@ export default [
                             "side",
                             "align",
                             "variant",
+                            // `<AboutContent context="page" | "modal" />`
+                            // — discriminator for which surface fired
+                            // an analytics event, not user copy.
+                            "context",
                         ],
                     },
                     // Ignore object-property values on common setup
@@ -178,6 +190,12 @@ export default [
                             "runtimeExecutable",
                             "packageManager",
                             "name",
+                            // Analytics-event prop discriminators —
+                            // `method`, `source`, `context` are all
+                            // PostHog event property keys, not copy.
+                            "method",
+                            "source",
+                            "context",
                         ],
                     },
                     // Additional common words that are discriminator

--- a/messages/en.json
+++ b/messages/en.json
@@ -15,7 +15,22 @@
         "checklist": "Checklist ({shortcut})",
         "suggest": "Suggest ({shortcut})",
         "more": "More",
-        "gameSetup": "Game setup ({shortcut})"
+        "gameSetup": "Game setup ({shortcut})",
+        "about": "About"
+    },
+    "splash": {
+        "title": "Welcome to the Clue solver",
+        "description": "Learn what this solver does for you, and start playing.",
+        "startPlaying": "Let's solve a murder!",
+        "dontShowAgain": "Don't show this again",
+        "close": "Close"
+    },
+    "about": {
+        "title": "More than process of elimination",
+        "motivation": "Every suggestion leaks information. Keeping track of who must hold what gets hard fast — too much to do in your head.",
+        "videoCallout": "This solver does the bookkeeping for you. It finds clues you'd miss and teaches the strategy as you play. Watch the kickoff video to learn the logic — so you can be the best detective in the room.",
+        "videoTitle": "Clue strategy explainer",
+        "pageHeading": "About the Clue solver"
     },
     "toolbar": {
         "undo": "↶ Undo ({shortcut})",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
 		"@opentelemetry/sdk-trace-web": "2.7.0",
 		"@opentelemetry/semantic-conventions": "1.40.0",
 		"@radix-ui/react-alert-dialog": "1.1.15",
+		"@radix-ui/react-dialog": "1.1.15",
 		"@radix-ui/react-popover": "1.1.15",
 		"@radix-ui/react-tooltip": "1.2.8",
 		"@sentry/nextjs": "10.50.0",
@@ -63,6 +64,7 @@
 		"posthog-js": "1.372.1",
 		"react": "19.2.5",
 		"react-dom": "19.2.5",
+		"react-youtube": "10.1.0",
 		"web-vitals": "5.2.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@radix-ui/react-alert-dialog':
         specifier: 1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@radix-ui/react-dialog':
+        specifier: 1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@radix-ui/react-popover':
         specifier: 1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -80,6 +83,9 @@ importers:
       react-dom:
         specifier: 19.2.5
         version: 19.2.5(react@19.2.5)
+      react-youtube:
+        specifier: 10.1.0
+        version: 10.1.0(react@19.2.5)
       web-vitals:
         specifier: 5.2.0
         version: 5.2.0
@@ -2627,6 +2633,14 @@ packages:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -3090,6 +3104,9 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  load-script@1.0.0:
+    resolution: {integrity: sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==}
+
   loader-runner@4.3.2:
     resolution: {integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==}
     engines: {node: '>=6.11.5'}
@@ -3103,6 +3120,10 @@ packages:
 
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
 
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
@@ -3180,6 +3201,9 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -3261,6 +3285,10 @@ packages:
 
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -3369,6 +3397,9 @@ packages:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
     engines: {node: '>=0.4.0'}
 
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   protobufjs@7.5.5:
     resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
     engines: {node: '>=12.0.0'}
@@ -3397,6 +3428,9 @@ packages:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
       react: ^19.2.5
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
@@ -3430,6 +3464,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-youtube@10.1.0:
+    resolution: {integrity: sha512-ZfGtcVpk0SSZtWCSTYOQKhfx5/1cfyEW1JN/mugGNfAxT3rmVJeMbGpA9+e78yG21ls5nc/5uZJETE3cm3knBg==}
+    engines: {node: '>= 14.x'}
+    peerDependencies:
+      react: '>=0.14.1'
 
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
@@ -3505,6 +3545,9 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  sister@3.0.2:
+    resolution: {integrity: sha512-p19rtTs+NksBRKW9qn0UhZ8/TUI9BPw9lmtHny+Y3TinWlOa9jWh9xB0AtPSdmOy49NJJJSSe0Ey4C7h0TrcYA==}
 
   smol-toml@1.6.1:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
@@ -3870,6 +3913,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  youtube-player@5.5.2:
+    resolution: {integrity: sha512-ZGtsemSpXnDky2AUYWgxjaopgB+shFHgXVpiJFeNB5nWEugpW1KWYDaHKuLqh2b67r24GtP6HoSW5swvf0fFIQ==}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -6146,6 +6192,10 @@ snapshots:
     transitivePeerDependencies:
       - '@noble/hashes'
 
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -6596,6 +6646,8 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  load-script@1.0.0: {}
+
   loader-runner@4.3.2: {}
 
   locate-path@6.0.0:
@@ -6605,6 +6657,10 @@ snapshots:
   lodash@4.18.1: {}
 
   long@5.3.2: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
 
   lru-cache@11.3.5: {}
 
@@ -6666,6 +6722,8 @@ snapshots:
     optionalDependencies:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
+
+  ms@2.0.0: {}
 
   ms@2.1.3: {}
 
@@ -6752,6 +6810,8 @@ snapshots:
     optional: true
 
   node-releases@2.0.38: {}
+
+  object-assign@4.1.1: {}
 
   obug@2.1.1: {}
 
@@ -6911,6 +6971,12 @@ snapshots:
 
   progress@2.0.3: {}
 
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
   protobufjs@7.5.5:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -6956,6 +7022,8 @@ snapshots:
       react: 19.2.5
       scheduler: 0.27.0
 
+  react-is@16.13.1: {}
+
   react-is@17.0.2: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.5):
@@ -6984,6 +7052,15 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.14
+
+  react-youtube@10.1.0(react@19.2.5):
+    dependencies:
+      fast-deep-equal: 3.1.3
+      prop-types: 15.8.1
+      react: 19.2.5
+      youtube-player: 5.5.2
+    transitivePeerDependencies:
+      - supports-color
 
   react@19.2.5: {}
 
@@ -7119,6 +7196,8 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   siginfo@2.0.0: {}
+
+  sister@3.0.2: {}
 
   smol-toml@1.6.1: {}
 
@@ -7400,5 +7479,13 @@ snapshots:
   yaml@2.8.3: {}
 
   yocto-queue@0.1.0: {}
+
+  youtube-player@5.5.2:
+    dependencies:
+      debug: 2.6.9
+      load-script: 1.0.0
+      sister: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   zod@4.3.6: {}

--- a/scripts/check-i18n-keys.mjs
+++ b/scripts/check-i18n-keys.mjs
@@ -31,7 +31,7 @@ const root = path.resolve(
 );
 const messagesPath = path.join(root, "messages/en.json");
 const srcDir = path.join(root, "src");
-const layoutFile = path.join(root, "app/layout.tsx");
+const appDir = path.join(root, "app");
 
 // --- load keys ----------------------------------------------------------
 const messages = JSON.parse(fs.readFileSync(messagesPath, "utf8"));
@@ -61,7 +61,7 @@ const walk = (dir) => {
     }
 };
 walk(srcDir);
-if (fs.existsSync(layoutFile)) srcFiles.push(layoutFile);
+if (fs.existsSync(appDir)) walk(appDir);
 
 const stringsInSource = new Set();
 const templateSuffixes = new Set();

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -17,6 +17,8 @@
  *   Feature usage       : whyTooltipOpened, checklistRowClicked,
  *                         undoUsed, redoUsed, settingsOpened,
  *                         languageChanged, localstorageCleared
+ *   Onboarding / splash : splashScreenViewed, splashScreenDismissed,
+ *                         youtubeEmbedPlayed, aboutLinkClicked
  *   Performance signals : webVital, deducerRun
  *
  * `$pageview` is auto-emitted by PostHog (capture_pageview: true) so it
@@ -144,6 +146,26 @@ export const languageChanged = (props: { from: string; to: string }): void =>
 
 export const localstorageCleared = (props: { hadActiveGame: boolean }): void =>
     capture("localstorage_cleared", props);
+
+// ── Onboarding / splash ───────────────────────────────────────────────────
+
+export const splashScreenViewed = (props: {
+    dismissedBefore: boolean;
+    daysSinceLastVisit: number | null;
+}): void => capture("splash_screen_viewed", props);
+
+export const splashScreenDismissed = (props: {
+    method: "start_playing" | "x_button";
+    dontShowAgainChecked: boolean;
+}): void => capture("splash_screen_dismissed", props);
+
+export const youtubeEmbedPlayed = (props: {
+    context: "page" | "modal";
+}): void => capture("youtube_embed_played", props);
+
+export const aboutLinkClicked = (props: {
+    source: "overflow_menu";
+}): void => capture("about_link_clicked", props);
 
 // ── Performance signals ───────────────────────────────────────────────────
 

--- a/src/logic/SplashState.test.ts
+++ b/src/logic/SplashState.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { DateTime } from "effect";
+import {
+    loadSplashState,
+    saveDismissed,
+    saveLastVisited,
+} from "./SplashState";
+
+const STORAGE_KEY = "effect-clue.splash.v1";
+
+afterEach(() => {
+    window.localStorage.clear();
+});
+
+describe("SplashState", () => {
+    test("returns empty state when nothing is stored", () => {
+        expect(loadSplashState()).toEqual({});
+    });
+
+    test("returns empty state when payload is malformed", () => {
+        window.localStorage.setItem(STORAGE_KEY, "not json");
+        expect(loadSplashState()).toEqual({});
+    });
+
+    test("returns empty state when schema rejects payload", () => {
+        window.localStorage.setItem(
+            STORAGE_KEY,
+            JSON.stringify({ version: 99, lastVisitedAt: "garbage" }),
+        );
+        expect(loadSplashState()).toEqual({});
+    });
+
+    test("round-trips lastVisitedAt", () => {
+        const now = DateTime.makeUnsafe("2026-04-25T12:00:00Z");
+        saveLastVisited(now);
+        const state = loadSplashState();
+        expect(state.lastVisitedAt).toEqual(now);
+        expect(state.lastDismissedAt).toBeUndefined();
+    });
+
+    test("round-trips lastDismissedAt", () => {
+        const now = DateTime.makeUnsafe("2026-04-25T12:00:00Z");
+        saveDismissed(now);
+        const state = loadSplashState();
+        expect(state.lastDismissedAt).toEqual(now);
+        expect(state.lastVisitedAt).toBeUndefined();
+    });
+
+    test("saving lastVisitedAt does not clobber lastDismissedAt", () => {
+        const dismissedAt = DateTime.makeUnsafe("2026-03-01T00:00:00Z");
+        const visitedAt = DateTime.makeUnsafe("2026-04-25T12:00:00Z");
+        saveDismissed(dismissedAt);
+        saveLastVisited(visitedAt);
+        const state = loadSplashState();
+        expect(state.lastDismissedAt).toEqual(dismissedAt);
+        expect(state.lastVisitedAt).toEqual(visitedAt);
+    });
+
+    test("saving lastDismissedAt does not clobber lastVisitedAt", () => {
+        const visitedAt = DateTime.makeUnsafe("2026-03-01T00:00:00Z");
+        const dismissedAt = DateTime.makeUnsafe("2026-04-25T12:00:00Z");
+        saveLastVisited(visitedAt);
+        saveDismissed(dismissedAt);
+        const state = loadSplashState();
+        expect(state.lastDismissedAt).toEqual(dismissedAt);
+        expect(state.lastVisitedAt).toEqual(visitedAt);
+    });
+
+    test("repeated saveLastVisited overwrites the timestamp", () => {
+        const earlier = DateTime.makeUnsafe("2026-03-01T00:00:00Z");
+        const later = DateTime.makeUnsafe("2026-04-25T12:00:00Z");
+        saveLastVisited(earlier);
+        saveLastVisited(later);
+        expect(loadSplashState().lastVisitedAt).toEqual(later);
+    });
+});

--- a/src/logic/SplashState.ts
+++ b/src/logic/SplashState.ts
@@ -1,0 +1,103 @@
+/**
+ * Persisted state for the about-app splash modal.
+ *
+ * Two timestamps live in localStorage:
+ *
+ * - `lastVisitedAt` — updated every time the user lands on `/play`.
+ *   Drives the re-engagement gate: if it's been > DURATION since the
+ *   last visit, we show the splash again on the next visit.
+ *
+ * - `lastDismissedAt` — set only when the user closes the splash with
+ *   the "don't show this again" checkbox ticked. Today the gate just
+ *   reads its truthiness ("has the user ever opted out?"); we store
+ *   the actual timestamp so future analytics can answer "when".
+ *
+ * Stored as ISO-8601 strings on disk — what `new Date().toJSON()`
+ * produces, easy to read in DevTools, easy to round-trip via `new
+ * Date(iso)`. We convert to/from `DateTime.Utc` at the boundary so
+ * the rest of the codebase keeps the Effect type.
+ *
+ * Mirrors the `CustomCardSets` pattern: `Schema.decodeUnknownResult`
+ * for reads (silent fallback to `{}` on malformed payload), try/catch
+ * for writes (private mode / quota). Saves merge into the existing
+ * payload so writing one timestamp never clobbers the other.
+ */
+import { DateTime, Result, Schema } from "effect";
+
+const PersistedSplashStateSchema = Schema.Struct({
+    version: Schema.Literal(1),
+    lastVisitedAt: Schema.optional(Schema.String),
+    lastDismissedAt: Schema.optional(Schema.String),
+});
+
+const decodeUnknown = Schema.decodeUnknownResult(PersistedSplashStateSchema);
+const encode = Schema.encodeSync(PersistedSplashStateSchema);
+
+const STORAGE_KEY = "effect-clue.splash.v1";
+
+export interface SplashState {
+    readonly lastVisitedAt?: DateTime.Utc;
+    readonly lastDismissedAt?: DateTime.Utc;
+}
+
+const parseIso = (iso: string): DateTime.Utc | undefined => {
+    const date = new Date(iso);
+    if (Number.isNaN(date.getTime())) return undefined;
+    return DateTime.makeUnsafe(date);
+};
+
+const formatIso = (dt: DateTime.Utc): string =>
+    new Date(DateTime.toEpochMillis(dt)).toISOString();
+
+export const loadSplashState = (): SplashState => {
+    if (typeof window === "undefined") return {};
+    try {
+        const raw = window.localStorage.getItem(STORAGE_KEY);
+        if (!raw) return {};
+        const decoded = decodeUnknown(JSON.parse(raw));
+        if (Result.isFailure(decoded)) return {};
+        const out: { -readonly [K in keyof SplashState]: SplashState[K] } = {};
+        if (decoded.success.lastVisitedAt !== undefined) {
+            const parsed = parseIso(decoded.success.lastVisitedAt);
+            if (parsed !== undefined) out.lastVisitedAt = parsed;
+        }
+        if (decoded.success.lastDismissedAt !== undefined) {
+            const parsed = parseIso(decoded.success.lastDismissedAt);
+            if (parsed !== undefined) out.lastDismissedAt = parsed;
+        }
+        return out;
+    } catch {
+        return {};
+    }
+};
+
+const writeMerged = (patch: Partial<SplashState>): void => {
+    if (typeof window === "undefined") return;
+    try {
+        const current = loadSplashState();
+        const lastVisitedAt = patch.lastVisitedAt ?? current.lastVisitedAt;
+        const lastDismissedAt =
+            patch.lastDismissedAt ?? current.lastDismissedAt;
+        const merged: {
+            version: 1;
+            lastVisitedAt?: string;
+            lastDismissedAt?: string;
+        } = { version: 1 };
+        if (lastVisitedAt !== undefined) {
+            merged.lastVisitedAt = formatIso(lastVisitedAt);
+        }
+        if (lastDismissedAt !== undefined) {
+            merged.lastDismissedAt = formatIso(lastDismissedAt);
+        }
+        const encoded = encode(merged);
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(encoded));
+    } catch {
+        // Quota exceeded, private mode, etc. — non-fatal.
+    }
+};
+
+export const saveLastVisited = (now: DateTime.Utc): void =>
+    writeMerged({ lastVisitedAt: now });
+
+export const saveDismissed = (now: DateTime.Utc): void =>
+    writeMerged({ lastDismissedAt: now });

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,0 +1,14 @@
+/**
+ * Single source of truth for in-app paths. Every `<a href>`,
+ * `router.replace`, `redirect`, and `window.open` should reference
+ * `routes.<name>` rather than hard-coding the string.
+ *
+ * If a future route ever needs path or query params, switch its entry
+ * to a function — e.g. `game: (id: string) => `/game/${id}` ` — and
+ * call sites keep the same shape.
+ */
+export const routes = {
+    root: "/",
+    play: "/play",
+    about: "/about",
+} as const;

--- a/src/ui/components/AboutContent.test.tsx
+++ b/src/ui/components/AboutContent.test.tsx
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const captureCalls: Array<{
+    event: string;
+    props: Record<string, unknown> | undefined;
+}> = [];
+
+vi.mock("../../analytics/posthog", () => ({
+    posthog: {
+        __loaded: true,
+        capture: (event: string, props?: Record<string, unknown>) => {
+            captureCalls.push({ event, props });
+        },
+    },
+}));
+
+vi.mock("next-intl", () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("react-youtube", () => ({
+    default: () => <div data-testid="yt-mock">video</div>,
+}));
+
+afterEach(() => {
+    captureCalls.length = 0;
+});
+
+const importContent = async () => {
+    const mod = await import("./AboutContent");
+    return mod.AboutContent;
+};
+
+describe("AboutContent", () => {
+    test("renders the video, title, and copy", async () => {
+        const AboutContent = await importContent();
+        render(<AboutContent context="page" />);
+        expect(screen.getByTestId("yt-mock")).toBeInTheDocument();
+        expect(screen.getByText("title")).toBeInTheDocument();
+        expect(screen.getByText("motivation")).toBeInTheDocument();
+        expect(screen.getByText("videoCallout")).toBeInTheDocument();
+    });
+
+    test("does not fire any analytics events on plain render", async () => {
+        const AboutContent = await importContent();
+        render(<AboutContent context="modal" />);
+        expect(captureCalls).toEqual([]);
+    });
+});

--- a/src/ui/components/AboutContent.tsx
+++ b/src/ui/components/AboutContent.tsx
@@ -1,0 +1,42 @@
+/**
+ * Shared "about" content for the splash modal on `/play` and the
+ * standalone `/about` page. The video at the top is the kickoff
+ * explainer; the copy below pitches what the solver does for you and
+ * sends you to the video for the strategy lesson.
+ *
+ * `context` is forwarded to every analytics event the user can fire
+ * from this surface so PostHog can split engagement by where they
+ * saw it (modal vs. page).
+ */
+"use client";
+
+import { useTranslations } from "next-intl";
+import { YouTubeEmbed } from "./YouTubeEmbed";
+
+const VIDEO_ID = "ijkDbdlpY6c";
+
+export function AboutContent({
+    context,
+}: {
+    readonly context: "page" | "modal";
+}) {
+    const t = useTranslations("about");
+    return (
+        <div className="flex flex-col gap-4">
+            <YouTubeEmbed
+                videoId={VIDEO_ID}
+                context={context}
+                title={t("videoTitle")}
+            />
+            <h2 className="m-0 font-display text-[22px] leading-tight">
+                {t("title")}
+            </h2>
+            <p className="m-0 text-[15px] leading-relaxed">
+                {t("motivation")}
+            </p>
+            <p className="m-0 text-[15px] leading-relaxed">
+                {t("videoCallout")}
+            </p>
+        </div>
+    );
+}

--- a/src/ui/components/BottomNav.tsx
+++ b/src/ui/components/BottomNav.tsx
@@ -4,11 +4,14 @@ import * as RadixPopover from "@radix-ui/react-popover";
 import { LayoutGroup, motion } from "motion/react";
 import { useTranslations } from "next-intl";
 import { useState } from "react";
+import { aboutLinkClicked } from "../../analytics/events";
 import { describeAction } from "../../logic/describeAction";
+import { routes } from "../../routes";
 import { useLongPress } from "../hooks/useLongPress";
 import { useClue } from "../state";
 import { label } from "../keyMap";
 import { T_SPRING_SOFT, T_STANDARD, useReducedTransition } from "../motion";
+import { ExternalLinkIcon } from "./Icons";
 import { OverflowMenu } from "./OverflowMenu";
 import { useToolbarActions } from "./Toolbar";
 
@@ -260,6 +263,14 @@ function BottomOverflowMenu({
                             shortcut: label("global.newGame"),
                         }),
                         onClick: onNewGame,
+                    },
+                    {
+                        label: t("about"),
+                        trailingIcon: <ExternalLinkIcon size={14} />,
+                        onClick: () => {
+                            aboutLinkClicked({ source: "overflow_menu" });
+                            window.open(routes.about, "about-page", "noopener");
+                        },
                     },
                 ]}
             />

--- a/src/ui/components/Icons.tsx
+++ b/src/ui/components/Icons.tsx
@@ -38,3 +38,73 @@ export function Envelope({ className, size = 18 }: IconProps) {
         </svg>
     );
 }
+
+/** Close glyph for modal headers and dismiss buttons. */
+export function XIcon({ className, size = 18 }: IconProps) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+            focusable="false"
+            className={className}
+        >
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+    );
+}
+
+/** Right-pointing arrow — paired with primary "get started" CTAs. */
+export function ArrowRightIcon({ className, size = 18 }: IconProps) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+            focusable="false"
+            className={className}
+        >
+            <line x1="5" y1="12" x2="19" y2="12" />
+            <polyline points="13 6 19 12 13 18" />
+        </svg>
+    );
+}
+
+/** Arrow leaving a frame — paired with links that open in a new tab. */
+export function ExternalLinkIcon({ className, size = 14 }: IconProps) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+            focusable="false"
+            className={className}
+        >
+            <path d="M14 4h6v6" />
+            <path d="M10 14L20 4" />
+            <path d="M19 13v6a1.5 1.5 0 0 1-1.5 1.5h-12A1.5 1.5 0 0 1 4 19V7a1.5 1.5 0 0 1 1.5-1.5H11" />
+        </svg>
+    );
+}

--- a/src/ui/components/OverflowMenu.tsx
+++ b/src/ui/components/OverflowMenu.tsx
@@ -2,12 +2,13 @@
 
 import * as RadixPopover from "@radix-ui/react-popover";
 import { motion } from "motion/react";
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import { T_FAST, useReducedTransition } from "../motion";
 
 interface OverflowMenuItem {
     readonly label: string;
     readonly active?: boolean;
+    readonly trailingIcon?: ReactNode;
     readonly onClick: () => void | Promise<void>;
 }
 
@@ -55,15 +56,15 @@ export function OverflowMenu({
                 >
                     {items.map((item, i) => {
                         const handleClick = closeThen(item.onClick);
-                        const content = item.active === undefined ? (
+                        const content = (
                             <MenuItem
                                 label={item.label}
-                                onClick={handleClick}
-                            />
-                        ) : (
-                            <MenuItem
-                                label={item.label}
-                                active={item.active}
+                                {...(item.active !== undefined
+                                    ? { active: item.active }
+                                    : {})}
+                                {...(item.trailingIcon !== undefined
+                                    ? { trailingIcon: item.trailingIcon }
+                                    : {})}
                                 onClick={handleClick}
                             />
                         );
@@ -87,10 +88,12 @@ export function OverflowMenu({
 function MenuItem({
     label,
     active,
+    trailingIcon,
     onClick,
 }: {
     readonly label: string;
     readonly active?: boolean;
+    readonly trailingIcon?: ReactNode;
     readonly onClick: () => void;
 }) {
     return (
@@ -98,11 +101,16 @@ function MenuItem({
             type="button"
             onClick={onClick}
             className={
-                "block w-full cursor-pointer rounded-[var(--radius)] border-none bg-transparent px-3 py-2 text-left text-[13px] hover:bg-hover " +
+                "flex w-full items-center justify-between gap-2 cursor-pointer rounded-[var(--radius)] border-none bg-transparent px-3 py-2 text-left text-[13px] hover:bg-hover " +
                 (active ? "text-accent font-semibold" : "text-inherit")
             }
         >
-            {label}
+            <span>{label}</span>
+            {trailingIcon !== undefined ? (
+                <span className="flex shrink-0 items-center text-muted">
+                    {trailingIcon}
+                </span>
+            ) : null}
         </button>
     );
 }

--- a/src/ui/components/SplashModal.test.tsx
+++ b/src/ui/components/SplashModal.test.tsx
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const captureCalls: Array<{
+    event: string;
+    props: Record<string, unknown> | undefined;
+}> = [];
+
+vi.mock("../../analytics/posthog", () => ({
+    posthog: {
+        __loaded: true,
+        capture: (event: string, props?: Record<string, unknown>) => {
+            captureCalls.push({ event, props });
+        },
+    },
+}));
+
+vi.mock("next-intl", () => ({
+    useTranslations: (ns?: string) => (key: string) =>
+        ns ? `${ns}.${key}` : key,
+}));
+
+vi.mock("react-youtube", () => ({
+    default: () => <div data-testid="yt-mock" />,
+}));
+
+afterEach(() => {
+    captureCalls.length = 0;
+});
+
+const importModal = async () => {
+    const mod = await import("./SplashModal");
+    return mod.SplashModal;
+};
+
+describe("SplashModal", () => {
+    test("renders title, content, and primary button when open", async () => {
+        const SplashModal = await importModal();
+        render(<SplashModal open onDismiss={() => {}} />);
+        expect(screen.getByText("splash.title")).toBeInTheDocument();
+        expect(screen.getByTestId("yt-mock")).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "splash.startPlaying" }),
+        ).toBeInTheDocument();
+    });
+
+    test("renders nothing when closed", async () => {
+        const SplashModal = await importModal();
+        render(<SplashModal open={false} onDismiss={() => {}} />);
+        expect(screen.queryByText("splash.title")).not.toBeInTheDocument();
+    });
+
+    test("'Start playing' fires dismiss with method=start_playing and the checkbox state", async () => {
+        const onDismiss = vi.fn();
+        const SplashModal = await importModal();
+        render(<SplashModal open onDismiss={onDismiss} />);
+        fireEvent.click(screen.getByRole("button", { name: "splash.startPlaying" }));
+        expect(onDismiss).toHaveBeenCalledWith(false);
+        expect(captureCalls).toEqual([
+            {
+                event: "splash_screen_dismissed",
+                props: {
+                    method: "start_playing",
+                    dontShowAgainChecked: false,
+                },
+            },
+        ]);
+    });
+
+    test("X close fires dismiss with method=x_button", async () => {
+        const onDismiss = vi.fn();
+        const SplashModal = await importModal();
+        render(<SplashModal open onDismiss={onDismiss} />);
+        fireEvent.click(screen.getByRole("button", { name: "splash.close" }));
+        expect(onDismiss).toHaveBeenCalledWith(false);
+        expect(captureCalls).toEqual([
+            {
+                event: "splash_screen_dismissed",
+                props: {
+                    method: "x_button",
+                    dontShowAgainChecked: false,
+                },
+            },
+        ]);
+    });
+
+    test("checkbox toggle propagates into the dismiss event and onDismiss arg", async () => {
+        const user = userEvent.setup();
+        const onDismiss = vi.fn();
+        const SplashModal = await importModal();
+        render(<SplashModal open onDismiss={onDismiss} />);
+        await user.click(screen.getByRole("checkbox"));
+        await user.click(screen.getByRole("button", { name: "splash.startPlaying" }));
+        expect(onDismiss).toHaveBeenCalledWith(true);
+        expect(captureCalls).toEqual([
+            {
+                event: "splash_screen_dismissed",
+                props: {
+                    method: "start_playing",
+                    dontShowAgainChecked: true,
+                },
+            },
+        ]);
+    });
+});

--- a/src/ui/components/SplashModal.tsx
+++ b/src/ui/components/SplashModal.tsx
@@ -1,0 +1,112 @@
+/**
+ * About-app splash modal shown on `/play` for first-time and dormant
+ * users. Wraps `<AboutContent />` in a Radix `Dialog` with:
+ *
+ *   - X close in the top-right
+ *   - "Start playing" primary button at the bottom
+ *   - "Don't show this again" checkbox above the button
+ *
+ * Both close paths funnel through the same dismiss handler so we
+ * always emit `splash_screen_dismissed` with `method` ("x_button" |
+ * "start_playing") and `dontShowAgainChecked`. ESC and overlay click
+ * are treated as the X close (`onOpenChange(false)`).
+ *
+ * The "show / don't show" decision lives in `useSplashGate` — this
+ * component is only the chrome.
+ */
+"use client";
+
+import * as Dialog from "@radix-ui/react-dialog";
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { splashScreenDismissed } from "../../analytics/events";
+import { AboutContent } from "./AboutContent";
+import { ArrowRightIcon, XIcon } from "./Icons";
+
+export function SplashModal({
+    open,
+    onDismiss,
+}: {
+    readonly open: boolean;
+    /** Fires when the user closes the modal by any path. */
+    readonly onDismiss: (dontShowAgain: boolean) => void;
+}) {
+    const t = useTranslations("splash");
+    const [dontShowAgain, setDontShowAgain] = useState(false);
+
+    const handleDismiss = (method: "start_playing" | "x_button") => {
+        splashScreenDismissed({
+            method,
+            dontShowAgainChecked: dontShowAgain,
+        });
+        onDismiss(dontShowAgain);
+    };
+
+    return (
+        <Dialog.Root
+            open={open}
+            onOpenChange={(next) => {
+                // eslint-disable-next-line i18next/no-literal-string
+                if (!next) handleDismiss("x_button");
+            }}
+        >
+            <Dialog.Portal>
+                <Dialog.Overlay className="fixed inset-0 z-40 bg-black/40" />
+                <Dialog.Content
+                    className={
+                        "fixed left-1/2 top-1/2 z-50 flex w-[min(92vw,640px)] max-h-[90vh] flex-col " +
+                        "-translate-x-1/2 -translate-y-1/2 rounded-[var(--radius)] border border-border " +
+                        "bg-panel shadow-[0_10px_28px_rgba(0,0,0,0.28)] focus:outline-none"
+                    }
+                >
+                    <div className="flex shrink-0 items-start justify-between gap-3 px-5 pt-5">
+                        <Dialog.Title className="m-0 font-display text-[20px] text-accent">
+                            {t("title")}
+                        </Dialog.Title>
+                        <Dialog.Close
+                            aria-label={t("close")}
+                            className="-mt-1 -mr-1 cursor-pointer rounded-[var(--radius)] border-none bg-transparent p-1 text-[#2a1f12] hover:bg-hover"
+                        >
+                            <XIcon size={18} />
+                        </Dialog.Close>
+                    </div>
+                    <Dialog.Description className="sr-only">
+                        {t("description")}
+                    </Dialog.Description>
+                    <div className="flex-1 overflow-y-auto px-5 pt-3">
+                        <AboutContent context="modal" />
+                    </div>
+                    <div className="shrink-0 border-t border-border bg-panel px-5 pt-4 pb-5">
+                        <button
+                            type="button"
+                            onClick={() => handleDismiss("start_playing")}
+                            className={
+                                "flex w-full cursor-pointer items-center justify-center gap-2 " +
+                                "rounded-[var(--radius)] border-2 border-accent bg-accent " +
+                                "px-6 py-3.5 text-[18px] font-bold text-white " +
+                                "shadow-[0_4px_14px_rgba(122,28,28,0.35)] " +
+                                "hover:bg-accent-hover hover:shadow-[0_6px_18px_rgba(122,28,28,0.45)] " +
+                                "active:translate-y-[1px] active:shadow-[0_2px_8px_rgba(122,28,28,0.35)] " +
+                                "transition-all"
+                            }
+                        >
+                            <span>{t("startPlaying")}</span>
+                            <ArrowRightIcon size={20} />
+                        </button>
+                        <label className="mt-3 flex items-center justify-center gap-2 text-[13px] text-muted">
+                            <input
+                                type="checkbox"
+                                checked={dontShowAgain}
+                                onChange={(e) =>
+                                    setDontShowAgain(e.target.checked)
+                                }
+                                className="h-4 w-4 cursor-pointer accent-accent"
+                            />
+                            <span>{t("dontShowAgain")}</span>
+                        </label>
+                    </div>
+                </Dialog.Content>
+            </Dialog.Portal>
+        </Dialog.Root>
+    );
+}

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -2,10 +2,13 @@
 
 import { useTranslations } from "next-intl";
 import { useState } from "react";
+import { aboutLinkClicked } from "../../analytics/events";
 import { describeAction } from "../../logic/describeAction";
+import { routes } from "../../routes";
 import { useConfirm } from "../hooks/useConfirm";
 import { useClue } from "../state";
 import { label } from "../keyMap";
+import { ExternalLinkIcon } from "./Icons";
 import { OverflowMenu } from "./OverflowMenu";
 import { Tooltip } from "./Tooltip";
 
@@ -142,6 +145,14 @@ export function Toolbar() {
                             shortcut: label("global.newGame"),
                         }),
                         onClick: onNewGame,
+                    },
+                    {
+                        label: tNav("about"),
+                        trailingIcon: <ExternalLinkIcon size={14} />,
+                        onClick: () => {
+                            aboutLinkClicked({ source: "overflow_menu" });
+                            window.open(routes.about, "about-page", "noopener");
+                        },
                     },
                 ]}
             />

--- a/src/ui/components/YouTubeEmbed.test.tsx
+++ b/src/ui/components/YouTubeEmbed.test.tsx
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+const captureCalls: Array<{
+    event: string;
+    props: Record<string, unknown> | undefined;
+}> = [];
+
+vi.mock("../../analytics/posthog", () => ({
+    posthog: {
+        __loaded: true,
+        capture: (event: string, props?: Record<string, unknown>) => {
+            captureCalls.push({ event, props });
+        },
+    },
+}));
+
+vi.mock("react-youtube", () => ({
+    default: ({
+        onPlay,
+        title,
+    }: {
+        onPlay?: () => void;
+        title?: string;
+    }) => (
+        <button
+            type="button"
+            data-testid="yt-mock-play"
+            aria-label={title ?? "play"}
+            onClick={() => onPlay?.()}
+        >
+            play
+        </button>
+    ),
+}));
+
+afterEach(() => {
+    captureCalls.length = 0;
+});
+
+const importEmbed = async () => {
+    const mod = await import("./YouTubeEmbed");
+    return mod.YouTubeEmbed;
+};
+
+describe("YouTubeEmbed", () => {
+    test("fires youtubeEmbedPlayed once on first play", async () => {
+        const YouTubeEmbed = await importEmbed();
+        render(<YouTubeEmbed videoId="abc" context="modal" />);
+        const play = screen.getByTestId("yt-mock-play");
+
+        fireEvent.click(play);
+        fireEvent.click(play);
+        fireEvent.click(play);
+
+        expect(captureCalls).toEqual([
+            { event: "youtube_embed_played", props: { context: "modal" } },
+        ]);
+    });
+
+    test("passes context=page through to the event", async () => {
+        const YouTubeEmbed = await importEmbed();
+        render(<YouTubeEmbed videoId="abc" context="page" />);
+        fireEvent.click(screen.getByTestId("yt-mock-play"));
+        expect(captureCalls).toEqual([
+            { event: "youtube_embed_played", props: { context: "page" } },
+        ]);
+    });
+
+    test("does not fire on mount alone", async () => {
+        const YouTubeEmbed = await importEmbed();
+        render(<YouTubeEmbed videoId="abc" context="modal" />);
+        expect(captureCalls).toEqual([]);
+    });
+});

--- a/src/ui/components/YouTubeEmbed.tsx
+++ b/src/ui/components/YouTubeEmbed.tsx
@@ -1,0 +1,53 @@
+/**
+ * Thin wrapper around `react-youtube` that fires a typed PostHog
+ * `youtube_embed_played` event the first time the user starts the
+ * video. We guard with a ref so that pause/seek/replay don't re-fire
+ * the event — one play per mount is what matters for the funnel.
+ *
+ * `context` distinguishes the splash modal from the standalone About
+ * page so we can split engagement by surface in PostHog.
+ */
+"use client";
+
+import { useRef } from "react";
+import YouTube from "react-youtube";
+import { youtubeEmbedPlayed } from "../../analytics/events";
+
+export function YouTubeEmbed({
+    videoId,
+    context,
+    title,
+}: {
+    readonly videoId: string;
+    readonly context: "page" | "modal";
+    readonly title?: string;
+}) {
+    const playedOnce = useRef(false);
+    // Size derives from context: the modal lives on a tight,
+    // height-constrained surface where the primary CTA must stay
+    // visible, so the embed is capped narrow. The standalone /about
+    // page has no such pressure — let it fill the page column.
+    const widthCap = context === "modal" ? "max-w-sm" : "max-w-2xl";
+    return (
+        <div
+            className={`mx-auto aspect-video w-full ${widthCap} overflow-hidden rounded-[var(--radius)] bg-black`}
+        >
+            <YouTube
+                videoId={videoId}
+                title={title ?? videoId}
+                className="h-full w-full"
+                iframeClassName="h-full w-full"
+                opts={{
+                    width: "100%",
+                    height: "100%",
+                    playerVars: { rel: 0, modestbranding: 1 },
+                }}
+                onPlay={() => {
+                    if (playedOnce.current) return;
+                    playedOnce.current = true;
+                    youtubeEmbedPlayed({ context });
+                }}
+            />
+        </div>
+    );
+}

--- a/src/ui/hooks/useSplashGate.test.tsx
+++ b/src/ui/hooks/useSplashGate.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "vitest";
+import { DateTime, Duration, Effect } from "effect";
+import {
+    ABOUT_APP_SPLASH_SCREEN_DISMISSAL_DURATION,
+    computeShouldShowSplash,
+} from "./useSplashGate";
+
+const runGate = (
+    state: Parameters<typeof computeShouldShowSplash>[0],
+    now: DateTime.Utc,
+    duration: Duration.Duration = ABOUT_APP_SPLASH_SCREEN_DISMISSAL_DURATION,
+): boolean => Effect.runSync(computeShouldShowSplash(state, now, duration));
+
+const at = (iso: string): DateTime.Utc => DateTime.makeUnsafe(iso);
+
+describe("computeShouldShowSplash", () => {
+    test("first visit ever → show", () => {
+        expect(runGate({}, at("2026-04-25T00:00:00Z"))).toBe(true);
+    });
+
+    test("returning, never opted out → show every time", () => {
+        const now = at("2026-04-25T00:00:00Z");
+        const lastVisitedAt = at("2026-04-24T23:00:00Z"); // 1h ago
+        expect(runGate({ lastVisitedAt }, now)).toBe(true);
+    });
+
+    test("opted out and visited recently → hide", () => {
+        const now = at("2026-04-25T00:00:00Z");
+        const lastVisitedAt = at("2026-04-24T00:00:00Z"); // 1d ago
+        const lastDismissedAt = at("2026-04-23T00:00:00Z");
+        expect(runGate({ lastVisitedAt, lastDismissedAt }, now)).toBe(false);
+    });
+
+    test("opted out but away > DURATION → show again (re-engagement)", () => {
+        const now = at("2026-04-25T00:00:00Z");
+        const lastVisitedAt = at("2026-02-01T00:00:00Z"); // ~12 weeks ago
+        const lastDismissedAt = at("2026-01-15T00:00:00Z");
+        expect(runGate({ lastVisitedAt, lastDismissedAt }, now)).toBe(true);
+    });
+
+    test("opted out and away exactly DURATION → still hide (strict greaterThan)", () => {
+        const now = at("2026-04-25T00:00:00Z");
+        const lastVisitedAt = DateTime.subtract(now, { weeks: 4 });
+        const lastDismissedAt = at("2026-01-01T00:00:00Z");
+        expect(runGate({ lastVisitedAt, lastDismissedAt }, now)).toBe(false);
+    });
+
+    test("opted out, lastVisitedAt missing (defensive) → show", () => {
+        // Should not happen in practice — once you've dismissed you've
+        // visited at least once — but the gate stays safe rather than
+        // crashing if the storage somehow gets into this state.
+        const now = at("2026-04-25T00:00:00Z");
+        const lastDismissedAt = at("2026-01-01T00:00:00Z");
+        expect(runGate({ lastDismissedAt }, now)).toBe(true);
+    });
+
+    test("custom duration is honored", () => {
+        const now = at("2026-04-25T00:00:00Z");
+        const lastVisitedAt = at("2026-04-23T00:00:00Z"); // 2d ago
+        const lastDismissedAt = at("2026-04-20T00:00:00Z");
+        // 1-day duration: 2d > 1d → show
+        expect(
+            runGate(
+                { lastVisitedAt, lastDismissedAt },
+                now,
+                Duration.days(1),
+            ),
+        ).toBe(true);
+        // 1-week duration: 2d < 1w → hide
+        expect(
+            runGate(
+                { lastVisitedAt, lastDismissedAt },
+                now,
+                Duration.weeks(1),
+            ),
+        ).toBe(false);
+    });
+});

--- a/src/ui/hooks/useSplashGate.tsx
+++ b/src/ui/hooks/useSplashGate.tsx
@@ -1,0 +1,95 @@
+/**
+ * Decides whether to show the about-app splash modal on `/play` mount.
+ *
+ * Gate (read both timestamps before writing the new visit):
+ *
+ *   show = lastDismissedAt is undefined           // never opted out
+ *       OR lastVisitedAt is undefined             // first visit
+ *       OR (now − lastVisitedAt) > DURATION       // dormant returnee
+ *
+ * Active users who opted out stay dismissed as long as they keep
+ * visiting; users who've been away ≥ DURATION see the splash again
+ * as a re-engagement nudge. The DURATION lives in code so we can tune
+ * it without a migration.
+ */
+"use client";
+
+import { useEffect, useState } from "react";
+import { DateTime, Duration, Effect } from "effect";
+import { TelemetryRuntime } from "../../observability/runtime";
+import { splashScreenViewed } from "../../analytics/events";
+import {
+    loadSplashState,
+    saveDismissed,
+    saveLastVisited,
+    type SplashState,
+} from "../../logic/SplashState";
+
+export const ABOUT_APP_SPLASH_SCREEN_DISMISSAL_DURATION = Duration.weeks(4);
+
+export const computeShouldShowSplash = Effect.fn("splash.computeGate")(
+    function* (
+        state: SplashState,
+        now: DateTime.Utc,
+        duration: Duration.Duration,
+    ) {
+        if (state.lastDismissedAt === undefined) return true;
+        if (state.lastVisitedAt === undefined) return true;
+        const elapsed = DateTime.distance(state.lastVisitedAt, now);
+        return Duration.isGreaterThan(elapsed, duration);
+    },
+);
+
+const daysBetween = (from: DateTime.Utc, to: DateTime.Utc): number => {
+    const ms = Duration.toMillis(DateTime.distance(from, to));
+    return Math.floor(ms / Duration.toMillis(Duration.days(1)));
+};
+
+export function useSplashGate(): {
+    /** True after mount when the gate decided to show. */
+    readonly showSplash: boolean;
+    /** Whether the user has previously checked "don't show again". */
+    readonly dismissedBefore: boolean;
+    /** Hides the splash; persists `lastDismissedAt` if `dontShowAgain`. */
+    readonly dismiss: (dontShowAgain: boolean) => void;
+} {
+    const [showSplash, setShowSplash] = useState(false);
+    const [dismissedBefore, setDismissedBefore] = useState(false);
+
+    useEffect(() => {
+        const state = loadSplashState();
+        const now = DateTime.nowUnsafe();
+        const should = TelemetryRuntime.runSync(
+            computeShouldShowSplash(
+                state,
+                now,
+                ABOUT_APP_SPLASH_SCREEN_DISMISSAL_DURATION,
+            ),
+        );
+        const wasDismissedBefore = state.lastDismissedAt !== undefined;
+        setDismissedBefore(wasDismissedBefore);
+        if (should) {
+            setShowSplash(true);
+            splashScreenViewed({
+                dismissedBefore: wasDismissedBefore,
+                daysSinceLastVisit:
+                    state.lastVisitedAt !== undefined
+                        ? daysBetween(state.lastVisitedAt, now)
+                        : null,
+            });
+        }
+        // Order is critical: read state and decide BEFORE we overwrite
+        // the visit timestamp, otherwise the gap is always 0.
+        saveLastVisited(now);
+    }, []);
+
+    const dismiss = (dontShowAgain: boolean) => {
+        if (dontShowAgain) {
+            saveDismissed(DateTime.nowUnsafe());
+            setDismissedBefore(true);
+        }
+        setShowSplash(false);
+    };
+
+    return { showSplash, dismissedBefore, dismiss };
+}


### PR DESCRIPTION
## Summary

- New players landing in the app see a dismissible splash modal on `/play` that explains what the solver does, embeds the kickoff strategy video, and ushers them into the game with a single big "Let's solve a murder! →" CTA. The modal is gated by localStorage timestamps so it doesn't pester returning players who've already opted out — but does come back as a re-engagement nudge for users who've been away ≥ 4 weeks.
- New `/about` route renders the same content as a standalone, shareable page. The overflow menu (desktop Toolbar + mobile BottomNav) gains an "About ↗" item that opens it in a named tab so successive clicks reuse the tab instead of stacking new ones.
- The root `/` is now a server-component redirect to `/play`. Under `output: "export"`, Next.js evaluates this at build time and emits a static meta-refresh — no client-side JS round-trip.

## Behavior changes (user-facing)

- **First visit:** redirects to `/play`, splash opens automatically. Heading "Welcome to the Clue solver", embedded "How to win Clue (Cluedo board game)" video, copy "More than process of elimination — Every suggestion leaks information…", and a prominent "Let's solve a murder! →" button. "Don't show this again" checkbox under the button (unchecked by default).
- **Closing the splash:** "Let's solve a murder!" or the X both close it. ESC and clicking outside also close. Without the checkbox, it shows again next visit. With the checkbox, it stays hidden until the user is away for > 4 weeks (`ABOUT_APP_SPLASH_SCREEN_DISMISSAL_DURATION` constant in `src/ui/hooks/useSplashGate.tsx`).
- **Overflow menu → About ↗:** opens `/about` in a named tab `about-page`, which means re-clicking re-uses the same tab.
- **`/about`:** standalone page with a heading and the same content, with a wider embed (the page has the whole column to fill, while the modal keeps a narrower embed so the CTA stays above the fold on small viewports).
- **Returning users who never opted out:** see the splash on every visit (we want them to be able to opt out at any point).

## Analytics

New typed event emitters in [`src/analytics/events.ts`](src/analytics/events.ts):

- `splash_screen_viewed` — props: `dismissedBefore: boolean`, `daysSinceLastVisit: number | null`
- `splash_screen_dismissed` — props: `method: "start_playing" | "x_button"`, `dontShowAgainChecked: boolean`
- `youtube_embed_played` — props: `context: "page" | "modal"` (fires once per mount on first PLAYING state)
- `about_link_clicked` — props: `source: "overflow_menu"`

**Suggested PostHog funnel** (needs to be created on the dashboard): `splash_screen_viewed → youtube_embed_played → splash_screen_dismissed`.

No existing funnels were moved or renamed.

## Tracing

The splash gate computation is wrapped in `Effect.fn("splash.computeGate")` and run via `TelemetryRuntime`, so it lands as a Honeycomb span.

## Storage

- New localStorage key: `effect-clue.splash.v1`
  - `version: 1`
  - `lastVisitedAt`: ISO-8601 timestamp (updated on every `/play` visit, AFTER the gate runs)
  - `lastDismissedAt`: ISO-8601 timestamp (set only when the user closes the modal with the "don't show again" checkbox ticked)

`Schema` is used for decode validation; malformed payloads silently fall back to an empty state. Saves merge into the existing payload so writing one timestamp never clobbers the other.

## New deps

- `@radix-ui/react-dialog@1.1.15` — Dialog primitive (we already had AlertDialog and Popover; Dialog is the right semantics for an info modal with X close)
- `react-youtube@10.1.0` — thin wrapper over the IFrame Player API; gives us a typed `onPlay` for the embed-played event

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm knip && pnpm i18n:check` — all green (426 tests passing)
- [x] Verified in `next-dev` preview:
  - [x] `/` → `/play`, splash opens with cleared localStorage
  - [x] "Let's solve a murder!" without checkbox → modal closes, splash reappears on reload
  - [x] "Let's solve a murder!" with checkbox → modal closes, stays hidden on reload, `lastDismissedAt` persisted
  - [x] `/about` renders directly with the same content (and a larger embed)
- [ ] After merge: verify analytics events flowing in PostHog and create the splash-engagement funnel on the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)