### PR TITLE
Move scroll to the page; restructure desktop/mobile layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,52 @@ If you amend or update a commit, re-run the full set — a previously-green comm
 
 For any change that's observable in the browser, use the `next-dev` preview (configured in `.claude/launch.json`) to exercise the change yourself before reporting the task done. Follow the `<verification_workflow>` from the system prompt: start/reload the preview, check console/network/logs, take a screenshot or snapshot as proof. Don't ask the user to verify manually.
 
+### Layout, scroll, and animation behaviors
+
+The structural pieces below are pinned by `src/ui/components/PlayLayout.test.tsx` (mobile mounts only the active pane; desktop mounts both side-by-side). The visual / animated / sticky-positioning pieces below **cannot** be tested in jsdom — `getBoundingClientRect` returns zeroes, `position: sticky` doesn't actually pin, `min-w-max-content` doesn't actually grow, transforms don't extend `body.scrollWidth`, and animations don't run. So when a change touches **page structure (`src/ui/Clue.tsx`, `src/ui/components/PlayLayout.tsx`), overall layout CSS (`<main>`, sticky positioning, `min-w-max`, `contain-paint`, `contain-inline-size`, the `--header-offset` variable), or slide animations (`slideVariants`, `AnimatePresence`)**, walk this list in the `next-dev` preview before reporting done.
+
+Resize the preview between viewports as you go — many of these regress on one breakpoint without affecting the other.
+
+**Vertical page scroll (test at any viewport):**
+
+- Wheel anywhere on the page advances the Checklist table — not just over the table itself. Wheeling over the header, the blank parchment around the section, the `+ add card` row, etc., all scroll the document. (The fix that this codifies — `Move scroll to the page, not an internal viewport` — relies on no ancestor having `overflow-y: auto/scroll/hidden/clip`.)
+- The sticky `<thead>` stays at the viewport top once the table's natural top has scrolled past. Column labels remain aligned with their columns.
+- Force a contradiction (e.g. mark the same suspect "yes" for two players) — `GlobalContradictionBanner` slides in at the top. The sticky `<thead>` sits **below** the banner (its `top:` resolves to `var(--contradiction-banner-offset, 0px) + var(--header-offset, 0px)`), not behind it. On desktop the sticky `<header>` also tucks under the banner.
+
+**Horizontal page scroll (Setup mode, viewport ≤ ~1200 px so the wide setup table doesn't fit naturally):**
+
+- `<main>` grows (`min-w-max`) past the viewport so the body picks up a horizontal scrollbar — that's how the user reaches the rightmost columns.
+- As you scroll horizontally:
+  - The page title `CLUE SOLVER` stays anchored to the viewport's left edge with normal padding (it doesn't butt against `x: 0`).
+  - The `Game setup` intro card, the card-pack row, and the hand-size warning each stay anchored at the section's natural left padding (~36 px from viewport-left, matching their resting position before the scroll).
+  - On desktop the Toolbar (Undo / Redo / `⋯`) stays in the visible top region.
+  - The sticky thead horizontally scrolls **with** the table so column headers stay aligned with the columns underneath them. (Don't add `sticky left-…` to the thead — it must move with horizontal scroll.)
+- Dropping back to scroll-x = 0 places everything in its natural rest position with no jump.
+
+**Mobile Suggest pane fits the viewport (Suggest mobile, viewport ≤ 800 px):**
+
+- Page does NOT have a horizontal scrollbar on this view — `body.scrollWidth === clientWidth`.
+- The `Add a [suggestion (⌘K)] [accusation (⌘I)]` text wraps. The `+ Suggester / + Suspect / + Weapon / + Room / + Passed by / + Refuted by / + Shown card` pill row wraps over multiple rows. Nothing extends past the right edge. (`SuggestionLogPanel`'s section uses `contain-inline-size` to stop its pill row's no-wrap intrinsic size from propagating into `<main>`'s `min-w-max` calculation. If you remove that class, mobile Suggest will spill horizontally.)
+
+**Setup ↔ Play slide animation (both desktop and mobile):**
+
+- Trigger the slide both directions — overflow menu → "Game setup" and back, or `⌘H` / `⌘K`.
+- Both panes overlap mid-flight (sync mode + opacity in `slideVariants`). There's no page-sized gap between when one pane finishes leaving and the other starts arriving — the entering pane is already moving in while the exiting pane is moving out.
+- The browser's horizontal scrollbar does NOT flash during the slide. (The off-screen pane's `translateX(±100%)` would otherwise extend `body.scrollWidth` mid-animation; `contain-paint` on the slide container clips that.)
+- After the slide completes, `window.scrollY` is back to 0 — switching tabs doesn't leave you mid-page.
+- Setup → Checklist on a wide setup table has a small known regression: the exiting `<Checklist>` re-renders with `inSetup: false` the moment `state.uiMode` flips, so its table layout shrinks while sliding out and `<main>` resizes accordingly. This isn't fixable without changing `<Checklist>`'s API to accept `inSetup` as a prop instead of reading from state. Verify it still feels acceptable; if the user complains, the refactor is the next step.
+
+**Mobile Checklist ↔ Suggest slide (`MobilePlayLayout`'s own `AnimatePresence`):**
+
+- Slide runs in both directions (Checklist → Suggest goes right, Suggest → Checklist goes left — `getDirection` based on `PLAY_POSITIONS`).
+- The inactive pane is **not** in the DOM after the slide — no off-screen suggestion log to find by horizontal-scrolling on mobile, no off-screen Checklist to find from Suggest. (Pinned by `PlayLayout.test.tsx` — but if you change the rendering pattern, eyeball it too because the test only checks one frame.)
+
+**Desktop side-by-side (viewport ≥ 800 px):**
+
+- The Checklist and the SuggestionLogPanel sit in a 2-column grid (`minmax(0,1fr) / minmax(320px,420px)` with `gap-5`).
+- The SuggestionLog column is sticky-top with a bounded `max-height` and its own internal `overflow-y-auto`. As the page scrolls vertically, the log pane stays in view; as the log's *internal* content overflows, the log scrolls inside its own frame.
+- Banner appearing / disappearing doesn't cause a layout jump in the table or the log — the banner publishes its height as `--contradiction-banner-offset`, which `<main>`'s padding-top consumes.
+
 ## Tests
 
 Write exhaustive tests for any code you add or modify.

--- a/src/ui/Clue.tsx
+++ b/src/ui/Clue.tsx
@@ -1,18 +1,17 @@
 "use client";
 
 import { AnimatePresence, motion, type Variants } from "motion/react";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { gameSetupStarted } from "../analytics/events";
 import { startSetup } from "../analytics/gameSession";
 import { BottomNav } from "./components/BottomNav";
 import { Checklist } from "./components/Checklist";
 import { GlobalContradictionBanner } from "./components/GlobalContradictionBanner";
-import { SuggestionLogPanel } from "./components/SuggestionLogPanel";
+import { PlayLayout } from "./components/PlayLayout";
 import { Toolbar } from "./components/Toolbar";
 import { TooltipProvider } from "./components/Tooltip";
 import { ConfirmProvider, useConfirm } from "./hooks/useConfirm";
-import { useIsDesktop } from "./hooks/useIsDesktop";
 import { SelectionProvider } from "./SelectionContext";
 import { useGlobalShortcut } from "./keyMap";
 import { T_STANDARD, useReducedTransition } from "./motion";
@@ -49,9 +48,9 @@ function getDirection(prev: UiMode, next: UiMode): Direction {
 }
 
 const slideVariants: Variants = {
-    initial: (dir: Direction) => ({ x: dir === 1 ? "100%" : "-100%" }),
-    animate: { x: 0 },
-    exit: (dir: Direction) => ({ x: dir === 1 ? "-100%" : "100%" }),
+    initial: (dir: Direction) => ({ x: dir === 1 ? "100%" : "-100%", opacity: 0 }),
+    animate: { x: 0, opacity: 1 },
+    exit: (dir: Direction) => ({ x: dir === 1 ? "-100%" : "100%", opacity: 0 }),
 };
 
 /**
@@ -89,13 +88,36 @@ const slideVariants: Variants = {
  */
 export function Clue() {
     const t = useTranslations("app");
+    const headerRef = useRef<HTMLElement>(null);
+    useLayoutEffect(() => {
+        const el = headerRef.current;
+        if (!el) return;
+        const root = document.documentElement;
+        const mq = window.matchMedia("(min-width: 800px)");
+        const write = () =>
+            root.style.setProperty(
+                "--header-offset",
+                mq.matches ? `${el.offsetHeight}px` : "0px",
+            );
+        write();
+        const ro = new ResizeObserver(write);
+        ro.observe(el);
+        mq.addEventListener("change", write);
+        return () => {
+            ro.disconnect();
+            mq.removeEventListener("change", write);
+        };
+    }, []);
     return (
         <TooltipProvider delayDuration={150} skipDelayDuration={50}>
           <ClueProvider>
            <ConfirmProvider>
            <SelectionProvider>
-            <main className="mx-auto flex h-[100dvh] max-w-[1400px] flex-col gap-5 px-5 pb-24 [@media(min-width:800px)]:pb-5 [padding-top:calc(var(--contradiction-banner-offset,0px)+1.5rem)]">
-                <header className="flex shrink-0 flex-wrap items-center justify-between gap-4">
+            <main className="mx-auto flex min-w-max max-w-[1400px] flex-col gap-5 px-5 pb-24 [@media(min-width:800px)]:pb-5 [padding-top:calc(var(--contradiction-banner-offset,0px)+1.5rem)]">
+                <header
+                    ref={headerRef}
+                    className="sticky left-5 flex max-w-[calc(100vw-2.5rem)] flex-wrap items-center justify-between gap-4 [@media(min-width:800px)]:top-[var(--contradiction-banner-offset,0px)] [@media(min-width:800px)]:z-30 [@media(min-width:800px)]:bg-bg [@media(min-width:800px)]:py-2"
+                >
                     <h1 className="m-0 text-[36px] uppercase tracking-[0.08em] text-accent drop-shadow-sm">
                         {t("title")}
                     </h1>
@@ -106,7 +128,7 @@ export function Clue() {
 
                 <GlobalContradictionBanner />
 
-                <div className="flex min-h-0 flex-1 flex-col">
+                <div className="flex flex-col">
                     <TabContent />
                 </div>
                 <NewGameShortcut />
@@ -150,13 +172,11 @@ function NewGameShortcut() {
  * new page in from the RIGHT (positions increasing), and the reverse
  * slides it in from the LEFT.
  *
- * On desktop, `checklist` and `suggest` collapse into a single play
- * grid (both panes visible side-by-side). The top-level
- * AnimatePresence keys on `"setup" | "play"` so switching between
- * checklist and suggest while on desktop does NOT trigger a slide —
- * both are already on screen. On mobile, within the play grid, each
- * pane is absolutely positioned and animates its `x` based on
- * `mode`, so the slide happens at the pane level there instead.
+ * `topLevelKey` is `"setup" | "play"` — checklist and suggest both
+ * map to `"play"` so switching between them at this layer does NOT
+ * trigger a slide. The Play view's internal layout (single active
+ * pane on mobile vs side-by-side on desktop, plus the Checklist ↔
+ * Suggest sub-tab transition) is `PlayLayout`'s job.
  */
 function TabContent() {
     const { state, hydrated } = useClue();
@@ -175,6 +195,22 @@ function TabContent() {
     const topLevelKey: "setup" | "play" =
         mode === UI_SETUP ? UI_SETUP : TOP_LEVEL_PLAY;
 
+    // With document-level scroll, the page doesn't reset when the
+    // top-level view changes — a deep scroll into the Checklist
+    // would otherwise leave the user mid-page after switching to
+    // Setup. Reset to the top on top-level toggles, skipping the
+    // initial mount so we don't override hydration's restored view.
+    const prevTopLevelKey = useRef(topLevelKey);
+    useEffect(() => {
+        if (prevTopLevelKey.current === topLevelKey) return;
+        prevTopLevelKey.current = topLevelKey;
+        const reduced =
+            typeof window !== "undefined" &&
+            window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+        // eslint-disable-next-line i18next/no-literal-string -- ScrollBehavior enum
+        window.scrollTo({ top: 0, behavior: reduced ? "auto" : "smooth" });
+    }, [topLevelKey]);
+
     // Until URL/localStorage hydration resolves the real view, render
     // a view-agnostic skeleton so the default `"setup"` pane doesn't
     // flash between initial mount and the hydrated dispatch. Gating
@@ -183,7 +219,7 @@ function TabContent() {
     // `hydrated` is true, so `initial={false}` correctly skips the
     // entry animation on whichever hydrated view wins.
     return (
-        <div className="relative h-full min-h-0 overflow-hidden">
+        <div className="relative grid grid-cols-[minmax(0,1fr)] [grid-template-areas:'stack'] contain-paint">
             {!hydrated ? (
                 <ViewSkeleton />
             ) : (
@@ -197,7 +233,7 @@ function TabContent() {
                         animate={VARIANT_ANIMATE}
                         exit={VARIANT_EXIT}
                         transition={transition}
-                        className="absolute inset-0 min-h-0"
+                        className="[grid-area:stack] min-w-0"
                     >
                         <Checklist />
                     </motion.div>
@@ -210,9 +246,9 @@ function TabContent() {
                         animate={VARIANT_ANIMATE}
                         exit={VARIANT_EXIT}
                         transition={transition}
-                        className="absolute inset-0 min-h-0"
+                        className="[grid-area:stack] min-w-0"
                     >
-                        <PlayGrid
+                        <PlayLayout
                             mode={mode === UI_SUGGEST ? UI_SUGGEST : UI_CHECKLIST}
                         />
                     </motion.div>
@@ -236,7 +272,7 @@ function TabContent() {
  */
 function ViewSkeleton() {
     const pane = (
-        <div className="flex h-full min-h-0 flex-col gap-3 rounded-[var(--radius)] border border-border/40 bg-panel/40 p-4">
+        <div className="flex min-h-[60vh] flex-col gap-3 rounded-[var(--radius)] border border-border/40 bg-panel/40 p-4">
             <div className="h-5 w-1/3 rounded bg-border/40" />
             <div className="h-3 w-2/3 rounded bg-border/30" />
             <div className="mt-1 min-h-20 flex-1 rounded bg-border/20" />
@@ -245,84 +281,13 @@ function ViewSkeleton() {
     return (
         <div
             aria-hidden
-            className="relative h-full min-h-0 motion-safe:animate-pulse [@media(min-width:800px)]:grid [@media(min-width:800px)]:grid-cols-[minmax(0,1fr)_minmax(320px,420px)] [@media(min-width:800px)]:gap-5"
+            className="relative min-h-[60vh] motion-safe:animate-pulse [@media(min-width:800px)]:grid [@media(min-width:800px)]:grid-cols-[minmax(0,1fr)_minmax(320px,420px)] [@media(min-width:800px)]:gap-5"
         >
             {pane}
-            <div className="hidden h-full min-h-0 [@media(min-width:800px)]:block">
+            <div className="hidden [@media(min-width:800px)]:block">
                 {pane}
             </div>
         </div>
     );
 }
 
-/**
- * Inside the play view. On desktop, a two-column grid with both
- * panes statically visible. On mobile, a relative container with
- * both panes absolutely positioned; each pane's `x` is driven by
- * its distance from the active mode, so switching checklist↔suggest
- * animates both panes sliding in sync.
- */
-function PlayGrid({ mode }: { readonly mode: "checklist" | "suggest" }) {
-    return (
-        <div className="relative h-full min-h-0 overflow-hidden [@media(min-width:800px)]:overflow-visible [@media(min-width:800px)]:grid [@media(min-width:800px)]:grid-cols-[minmax(0,1fr)_minmax(320px,420px)] [@media(min-width:800px)]:gap-5">
-            <PlayPane paneMode={UI_CHECKLIST} currentMode={mode}>
-                <Checklist />
-            </PlayPane>
-            <PlayPane
-                paneMode={UI_SUGGEST}
-                currentMode={mode}
-                className="overflow-y-auto"
-            >
-                <SuggestionLogPanel />
-            </PlayPane>
-        </div>
-    );
-}
-
-/**
- * A single Play pane that adapts to the breakpoint:
- *
- * - Desktop (≥800px): static grid member, no transform. Both panes
- *   always visible.
- * - Mobile (<800px): absolutely positioned inside `PlayGrid`. Its
- *   `x` animates based on `POSITIONS[paneMode] - POSITIONS[currentMode]`
- *   — so when the active pane is the Checklist, the Suggest pane
- *   sits at `x: 100%` (off to the right); when active flips to
- *   Suggest, both panes animate their x simultaneously.
- *
- * Inactive mobile panes are marked `aria-hidden` and `inert` so
- * keyboard focus doesn't land inside an off-screen pane.
- */
-function PlayPane({
-    paneMode,
-    currentMode,
-    className = "",
-    children,
-}: {
-    readonly paneMode: "checklist" | "suggest";
-    readonly currentMode: "checklist" | "suggest";
-    readonly className?: string;
-    readonly children: React.ReactNode;
-}) {
-    const isDesktop = useIsDesktop();
-    const transition = useReducedTransition(T_STANDARD, { fadeMs: 120 });
-    const offset = POSITIONS[paneMode] - POSITIONS[currentMode];
-    const isActive = offset === 0;
-    const mobileInactive = !isDesktop && !isActive;
-
-    return (
-        <motion.div
-            className={
-                "min-h-0 min-w-0 " +
-                className +
-                (isDesktop ? "" : " absolute inset-0")
-            }
-            animate={{ x: isDesktop ? 0 : `${offset * 100}%` }}
-            transition={transition}
-            aria-hidden={mobileInactive || undefined}
-            inert={mobileInactive}
-        >
-            {children}
-        </motion.div>
-    );
-}

--- a/src/ui/components/Checklist.deduce.test.tsx
+++ b/src/ui/components/Checklist.deduce.test.tsx
@@ -16,6 +16,14 @@ vi.mock("next-intl", () => {
     };
 });
 
+// Pin desktop layout so the SuggestionLogPanel pairing tests below see
+// the side-by-side two-pane structure. On mobile only the active pane
+// is mounted, so a checklist-mode mobile render wouldn't include the
+// SuggestionLogPanel — that's the point of the breakpoint split.
+vi.mock("../hooks/useIsDesktop", () => ({
+    useIsDesktop: () => true,
+}));
+
 vi.mock("motion/react", () => {
     const motion = new Proxy(
         {},
@@ -159,8 +167,8 @@ describe("Checklist — deduce mode — body layout", () => {
     });
 });
 
-describe("Checklist — deduce mode — SuggestionLogPanel pairing", () => {
-    test("the PlayGrid also mounts SuggestionLogPanel alongside the Checklist", async () => {
+describe("Checklist — deduce mode — SuggestionLogPanel pairing (desktop)", () => {
+    test("the desktop play layout mounts SuggestionLogPanel alongside the Checklist", async () => {
         render(<Clue />);
         await waitForDeduceChecklist();
         // SuggestionLogPanel renders a section with header id

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -449,7 +449,7 @@ export function Checklist() {
         <section
             ref={rootRef}
             id="checklist"
-            className="flex h-full min-w-0 flex-col rounded-[var(--radius)] border border-border bg-panel p-4"
+            className="min-w-max rounded-[var(--radius)] border border-border bg-panel p-4"
             onMouseLeave={onGridLeave}
             onBlur={e => {
                 // Focus left the checklist root entirely (relatedTarget
@@ -462,7 +462,7 @@ export function Checklist() {
             }}
         >
             {inSetup && (
-                <div className="mb-4 shrink-0 rounded-[var(--radius)] border border-accent/40 bg-accent/5 px-4 py-3">
+                <div className="sticky left-9 mb-4 max-w-[calc(100vw-4.5rem)] shrink-0 rounded-[var(--radius)] border border-accent/40 bg-accent/5 px-4 py-3">
                     <h2 className="m-0 font-display text-[20px] text-accent">
                         {tSetup("title")}
                     </h2>
@@ -492,11 +492,11 @@ export function Checklist() {
                     </div>
                 </div>
             )}
-            <div className="shrink-0">
+            <div className="sticky left-9 max-w-[calc(100vw-4.5rem)] shrink-0">
                 {inSetup ? <CardPackRow /> : <CaseFileHeader knowledge={knowledge} />}
             </div>
             {inSetup && handSizeMismatch && (
-                <div className="mb-3 shrink-0 rounded-[var(--radius)] border border-warning-border bg-warning-bg px-3 py-2 text-[13px] text-warning">
+                <div className="sticky left-9 mb-3 max-w-[calc(100vw-4.5rem)] shrink-0 rounded-[var(--radius)] border border-warning-border bg-warning-bg px-3 py-2 text-[13px] text-warning">
                     {tSetup("handSizeMismatch", {
                         total: handSizesTotal,
                         expected: totalDealt,
@@ -504,9 +504,9 @@ export function Checklist() {
                     })}
                 </div>
             )}
-            <div className="-mx-4 min-h-0 flex-1 overflow-auto px-4">
+            <div className="-mx-4 px-4">
             <table className="w-full border-separate border-spacing-0 border-t border-l border-border text-[13px]">
-                <thead className="sticky top-0 z-20 bg-row-header">
+                <thead className="sticky top-[calc(var(--contradiction-banner-offset,0px)+var(--header-offset,0px))] z-20 bg-row-header">
                     <tr>
                         <th className="border-r border-b border-border bg-row-header px-2 py-1 text-center text-[10px] font-semibold uppercase tracking-[0.05em] text-muted">
                             {inSetup ? null : label("global.gotoChecklist")}

--- a/src/ui/components/PlayLayout.test.tsx
+++ b/src/ui/components/PlayLayout.test.tsx
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { createElement, forwardRef } from "react";
+import type { ReactNode } from "react";
+
+// -----------------------------------------------------------------------
+// Mocks — same shape as the other Clue tests. `motion/react` becomes
+// plain DOM elements (jsdom can't run real animations); `next-intl`
+// passes keys through verbatim.
+// -----------------------------------------------------------------------
+
+vi.mock("next-intl", () => {
+    const t = (key: string, values?: Record<string, unknown>): string =>
+        values ? `${key}:${JSON.stringify(values)}` : key;
+    (t as unknown as { rich: unknown }).rich = (key: string): string => key;
+    return {
+        useTranslations: () => t,
+        useLocale: () => "en",
+    };
+});
+
+vi.mock("motion/react", () => {
+    const motion = new Proxy(
+        {},
+        {
+            get: (_t, tag: string) =>
+                forwardRef(
+                    (
+                        props: Record<string, unknown>,
+                        ref: React.Ref<HTMLElement>,
+                    ) => {
+                        const {
+                            layout: _layout,
+                            layoutId: _layoutId,
+                            initial: _initial,
+                            animate: _animate,
+                            exit: _exit,
+                            transition: _transition,
+                            variants: _variants,
+                            custom: _custom,
+                            whileHover: _whileHover,
+                            whileTap: _whileTap,
+                            ...rest
+                        } = props;
+                        return createElement(tag, { ...rest, ref });
+                    },
+                ),
+        },
+    );
+    return {
+        motion,
+        AnimatePresence: ({ children }: { children: ReactNode }) => children,
+        useReducedMotion: () => false,
+        LayoutGroup: ({ children }: { children: ReactNode }) => children,
+    };
+});
+
+// `useIsDesktop` is module-mocked at the top so each describe block
+// can swap its return value via `beforeEach` (mirrors the pattern in
+// `SuggestionLogPanel.editMode.test.tsx`).
+vi.mock("../hooks/useIsDesktop", () => ({
+    useIsDesktop: () => true,
+}));
+
+import { render, waitFor } from "@testing-library/react";
+import { Clue } from "../Clue";
+
+const setIsDesktop = async (value: boolean): Promise<void> => {
+    const mod = await import("../hooks/useIsDesktop");
+    (mod as { useIsDesktop: () => boolean }).useIsDesktop = () => value;
+};
+
+// Two stable selectors that pin which pane is mounted in the DOM:
+// - `#checklist` is on the Checklist `<section>`.
+// - `#prior-suggestions` is the heading id inside SuggestionLogPanel.
+const findChecklist = (): HTMLElement | null =>
+    document.getElementById("checklist");
+const findSuggestionLog = (): HTMLElement | null =>
+    document.getElementById("prior-suggestions");
+
+beforeEach(() => {
+    window.localStorage.clear();
+    window.history.replaceState(null, "", "/");
+});
+
+describe("PlayLayout — desktop renders both panes side-by-side", () => {
+    beforeEach(async () => {
+        await setIsDesktop(true);
+    });
+
+    test("checklist mode mounts the Checklist AND the SuggestionLogPanel", async () => {
+        window.history.replaceState(null, "", "/?view=checklist");
+        render(<Clue />);
+        await waitFor(() => {
+            expect(findChecklist()).toBeInTheDocument();
+        });
+        // On desktop, switching to either play sub-mode keeps both panes
+        // visible — the breakpoint owns the layout, not the sub-mode.
+        // This is `DesktopPlayLayout` rendering Checklist + the sticky
+        // SuggestionLogPanel column at all times.
+        expect(findSuggestionLog()).toBeInTheDocument();
+    });
+
+    test("suggest mode also mounts both panes (no breakpoint-level slide)", async () => {
+        window.history.replaceState(null, "", "/?view=suggest");
+        render(<Clue />);
+        await waitFor(() => {
+            expect(findSuggestionLog()).toBeInTheDocument();
+        });
+        expect(findChecklist()).toBeInTheDocument();
+    });
+});
+
+describe("PlayLayout — mobile mounts only the active pane", () => {
+    beforeEach(async () => {
+        await setIsDesktop(false);
+    });
+
+    test("checklist mode: Checklist is mounted, SuggestionLogPanel is NOT", async () => {
+        window.history.replaceState(null, "", "/?view=checklist");
+        render(<Clue />);
+        await waitFor(() => {
+            expect(findChecklist()).toBeInTheDocument();
+        });
+        // The whole point of the mobile restructure: on mobile there's
+        // no inactive pane lurking off-screen, so horizontal page scroll
+        // on a wide setup table never reveals a hidden Suggest column,
+        // and SuggestionLogPanel's pill row doesn't drag main's
+        // max-content sizing while the user is on the Checklist tab.
+        expect(findSuggestionLog()).not.toBeInTheDocument();
+    });
+
+    test("suggest mode: SuggestionLogPanel is mounted, Checklist is NOT", async () => {
+        window.history.replaceState(null, "", "/?view=suggest");
+        render(<Clue />);
+        await waitFor(() => {
+            expect(findSuggestionLog()).toBeInTheDocument();
+        });
+        expect(findChecklist()).not.toBeInTheDocument();
+    });
+});

--- a/src/ui/components/PlayLayout.tsx
+++ b/src/ui/components/PlayLayout.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { AnimatePresence, motion, type Variants } from "motion/react";
+import { useEffect, useRef } from "react";
+import { useIsDesktop } from "../hooks/useIsDesktop";
+import { T_STANDARD, useReducedTransition } from "../motion";
+import { Checklist } from "./Checklist";
+import { SuggestionLogPanel } from "./SuggestionLogPanel";
+
+// Non user-facing literals.
+const VARIANT_INITIAL = "initial";
+const VARIANT_ANIMATE = "animate";
+const VARIANT_EXIT = "exit";
+const UI_CHECKLIST: "checklist" = "checklist";
+const UI_SUGGEST: "suggest" = "suggest";
+
+type PlayMode = "checklist" | "suggest";
+type Direction = 1 | -1;
+
+const PLAY_POSITIONS: Record<PlayMode, number> = {
+    checklist: 0,
+    suggest: 1,
+};
+
+function getDirection(prev: PlayMode, next: PlayMode): Direction {
+    return PLAY_POSITIONS[next] >= PLAY_POSITIONS[prev] ? 1 : -1;
+}
+
+const slideVariants: Variants = {
+    initial: (dir: Direction) => ({ x: dir === 1 ? "100%" : "-100%", opacity: 0 }),
+    animate: { x: 0, opacity: 1 },
+    exit: (dir: Direction) => ({ x: dir === 1 ? "-100%" : "100%", opacity: 0 }),
+};
+
+/**
+ * Layout for the Play view. Renders different React trees by
+ * breakpoint instead of one tree with CSS hiding:
+ *
+ * - **Desktop (≥800px)**: a two-column grid with the `Checklist` and
+ *   the `SuggestionLogPanel` side-by-side. The log pane is sticky on
+ *   both axes (`top`+`right`) so it stays anchored to the viewport's
+ *   top-right corner as the page scrolls — vertically through long
+ *   tables and horizontally through wide ones.
+ * - **Mobile (<800px)**: only the active pane is rendered. Switching
+ *   between Checklist and Suggest cross-fades the two via
+ *   `AnimatePresence` — slide variants combine an x-axis translate
+ *   with opacity, so the entering and exiting panes overlap during
+ *   the transition (no spatial gap) without leaking the off-screen
+ *   pane visually. The two views are genuinely separate, not stacked,
+ *   so horizontal page scroll on a wide setup table never reveals an
+ *   inactive pane "to the side". The mobile container clips
+ *   horizontal slide overflow as a safety net.
+ */
+export function PlayLayout({ mode }: { readonly mode: PlayMode }) {
+    const isDesktop = useIsDesktop();
+    return isDesktop ? <DesktopPlayLayout /> : <MobilePlayLayout mode={mode} />;
+}
+
+function DesktopPlayLayout() {
+    return (
+        <div className="grid grid-cols-[minmax(0,1fr)_minmax(320px,420px)] items-start gap-5">
+            <Checklist />
+            <div className="sticky right-5 top-[calc(var(--contradiction-banner-offset,0px)+var(--header-offset,0px)+1.5rem)] max-h-[calc(100dvh-var(--contradiction-banner-offset,0px)-var(--header-offset,0px)-3rem)] min-w-0 overflow-y-auto">
+                <SuggestionLogPanel />
+            </div>
+        </div>
+    );
+}
+
+function MobilePlayLayout({ mode }: { readonly mode: PlayMode }) {
+    const transition = useReducedTransition(T_STANDARD, { fadeMs: 120 });
+
+    // Track the previous mode to compute slide direction. Updates via
+    // useEffect so render sees the PREVIOUS value alongside the new
+    // mode — which is what lets us choose the correct enter/exit side.
+    const prevModeRef = useRef<PlayMode>(mode);
+    const direction = getDirection(prevModeRef.current, mode);
+    useEffect(() => {
+        prevModeRef.current = mode;
+    }, [mode]);
+
+    return (
+        <div className="relative grid grid-cols-[minmax(0,1fr)] [grid-template-areas:'stack'] overflow-x-clip">
+            <AnimatePresence custom={direction} initial={false}>
+                {mode === UI_CHECKLIST ? (
+                    <motion.div
+                        key={UI_CHECKLIST}
+                        custom={direction}
+                        variants={slideVariants}
+                        initial={VARIANT_INITIAL}
+                        animate={VARIANT_ANIMATE}
+                        exit={VARIANT_EXIT}
+                        transition={transition}
+                        className="[grid-area:stack] min-w-0"
+                    >
+                        <Checklist />
+                    </motion.div>
+                ) : (
+                    <motion.div
+                        key={UI_SUGGEST}
+                        custom={direction}
+                        variants={slideVariants}
+                        initial={VARIANT_INITIAL}
+                        animate={VARIANT_ANIMATE}
+                        exit={VARIANT_EXIT}
+                        transition={transition}
+                        className="[grid-area:stack] min-w-0"
+                    >
+                        <SuggestionLogPanel />
+                    </motion.div>
+                )}
+            </AnimatePresence>
+        </div>
+    );
+}

--- a/src/ui/components/SuggestionLogPanel.editMode.test.tsx
+++ b/src/ui/components/SuggestionLogPanel.editMode.test.tsx
@@ -84,7 +84,9 @@ const getRow = (): HTMLElement => {
     return el;
 };
 
-const seedOneSuggestionAndMount = async (): Promise<void> => {
+const seedOneSuggestionAndMount = async (
+    view: "checklist" | "suggest" = "checklist",
+): Promise<void> => {
     const setup = CLASSIC_SETUP_3P;
     const mustard = cardByName(setup, "Col. Mustard");
     const knife = cardByName(setup, "Knife");
@@ -103,9 +105,17 @@ const seedOneSuggestionAndMount = async (): Promise<void> => {
         ],
         accusations: [],
     });
+    if (view === "suggest") {
+        // The mobile play layout only mounts the active pane, so
+        // exercising PriorSuggestionItem on mobile requires landing
+        // on the suggest pane explicitly. Desktop renders both panes
+        // side-by-side regardless, so the default
+        // (`view: "checklist"`) is fine for desktop tests.
+        window.history.replaceState(null, "", "/?view=suggest");
+    }
     render(<Clue />);
     await waitFor(() => {
-        expect(window.location.search).toContain("view=checklist");
+        expect(window.location.search).toContain(`view=${view}`);
     });
     await waitFor(() => {
         expect(
@@ -335,7 +345,7 @@ describe("PriorSuggestionItem — entering edit mode (mobile two-tap)", () => {
     });
 
     test("first tap reveals the Edit button without entering edit mode", async () => {
-        await seedOneSuggestionAndMount();
+        await seedOneSuggestionAndMount("suggest");
         fireEvent.click(getRow());
         await waitFor(() => {
             expect(
@@ -346,7 +356,7 @@ describe("PriorSuggestionItem — entering edit mode (mobile two-tap)", () => {
     });
 
     test("tapping the Edit button enters edit mode", async () => {
-        await seedOneSuggestionAndMount();
+        await seedOneSuggestionAndMount("suggest");
         fireEvent.click(getRow());
         await waitFor(() => {
             expect(
@@ -358,7 +368,7 @@ describe("PriorSuggestionItem — entering edit mode (mobile two-tap)", () => {
     });
 
     test("tapping outside while the Edit button is visible cancels pre-edit mode", async () => {
-        await seedOneSuggestionAndMount();
+        await seedOneSuggestionAndMount("suggest");
         fireEvent.click(getRow());
         await waitFor(() => {
             expect(
@@ -378,7 +388,7 @@ describe("PriorSuggestionItem — entering edit mode (mobile two-tap)", () => {
     });
 
     test("tapping inside the row while in pre-edit mode does NOT dismiss it", async () => {
-        await seedOneSuggestionAndMount();
+        await seedOneSuggestionAndMount("suggest");
         fireEvent.click(getRow());
         await waitFor(() => {
             expect(

--- a/src/ui/components/SuggestionLogPanel.tsx
+++ b/src/ui/components/SuggestionLogPanel.tsx
@@ -81,7 +81,7 @@ const LABEL_ROW = "flex items-center gap-1.5 text-[13px]";
 export function SuggestionLogPanel() {
     const t = useTranslations("suggestions");
     return (
-        <section className="min-w-0 rounded-[var(--radius)] border border-border bg-panel p-4">
+        <section className="min-w-0 contain-inline-size rounded-[var(--radius)] border border-border bg-panel p-4">
             <h2 className="m-0 mb-3 text-[16px] uppercase tracking-[0.05em] text-accent">
                 {t("title")}
             </h2>

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -44,6 +44,26 @@ if (typeof window !== "undefined" && typeof window.matchMedia !== "function") {
     });
 }
 
+// jsdom doesn't ship `ResizeObserver` either. The Clue layout uses one
+// to publish the header height into a CSS variable; without a stub the
+// `useLayoutEffect` would crash on mount.
+if (typeof globalThis.ResizeObserver === "undefined") {
+    class ResizeObserverStub {
+        observe(): void {}
+        unobserve(): void {}
+        disconnect(): void {}
+    }
+    (globalThis as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver =
+        ResizeObserverStub as unknown as typeof ResizeObserver;
+}
+
+// jsdom logs `Not implemented: Window's scrollTo() method` for any
+// `window.scrollTo` call. The Clue layout calls it on Setup ↔ Play
+// switches to reset page scroll; stub it so tests stay quiet.
+if (typeof window !== "undefined") {
+    window.scrollTo = (() => {}) as typeof window.scrollTo;
+}
+
 // jsdom ships without `TextEncoder` / `TextDecoder` on the global.
 // Some dependencies (effect's `Encoding` module) reference them at
 // module-load time, so polyfill before any test imports them.


### PR DESCRIPTION
## Summary

- Wheel events anywhere on the page now scroll the Checklist table, vertically and horizontally — the table no longer lives inside its own internal scroll viewport
- Mobile and desktop play views are now real React forks (mobile mounts only the active pane; desktop mounts both side-by-side) instead of a CSS hide-one-column pattern, codified in a new `PlayLayout` component
- Setup ↔ Play slides cross-fade without a page-sized gap or a flashing browser scrollbar; the page header, intro card, and card-pack row stay anchored to their natural left padding during horizontal page scroll on wide setup tables

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm knip && pnpm i18n:check` (567 / 567)
- [x] `PlayLayout.test.tsx` covers desktop-mounts-both / mobile-mounts-only-active for both `?view=checklist` and `?view=suggest`
- [ ] Manual checks per the new "Layout, scroll, and animation behaviors" section in CLAUDE.md, in the `next-dev` preview:
  - [ ] Vertical: wheel anywhere advances the table; sticky `<thead>` stays at viewport top and tucks under the contradiction banner when present
  - [ ] Horizontal (Setup mode, viewport ≤ ~1200): page picks up a horizontal scrollbar; CLUE SOLVER + Game setup card + USE CARD PACK row stay anchored at their natural left padding (NOT butted against `x: 0`); sticky `<thead>` horizontally scrolls *with* the table
  - [ ] Mobile Suggest fits viewport — no horizontal scrollbar; pill row wraps over multiple rows
  - [ ] Setup ↔ Play cross-fade: both panes overlap mid-flight (no page-sized gap), browser scrollbar doesn't flash, scroll resets to top after switch
  - [ ] Mobile Checklist ↔ Suggest slide; only the active pane is in the DOM after the slide
  - [ ] Desktop side-by-side: SuggestionLogPanel sticky-top with bounded max-height + internal `overflow-y-auto`

🤖 Generated with [Claude Code](https://claude.com/claude-code)