### PR TITLE
Scroll dropdown to keep arrow-key highlight visible

### DIFF
--- a/src/ui/components/SuggestionPills.test.tsx
+++ b/src/ui/components/SuggestionPills.test.tsx
@@ -1,10 +1,10 @@
-import { describe, expect, test, vi, type Mock } from "vitest";
+import { afterEach, describe, expect, test, vi, type Mock } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { useEffect, useState } from "react";
 import { Player } from "../../logic/GameObjects";
 import type { Option } from "./SuggestionPills";
-import { MultiSelectList, NOBODY } from "./SuggestionPills";
+import { MultiSelectList, NOBODY, SingleSelectList } from "./SuggestionPills";
 
 const A = Player("Anisha");
 const B = Player("Bob");
@@ -163,6 +163,33 @@ describe("MultiSelectList — onCommit identity stability", () => {
         expect(onCommit).toHaveBeenCalledWith([A]);
     });
 
+    test("ArrowDown scrolls newly-highlighted row into view", async () => {
+        // Arrow-key navigation must scroll the focused row into view so it
+        // stays visible past the popover's `max-h-[240px]` cutoff. jsdom
+        // doesn't define `scrollIntoView`, so install a stub on the
+        // prototype before spying on it.
+        const user = userEvent.setup();
+        const spy = vi.spyOn(Element.prototype, "scrollIntoView");
+        render(
+            <MultiSelectList
+                options={playerOpts}
+                selected={[]}
+                nobodyChosen={false}
+                nobodyLabel="Nobody"
+                commitHint="Press Enter"
+                onCommit={vi.fn()}
+            />,
+        );
+        // Mount fires once for the initial focused row (Nobody at idx 0).
+        const baseline = spy.mock.calls.length;
+        screen.getByRole("listbox").focus();
+        await user.keyboard("{ArrowDown}");
+        await user.keyboard("{ArrowDown}");
+        expect(spy.mock.calls.length).toBeGreaterThan(baseline);
+        expect(spy).toHaveBeenLastCalledWith({ block: "nearest" });
+        spy.mockRestore();
+    });
+
     test("selecting Nobody commits NOBODY and advances", async () => {
         const user = userEvent.setup();
         const onCommit = vi.fn();
@@ -179,5 +206,52 @@ describe("MultiSelectList — onCommit identity stability", () => {
         await user.click(screen.getByRole("option", { name: /Nobody passed/ }));
         expect(onCommit).toHaveBeenCalledTimes(1);
         expect(onCommit).toHaveBeenCalledWith(NOBODY);
+    });
+});
+
+describe("SingleSelectList — keyboard scroll-into-view", () => {
+    const longOpts: ReadonlyArray<Option<string>> = Array.from(
+        { length: 12 },
+        (_, i) => ({ value: `v${i}`, label: `Option ${i}` }),
+    );
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    test("ArrowDown scrolls the newly-highlighted row into view", async () => {
+        const user = userEvent.setup();
+        const spy = vi.spyOn(Element.prototype, "scrollIntoView");
+        render(
+            <SingleSelectList
+                options={longOpts}
+                selected={null}
+                onCommit={vi.fn()}
+                nobodyLabel={null}
+                nobodyValue={null}
+            />,
+        );
+        const baseline = spy.mock.calls.length;
+        screen.getByRole("listbox").focus();
+        await user.keyboard("{ArrowDown}");
+        await user.keyboard("{ArrowDown}");
+        expect(spy.mock.calls.length).toBeGreaterThan(baseline);
+        expect(spy).toHaveBeenLastCalledWith({ block: "nearest" });
+    });
+
+    test("scrolls pre-selected option into view on mount", () => {
+        const spy = vi.spyOn(Element.prototype, "scrollIntoView");
+        render(
+            <SingleSelectList
+                options={longOpts}
+                selected="v9"
+                onCommit={vi.fn()}
+                nobodyLabel={null}
+                nobodyValue={null}
+            />,
+        );
+        // Mount-time effect fires for the initial focusedIdx, which lands
+        // on the pre-selected row (index 9 in the 12-option list).
+        expect(spy).toHaveBeenCalledWith({ block: "nearest" });
     });
 });

