### PR TITLE
Fix case-file focus ring, hide popovers in setup, hover-highlight on prior accusations

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -111,11 +111,21 @@ h3 {
 /* Global focus-visible outline: a high-contrast oxblood ring so
    keyboard users always know where they are. Applied via the
    :focus-visible pseudo-class so mouse clicks don't trigger it.
-   Components that already use `focus-visible:ring-*` classes
-   compose with this outline — both show together. */
-*:focus-visible {
-    outline: 3px solid var(--color-accent);
-    outline-offset: 2px;
-    border-radius: 3px;
+
+   Wrapped in `@layer base` so Tailwind's utility classes (which
+   live in `@layer utilities`) can opt out per-element with
+   `focus-visible:outline-none focus-visible:ring-1 …`. Components
+   that don't override compose with this outline — both show
+   together. The opt-out matters for `<td>` cells, where outlines
+   on `border-collapse: separate` tables get sheared off at the
+   left column boundary; those cells switch to a `ring` (box-
+   shadow) which respects z-index escape and renders cleanly on
+   all four sides. */
+@layer base {
+    *:focus-visible {
+        outline: 3px solid var(--color-accent);
+        outline-offset: 2px;
+        border-radius: 3px;
+    }
 }
 

--- a/src/ui/SelectionContext.test.tsx
+++ b/src/ui/SelectionContext.test.tsx
@@ -45,3 +45,36 @@ describe("SelectionContext — suggestion-log cross-highlight is unchanged", () 
         expect(result.current.activeSuggestionIndex).toBe(2);
     });
 });
+
+describe("SelectionContext — accusation-log hover", () => {
+    test("hoveredAccusationIndex defaults to null", () => {
+        const { result } = renderHook(() => useSelection(), { wrapper });
+        expect(result.current.hoveredAccusationIndex).toBeNull();
+        expect(result.current.activeAccusationIndex).toBeNull();
+    });
+
+    test("setHoveredAccusation(idx) drives activeAccusationIndex", () => {
+        const { result } = renderHook(() => useSelection(), { wrapper });
+        act(() => result.current.setHoveredAccusation(3));
+        expect(result.current.hoveredAccusationIndex).toBe(3);
+        expect(result.current.activeAccusationIndex).toBe(3);
+    });
+
+    test("setHoveredAccusation(null) clears it", () => {
+        const { result } = renderHook(() => useSelection(), { wrapper });
+        act(() => result.current.setHoveredAccusation(0));
+        act(() => result.current.setHoveredAccusation(null));
+        expect(result.current.activeAccusationIndex).toBeNull();
+    });
+
+    test("accusation hover and suggestion hover are independent — both can be active simultaneously", () => {
+        // Useful for the cell-highlight check, which combines both
+        // sources via OR. A cell whose chain references either an
+        // active suggestion OR an active accusation lights up.
+        const { result } = renderHook(() => useSelection(), { wrapper });
+        act(() => result.current.setHoveredSuggestion(1));
+        act(() => result.current.setHoveredAccusation(2));
+        expect(result.current.activeSuggestionIndex).toBe(1);
+        expect(result.current.activeAccusationIndex).toBe(2);
+    });
+});

--- a/src/ui/SelectionContext.tsx
+++ b/src/ui/SelectionContext.tsx
@@ -20,6 +20,11 @@ import type { Cell } from "../logic/Knowledge";
  *  - **Suggestion log → checklist cells:** `hoveredSuggestionIndex`
  *    (mouse hover, desktop-only) + `selectedSuggestionIndex` (tap/click
  *    pin). `activeSuggestionIndex = selected ?? hovered`.
