### PR TITLE
Match focus ring-offset to cell bg so the gap looks transparent

### DIFF
--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -1865,8 +1865,15 @@ const CELL_BASE =
 // the column boundary. Box-shadow paints with the element's own
 // stacking context and respects z-index escape, so the ring renders
 // on all four sides regardless of which cell its neighbour is.
+//
+// The ring-offset color is set per-cell to match the cell's own
+// background (`ring-offset-yes-bg`, `ring-offset-no-bg`, or
+// `ring-offset-white`) so the 2px offset blends into the cell —
+// visually equivalent to the transparent offset CSS outlines have.
+// Without that match the offset would render as a solid panel band
+// and the focus indicator would look like a thick double-ring.
 const CELL_INTERACTIVE =
-    " cursor-pointer hover:z-30 hover:rounded-[2px] hover:ring-2 hover:ring-accent/30 focus-visible:z-40 focus-visible:ring-1 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-panel focus-visible:rounded-[2px] focus-visible:outline-none";
+    " cursor-pointer hover:z-30 hover:rounded-[2px] hover:ring-2 hover:ring-accent/30 focus-visible:z-40 focus-visible:ring-1 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:rounded-[2px] focus-visible:outline-none";
 
 const CELL_HIGHLIGHTED =
     " z-30 ring-2 ring-accent ring-offset-1 ring-offset-panel";
@@ -1878,7 +1885,10 @@ const cellClass = (
 ): string => {
     let base = interactive ? `${CELL_BASE}${CELL_INTERACTIVE}` : CELL_BASE;
     if (highlighted) base += CELL_HIGHLIGHTED;
-    if (value === Y) return `${base} bg-yes-bg text-yes`;
-    if (value === N) return `${base} bg-no-bg text-no`;
-    return `${base} bg-white`;
+    // Bg + matching ring-offset color so the focus ring's offset
+    // blends into the cell's own background (mimics the transparent
+    // gap of the outline-based indicator we replaced).
+    if (value === Y) return `${base} bg-yes-bg text-yes focus-visible:ring-offset-yes-bg`;
+    if (value === N) return `${base} bg-no-bg text-no focus-visible:ring-offset-no-bg`;
+    return `${base} bg-white focus-visible:ring-offset-white`;
 };


### PR DESCRIPTION
## Summary

Tiny visual tweak on top of [#82](https://github.com/LetsGetIntoIt/effect-clue/pull/82): the focus indicator's offset gap now matches the cell's own background, so it visually reads as a "thin maroon line floating 2px from the cell" — the same look the previous `outline-1 outline-offset-2` had — instead of a solid cream band that made it look like a thick double-ring.

### What was wrong

#82 swapped `focus-visible:outline-1 outline-offset-2` → `focus-visible:ring-1 ring-offset-2 ring-offset-panel` to fix the case-file column's left-edge clipping. Outline-offset is naturally transparent: you see the cell's bg through the gap. Ring-offset is a *solid color* — `ring-offset-panel` painted the offset region in the panel's cream tone (#f7f0dc), which clashed with `bg-yes-bg` (light green) and `bg-no-bg` (peachy pink) cells. Visually the indicator looked like a thick maroon outline + an inner cream band.

### The fix

Set `--tw-ring-offset-color` per cell variant in `cellClass`:

| cell value | bg utility | ring-offset utility |
|---|---|---|
| Y | `bg-yes-bg` | `focus-visible:ring-offset-yes-bg` |
| N | `bg-no-bg` | `focus-visible:ring-offset-no-bg` |
| ? | `bg-white` | `focus-visible:ring-offset-white` |

Now the offset paint uses the same color as the cell's bg, so the 2px offset region is invisible against the cell — visually equivalent to a transparent gap. The 1px maroon ring still renders cleanly outside the offset thanks to box-shadow's z-40 escape (no clipping at the cell's left edge).

### Confirmed working

Verified via DevTools-style force-render in the preview:

```
box-shadow: rgb(240, 212, 200) 0px 0px 0px 2px,
            rgb(122, 28, 28) 0px 0px 0px 3px;
background-color: rgb(240, 212, 200);
```

The first shadow color exactly matches the cell's `background-color`, so the offset blends in. Outer 1px ring of `rgb(122, 28, 28)` (accent) is visible.

### Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm knip && pnpm i18n:check` — all green (672 tests)
- [x] Force-rendered the focus styles on a `bg-no-bg` case-file cell; confirmed the box-shadow's inner 2px color matches `getComputedStyle().backgroundColor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)