### PR TITLE
Failed-accusation Tier 2 narrowing + case-file popovers

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -167,6 +167,10 @@
         "failed-accusation": {
             "detailKnown": "{accuser}'s accusation #{number} ({cardLabels}) failed, so the case file isn't all three of those — and the other two are already pinned, so {cellCard} can't be in the case file either.",
             "detailUnknown": "A failed accusation #{number} named {cellCard}; the other two cards in that accusation are already pinned to the case file, so {cellCard} can't be."
+        },
+        "failed-accusation-pairwise": {
+            "headline": "Failed accusations",
+            "detail": "{pinnedCardLabel} is in the case file, and accusations {accusationNumbers} together rule out every still-possible third card paired with {cellCard}. So {cellCard} can't be in the case file."
         }
     },
     "recommendations": {

--- a/src/logic/ContradictionKind.ts
+++ b/src/logic/ContradictionKind.ts
@@ -36,6 +36,10 @@ export type ContradictionKind =
           readonly accusationIndex: number;
       }
     | {
+          readonly _tag: "FailedAccusationPairwiseNarrowing";
+          readonly accusationIndices: ReadonlyArray<number>;
+      }
+    | {
           readonly _tag: "SliceCardOwnership";
           readonly card: Card;
           readonly direction: "over" | "under";

--- a/src/logic/Deducer.test.ts
+++ b/src/logic/Deducer.test.ts
@@ -362,6 +362,144 @@ describe("deduce — failed accusations", () => {
         expect(result.failure.contradictionKind?._tag).toBe("FailedAccusation");
     });
 
+    test("Tier 2: case_S=Y + accusations covering every room for (S, W) → case_W=N", () => {
+        // Pin Plum (suspect) Y in case file. Don't pin any weapon or
+        // room. Then file failed accusations (Plum, Knife, R) for every
+        // room R — together they exhaust the room category. Tier 1
+        // alone can't fire (each accusation has only 1 Y, 0 N), but
+        // Tier 2 should deduce: case_Knife = N.
+        let knowledge = emptyKnowledge;
+        knowledge = setCell(knowledge, Cell(CaseFileOwner(), PLUM), Y);
+        const roomsCategory = expectDefined(
+            setup.categories.find(c => c.name === "Room"),
+            "Room category",
+        );
+        const rooms = cardIdsInCategory(setup, roomsCategory.id);
+        const accusations = rooms.map(r =>
+            Accusation({ accuser: A, cards: [PLUM, KNIFE, r] }),
+        );
+        const result = runDeduce(setup, [], knowledge, accusations);
+        expect(Result.isSuccess(result)).toBe(true);
+        if (!Result.isSuccess(result)) return;
+        expect(getCellByOwnerCard(result.success, CaseFileOwner(), KNIFE)).toBe(N);
+    });
+
+    test("Tier 2: case_R=Y + accusations covering every suspect for (W, R) → case_W=N", () => {
+        // Symmetric to the above but pinned on the room side: pin
+        // Conservatory Y in case file, then file (S, Knife, Conservatory)
+        // for every suspect S so that the (suspect, _ , Conservatory)
+        // pair "Knife as partner pinned by Conservatory" is exhausted.
+        // Wait — Tier 2's pinned/partner/z roles are symmetric across
+        // all 6 orderings. Pinning Conservatory and exhausting the
+        // suspect category over (W=Knife, R=Conservatory) accusations
+        // forces case_Knife = N.
+        let knowledge = emptyKnowledge;
+        knowledge = setCell(knowledge, Cell(CaseFileOwner(), CONSERV), Y);
+        const accusations = suspects.map(s =>
+            Accusation({ accuser: A, cards: [s, KNIFE, CONSERV] }),
+        );
+        const result = runDeduce(setup, [], knowledge, accusations);
+        expect(Result.isSuccess(result)).toBe(true);
+        if (!Result.isSuccess(result)) return;
+        expect(getCellByOwnerCard(result.success, CaseFileOwner(), KNIFE)).toBe(N);
+    });
+
+    test("Tier 2: doesn't fire when one candidate room isn't covered", () => {
+        // Pin Plum Y in case file. File (Plum, Knife, R) for every
+        // room *except* Library — leaves Library uncovered. Tier 2
+        // must NOT force case_Knife=N because the case file could
+        // still be (Plum, Knife, Library) which isn't refuted by any
+        // failed accusation.
+        let knowledge = emptyKnowledge;
+        knowledge = setCell(knowledge, Cell(CaseFileOwner(), PLUM), Y);
+        const roomsCategory = expectDefined(
+            setup.categories.find(c => c.name === "Room"),
+            "Room category",
+        );
+        const rooms = cardIdsInCategory(setup, roomsCategory.id);
+        const accusations = rooms
+            .filter(r => r !== LIBRARY)
+            .map(r => Accusation({ accuser: A, cards: [PLUM, KNIFE, r] }));
+        const result = runDeduce(setup, [], knowledge, accusations);
+        expect(Result.isSuccess(result)).toBe(true);
+        if (!Result.isSuccess(result)) return;
+        expect(
+            getCellByOwnerCard(result.success, CaseFileOwner(), KNIFE),
+        ).toBeUndefined();
+    });
+
+    test("Tier 2 + already-N rooms: candidate set excludes them, narrowing still works", () => {
+        // Pin Plum Y in case file. Manually mark every room except
+        // Conservatory and Library as N for case file (so the room
+        // category is narrowed to two candidates). File only two
+        // failed accusations: (Plum, Knife, Conservatory) and
+        // (Plum, Knife, Library). Tier 2 sees that the candidate set
+        // {Conservatory, Library} is exactly covered, so it forces
+        // case_Knife = N.
+        let knowledge = emptyKnowledge;
+        knowledge = setCell(knowledge, Cell(CaseFileOwner(), PLUM), Y);
+        const roomsCategory = expectDefined(
+            setup.categories.find(c => c.name === "Room"),
+            "Room category",
+        );
+        const rooms = cardIdsInCategory(setup, roomsCategory.id);
+        for (const r of rooms) {
+            if (r === CONSERV || r === LIBRARY) continue;
+            knowledge = setCell(knowledge, Cell(CaseFileOwner(), r), N);
+        }
+        const accusations = [
+            Accusation({ accuser: A, cards: [PLUM, KNIFE, CONSERV] }),
+            Accusation({ accuser: A, cards: [PLUM, KNIFE, LIBRARY] }),
+        ];
+        const result = runDeduce(setup, [], knowledge, accusations);
+        expect(Result.isSuccess(result)).toBe(true);
+        if (!Result.isSuccess(result)) return;
+        expect(getCellByOwnerCard(result.success, CaseFileOwner(), KNIFE)).toBe(N);
+    });
+
+    test("Tier 2 cascades: forced N opens slice → forced Y → Tier 1 fires next iteration", () => {
+        // Same pigeonhole as above, but narrow the WEAPON category to
+        // just {Knife, Rope} via case-file Ns. Tier 2 forces
+        // case_Knife=N, the case-file slice then forces case_Rope=Y,
+        // and then Tier 1 fires on each (Plum, Knife, R) accusation —
+        // but those accusations name Knife (now N), so they're
+        // trivially satisfied. Instead Tier 2 fires AGAIN under the
+        // (Rope is now Y) configuration if there are also accusations
+        // pairing Rope with Plum.
+        //
+        // Simpler cascade check: pin Plum=Y, narrow rooms to one
+        // candidate. The slice forces that room=Y, and Tier 1 then
+        // gets (Y, Y, ?) → forces the third card to N. We verify the
+        // final outcome.
+        let knowledge = emptyKnowledge;
+        knowledge = setCell(knowledge, Cell(CaseFileOwner(), PLUM), Y);
+        const roomsCategory = expectDefined(
+            setup.categories.find(c => c.name === "Room"),
+            "Room category",
+        );
+        const rooms = cardIdsInCategory(setup, roomsCategory.id);
+        // Knock all rooms but Conservatory to N → slice forces
+        // case_Conservatory=Y.
+        for (const r of rooms) {
+            if (r === CONSERV) continue;
+            knowledge = setCell(knowledge, Cell(CaseFileOwner(), r), N);
+        }
+        const accusations = [
+            Accusation({ accuser: A, cards: [PLUM, KNIFE, CONSERV] }),
+        ];
+        const result = runDeduce(setup, [], knowledge, accusations);
+        expect(Result.isSuccess(result)).toBe(true);
+        if (!Result.isSuccess(result)) return;
+        // case_Conservatory should be Y (slice), and then Tier 1
+        // fires: (Plum=Y, Knife=?, Conserv=Y) → Knife=N.
+        expect(
+            getCellByOwnerCard(result.success, CaseFileOwner(), CONSERV),
+        ).toBe(Y);
+        expect(
+            getCellByOwnerCard(result.success, CaseFileOwner(), KNIFE),
+        ).toBe(N);
+    });
+
     test("cascade: failed accusation N + consistency slice → forces the right Y", () => {
         let knowledge = emptyKnowledge;
         // Knock the suspect category down to two candidates: PLUM + MUSTARD,

--- a/src/logic/Provenance.test.ts
+++ b/src/logic/Provenance.test.ts
@@ -10,6 +10,7 @@ import {
     describeReason,
     DisjointGroupsHandLock,
     FailedAccusation,
+    FailedAccusationPairwiseNarrowing,
     NonRefuters,
     PlayerHand,
     type Provenance,
@@ -95,6 +96,19 @@ describe("ReasonKind constructors", () => {
         expect(r._tag).toBe("FailedAccusation");
         if (r._tag !== "FailedAccusation") throw new Error("unreachable");
         expect(r.accusationIndex).toBe(4);
+    });
+
+    test("FailedAccusationPairwiseNarrowing tags itself and carries pinnedCard + indices", () => {
+        const r = FailedAccusationPairwiseNarrowing({
+            pinnedCard: PLUM,
+            accusationIndices: [0, 2, 5],
+        });
+        expect(r._tag).toBe("FailedAccusationPairwiseNarrowing");
+        if (r._tag !== "FailedAccusationPairwiseNarrowing") {
+            throw new Error("unreachable");
+        }
+        expect(r.pinnedCard).toBe(PLUM);
+        expect(r.accusationIndices).toEqual([0, 2, 5]);
     });
 });
 
@@ -567,5 +581,70 @@ describe("failed-accusation provenance", () => {
         expect(last?.reason.kind._tag).toBe("FailedAccusation");
         if (last?.reason.kind._tag !== "FailedAccusation") return;
         expect(last.reason.kind.accusationIndex).toBe(0);
+    });
+});
+
+describe("failed-accusation-pairwise (Tier 2) provenance", () => {
+    test("describeReason → failed-accusation-pairwise with pinned card + numbers", () => {
+        const cell = Cell(CaseFileOwner(), KNIFE);
+        const reason: Reason = {
+            iteration: 1,
+            kind: FailedAccusationPairwiseNarrowing({
+                pinnedCard: PLUM,
+                accusationIndices: [0, 2, 4],
+            }),
+            value: N,
+            dependsOn: [],
+        };
+        const desc = describeReason(reason, cell, setup, [], []);
+        expect(desc.kind).toBe("failed-accusation-pairwise");
+        if (desc.kind !== "failed-accusation-pairwise") return;
+        expect(desc.params.pinnedCardLabel).toBe("Prof. Plum");
+        expect(desc.params.accusationIndices).toEqual([0, 2, 4]);
+        expect(desc.params.accusationNumbers).toBe("#1, #3, #5");
+        expect(desc.params.value).toBe(N);
+        expect(desc.params.cellCard).toBe("Knife");
+        expect(desc.params.cellPlayer).toBe("Case file");
+    });
+
+    test("chainFor walks back to a FailedAccusationPairwiseNarrowing reason", () => {
+        // Pin PLUM=Y, file (PLUM, KNIFE, R) for every room — Tier 2
+        // forces case_KNIFE=N and the provenance entry should reference
+        // the new ReasonKind.
+        let knowledge = emptyKnowledge;
+        knowledge = setCell(knowledge, Cell(CaseFileOwner(), PLUM), Y);
+        const roomsCategory = setup.categories.find(c => c.name === "Room")!;
+        const accusations = roomsCategory.cards.map(r =>
+            Accusation({ accuser: A, cards: [PLUM, KNIFE, r.id] }),
+        );
+        const result = runDeduceWithExplanations(
+            setup,
+            [],
+            knowledge,
+            accusations,
+        );
+        expect(Result.isSuccess(result)).toBe(true);
+        if (!Result.isSuccess(result)) return;
+        const knifeCell = Cell(CaseFileOwner(), KNIFE);
+        const chain = chainFor(result.success.provenance, knifeCell);
+        const last = chain[chain.length - 1];
+        expect(last?.cell).toEqual(knifeCell);
+        expect(last?.reason.kind._tag).toBe("FailedAccusationPairwiseNarrowing");
+        if (last?.reason.kind._tag !== "FailedAccusationPairwiseNarrowing") {
+            return;
+        }
+        expect(last.reason.kind.pinnedCard).toBe(PLUM);
+        expect(last.reason.kind.accusationIndices.length).toBe(
+            accusations.length,
+        );
+        // dependsOn includes the pinned PLUM cell + every case-file
+        // room cell so the tooltip can walk back to "we knew PLUM was
+        // in the case file" and "rooms X, Y, Z were the candidates".
+        expect(last.reason.dependsOn.length).toBeGreaterThan(1);
+        expect(
+            last.reason.dependsOn.some(c =>
+                c.owner._tag === "CaseFile" && c.card === PLUM,
+            ),
+        ).toBe(true);
     });
 });