+ *  - **Accusation log → checklist cells:** `hoveredAccusationIndex`
+ *    (mouse hover, desktop-only). `activeAccusationIndex = hovered`
+ *    today — accusations don't have a tap/click pin yet because the
+ *    only deductions they drive are case-file Ns and the row→cells
+ *    mapping is unambiguous.
  *  - **Checklist cells → suggestion log:** `popoverCell` is the cell
  *    whose "why" popover is currently visible (opened by delayed hover,
  *    click, tap, or keyboard activation, closed by the hover-intent
@@ -32,10 +37,17 @@ interface SelectionContextValue {
     readonly setHoveredSuggestion: (i: number | null) => void;
     readonly selectedSuggestionIndex: number | null;
     readonly setSelectedSuggestion: (i: number | null) => void;
+    readonly hoveredAccusationIndex: number | null;
+    readonly setHoveredAccusation: (i: number | null) => void;
     readonly popoverCell: Cell | null;
     readonly setPopoverCell: (c: Cell | null) => void;
     /** Selection takes precedence over hover (suggestion log only). */
     readonly activeSuggestionIndex: number | null;
+    /**
+     * Active accusation index for the cross-highlight. No selection
+     * pin yet, so this just mirrors hover.
+     */
+    readonly activeAccusationIndex: number | null;
     /**
      * The cell whose "why" popover is currently visible. Drives the
      * suggestion→cell cross-highlight. `null` when no popover is open.
@@ -56,10 +68,16 @@ export function SelectionProvider({
     const [selectedSuggestionIndex, setSelectedSuggestion] = useState<
         number | null
     >(null);
+    const [hoveredAccusationIndex, setHoveredAccusationState] = useState<
+        number | null
+    >(null);
     const [popoverCell, setPopoverCellState] = useState<Cell | null>(null);
 
     const setHoveredSuggestion = useCallback((i: number | null) => {
         setHovered(i);
+    }, []);
+    const setHoveredAccusation = useCallback((i: number | null) => {
+        setHoveredAccusationState(i);
     }, []);
     const setPopoverCell = useCallback((c: Cell | null) => {
         setPopoverCellState(c);
@@ -71,16 +89,21 @@ export function SelectionProvider({
             setHoveredSuggestion,
             selectedSuggestionIndex,
             setSelectedSuggestion,
+            hoveredAccusationIndex,
+            setHoveredAccusation,
             popoverCell,
             setPopoverCell,
             activeSuggestionIndex:
                 selectedSuggestionIndex ?? hoveredSuggestionIndex,
+            activeAccusationIndex: hoveredAccusationIndex,
             activeCell: popoverCell,
         }),
         [
             hoveredSuggestionIndex,
             setHoveredSuggestion,
             selectedSuggestionIndex,
+            hoveredAccusationIndex,
+            setHoveredAccusation,
             popoverCell,
             setPopoverCell,
         ],

--- a/src/ui/components/Checklist.deduce.test.tsx
+++ b/src/ui/components/Checklist.deduce.test.tsx
@@ -286,6 +286,18 @@ describe("Checklist — case-file deduction popover", () => {
         // Asserting the absence of `aria-pressed` (which is set on
         // setup-mode toggleable cells) is a stable proxy.
         expect(caseFileCell.getAttribute("aria-pressed")).toBeNull();
+
+        // The focus indicator uses `ring-*` (box-shadow) instead of
+        // `outline-*`. Outlines on `<td>` cells in
+        // border-collapse:separate tables get sheared off at the left
+        // column boundary; box-shadow doesn't. Pinned via classes so
+        // a future regression to outline-* trips the test.
+        expect(caseFileCell.className).toMatch(/focus-visible:ring-1/);
+        expect(caseFileCell.className).toMatch(/focus-visible:ring-accent/);
+        expect(caseFileCell.className).toMatch(/focus-visible:outline-none/);
+        expect(caseFileCell.className).not.toMatch(
+            /focus-visible:outline-1\b/,
+        );
     });
 
     test("an undeduced case-file cell stays non-interactive (no popover affordance)", async () => {

--- a/src/ui/components/Checklist.setup.test.tsx
+++ b/src/ui/components/Checklist.setup.test.tsx
@@ -253,4 +253,120 @@ describe("Checklist — setup mode — scope of rendered controls", () => {
         // Silence unused-import TS warning for `within`.
         expect(within).toBeDefined();
     });
+
+    test("case-file body cells are NOT popover triggers in setup mode (even when deduced)", async () => {
+        // Setup mode is for entering inputs, not exploring the
+        // deduction chain. Even when the card-ownership slice has
+        // already pinned a case-file value, the cell should remain
+        // a plain non-interactive `<td>` — no role=button, no
+        // aria-haspopup, no data-cell-col, no focus ring.
+        const session = {
+            version: 6,
+            setup: {
+                players: ["Player 1", "Player 2", "Player 3", "Player 4"],
+                categories: [
+                    {
+                        id: "category-suspects",
+                        name: "Suspect",
+                        cards: [
+                            { id: "card-miss-scarlet", name: "Miss Scarlet" },
+                            { id: "card-col-mustard", name: "Col. Mustard" },
+                            { id: "card-mrs-white", name: "Mrs. White" },
+                            { id: "card-mr-green", name: "Mr. Green" },
+                            { id: "card-mrs-peacock", name: "Mrs. Peacock" },
+                            { id: "card-prof-plum", name: "Prof. Plum" },
+                        ],
+                    },
+                    {
+                        id: "category-weapons",
+                        name: "Weapon",
+                        cards: [
+                            { id: "card-candlestick", name: "Candlestick" },
+                            { id: "card-knife", name: "Knife" },
+                            { id: "card-lead-pipe", name: "Lead pipe" },
+                            { id: "card-revolver", name: "Revolver" },
+                            { id: "card-rope", name: "Rope" },
+                            { id: "card-wrench", name: "Wrench" },
+                        ],
+                    },
+                    {
+                        id: "category-rooms",
+                        name: "Room",
+                        cards: [
+                            { id: "card-kitchen", name: "Kitchen" },
+                            { id: "card-ball-room", name: "Ball room" },
+                            { id: "card-conservatory", name: "Conservatory" },
+                            { id: "card-dining-room", name: "Dining room" },
+                            { id: "card-billiard-room", name: "Billiard room" },
+                            { id: "card-library", name: "Library" },
+                            { id: "card-lounge", name: "Lounge" },
+                            { id: "card-hall", name: "Hall" },
+                            { id: "card-study", name: "Study" },
+                        ],
+                    },
+                ],
+            },
+            // Player 1 holds every non-Plum suspect → slice forces
+            // case_Plum=Y. We're in setup mode so the cell should
+            // STILL render the deduced value but without any popover
+            // affordance.
+            hands: [
+                {
+                    player: "Player 1",
+                    cards: [
+                        "card-miss-scarlet",
+                        "card-col-mustard",
+                        "card-mrs-white",
+                        "card-mr-green",
+                        "card-mrs-peacock",
+                    ],
+                },
+            ],
+            handSizes: [
+                { player: "Player 1", size: 5 },
+                { player: "Player 2", size: 5 },
+                { player: "Player 3", size: 4 },
+                { player: "Player 4", size: 4 },
+            ],
+            suggestions: [],
+            accusations: [],
+        };
+        window.localStorage.setItem(
+            "effect-clue.session.v6",
+            JSON.stringify(session),
+        );
+        // Ensure URL doesn't push us into deduce mode.
+        window.history.replaceState(null, "", "/");
+
+        render(<Clue />);
+        await waitForSetupChecklist();
+
+        // Sanity: deduce wired up — the Plum suspect row's case-file
+        // cell should display the deduced ✓ glyph. In setup mode the
+        // card name is an InlineTextEdit input; we find the row by
+        // its initial value.
+        const plumInput = Array.from(
+            document.querySelectorAll<HTMLInputElement>("input"),
+        ).find(i => i.value === "Prof. Plum");
+        expect(plumInput).toBeDefined();
+        if (!plumInput) return;
+        const plumRow = plumInput.closest("tr");
+        expect(plumRow).toBeDefined();
+        if (!plumRow) return;
+        const tds = Array.from(plumRow.querySelectorAll("td"));
+        const caseFileCell = tds[tds.length - 1];
+        expect(caseFileCell).toBeDefined();
+        if (!caseFileCell) return;
+        // The deduced value renders…
+        expect(caseFileCell.textContent?.trim()).toBe("✓");
+        // …but the cell stays non-interactive (no popover affordance).
+        expect(caseFileCell.getAttribute("role")).toBeNull();
+        expect(caseFileCell.getAttribute("aria-haspopup")).toBeNull();
+        expect(caseFileCell.getAttribute("tabindex")).toBeNull();
+        expect(caseFileCell.getAttribute("data-cell-col")).toBeNull();
+        // No focus-visible ring class either — the styling for
+        // interactive cells comes via CELL_INTERACTIVE which the gate
+        // skips for setup-mode case-file cells.
+        expect(caseFileCell.className).not.toMatch(/focus-visible:ring-1/);
+    });
 });

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -215,6 +215,7 @@ export function Checklist() {
     const { state, dispatch, derived } = useClue();
     const {
         activeSuggestionIndex,
+        activeAccusationIndex,
         popoverCell,
         setPopoverCell,
     } = useSelection();
@@ -396,23 +397,45 @@ export function Checklist() {
     };
 
     /**
-     * Cross-highlight: when the user hovers a suggestion row in
-     * PriorSuggestions, highlight every cell whose provenance chain
-     * referenced that suggestion's index.
+     * Cross-highlight: when the user hovers a row in the prior
+     * suggestion or accusation log, highlight every cell whose
+     * provenance chain references that row's index. Suggestions can
+     * additionally be pinned via tap/click; accusations are
+     * hover-only today.
      */
     const cellIsHighlighted = (owner: Owner, card: Card): boolean => {
-        if (activeSuggestionIndex === null) return false;
+        if (activeSuggestionIndex === null && activeAccusationIndex === null) {
+            return false;
+        }
         if (!provenance) return false;
         const chain = chainFor(provenance, Cell(owner, card));
         for (const { reason } of chain) {
             const tag = reason.kind._tag;
-            const idx =
-                tag === "NonRefuters"
-                || tag === "RefuterShowed"
-                || tag === "RefuterOwnsOneOf"
-                    ? reason.kind.suggestionIndex
-                    : undefined;
-            if (idx === activeSuggestionIndex) return true;
+            if (activeSuggestionIndex !== null) {
+                const idx =
+                    tag === "NonRefuters"
+                    || tag === "RefuterShowed"
+                    || tag === "RefuterOwnsOneOf"
+                        ? reason.kind.suggestionIndex
+                        : undefined;
+                if (idx === activeSuggestionIndex) return true;
+            }
+            if (activeAccusationIndex !== null) {
+                if (
+                    tag === "FailedAccusation"
+                    && reason.kind.accusationIndex === activeAccusationIndex
+                ) {
+                    return true;
+                }
+                if (
+                    tag === "FailedAccusationPairwiseNarrowing"
+                    && reason.kind.accusationIndices.includes(
+                        activeAccusationIndex,
+                    )
+                ) {
+                    return true;
+                }
+            }
         }
         return false;
     };
@@ -843,9 +866,27 @@ export function Checklist() {
                                                     )}
                                             </>
                                         );
