### PR TITLE
Polish splash modal: body bottom padding and label cursor

### DIFF
--- a/src/ui/components/SplashModal.tsx
+++ b/src/ui/components/SplashModal.tsx
@@ -73,7 +73,7 @@ export function SplashModal({
                     <Dialog.Description className="sr-only">
                         {t("description")}
                     </Dialog.Description>
-                    <div className="flex-1 overflow-y-auto px-5 pt-3">
+                    <div className="flex-1 overflow-y-auto px-5 pt-3 pb-5">
                         <AboutContent context="modal" />
                     </div>
                     <div className="shrink-0 border-t border-border bg-panel px-5 pt-4 pb-5">
@@ -93,7 +93,7 @@ export function SplashModal({
                             <span>{t("startPlaying")}</span>
                             <ArrowRightIcon size={20} />
                         </button>
-                        <label className="mt-3 flex items-center justify-center gap-2 text-[13px] text-muted">
+                        <label className="mt-3 flex cursor-pointer items-center justify-center gap-2 text-[13px] text-muted">
                             <input
                                 type="checkbox"
                                 checked={dontShowAgain}


### PR DESCRIPTION
## Summary

Two small polish tweaks to the splash modal:

- More breathing room between the body text and the sticky footer divider — the last paragraph was sitting flush against the divider above the CTA.
- Pointer cursor on the "Don't show this again" row, so the whole label reads as clickable, not just the checkbox itself.

## Test plan

- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test` / `pnpm knip` / `pnpm i18n:check` all green
- [x] Verified in `next-dev` preview that body now has bottom padding before the footer divider
- [x] Verified `cursor: pointer` resolves on the label via `preview_inspect`

## Commits

- `Polish splash modal: body bottom padding and label cursor` — adds `pb-5` to the scrollable body wrapper and `cursor-pointer` to the `<label>` in `SplashModal.tsx`. The cursor isn't browser-default on labels (only on the underlying input), so the text portion needed the explicit style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)