--- a/src/ui/components/SuggestionPills.tsx
+++ b/src/ui/components/SuggestionPills.tsx
@@ -458,6 +458,14 @@ export function SingleSelectList<T>({
         listRef.current?.focus();
     }, []);
 
+    const focusedRowRef = useRef<HTMLLIElement | null>(null);
+    useEffect(() => {
+        focusedRowRef.current?.scrollIntoView(
+            // eslint-disable-next-line i18next/no-literal-string -- DOM enum values
+            { block: "nearest" },
+        );
+    }, [focusedIdx]);
+
     const commitAt = useCallback(
         (i: number) => {
             const row = rows[i];
@@ -516,6 +524,7 @@ export function SingleSelectList<T>({
                 return (
                     <li
                         key={i}
+                        ref={highlighted ? focusedRowRef : null}
                         role="option"
                         aria-selected={isSelected}
                         className={
@@ -583,6 +592,14 @@ export function MultiSelectList({
     useEffect(() => {
         listRef.current?.focus();
     }, []);
+
+    const focusedRowRef = useRef<HTMLLIElement | null>(null);
+    useEffect(() => {
+        focusedRowRef.current?.scrollIntoView(
+            // eslint-disable-next-line i18next/no-literal-string -- DOM enum values
+            { block: "nearest" },
+        );
+    }, [focusedIdx]);
 
     // On unmount, persist the toggled set without advancing. Covers
     // Esc, outside-click, and clicking another pill. `committedRef`
@@ -683,6 +700,7 @@ export function MultiSelectList({
                 className="m-0 max-h-[240px] list-none overflow-y-auto p-0 outline-none"
             >
                 <li
+                    ref={focusedIdx === 0 ? focusedRowRef : null}
                     role="option"
                     aria-selected={nobodyChosen}
                     className={
@@ -704,6 +722,7 @@ export function MultiSelectList({
                     return (
                         <li
                             key={String(opt.value)}
+                            ref={highlighted ? focusedRowRef : null}
                             role="option"
                             aria-selected={checked}
                             className={

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -64,6 +64,16 @@ if (typeof window !== "undefined") {
     window.scrollTo = (() => {}) as typeof window.scrollTo;
 }
 
+// jsdom doesn't define `Element.prototype.scrollIntoView`. The dropdown
+// list components call it to keep the arrow-key-highlighted row visible;
+// without a stub any test that mounts those popovers would crash.
+if (
+    typeof Element !== "undefined" &&
+    typeof Element.prototype.scrollIntoView !== "function"
+) {
+    Element.prototype.scrollIntoView = function () {};
+}
+
 // jsdom ships without `TextEncoder` / `TextDecoder` on the global.
 // Some dependencies (effect's `Encoding` module) reference them at
 // module-load time, so polyfill before any test imports them.


### PR DESCRIPTION
## Summary

In the suggestion and accusation forms, when a pill opened a dropdown of options taller than the popover's 240 px cutoff (e.g. the room dropdown with 9 options), arrow keys moved the highlight without scrolling the list. The highlighted row could sit below the visible portion, so you couldn't see what you had selected and couldn't reach options past the cutoff with the keyboard.

Both forms share the same `SingleSelectList` / `MultiSelectList` components in [SuggestionPills.tsx](src/ui/components/SuggestionPills.tsx), so a single fix covers both flows. ArrowDown / ArrowUp / Home / End now keep the highlighted row in view (`block: "nearest"` — only scrolls when the row is actually outside the viewport, so no jitter when navigating within view). Mounting the popover with a pre-selected option deep in a long list also scrolls that option into view on first paint.

## Commits

- **Scroll dropdown to keep arrow-key highlight visible** — adds a ref pointing at the currently-highlighted `<li>` plus a `useEffect([focusedIdx])` calling `scrollIntoView({ block: "nearest" })` in both list components. Polyfills `Element.prototype.scrollIntoView` in `vitest.setup.ts` so existing tests that mount these popovers don't crash on the new call. Adds three new tests spying on the prototype call.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm knip && pnpm i18n:check` — all green
- [x] Verified in next-dev preview: opened the Room dropdown (9 options, 240 px viewport, 320 px content). Walking ArrowDown past the visible boundary produced `scrollTop` 0 → 8.5 → 44 → 79.5 (≈ max). ArrowUp walked back symmetrically. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)