+                                        // A cell needs the interactive
+                                        // ring style when the user can
+                                        // focus or hover it: Setup-mode
+                                        // toggleable cells, Play-mode
+                                        // player cells with a deduction,
+                                        // and Play-mode case-file cells
+                                        // with a deduction. Setup mode
+                                        // intentionally gives case-file
+                                        // cells NO popover affordance —
+                                        // setup is for entering inputs,
+                                        // not exploring the deduction
+                                        // chain.
+                                        const popoverInteractive =
+                                            tooltipContent !== undefined
+                                            && !inSetup
+                                            && (playInteractive || !isPlayerCell);
                                         const tdClassName = cellClass(
                                             value,
-                                            setupInteractive || playInteractive,
+                                            setupInteractive
+                                                || playInteractive
+                                                || popoverInteractive,
                                             isHighlighted,
                                         );
                                         const thisCellForHover = Cell(
@@ -946,19 +987,22 @@ export function Checklist() {
                                                     {cellContent}
                                                 </td>
                                             );
-                                        } else if (
-                                            tooltipContent &&
-                                            (playInteractive || !isPlayerCell)
-                                        ) {
+                                        } else if (popoverInteractive) {
                                             // Either:
                                             //   - Play-mode player cell with
                                             //     a deduction (the original
                                             //     case), OR
-                                            //   - Case-file cell with a
-                                            //     deduction (in either Setup
-                                            //     or Play mode — the case
-                                            //     file is read-only and
-                                            //     value is always derived).
+                                            //   - Play-mode case-file cell
+                                            //     with a deduction (the
+                                            //     case file is read-only
+                                            //     and the value is always
+                                            //     derived).
+                                            //
+                                            // Setup mode intentionally
+                                            // skips this branch: the
+                                            // checklist there is for
+                                            // entering inputs, not
+                                            // exploring deductions.
                                             //
                                             // Both render the same
                                             // InfoPopover wrapper so the
@@ -1813,8 +1857,16 @@ const CELL_BASE =
 // outline was painted over by its neighbors (each cell has
 // position:relative, so without z-index escape they stack in DOM
 // order and the right neighbour wins).
+//
+// Focus indicator: `ring-1 ring-offset-2` (box-shadow) instead of
+// `outline-1 outline-offset-2`. Outlines on `<td>` cells in
+// `border-collapse: separate` get clipped at the cell's left edge —
+// reproducible on the case-file column whose left neighbour ends at
+// the column boundary. Box-shadow paints with the element's own
+// stacking context and respects z-index escape, so the ring renders
+// on all four sides regardless of which cell its neighbour is.
 const CELL_INTERACTIVE =
-    " cursor-pointer hover:z-30 hover:rounded-[2px] hover:ring-2 hover:ring-accent/30 focus-visible:z-40 focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:rounded-[2px]";
+    " cursor-pointer hover:z-30 hover:rounded-[2px] hover:ring-2 hover:ring-accent/30 focus-visible:z-40 focus-visible:ring-1 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-panel focus-visible:rounded-[2px] focus-visible:outline-none";
 
 const CELL_HIGHLIGHTED =
     " z-30 ring-2 ring-accent ring-offset-1 ring-offset-panel";

--- a/src/ui/components/SuggestionLogPanel.tsx
+++ b/src/ui/components/SuggestionLogPanel.tsx
@@ -1607,7 +1607,7 @@ function PriorAccusationItem({
     const t = useTranslations("accusations");
     const tSug = useTranslations("suggestions");
     const { state, dispatch, derived } = useClue();
-    const { activeCell } = useSelection();
+    const { activeCell, setHoveredAccusation } = useSelection();
     const confirm = useConfirm();
     const isDesktop = useIsDesktop();
     const setup = state.setup;
@@ -1672,6 +1672,22 @@ function PriorAccusationItem({
         else if (!showMobileEditButton) setShowMobileEditButton(true);
     };
 
+    // Desktop hover preview, mirrors PriorSuggestionItem. Touch is
+    // filtered out (pointerType !== "mouse") so iOS Safari's tap-as-
+    // pointerenter doesn't ghost-highlight after every row tap. Feeds
+    // the accusation → cell cross-highlight via `activeAccusationIndex`.
+    const onPointerEnter = (e: React.PointerEvent) => {
+        if (e.pointerType !== "mouse") return;
+        setHoveredAccusation(idx);
+    };
+    const onPointerLeave = (e: React.PointerEvent) => {
+        if (e.pointerType !== "mouse") return;
+        // Keep the highlight while a pill popover (portalled outside
+        // the row) is open — the user is mid-edit and the mouse may
+        // be travelling through the portal back into the row.
+        if (!hasOpenPillPopover()) setHoveredAccusation(null);
+    };
+
     // Outside-click cancel — same pattern as `PriorSuggestionItem`.
     // Armed while editing OR while the mobile pre-edit Edit button is
     // visible; `exitEdit()` clears both flags.
@@ -1722,12 +1738,25 @@ function PriorAccusationItem({
                     ? "ring-2 ring-accent ring-offset-1 ring-offset-panel "
                     : "hover:ring-2 hover:ring-accent hover:ring-offset-1 hover:ring-offset-panel ")
             }
+            onPointerEnter={onPointerEnter}
+            onPointerLeave={onPointerLeave}
             onClick={onRowClick}
             onFocus={e => {
-                if (e.currentTarget === e.target) setIsRowFocused(true);
+                // Row itself gained focus (not a descendant) — feed
+                // the cross-highlight so keyboard nav also lights up
+                // the related cells.
+                if (e.currentTarget === e.target) {
+                    setHoveredAccusation(idx);
+                    setIsRowFocused(true);
+                }
             }}
             onBlur={e => {
                 if (e.target === e.currentTarget) setIsRowFocused(false);
+                // Keep the cross-panel highlight while focus stays
+                // anywhere inside the row (pills / popovers / ×).
+                const next = e.relatedTarget as Node | null;
+                if (next && e.currentTarget.contains(next)) return;
+                setHoveredAccusation(null);
             }}
             onKeyDown={e => {
                 const native = e.nativeEvent;


### PR DESCRIPTION
## Summary

Three small fixes around the case-file column and the prior-log hover affordance, all surfaced after [#80](https://github.com/LetsGetIntoIt/effect-clue/pull/80) shipped.

### Behaviour changes

- **Case-file focus outlines no longer get sheared off on the left.** Outlines on `<td>` elements in `border-collapse: separate` tables get clipped at the cell's left edge by the table painting model — visible specifically on the case-file column whose left neighbour ends at a column boundary the outline-offset region tries to paint into. Box-shadow doesn't have this limitation, so checklist body cells now use `focus-visible:ring-1 ring-accent ring-offset-2 ring-offset-panel` instead of `focus-visible:outline-1 outline-offset-2`. The global `*:focus-visible` outline rule in `app/globals.css` moved into `@layer base` so the utility-layer `outline-none` opt-out actually wins (utility-layered rules beat base-layered ones; both layered lose to unlayered).

- **Setup-mode case-file cells no longer offer the deduction-chain popover.** Setup is for entering inputs; exploring the deduction chain belongs to play mode. Cells fall back to a plain non-interactive `<td>` — no `role=button`, no `aria-haspopup`, no `data-cell-col`, no focus ring — but the deduced value still renders so users still see the slice's conclusion.

- **Hovering a prior failed accusation row now lights up the cells it pinned**, mirroring the existing prior-suggestion hover. Touch is filtered out (mouse-only) so iOS Safari's tap-as-pointerenter doesn't ghost-highlight after every row tap.

### Confirmed working

Verified all three in the dev preview at desktop (1280×900):

- A focused case-file cell shows the box-shadow ring on **all four sides**, no left-edge clipping. Compared `<td>` cells with the production `focus-visible:ring-1 …` utilities; the compiled `.focus-visible\:ring-1:focus-visible { box-shadow: …; }` rule fires. Tested with multiple cells focused simultaneously to confirm there's no asymmetric stacking issue.
- Switching to setup mode (⌘H) on a session whose card-ownership slice has pinned the case-file: the Plum case-file cell still renders the `✓` glyph but has `role=null`, `data-cell-col=null`, `aria-haspopup=null`, no `focus-visible:ring-1` class. Switching back to play mode (⌘J) re-attaches the popover.
- On the desktop layout with the Suggestion Log panel mounted, hovering one of the 9 prior accusation rows applies `ring-2 ring-accent ring-offset-1 ring-offset-panel` to the case-file cell whose Tier-2 deduction names that accusation index. Hover-leave drops the highlight.

### Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm knip && pnpm i18n:check` — all green (672 tests, +5 over `main`)
- [x] New `Checklist.setup.test.tsx` test pins the no-popover-in-setup behaviour (deduced ✓ glyph but no `role=button` / `aria-haspopup` / `data-cell-col` / `focus-visible:ring-1`)
- [x] Updated `Checklist.deduce.test.tsx` test pins `focus-visible:ring-1` and `focus-visible:outline-none` on case-file cells, and asserts the absence of `focus-visible:outline-1` so a regression to outline-* trips the test
- [x] New `SelectionContext.test.tsx` tests cover `hoveredAccusationIndex` / `setHoveredAccusation` / `activeAccusationIndex` and confirm accusation + suggestion hover are independent slots

### Commits

- **`60c1712` Fix case-file focus ring, hide popovers in setup, hover-highlight on prior accusations** — `app/globals.css` wraps the global `*:focus-visible` outline in `@layer base`. `src/ui/components/Checklist.tsx` swaps `outline-*` → `ring-*` in `CELL_INTERACTIVE`, gates the InfoPopover branch on `!inSetup` (via the new `popoverInteractive` flag), and threads `activeAccusationIndex` into `cellIsHighlighted` so the function returns true when an active accusation matches a `FailedAccusation` or `FailedAccusationPairwiseNarrowing` chain entry. `src/ui/SelectionContext.tsx` adds the `hoveredAccusationIndex` slot. `src/ui/components/SuggestionLogPanel.tsx` wires `PriorAccusationItem`'s `onPointerEnter` / `onPointerLeave` / row `onFocus` / `onBlur` to `setHoveredAccusation` (mirrors `PriorSuggestionItem`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)