--- a/src/logic/Provenance.ts
+++ b/src/logic/Provenance.ts
@@ -60,6 +60,23 @@ class DisjointGroupsHandLockImpl extends Data.TaggedClass(
 class FailedAccusationImpl extends Data.TaggedClass("FailedAccusation")<{
     readonly accusationIndex: number;
 }> {}
+class FailedAccusationPairwiseNarrowingImpl extends Data.TaggedClass(
+    "FailedAccusationPairwiseNarrowing",
+)<{
+    /**
+     * The case-file Y card that activated the narrowing — knowing this
+     * card is in the case file is what reduces every accusation in
+     * `accusationIndices` to a 2-card constraint over the partner +
+     * third-category cards.
+     */
+    readonly pinnedCard: Card;
+    /**
+     * The accusations (by index in the input array) whose third-category
+     * cards collectively cover every still-candidate card in that
+     * category, forcing the partner card to N.
+     */
+    readonly accusationIndices: ReadonlyArray<number>;
+}> {}
 
 export type ReasonKind =
     | InitialKnownCardImpl
@@ -71,7 +88,8 @@ export type ReasonKind =
     | RefuterShowedImpl
     | RefuterOwnsOneOfImpl
     | DisjointGroupsHandLockImpl
-    | FailedAccusationImpl;
+    | FailedAccusationImpl
+    | FailedAccusationPairwiseNarrowingImpl;
 
 const InitialKnownCard = (): ReasonKind => new InitialKnownCardImpl();
 // InitialHandSize is declared in the ReasonKind union but not yet
@@ -99,6 +117,10 @@ export const DisjointGroupsHandLock = (params: {
 export const FailedAccusation = (params: {
     readonly accusationIndex: number;
 }): ReasonKind => new FailedAccusationImpl(params);
+export const FailedAccusationPairwiseNarrowing = (params: {
+    readonly pinnedCard: Card;
+    readonly accusationIndices: ReadonlyArray<number>;
+}): ReasonKind => new FailedAccusationPairwiseNarrowingImpl(params);
 
 /**
  * A short, human-readable reason for why a particular cell has the value
@@ -284,6 +306,17 @@ export type ReasonDescription =
               // (stale provenance entry — accusation removed).
               readonly cardLabels: string | undefined;
           };
+      }
+    | {
+          readonly kind: "failed-accusation-pairwise";
+          readonly params: CellParams & {
+              readonly pinnedCardLabel: string;
+              readonly accusationIndices: ReadonlyArray<number>;
+              // 1-based, comma-separated for the i18n template; rendered
+              // as e.g. "#3, #5, #7" so users can find the contributing
+              // accusations in the log.
+              readonly accusationNumbers: string;
+          };
       };
 
 export const describeReason = (
@@ -406,6 +439,20 @@ export const describeReason = (
                     },
                 };
             },
+            FailedAccusationPairwiseNarrowing: ({
+                pinnedCard,
+                accusationIndices,
+            }): ReasonDescription => ({
+                kind: "failed-accusation-pairwise",
+                params: {
+                    ...base,
+                    pinnedCardLabel: cardName(setup, pinnedCard),
+                    accusationIndices,
+                    accusationNumbers: accusationIndices
+                        .map(i => `#${i + 1}`)
+                        .join(", "),
+                },
+            }),
         }),
     );
 };
@@ -460,7 +507,7 @@ export const deduceWithExplanations = Effect.fn("deducer.evaluateWithProvenance"
                 const before = current;
                 current = applyConsistencyRules(setup, tracer)(current);
                 current = applyDeductionRules(setup, suggestions, tracer)(current);
-                current = applyAccusationRules(accusations, tracer)(current);
+                current = applyAccusationRules(accusations, setup, tracer)(current);
                 if (Equal.equals(current, before)) break;
             }
         } catch (e) {

--- a/src/logic/Rules.test.ts
+++ b/src/logic/Rules.test.ts
@@ -23,6 +23,7 @@ import {
     caseFileCategorySlices,
     disjointGroupsHandLock,
     failedAccusationEliminate,
+    failedAccusationPairwiseNarrow,
     nonRefutersDontHaveSuggestedCards,
     playerHandSlices,
     refuterOwnsOneOf,
@@ -910,5 +911,123 @@ describe("failedAccusationEliminate", () => {
         k = setCell(k, Cell(CaseFileOwner(), KNIFE), Y);
         const next = failedAccusationEliminate([])(k);
         expect(next).toEqual(k);
+    });
+});
+
+// -----------------------------------------------------------------------
+// failedAccusationPairwiseNarrow (Tier 2)
+// -----------------------------------------------------------------------
+
+describe("failedAccusationPairwiseNarrow", () => {
+    const SCARLET = cardByName(setup, "Miss Scarlet");
+    const ROPE    = cardByName(setup, "Rope");
+    const LIBRARY = cardByName(setup, "Library");
+    const failed = (accuser: Player, cards: ReadonlyArray<Card>) =>
+        Accusation({ accuser, cards });
+
+    test("no-op when accusations is empty", () => {
+        const k = failedAccusationPairwiseNarrow([], setup)(emptyKnowledge);
+        expect(k).toEqual(emptyKnowledge);
+    });
+
+    test("no-op when no card is pinned to Y in the case file", () => {
+        // One accusation but no pinned card — Tier 2 has nothing to
+        // build on.
+        const accusations = [failed(A, [PLUM, KNIFE, CONSERV])];
+        const k = failedAccusationPairwiseNarrow(accusations, setup)(emptyKnowledge);
+        expect(k).toEqual(emptyKnowledge);
+    });
+
+    test("forces partner=N when pinned=Y and every candidate-z is covered", () => {
+        // Pin PLUM=Y. File (PLUM, KNIFE, R) for every room. Tier 2
+        // should force case_KNIFE=N.
+        let k = emptyKnowledge;
+        k = setCell(k, Cell(CaseFileOwner(), PLUM), Y);
+        const accusations = rooms.map(r => failed(A, [PLUM, KNIFE, r]));
+        k = failedAccusationPairwiseNarrow(accusations, setup)(k);
+        expect(getCellByOwnerCard(k, CaseFileOwner(), KNIFE)).toBe(N);
+    });
+
+    test("doesn't fire if any candidate room is uncovered", () => {
+        let k = emptyKnowledge;
+        k = setCell(k, Cell(CaseFileOwner(), PLUM), Y);
+        // File for every room except CONSERV — leaves CONSERV
+        // uncovered, so case file might still be (PLUM, KNIFE, CONSERV).
+        const accusations = rooms
+            .filter(r => r !== CONSERV)
+            .map(r => failed(A, [PLUM, KNIFE, r]));
+        const next = failedAccusationPairwiseNarrow(accusations, setup)(k);
+        expect(getCellByOwnerCard(next, CaseFileOwner(), KNIFE)).toBeUndefined();
+    });
+
+    test("uses already-N cells to shrink the candidate set", () => {
+        // Pin PLUM=Y. Every room except CONSERV and LIBRARY is N (so
+        // candidates = {CONSERV, LIBRARY}). File only two accusations
+        // matching those two rooms — Tier 2 should force case_KNIFE=N
+        // even though most rooms aren't covered (they're already N).
+        let k = emptyKnowledge;
+        k = setCell(k, Cell(CaseFileOwner(), PLUM), Y);
+        for (const r of rooms) {
+            if (r === CONSERV || r === LIBRARY) continue;
+            k = setCell(k, Cell(CaseFileOwner(), r), N);
+        }
+        const accusations = [
+            failed(A, [PLUM, KNIFE, CONSERV]),
+            failed(A, [PLUM, KNIFE, LIBRARY]),
+        ];
+        k = failedAccusationPairwiseNarrow(accusations, setup)(k);
+        expect(getCellByOwnerCard(k, CaseFileOwner(), KNIFE)).toBe(N);
+    });
+
+    test("doesn't fire when partner is already known (Y or N)", () => {
+        let k = emptyKnowledge;
+        k = setCell(k, Cell(CaseFileOwner(), PLUM), Y);
+        k = setCell(k, Cell(CaseFileOwner(), KNIFE), N);
+        const accusations = rooms.map(r => failed(A, [PLUM, KNIFE, r]));
+        // Already-N partner: skipped (no change).
+        const next = failedAccusationPairwiseNarrow(accusations, setup)(k);
+        expect(next).toEqual(k);
+    });
+
+    test("works with the symmetric ordering (case_R=Y, partner=W)", () => {
+        // Pin CONSERV=Y. File (S, KNIFE, CONSERV) for every suspect
+        // S. Tier 2's "pinned=CONSERV, partner=KNIFE, z-category=
+        // suspects" ordering should force case_KNIFE=N.
+        let k = emptyKnowledge;
+        k = setCell(k, Cell(CaseFileOwner(), CONSERV), Y);
+        const accusations = suspects.map(s => failed(A, [s, KNIFE, CONSERV]));
+        k = failedAccusationPairwiseNarrow(accusations, setup)(k);
+        expect(getCellByOwnerCard(k, CaseFileOwner(), KNIFE)).toBe(N);
+    });
+
+    test("tracer records FailedAccusationPairwiseNarrowing kind with pinnedCard + accusationIndices", () => {
+        let k = emptyKnowledge;
+        k = setCell(k, Cell(CaseFileOwner(), PLUM), Y);
+        const accusations = rooms.map(r => failed(A, [PLUM, KNIFE, r]));
+        const records: SetCellRecord[] = [];
+        const tracer: Tracer = r => records.push(r);
+        failedAccusationPairwiseNarrow(accusations, setup, tracer)(k);
+        expect(records).toHaveLength(1);
+        const rec = expectAt(records, 0);
+        expect(rec.value).toBe(N);
+        expect(rec.cell).toEqual(Cell(CaseFileOwner(), KNIFE));
+        expect(rec.kind._tag).toBe("FailedAccusationPairwiseNarrowing");
+        if (rec.kind._tag !== "FailedAccusationPairwiseNarrowing") return;
+        expect(rec.kind.pinnedCard).toBe(PLUM);
+        expect(rec.kind.accusationIndices).toHaveLength(rooms.length);
+        // dependsOn includes pinned cell + every case-file room cell.
+        expect(rec.dependsOn).toHaveLength(1 + rooms.length);
+    });
+
+    test("does NOT fire when partner is unknown but covered set is empty", () => {
+        // PLUM pinned but no accusations name (PLUM, KNIFE, *) — so
+        // for the (PLUM, KNIFE) ordering coveredZ is empty and the
+        // rule sees no support.
+        let k = emptyKnowledge;
+        k = setCell(k, Cell(CaseFileOwner(), PLUM), Y);
+        const accusations = [failed(A, [SCARLET, ROPE, CONSERV])];
+        const next = failedAccusationPairwiseNarrow(accusations, setup)(k);
+        // Nothing was forced.
+        expect(getCellByOwnerCard(next, CaseFileOwner(), KNIFE)).toBeUndefined();
     });
 });

--- a/src/logic/Rules.ts
+++ b/src/logic/Rules.ts
@@ -23,12 +23,14 @@ import {
 } from "./GameSetup";
 import { Accusation, accusationCards } from "./Accusation";
 import { Suggestion, suggestionCards, suggestionNonRefuters } from "./Suggestion";
+import { cardIdsInCategory, categoryOfCard } from "./CardSet";
 import type { ReasonKind, Tracer } from "./Provenance";
 import {
     CardOwnership,
     CaseFileCategory,
     DisjointGroupsHandLock,
     FailedAccusation,
+    FailedAccusationPairwiseNarrowing,
     NonRefuters,
     PlayerHand,
     RefuterOwnsOneOf,
@@ -681,6 +683,204 @@ export const failedAccusationEliminate = (
     return k;
 };
 
+/**
+ * Multi-accusation pairwise narrowing.
+ *
+ * Tier-1 (`failedAccusationEliminate`) only sees one accusation at a
+ * time. This rule combines failed accusations that share two of three
+ * cards to extract deductions Tier 1 can't reach on its own.
+ *
+ * The constraint a failed accusation imposes is
+ *   ¬(case_S ∧ case_W ∧ case_R).
+ * Combined with category exclusivity (each category contributes exactly
+ * one Y to the case-file row), the following extra rule holds:
+ *
+ *   For an ordered pair (X, Y) of cards from different categories, let
+ *     ZCoverage(X, Y) = { z : (X, Y, z) is a failed accusation, z in
+ *                        the third category }.
+ *   If case_X = Y AND every still-candidate z (i.e. case_z ≠ N) is in
+ *   ZCoverage(X, Y), then case_Y = N.
+ *
+ * Sketch of why: assume case_Y = Y as well. Then for every accusation
+ * (X, Y, z) in the index, Tier 1 forces case_z = N. But category
+ * exclusivity demands at least one z in the third category be Y, and
+ * the still-candidate z's are exactly the ones Tier 1 would force to
+ * N. Contradiction → case_Y must be N.
+ *
+ * The rule walks all 6 directed (pinned, partner, z-category) shapes —
+ * suspects pinned + weapons partner, suspects pinned + rooms partner,
+ * weapons pinned + suspects partner, etc. — so any failed-accusation
+ * pattern that fits the criterion fires regardless of which category
+ * the user happened to deduce first.
+ *
+ * Complexity: O(|accusations| + |categories|² × max-cards-per-category)
+ * per pass. Trivial at Clue's scale (~6 suspects × 6 weapons × 9 rooms,
+ * a handful of accusations).
+ */
+export const failedAccusationPairwiseNarrow = (
+    accusations: ReadonlyArray<Accusation>,
+    setup: GameSetup,
+    tracer?: Tracer,
+) => (knowledge: Knowledge): Knowledge => {
+    if (accusations.length === 0) return knowledge;
+    let k = knowledge;
+    const caseFile = CaseFileOwner();
+
+    // Index every accusation under all 6 ordered (pinned, partner)
+    // pairs. The map's value is a list of (z-card, accusation index)
+    // entries — z-card is the third card of the triple, the one the
+    // partner would force to N if both pinned and partner were Y.
+    type Entry = { readonly z: Card; readonly accusationIndex: number };
+    type Key = string;
+    const keyOf = (pinned: Card, partner: Card): Key =>
+        `${String(pinned)}|${String(partner)}`;
+    const index = new Map<Key, Entry[]>();
+    const partners = new Map<Key, { readonly pinned: Card; readonly partner: Card }>();
+
+    accusations.forEach((accusation, accusationIndex) => {
+        const cards = accusationCards(accusation);
+        if (cards.length !== 3) return; // Clue invariant; defensive
+        for (let a = 0; a < 3; a++) {
+            for (let b = 0; b < 3; b++) {
+                if (a === b) continue;
+                const c = 3 - a - b;
+                const pinned = cards[a]!;
+                const partner = cards[b]!;
+                const z = cards[c]!;
+                const key = keyOf(pinned, partner);
+                const entries = index.get(key);
+                if (entries === undefined) {
+                    index.set(key, [{ z, accusationIndex }]);
+                    partners.set(key, { pinned, partner });
+                } else {
+                    entries.push({ z, accusationIndex });
+                }
+            }
+        }
+    });
+
+    for (const [key, entries] of index) {
+        const meta = partners.get(key)!;
+        const { pinned, partner } = meta;
+
+        // Skip unless the pinned card is Y and the partner is unknown.
+        // If partner is already N nothing to add; if partner is Y,
+        // Tier 1 + slices will surface the contradiction (or the
+        // user's input is over-constrained and they need to resolve
+        // it themselves).
+        const pinnedCell = Cell(caseFile, pinned);
+        const partnerCell = Cell(caseFile, partner);
+        if (getCell(k, pinnedCell) !== Y) continue;
+        if (getCell(k, partnerCell) !== undefined) continue;
+
+        // Determine the third category from any of the entries' z's
+        // (every z in this index entry shares a category by Clue's
+        // one-card-per-category-per-accusation invariant).
+        const zCategoryId = categoryOfCard(setup.cardSet, entries[0]!.z);
+        if (zCategoryId === undefined) continue;
+        const zCategoryCards = cardIdsInCategory(setup.cardSet, zCategoryId);
+        if (zCategoryCards.length === 0) continue;
+
+        // Build the candidate-z set (cards in the third category whose
+        // case-file cell is not yet N) and the covered-z set (the
+        // accusation-witnessed z cards).
+        const candidates: Card[] = [];
+        for (const z of zCategoryCards) {
+            if (getCell(k, Cell(caseFile, z)) !== N) candidates.push(z);
+        }
+        if (candidates.length === 0) {
+            // Category exclusivity has already collapsed — let the
+            // case-file slice surface the contradiction on its next
+            // pass. Don't emit a silent N here.
+            continue;
+        }
+        const covered = new Set<string>();
+        const contributingAccusationIndices: number[] = [];
+        const seenAccusations = new Set<number>();
+        for (const entry of entries) {
+            covered.add(String(entry.z));
+            if (!seenAccusations.has(entry.accusationIndex)) {
+                seenAccusations.add(entry.accusationIndex);
+                contributingAccusationIndices.push(entry.accusationIndex);
+            }
+        }
+
+        // Every candidate must be in the covered set for the rule to
+        // fire. (If any candidate isn't covered, the case file might
+        // still resolve to that uncovered z, leaving the partner free
+        // to be Y.)
+        let allCovered = true;
+        for (const z of candidates) {
+            if (!covered.has(String(z))) {
+                allCovered = false;
+                break;
+            }
+        }
+        if (!allCovered) continue;
+
+        // Trim the contributing-accusation list to only the ones whose
+        // z lies in the candidate set — accusations whose z is already
+        // known N didn't actually do work in this firing.
+        const candidateSet = new Set<string>(candidates.map(String));
+        const usefulAccusations: number[] = [];
+        const seenUseful = new Set<number>();
+        for (const entry of entries) {
+            if (
+                candidateSet.has(String(entry.z))
+                && !seenUseful.has(entry.accusationIndex)
+            ) {
+                seenUseful.add(entry.accusationIndex);
+                usefulAccusations.push(entry.accusationIndex);
+            }
+        }
+        const accusationIndices = usefulAccusations.length > 0
+            ? usefulAccusations
+            : contributingAccusationIndices;
+
+        const before = k;
+        try {
+            k = setCell(k, partnerCell, N);
+        } catch (e) {
+            if (e instanceof Contradiction) {
+                throw new Contradiction({
+                    reason: e.reason,
+                    offendingCells: e.offendingCells.length
+                        ? e.offendingCells
+                        : [partnerCell, pinnedCell],
+                    sliceLabel: e.sliceLabel,
+                    accusationIndex: accusationIndices[0],
+                    contradictionKind: {
+                        _tag: "FailedAccusationPairwiseNarrowing",
+                        accusationIndices,
+                    },
+                });
+            }
+            throw e;
+        }
+        if (k !== before && tracer) {
+            // dependsOn is the pinned cell plus every case-file cell in
+            // the third category — both the candidate cells (which the
+            // rule would have forced to N if partner were Y) and the
+            // already-N cells (which is why the candidate set is what
+            // it is).
+            const dependsOn: Cell[] = [pinnedCell];
+            for (const z of zCategoryCards) {
+                dependsOn.push(Cell(caseFile, z));
+            }
+            tracer({
+                cell: partnerCell,
+                value: N,
+                kind: FailedAccusationPairwiseNarrowing({
+                    pinnedCard: pinned,
+                    accusationIndices,
+                }),
+                dependsOn,
+            });
+        }
+    }
+    return k;
+};
+
 // ---- Top-level rule application ----------------------------------------
 
 /**
@@ -721,18 +921,23 @@ export const applyDeductionRules = (
 );
 
 /**
- * Apply every accusation-driven rule once. Currently just
- * `failedAccusationEliminate`, but kept as a layer of its own so the
- * fixed-point loop in `applyAllRules` (and in `deduceWithExplanations`)
- * can interleave accusation Ns with consistency-slice cascades the
- * same way it interleaves suggestion Ns.
+ * Apply every accusation-driven rule once. The fixed-point loop in
+ * `applyAllRules` (and in `deduceWithExplanations`) interleaves these
+ * with the slice combinator and suggestion rules so each rule can
+ * consume the others' Ys / Ns on the next pass.
+ *
+ * Order: Tier-1 unit propagation runs first so any (Y, Y, ?) the slice
+ * combinator just produced lands a forced N; Tier-2 pairwise narrowing
+ * then handles the multi-accusation pigeonhole patterns Tier 1 misses.
  */
 export const applyAccusationRules = (
     accusations: ReadonlyArray<Accusation>,
+    setup: GameSetup,
     tracer?: Tracer,
 ) => (knowledge: Knowledge): Knowledge => pipe(
     knowledge,
     failedAccusationEliminate(accusations, tracer),
+    failedAccusationPairwiseNarrow(accusations, setup, tracer),
 );
 
 /**
@@ -749,5 +954,5 @@ export const applyAllRules = (
     knowledge,
     applyConsistencyRules(setup, tracer),
     applyDeductionRules(setup, suggestions, tracer),
-    applyAccusationRules(accusations, tracer),
+    applyAccusationRules(accusations, setup, tracer),
 );

--- a/src/ui/components/Checklist.deduce.test.tsx
+++ b/src/ui/components/Checklist.deduce.test.tsx
@@ -167,6 +167,162 @@ describe("Checklist — deduce mode — body layout", () => {
     });
 });
 
+// -----------------------------------------------------------------------
+// Case-file body cells expose the same popover affordance as
+// play-mode player cells when there's a deduction to explain — the
+// case file's value is always derived (the column is read-only), so
+// tooltipContent is the only thing the user sees, and they need a
+// hover/click/keyboard path to it.
+// -----------------------------------------------------------------------
+
+describe("Checklist — case-file deduction popover", () => {
+    test("a deduced case-file cell exposes role=button + aria-haspopup + data-cell-col, with no toggle handler", async () => {
+        // Seed a session where the card-ownership slice can pin the
+        // case file: every non-Plum suspect is dealt to Player 1, so
+        // case_Plum gets deduced=Y and the popover should attach.
+        const session = {
+            version: 6,
+            setup: {
+                players: ["Player 1", "Player 2", "Player 3", "Player 4"],
+                categories: [
+                    {
+                        id: "category-suspects",
+                        name: "Suspect",
+                        cards: [
+                            { id: "card-miss-scarlet", name: "Miss Scarlet" },
+                            { id: "card-col-mustard", name: "Col. Mustard" },
+                            { id: "card-mrs-white", name: "Mrs. White" },
+                            { id: "card-mr-green", name: "Mr. Green" },
+                            { id: "card-mrs-peacock", name: "Mrs. Peacock" },
+                            { id: "card-prof-plum", name: "Prof. Plum" },
+                        ],
+                    },
+                    {
+                        id: "category-weapons",
+                        name: "Weapon",
+                        cards: [
+                            { id: "card-candlestick", name: "Candlestick" },
+                            { id: "card-knife", name: "Knife" },
+                            { id: "card-lead-pipe", name: "Lead pipe" },
+                            { id: "card-revolver", name: "Revolver" },
+                            { id: "card-rope", name: "Rope" },
+                            { id: "card-wrench", name: "Wrench" },
+                        ],
+                    },
+                    {
+                        id: "category-rooms",
+                        name: "Room",
+                        cards: [
+                            { id: "card-kitchen", name: "Kitchen" },
+                            { id: "card-ball-room", name: "Ball room" },
+                            { id: "card-conservatory", name: "Conservatory" },
+                            { id: "card-dining-room", name: "Dining room" },
+                            { id: "card-billiard-room", name: "Billiard room" },
+                            { id: "card-library", name: "Library" },
+                            { id: "card-lounge", name: "Lounge" },
+                            { id: "card-hall", name: "Hall" },
+                            { id: "card-study", name: "Study" },
+                        ],
+                    },
+                ],
+            },
+            hands: [
+                {
+                    player: "Player 1",
+                    cards: [
+                        "card-miss-scarlet",
+                        "card-col-mustard",
+                        "card-mrs-white",
+                        "card-mr-green",
+                        "card-mrs-peacock",
+                    ],
+                },
+            ],
+            handSizes: [
+                { player: "Player 1", size: 5 },
+                { player: "Player 2", size: 5 },
+                { player: "Player 3", size: 4 },
+                { player: "Player 4", size: 4 },
+            ],
+            suggestions: [],
+            accusations: [],
+        };
+        window.localStorage.setItem(
+            "effect-clue.session.v6",
+            JSON.stringify(session),
+        );
+
+        render(<Clue />);
+        await waitForDeduceChecklist();
+
+        // Find the case-file body cell on the Plum row. The case-file
+        // column is the rightmost data-cell-col on each row.
+        const allBodyCells = Array.from(
+            document.querySelectorAll<HTMLElement>("[data-cell-row][data-cell-col]"),
+        );
+        const colNumbers = allBodyCells
+            .map(c => Number(c.getAttribute("data-cell-col")))
+            .filter(n => !Number.isNaN(n) && n >= 0);
+        const maxCol = Math.max(...colNumbers);
+        // 4 players + 1 case-file = 5 columns (cols 0..4). Without my
+        // change case-file wouldn't advertise data-cell-col at all.
+        expect(maxCol).toBeGreaterThanOrEqual(4);
+
+        // Pick a row where the case-file is deduced. Plum (index 5 in
+        // suspects) is the only suspect not dealt — case_Plum=Y.
+        const plumCells = allBodyCells.filter(c => c.getAttribute("data-cell-row") === "5");
+        const caseFileCell = plumCells.find(
+            c => c.getAttribute("data-cell-col") === String(maxCol),
+        );
+        expect(caseFileCell).toBeDefined();
+        if (!caseFileCell) return;
+        expect(caseFileCell.getAttribute("role")).toBe("button");
+        expect(caseFileCell.getAttribute("aria-haspopup")).toBe("dialog");
+        expect(caseFileCell.getAttribute("tabindex")).toBe("0");
+        // Crucially: clicking a case-file cell must NOT toggle a
+        // known-card entry — the column is read-only. The click /
+        // toggle wiring lives on player cells only; for case-file we
+        // mount InfoPopover but no onClick that mutates state.
+        // Asserting the absence of `aria-pressed` (which is set on
+        // setup-mode toggleable cells) is a stable proxy.
+        expect(caseFileCell.getAttribute("aria-pressed")).toBeNull();
+    });
+
+    test("an undeduced case-file cell stays non-interactive (no popover affordance)", async () => {
+        // Same session as above, but deuce-mode renders just the
+        // empty checklist by default — no deductions firing. Look at
+        // a row whose case-file cell has no value: it should NOT
+        // expose role=button or aria-haspopup.
+        // Reuse the empty fresh state by doing nothing extra.
+        render(<Clue />);
+        await waitForDeduceChecklist();
+        const allBodyCells = Array.from(
+            document.querySelectorAll<HTMLElement>("[data-cell-row][data-cell-col]"),
+        );
+        // The case-file column won't advertise data-cell-col when
+        // there's no deduction (it falls back to the plain-td path).
+        // Check: at least one row exists with NO data-cell-col on its
+        // last cell — i.e. the case-file column for an empty state.
+        const lastTrs = Array.from(document.querySelectorAll<HTMLElement>("tr"));
+        const anyRowWithUndeducedCaseFile = lastTrs.some(tr => {
+            const tds = Array.from(tr.querySelectorAll("td"));
+            const last = tds[tds.length - 1];
+            // Plain td case-file cell — no data-cell-col set, no
+            // role attribute.
+            return (
+                last !== undefined
+                && last.getAttribute("data-cell-col") === null
+                && last.getAttribute("role") === null
+            );
+        });
+        expect(anyRowWithUndeducedCaseFile).toBe(true);
+        // Sanity: the body cells we DID find still cover the player
+        // columns (so the assertion above isn't accidentally passing
+        // because of a totally empty grid).
+        expect(allBodyCells.length).toBeGreaterThan(0);
+    });
+});
+
 describe("Checklist — deduce mode — SuggestionLogPanel pairing (desktop)", () => {
     test("the desktop play layout mounts SuggestionLogPanel alongside the Checklist", async () => {
         render(<Clue />);

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -1461,6 +1461,17 @@ const resolveReasonCopy = (
                 }),
             };
         }
+        case "failed-accusation-pairwise":
+            return {
+                headline: tReasons("failed-accusation-pairwise.headline"),
+                detail: tReasons("failed-accusation-pairwise.detail", {
+                    cellPlayer: desc.params.cellPlayer,
+                    cellCard: desc.params.cellCard,
+                    pinnedCardLabel: desc.params.pinnedCardLabel,
+                    accusationCount: desc.params.accusationIndices.length,
+                    accusationNumbers: desc.params.accusationNumbers,
+                }),
+            };
     }
 };
 

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -947,9 +947,25 @@ export function Checklist() {
                                                 </td>
                                             );
                                         } else if (
-                                            playInteractive &&
-                                            tooltipContent
+                                            tooltipContent &&
+                                            (playInteractive || !isPlayerCell)
                                         ) {
+                                            // Either:
+                                            //   - Play-mode player cell with
+                                            //     a deduction (the original
+                                            //     case), OR
+                                            //   - Case-file cell with a
+                                            //     deduction (in either Setup
+                                            //     or Play mode — the case
+                                            //     file is read-only and
+                                            //     value is always derived).
+                                            //
+                                            // Both render the same
+                                            // InfoPopover wrapper so the
+                                            // deduction chain is reachable
+                                            // by hover, click, tap, and
+                                            // keyboard (Enter / Space) with
+                                            // arrow-key grid navigation.
                                             const thisCell = Cell(
                                                 owner,
                                                 entry.id,
@@ -1782,11 +1798,26 @@ function AnimatedCellGlyph({ value }: { readonly value: CellValue | undefined })
 const CELL_BASE =
     "w-9 min-w-9 border-r border-b border-border px-2 py-1 text-center font-semibold relative";
 
+// Z-index ladder for the checklist:
+//   - sticky <thead>            : z-20 (anchored at top during scroll)
+//   - body cell hover ring      : z-30 (above thead so the hover ring
+//                                 doesn't get clipped when the cell is
+//                                 near the top of the viewport)
+//   - cross-pane highlight ring : z-30 (same reason)
+//   - body cell focus-visible   : z-40 (above hover so a hovered ring
+//                                 doesn't obscure the focused outline,
+//                                 and well above any neighboring cell
+//                                 painted in document order)
+// Without these bumps, a hovered cell sitting under the sticky thead
+// got its top ring sheared off, and a focused cell's right/bottom
+// outline was painted over by its neighbors (each cell has
+// position:relative, so without z-index escape they stack in DOM
+// order and the right neighbour wins).
 const CELL_INTERACTIVE =
-    " cursor-pointer hover:z-10 hover:rounded-[2px] hover:ring-2 hover:ring-accent/30 focus-visible:z-20 focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:rounded-[2px]";
+    " cursor-pointer hover:z-30 hover:rounded-[2px] hover:ring-2 hover:ring-accent/30 focus-visible:z-40 focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:rounded-[2px]";
 
 const CELL_HIGHLIGHTED =
-    " z-10 ring-2 ring-accent ring-offset-1 ring-offset-panel";
+    " z-30 ring-2 ring-accent ring-offset-1 ring-offset-panel";
 
 const cellClass = (
     value: CellValue | undefined,

--- a/src/ui/state.test.tsx
+++ b/src/ui/state.test.tsx
@@ -802,4 +802,95 @@ describe("accusations end-to-end", () => {
             getCell(ded2.success, Cell(CaseFileOwner(), CONSERV)),
         ).toBe(N_VAL);
     });
+
+    test("Tier 2: failed accusations covering every room force the partner weapon to N (case_S=Y, no case_W=Y yet)", () => {
+        // The user's reported flow but stripped to the Tier-2-only
+        // case: pin PLUM=Y in case file by assigning every other
+        // suspect to a player; do NOT narrow weapons. Then file
+        // failed accusations (PLUM, KNIFE, R) for every room.
+        // Tier 1 alone can't fire — only one case-file Y per
+        // accusation. Tier 2's pigeonhole-over-rooms must force
+        // case_KNIFE = N.
+        const { result } = renderClue();
+        const setup = CLASSIC_SETUP_3P;
+        const A = Player("Anisha");
+        const B = Player("Bob");
+        const C = Player("Cho");
+        const PLUM = cardByName(setup, "Prof. Plum");
+        const KNIFE = cardByName(setup, "Knife");
+
+        const otherSuspects = setup.categories
+            .find(c => c.name === "Suspect")!
+            .cards.filter(e => e.id !== PLUM)
+            .map(e => e.id);
+        const rooms = setup.categories.find(c => c.name === "Room")!.cards.map(
+            c => c.id,
+        );
+
+        act(() =>
+            result.current.dispatch({
+                type: "replaceSession",
+                session: {
+                    setup,
+                    // Only suspects-other-than-Plum are dealt to A. No
+                    // weapon assignments — case_KNIFE is genuinely
+                    // unknown going in.
+                    hands: [
+                        {
+                            player: A,
+                            cards: otherSuspects,
+                        },
+                    ],
+                    handSizes: [
+                        // 5 suspects to A, rest of the deck (6 weapons
+                        // - 1 case-file weapon = 5; 9 rooms - 1
+                        // case-file room = 8) split across B+C+A.
+                        // 21 total - 3 case file = 18 dealt; A has 5
+                        // already; B+C carry 13 between them. Use 7+6.
+                        { player: A, size: 5 },
+                        { player: B, size: 7 },
+                        { player: C, size: 6 },
+                    ],
+                    suggestions: [],
+                    accusations: [],
+                },
+            }),
+        );
+
+        // Sanity: PLUM should now be pinned Y; KNIFE should still be
+        // unknown in the case file.
+        const ded1 = result.current.derived.deductionResult;
+        if (!Result.isSuccess(ded1)) {
+            throw new Error(
+                `expected initial deduction to succeed, got: ${JSON.stringify(ded1)}`,
+            );
+        }
+        expect(getCell(ded1.success, Cell(CaseFileOwner(), PLUM))).toBe(Y_VAL);
+        expect(
+            getCell(ded1.success, Cell(CaseFileOwner(), KNIFE)),
+        ).toBeUndefined();
+
+        // Log a failed accusation (PLUM, KNIFE, R) for every room.
+        for (const roomId of rooms) {
+            act(() =>
+                result.current.dispatch({
+                    type: "addAccusation",
+                    accusation: {
+                        id: AccusationId(""),
+                        accuser: A,
+                        cards: [PLUM, KNIFE, roomId],
+                    },
+                }),
+            );
+        }
+
+        // Tier 2 should now force case_KNIFE = N.
+        const ded2 = result.current.derived.deductionResult;
+        if (!Result.isSuccess(ded2)) {
+            throw new Error(
+                `expected deduction to remain successful, got: ${JSON.stringify(ded2)}`,
+            );
+        }
+        expect(getCell(ded2.success, Cell(CaseFileOwner(), KNIFE))).toBe(N_VAL);
+    });
 });


### PR DESCRIPTION
## Summary

Failed accusations now produce more deductions, and the case-file column finally has a way to show *why* a value is what it is.

### Behaviour changes

- **Failed accusations now fire a multi-accusation pigeonhole deduction.** Previously, a failed accusation only forced a value when two of the three case-file cards were already pinned. Now, if one card is pinned in the case file and a set of failed accusations sharing that card-plus-partner exhausts every still-candidate third card, the partner is forced to N — even with the partner and the third category still unknown. Example: pin Miss Scarlet in the case file, then file failed accusations `(Scarlet, Rope, Ballroom)`, `(Scarlet, Rope, Library)`, … one for every room. The solver now derives `case_Rope = N` directly.

- **Case-file deduction popovers are now hover/click/keyboard accessible.** The case-file column is read-only — its values are always derived — but until now there was no way to see the deduction chain that produced them. Clicking, tapping, hovering, or Tab+Enter on a case-file cell with a deduced value now opens the same explanation popover that play-mode player cells have always had. Arrow-Right from the rightmost player column now reaches the case-file column too.

- **Focus and hover outlines no longer get clipped by neighbours or the sticky thead.** The z-index ladder was reshuffled so a hovered cell's ring (now `z-30`) and a focus-visible outline (now `z-40`) escape above the sticky thead at `z-20` and the implicit `z-auto` of adjacent body cells. Before this, the right/bottom of a focus outline could be sheared off by the next-row / next-column cell painted later in document order, and the top of a hover ring could disappear under the sticky header during scroll.

### Confirmed working

Reproduced the original report `(Scarlet, Rope, Ball room)` failed accusation + Scarlet/Rope pinned via card-ownership slice → Ball room shows `·` (N) in case file. Tier 1 was already firing; the user just couldn't see *why* until the popover was wired up. The new tooltip walks the full chain back to the user's input: card-ownership cascades → "case file holds exactly one Suspect" → "Player 1's accusation #1 (...) failed, so ... Ball room can't be in the case file."

### Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm knip && pnpm i18n:check` — all green (667 tests)
- [x] Tier 1 verified end-to-end in dev preview: failed `(Scarlet, Rope, Ball room)` + every non-Scarlet suspect / non-Rope weapon assigned to a player → Ball room shows `·` in case file with the explanation chain
- [x] Tier 2 verified end-to-end in dev preview: failed `(Scarlet, Rope, R)` for every room + Scarlet pinned via slice → Rope shows `·` in case file with the new "accusations #1, #2, … together rule out every still-possible third card" copy
- [x] Click, hover (after delay), Tab+Enter, Escape, Arrow-Right all wired up on case-file cells

### Commits

- **`cfde1ff` Add Tier 2 multi-accusation pairwise narrowing for failed accusations** — new `failedAccusationPairwiseNarrow` rule in `src/logic/Rules.ts` walks all 6 directed (pinned, partner, z-category) orderings, indexes accusations by pair, fires only when every still-candidate z is covered AND the candidate set is non-empty. Plumbs `setup` through `applyAccusationRules` and the `deduceWithExplanations` call site. New `FailedAccusationPairwiseNarrowing` ReasonKind in `src/logic/Provenance.ts` carries `pinnedCard` + `accusationIndices`. New i18n keys under `reasons.failed-accusation-pairwise`. New unit/integration tests in `Rules.test.ts`, `Deducer.test.ts`, `state.test.tsx`, `Provenance.test.ts`. Tier 3 (single-card full-coverage aggregation) intentionally deferred.

- **`b6bf534` Make case-file deductions reachable via hover, click, and keyboard** — widened the InfoPopover gate in `src/ui/components/Checklist.tsx` from `playInteractive && tooltipContent` to `tooltipContent && (playInteractive || !isPlayerCell)` so case-file cells get the same `role=button` / `aria-haspopup=dialog` / `tabindex=0` / `data-cell-row|col` treatment as play-mode player cells. Bumped `hover` z-index 10 → 30, `focus-visible` 20 → 40, `highlighted` 10 → 30 so outlines escape above the sticky thead and adjacent cells. New tests in `Checklist.deduce.test.tsx` pin both behaviours.

### Observability / analytics

No new events. The existing `why_tooltip_opened` event already fires on popover open via `popoverCell` state — it now fires for case-file cells too, automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)