### PR TITLE
Add production URL to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A solver for the board game **Clue** (a.k.a. *Cluedo*) — a single-page web app
 
 The app is a client-only static SPA. There is no server, no API, and no account: state lives in `localStorage` and the deducer runs in your browser.
 
-> **Production:** _TBD — fill in deployment URL_
+> **Production:** <https://winclue.vercel.app/>
 
 ---
 


### PR DESCRIPTION
## Summary

- Replaces the TBD placeholder in the README's Production callout with the live deployment URL: https://winclue.vercel.app/.

## Test plan

- [x] README renders the link correctly

## Commits

- **Add production URL to README** — swaps the `_TBD — fill in deployment URL_` line for `<https://winclue.vercel.app/>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)