### PR TITLE
Match cell focus ring thickness to the global outline (3px)

### DIFF
--- a/src/ui/components/Checklist.deduce.test.tsx
+++ b/src/ui/components/Checklist.deduce.test.tsx
@@ -290,9 +290,12 @@ describe("Checklist — case-file deduction popover", () => {
         // The focus indicator uses `ring-*` (box-shadow) instead of
         // `outline-*`. Outlines on `<td>` cells in
         // border-collapse:separate tables get sheared off at the left
-        // column boundary; box-shadow doesn't. Pinned via classes so
-        // a future regression to outline-* trips the test.
-        expect(caseFileCell.className).toMatch(/focus-visible:ring-1/);
+        // column boundary; box-shadow doesn't. 3px width matches the
+        // global *:focus-visible outline so it reads at the same
+        // weight as every other focusable element on the page.
+        // Pinned via classes so a future regression to outline-* (or
+        // a thinner ring) trips the test.
+        expect(caseFileCell.className).toMatch(/focus-visible:ring-\[3px\]/);
         expect(caseFileCell.className).toMatch(/focus-visible:ring-accent/);
         expect(caseFileCell.className).toMatch(/focus-visible:outline-none/);
         expect(caseFileCell.className).not.toMatch(

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -1858,13 +1858,18 @@ const CELL_BASE =
 // position:relative, so without z-index escape they stack in DOM
 // order and the right neighbour wins).
 //
-// Focus indicator: `ring-1 ring-offset-2` (box-shadow) instead of
-// `outline-1 outline-offset-2`. Outlines on `<td>` cells in
+// Focus indicator: `ring-[3px] ring-offset-2` (box-shadow) instead of
+// `outline-3 outline-offset-2`. Outlines on `<td>` cells in
 // `border-collapse: separate` get clipped at the cell's left edge —
 // reproducible on the case-file column whose left neighbour ends at
 // the column boundary. Box-shadow paints with the element's own
 // stacking context and respects z-index escape, so the ring renders
 // on all four sides regardless of which cell its neighbour is.
+//
+// 3px ring matches the global `*:focus-visible` outline width set
+// in `app/globals.css` so checklist cells read at the same weight
+// as every other focusable element on the page (inputs, buttons,
+// etc.).
 //
 // The ring-offset color is set per-cell to match the cell's own
 // background (`ring-offset-yes-bg`, `ring-offset-no-bg`, or
@@ -1873,7 +1878,7 @@ const CELL_BASE =
 // Without that match the offset would render as a solid panel band
 // and the focus indicator would look like a thick double-ring.
 const CELL_INTERACTIVE =
-    " cursor-pointer hover:z-30 hover:rounded-[2px] hover:ring-2 hover:ring-accent/30 focus-visible:z-40 focus-visible:ring-1 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:rounded-[2px] focus-visible:outline-none";
+    " cursor-pointer hover:z-30 hover:rounded-[2px] hover:ring-2 hover:ring-accent/30 focus-visible:z-40 focus-visible:ring-[3px] focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:rounded-[2px] focus-visible:outline-none";
 
 const CELL_HIGHLIGHTED =
     " z-30 ring-2 ring-accent ring-offset-1 ring-offset-panel";


### PR DESCRIPTION
## Summary

Tiny visual tweak on top of [#83](https://github.com/LetsGetIntoIt/effect-clue/pull/83): bump checklist cell focus rings from `ring-1` (1px) to `ring-[3px]` so they read at the same weight as every other focusable element on the page.

The global `*:focus-visible` rule in [app/globals.css](app/globals.css) already uses `outline: 3px solid var(--color-accent)`, so inputs, buttons, and nav items all show a 3px ring on keyboard focus. The previous 1px on cells was visibly thinner and felt stylistically inconsistent.

### Confirmed working

Force-rendered the focus styles in the dev preview on a `bg-no-bg` case-file cell — the box-shadow now produces a thick maroon ring matching the player-name input's focus ring. Compiled CSS verified: `.focus-visible\:ring-\[3px\]:focus-visible { --tw-ring-shadow: … 0 0 0 calc(3px + var(--tw-ring-offset-width)) … }`.

### Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm knip && pnpm i18n:check` — all green (672 tests)
- [x] Updated the `Checklist.deduce.test.tsx` pinning to assert `focus-visible:ring-[3px]` instead of `focus-visible:ring-1`, so a regression to a thinner ring trips the test

🤖 Generated with [Claude Code](https://claude.com/claude-code)