### PR TITLE
Forbid type-hack shortcuts when fixing CI failures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,18 @@ When modifying behavior:
 
 Tests live next to source (`Foo.test.ts(x)` beside `Foo.ts(x)`) — match that pattern.
 
+## Forbidden shortcuts when fixing failures
+
+When a check (typecheck, lint, test, knip, i18n:check, build) fails, fix the *cause*, not the *symptom*. The following shortcuts are never acceptable:
+
+- **No `as any`, `as unknown as T`, or other unsafe type casts.** A cast is only acceptable when there's a real runtime guard right next to it that proves the type. If the type system is complaining, the type system is right — narrow the type, fix the inferred shape, or add proper validation. Typed silence hides bugs that surface in production.
+- **No deleting code to make a check pass.** If knip flags an export, verify it's actually unused before removing — `grep` for it across `src/` and the tests. If the type error comes from a function being called wrong, fix the call site or the signature; don't delete the function. The only time deletion is the right answer is when the *task itself* is "remove dead code" and you've verified nothing references it.
+- **No removing or skipping tests to make them pass.** If a test is failing, the test is telling you something. Either the production code is wrong (fix it), the test's expectation is outdated and you understand *why* it changed (update the assertion with a comment explaining the new behavior), or the test is genuinely flaky (mark it and tell the user — don't silently `.skip`).
+- **No `// @ts-ignore` / `// @ts-expect-error` / `eslint-disable` to silence errors you don't understand.** A disable comment is a promise that you investigated and the suppression is correct. If you didn't investigate, don't suppress.
+- **No stubbing or no-op'ing failing code paths.** Returning `null`, `undefined`, or an empty object to make a function "type-check" or "not throw" is the same class of error as `as any` — it hides the bug behind a shape that's locally valid but semantically wrong.
+
+If a fix would require any of the above, stop and surface the problem to the user instead of pushing forward.
+
 ## Observability and analytics
 
 For **every change** — not just observability-flavored work — pause to think across the whole app, not just the diff:


### PR DESCRIPTION
## Summary

Adds a new project rule for Claude: when a check fails, fix the *cause*, not the *symptom*. The list of shortcuts banned in CLAUDE.md:

- No `as any` / `as unknown as T` / unsafe casts without a real runtime guard.
- No deleting code (or tests, or exports) to make a check pass — unless the task itself is "remove dead code."
- No `// @ts-ignore` / `// @ts-expect-error` / `eslint-disable` to silence errors that weren't actually understood.
- No stubbing or no-op'ing failing code paths to make them type-check.

The motivation is the new daily Renovate-PR triage routine, but the rule applies to every change Claude makes in this repo — not just that routine.

## Test plan

- [x] `pnpm typecheck` (clean)
- [x] `pnpm lint` (clean)
- [x] `pnpm test` (38 files / 441 tests pass)
- [x] `pnpm knip` (clean)
- [x] `pnpm i18n:check` (197 keys scanned, all referenced)
- [x] `git diff CLAUDE.md` shows only the new section, inserted between "Tests" and "Observability and analytics" — no other changes.

## Commits

- **Forbid type-hack shortcuts when fixing CI failures** — adds a "Forbidden shortcuts when fixing failures" section to CLAUDE.md. Markdown-only; no code paths affected.