### PR TITLE
Tour popover round 4: positioning, isolation, precedence + verification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,58 @@ Resize the preview between viewports as you go — many of these regress on one 
 - The SuggestionLog column is sticky-top with a bounded `max-height` and its own internal `overflow-y-auto`. As the page scrolls vertically, the log pane stays in view; as the log's *internal* content overflows, the log scrolls inside its own frame.
 - Banner appearing / disappearing doesn't cause a layout jump in the table or the log — the banner publishes its height as `--contradiction-banner-offset`, which `<main>`'s padding-top consumes.
 
+### Tour-popover verification
+
+The tour popover system (`src/ui/tour/TourPopover.tsx`, `src/ui/tour/tours.ts`) positions a Radix popover next to a "spotlight" cutout that highlights the anchor element. jsdom can't run layout, so popover/spotlight pixel positions cannot be unit-tested — they're verified manually in the `next-dev` preview at both viewport breakpoints whenever you touch:
+
+- `src/ui/tour/tours.ts` — step config (`anchor`, `popoverAnchor`, `popoverAnchorPriority`, `side`, `align`, `sideByViewport`, `viewport`).
+- `src/ui/tour/TourPopover.tsx` — anchor resolution, side/align resolution, positioning effect.
+- A `data-tour-anchor="…"` attribute on any DOM node — adding, removing, or moving one changes which element drives spotlight + popover position.
+- `src/ui/onboarding/StartupCoordinator.tsx` precedence rules — changes which tour fires when.
+
+**Verification workflow.** For each tour, walk every step at desktop **1280×800** AND mobile **375×812** in the `next-dev` preview. For each step:
+
+1. **Popover fully on-screen** — `top ≥ 0 && left ≥ 0 && right ≤ vw && bottom ≤ vh`. *Hard requirement.*
+2. **Spotlight surrounds the right anchor element(s)** — visually confirm the dimming hole encloses what the copy is referring to.
+3. **Popover doesn't block the spotlight area** — *soft requirement*. If unavoidable (anchor extends past the viewport), the popover MUST cover the *less important* part of the spotlight (e.g. cover top rows of a tall column rather than the center). Popover visibility wins; partial spotlight occlusion is acceptable.
+4. **No console warnings** — particularly the React 19 "Each child in a list should have a unique 'key' prop" warning, which fires when Radix's Slot iterates Popover.Content's children. Resolved today by wrapping the popover's inner content in a single `<div className="contents">`; if you restructure the children, re-verify.
+5. **Step counter matches the visible viewport** — mobile-only steps (`viewport: "mobile"`) don't appear on desktop, and the "step N of M" counter reflects the post-filter list. After resizing mid-tour, the counter re-derives via `useFilterStepsByViewport`.
+
+**Tour matrix to walk** (post-round-4):
+
+| Tour | Desktop steps | Mobile steps | Mobile-only steps |
+|------|---------------|--------------|-------------------|
+| `setup` (6) | 6 | 6 | — |
+| `checklistSuggest` (4 desktop / 5 mobile) | 4 | 5 | `bottom-nav-suggest` (between `checklist-case-file` and `suggest-prior-log`) |
+| `firstSuggestion` (1) | 1 | 1 | — *(viewport-conditional anchor: `desktop-checklist-area` desktop, `bottom-nav-checklist` mobile)* |
+
+**Steps with known popover/spotlight overlap** (acceptable per #3 above):
+
+- `setup-known-cell` mobile — popover covers the top ~3 rows of the player column. Desktop sits to the RIGHT of the column (no overlap, full column visible) via `sideByViewport`.
+- `firstSuggestion` desktop — anchor is the entire deduction grid (~880 px tall, exceeds viewport). Popover clamps near the top with overlap. Mobile anchors to the BottomNav Checklist tab — small, no overlap.
+
+**Sequencing & precedence** (covered by `src/ui/onboarding/StartupCoordinator.test.tsx` + `src/ui/tour/screenKey.test.ts` — no manual walk needed unless you change `TOUR_PRECEDENCE` or add a new screen):
+
+- Splash always wins ahead of tour and install at boot.
+- After splash dismisses, the coordinator picks the highest-priority eligible tour from `TOUR_PRECEDENCE = ["setup", "checklistSuggest"]`. If that tour belongs to a different screen than the user landed on, the coordinator dispatches `setUiMode` to redirect.
+- A tour completing (Next on the last step) writes `lastDismissedAt` for that screen — same gate effect as Skip / Esc / X. The 4-week re-engage cadence applies to both completion and dismissal.
+- After a tour fires, install is suppressed for the rest of the session.
+
+**Test scenarios to walk in the preview** (clear `effect-clue.*` keys in localStorage between each one):
+
+1. **Brand-new user lands on `/`** → splash → setup tour (6 steps).
+2. **Brand-new user lands on `/play?view=checklist`** → splash → coordinator redirects to `?view=setup` → setup tour fires.
+3. **Returning user (setup completed) lands on `/play`** → no redirect → checklist+suggest tour (4 desktop / 5 mobile steps).
+4. **Returning user with all tours completed lands on `/play`** → no tour, install prompt fires (if eligible).
+5. **Resize from desktop to mobile mid-tour during `checklistSuggest`** → step counter re-derives (4 → 5 if not yet past the new mobile-only step).
+6. **Tour active + try `⌘K` / arrow keys / Tab** → keyboard isolator swallows everything except `Esc` (dismiss) and keys targeting popover content (Tab between Back / Skip / Next).
+7. **Tour active + click backdrop** → tour stays active. Click ⌘+wheel scroll the page → page scrolls (veil doesn't lock scroll).
+
+When a layout change makes any of these scenarios fail, prefer fixing in this order:
+1. Adjust `side`/`align` (or `sideByViewport`) on the affected step.
+2. Adjust `popoverAnchor` to a smaller / better-positioned element if the spotlight anchor is too large.
+3. As a last resort, add or remove a step.
+
 ## Tests
 
 Write exhaustive tests for any code you add or modify.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,53 +124,44 @@ Resize the preview between viewports as you go — many of these regress on one 
 
 The tour popover system (`src/ui/tour/TourPopover.tsx`, `src/ui/tour/tours.ts`) positions a Radix popover next to a "spotlight" cutout that highlights the anchor element. jsdom can't run layout, so popover/spotlight pixel positions cannot be unit-tested — they're verified manually in the `next-dev` preview at both viewport breakpoints whenever you touch:
 
-- `src/ui/tour/tours.ts` — step config (`anchor`, `popoverAnchor`, `popoverAnchorPriority`, `side`, `align`, `sideByViewport`, `viewport`).
+- `src/ui/tour/tours.ts` — step config (`anchor`, `popoverAnchor`, `popoverAnchorPriority`, `side`, `align`, `sideByViewport`, `viewport`, `anchorByViewport`).
 - `src/ui/tour/TourPopover.tsx` — anchor resolution, side/align resolution, positioning effect.
 - A `data-tour-anchor="…"` attribute on any DOM node — adding, removing, or moving one changes which element drives spotlight + popover position.
 - `src/ui/onboarding/StartupCoordinator.tsx` precedence rules — changes which tour fires when.
 
-**Verification workflow.** For each tour, walk every step at desktop **1280×800** AND mobile **375×812** in the `next-dev` preview. For each step:
+**Verification rule.** For every tour the app can launch, walk every step at desktop (1280×800) AND mobile (375×812) in the `next-dev` preview. For each step:
 
-1. **Popover fully on-screen** — `top ≥ 0 && left ≥ 0 && right ≤ vw && bottom ≤ vh`. *Hard requirement.*
-2. **Spotlight surrounds the right anchor element(s)** — visually confirm the dimming hole encloses what the copy is referring to.
-3. **Popover doesn't block the spotlight area** — *soft requirement*. If unavoidable (anchor extends past the viewport), the popover MUST cover the *less important* part of the spotlight (e.g. cover top rows of a tall column rather than the center). Popover visibility wins; partial spotlight occlusion is acceptable.
-4. **No console warnings** — particularly the React 19 "Each child in a list should have a unique 'key' prop" warning, which fires when Radix's Slot iterates Popover.Content's children. Resolved today by wrapping the popover's inner content in a single `<div className="contents">`; if you restructure the children, re-verify.
-5. **Step counter matches the visible viewport** — mobile-only steps (`viewport: "mobile"`) don't appear on desktop, and the "step N of M" counter reflects the post-filter list. After resizing mid-tour, the counter re-derives via `useFilterStepsByViewport`.
+1. **Popover fully on-screen** — `top ≥ 0 && left ≥ 0 && right ≤ vw && bottom ≤ vh`. ***Hard requirement.*** A clipped popover means the user can't read the copy or click Next, so the tour stalls.
+2. **Popover doesn't cover the spotlight area** — *soft requirement.* The spotlight is the user's "look here" cue; the popover blocking it defeats the purpose. If avoiding overlap forces the popover off-screen, **prefer popover visibility** (rule #1 always wins). When overlap is unavoidable, position the popover so it covers the *less important* part of the spotlight (e.g. the top of a tall column the user is being introduced to, not the middle).
+3. **No console warnings during the tour** — particularly React's "Each child in a list should have a unique 'key' prop" warning that surfaces when Radix's Slot iterates `Popover.Content`'s children. The current fix is a `<div className="contents">` wrapper; if you restructure those children, re-verify.
 
-**Tour matrix to walk** (post-round-4):
+Sequencing and precedence are covered by `src/ui/onboarding/StartupCoordinator.test.tsx` + `src/ui/tour/screenKey.test.ts` — those tests pin which tour fires under which conditions, the splash → tour → install ordering, the brand-new-user redirect, and that completion locks the gate. **You don't need to walk those scenarios manually unless you change `TOUR_PRECEDENCE`, add a new screen to the tour registry, or touch the gate logic.** The manual walk is purely about pixel positioning.
 
-| Tour | Desktop steps | Mobile steps | Mobile-only steps |
-|------|---------------|--------------|-------------------|
-| `setup` (6) | 6 | 6 | — |
-| `checklistSuggest` (4 desktop / 5 mobile) | 4 | 5 | `bottom-nav-suggest` (between `checklist-case-file` and `suggest-prior-log`) |
-| `firstSuggestion` (1) | 1 | 1 | — *(viewport-conditional anchor: `desktop-checklist-area` desktop, `bottom-nav-checklist` mobile)* |
+**Enumerating the tours.** The full list of tours that can launch lives in `src/ui/tour/tours.ts` under the `TOURS` registry. Today (subject to drift — re-read the registry as the source of truth):
 
-**Steps with known popover/spotlight overlap** (acceptable per #3 above):
+- **`setup`** — fires on first visit to the Setup pane. How to launch: clear `effect-clue.*` from localStorage and load `/play?view=setup`. (Brand-new users landing anywhere else get redirected here by the coordinator.)
+- **`checklistSuggest`** — fires on first visit to the Play pane (Checklist + Suggest). Launch: dismiss `setup` first (e.g. seed `effect-clue.tour.setup.v1` with `lastDismissedAt`), then load `/play?view=checklist`. Step count is viewport-conditional today (one mobile-only step) — verify the "N of M" counter matches what's visible.
+- **`firstSuggestion`** — fires once per 4-week window when the user logs the first suggestion of any session. Launch: clear all tour state, dismiss splash + the per-screen tours, set up a game with default players, navigate to suggest mode, and submit the form. The popover fires immediately after the suggestion is added.
 
-- `setup-known-cell` mobile — popover covers the top ~3 rows of the player column. Desktop sits to the RIGHT of the column (no overlap, full column visible) via `sideByViewport`.
-- `firstSuggestion` desktop — anchor is the entire deduction grid (~880 px tall, exceeds viewport). Popover clamps near the top with overlap. Mobile anchors to the BottomNav Checklist tab — small, no overlap.
+If you add a new tour to the registry, add it to this list AND walk it at both breakpoints before merging.
 
-**Sequencing & precedence** (covered by `src/ui/onboarding/StartupCoordinator.test.tsx` + `src/ui/tour/screenKey.test.ts` — no manual walk needed unless you change `TOUR_PRECEDENCE` or add a new screen):
+**Step launchers.** When you need to ship a step deep in a multi-step tour without walking the earlier steps every time:
 
-- Splash always wins ahead of tour and install at boot.
-- After splash dismisses, the coordinator picks the highest-priority eligible tour from `TOUR_PRECEDENCE = ["setup", "checklistSuggest"]`. If that tour belongs to a different screen than the user landed on, the coordinator dispatches `setUiMode` to redirect.
-- A tour completing (Next on the last step) writes `lastDismissedAt` for that screen — same gate effect as Skip / Esc / X. The 4-week re-engage cadence applies to both completion and dismissal.
-- After a tour fires, install is suppressed for the rest of the session.
+- The "Restart tour" overflow-menu item (in the ⋯ menu) wipes every per-screen tour-gate flag and re-fires the tour for the user's *current* screen. Useful for re-running setup or checklistSuggest without crafting localStorage by hand.
+- For mid-tour steps, advance via the popover's Next button. There's no "jump to step N" affordance today — if you need one, advance with the keyboard (Tab → Tab → Tab → Enter cycles to Next).
 
-**Test scenarios to walk in the preview** (clear `effect-clue.*` keys in localStorage between each one):
+**Drift signals.** While walking the tours, if any of these surface, treat them as bugs:
 
-1. **Brand-new user lands on `/`** → splash → setup tour (6 steps).
-2. **Brand-new user lands on `/play?view=checklist`** → splash → coordinator redirects to `?view=setup` → setup tour fires.
-3. **Returning user (setup completed) lands on `/play`** → no redirect → checklist+suggest tour (4 desktop / 5 mobile steps).
-4. **Returning user with all tours completed lands on `/play`** → no tour, install prompt fires (if eligible).
-5. **Resize from desktop to mobile mid-tour during `checklistSuggest`** → step counter re-derives (4 → 5 if not yet past the new mobile-only step).
-6. **Tour active + try `⌘K` / arrow keys / Tab** → keyboard isolator swallows everything except `Esc` (dismiss) and keys targeting popover content (Tab between Back / Skip / Next).
-7. **Tour active + click backdrop** → tour stays active. Click ⌘+wheel scroll the page → page scrolls (veil doesn't lock scroll).
+- Popover left edge < 0 or right edge > viewport width — usually a `side: "left"` / `side: "right"` step on a viewport too narrow to fit. Fix with `sideByViewport` flipping to `top` / `bottom` on the affected breakpoint.
+- Popover top edge < 0 — usually `side: "top"` against a tall anchor whose top is near `y=0` (Radix tries to put it above, no room). Fix with a smaller `popoverAnchor` (a small element at a known position inside the spotlight area), or flip `side: "bottom"`.
+- Popover anchored to the trigger of an open dropdown but ending up where it covers the dropdown's items — `popoverAnchorPriority: "last-visible"` resolves to the portaled menu content instead of the trigger.
+- Step counter shows e.g. "5 of 5" on desktop where you expect "4 of 4" — a step's `viewport: "mobile"` (or `"desktop"`) field is missing, so `useFilterStepsByViewport` lets the wrong step through. Or vice versa.
 
-When a layout change makes any of these scenarios fail, prefer fixing in this order:
+When a layout change makes any of the requirements above fail, prefer fixing in this order:
 1. Adjust `side`/`align` (or `sideByViewport`) on the affected step.
 2. Adjust `popoverAnchor` to a smaller / better-positioned element if the spotlight anchor is too large.
-3. As a last resort, add or remove a step.
+3. Adjust `anchorByViewport` to point at a different DOM node per breakpoint.
+4. As a last resort, add or remove a step.
 
 ## Tests
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -391,6 +391,10 @@
             "caseFile": {
                 "title": "The case file",
                 "body": "When the solver narrows a category to a single suspect / weapon / room, the case-file column shows it — that's your accusation."
+            },
+            "gotoSuggest": {
+                "title": "Tap Suggest to log a suggestion",
+                "body": "Suggestions live on the Suggest pane. Tap the tab to switch over and log the first one."
             }
         },
         "suggest": {

--- a/src/ui/Clue.tsx
+++ b/src/ui/Clue.tsx
@@ -25,7 +25,18 @@ import { SplashModal } from "./components/SplashModal";
 import { ClueProvider, useClue } from "./state";
 import { TourProvider, useTour } from "./tour/TourProvider";
 import { TourPopover } from "./tour/TourPopover";
-import { useTourGate } from "./tour/useTourGate";
+import {
+    computeShouldShowTour,
+    TOUR_RE_ENGAGE_DURATION,
+    useTourGate,
+} from "./tour/useTourGate";
+import {
+    loadTourState,
+    saveTourDismissed,
+    saveTourVisited,
+} from "./tour/TourState";
+import { TelemetryRuntime } from "../observability/runtime";
+import { DateTime } from "effect";
 import { screenKeyForUiMode, uiModeForScreenKey } from "./tour/screenKey";
 
 // Non user-facing literals.
@@ -300,29 +311,33 @@ function TourScreenGate() {
 }
 
 /**
- * Mid-game tour: when the user logs their first suggestion of a
- * game, point at the deduction grid (desktop) or the Checklist
- * BottomNav tab (mobile) and explain that the solver re-runs with
- * each addition. Same 4-week dormancy gate as the other tours via
- * `useTourGate("firstSuggestion")`. Fires at most once per user per
- * 4-week window — explicitly NOT once-per-game; if the user solves
- * a case, starts a new one, and logs the first suggestion of THAT
- * game, the gate's dismissal timestamp suppresses a re-fire.
+ * Mid-game tour: when the user adds a suggestion while the
+ * `firstSuggestion` gate is fresh, point at the deduction grid
+ * (desktop) or the Checklist BottomNav tab (mobile) and explain
+ * that the solver re-runs with each addition. Fires at most once
+ * per user per 4-week window — explicitly NOT once-per-game; if
+ * the user solves a case, starts a new one, and logs a suggestion,
+ * the previously-saved dismissal suppresses a re-fire.
  *
- * Trigger: a 0 → 1 transition on `state.suggestions.length`.
- * Detected by tracking the last seen length in a ref so the
- * comparison is "actually went from empty to non-empty in this
- * mount", not "currently has > 0 suggestions" (which would re-fire
- * on every mount of a hydrated session).
+ * Trigger: ANY suggestion-count increase since this mount, gated
+ * by a fresh read of `tour.firstSuggestion` localStorage at the
+ * moment of the addition. "Fresh read" matters: when the user
+ * clicks ⋯ → "Take tour" mid-game, `restartTourForScreen` wipes
+ * EVERY tour key (including `firstSuggestion`). Reading the gate
+ * at trigger time picks up that wipe — the next suggestion they
+ * log re-fires the tour. A mount-time gate snapshot wouldn't, and
+ * the user would have to refresh the page to see it again.
+ *
+ * Tracks the last seen length in a ref so we only fire on a real
+ * "user added something this session" transition, not on every
+ * mount of a hydrated session that already has suggestions. The
+ * `firedRef` guard keeps it to one fire per mount even if the user
+ * adds several suggestions in a row.
  */
 function FirstSuggestionTourGate() {
     const { state, hydrated } = useClue();
     const { startTour, activeScreen } = useTour();
     const { phase } = useStartupCoordinator();
-    const { shouldShow, dismiss } = useTourGate(
-        FIRST_SUGGESTION_SCREEN_KEY,
-        { enabled: hydrated },
-    );
     const lastSeenLengthRef = useRef<number | null>(null);
     const firedRef = useRef(false);
 
@@ -333,33 +348,42 @@ function FirstSuggestionTourGate() {
             lastSeenLengthRef.current = currentLength;
             return;
         }
-        // Detect 0 → 1+ transition (the user just logged their
-        // first suggestion of this mount). `>` rather than `=== 1`
-        // so multi-suggestion-add edge cases (unlikely, but possible
-        // via `loadSession` if we ever build one) still trigger.
-        const isFirstAddition =
-            lastSeenLengthRef.current === 0 && currentLength > 0;
+        // Fire on ANY increase (going up by one or more) — not just
+        // the 0 → 1+ transition, because the user may already have
+        // suggestions logged when the gate becomes eligible (e.g.
+        // they cleared it via "Take tour" mid-game).
+        const justAdded = currentLength > lastSeenLengthRef.current;
         lastSeenLengthRef.current = currentLength;
-        if (!isFirstAddition) return;
+        if (!justAdded) return;
         if (!hydrated) return;
-        if (!shouldShow) return;
         if (activeScreen) return;
         if (firedRef.current) return;
         if (phase === "boot" || phase === "splash" || phase === "install") {
             return;
         }
+        // Gate evaluated FRESH at trigger time, not at mount time.
+        // This is what makes "Take tour"'s mid-session wipe of
+        // `tour.firstSuggestion.v1` take effect on the next add —
+        // a snapshot from useTourGate at mount would miss the wipe.
+        const now = DateTime.nowUnsafe();
+        const shouldShow = TelemetryRuntime.runSync(
+            computeShouldShowTour(
+                loadTourState(FIRST_SUGGESTION_SCREEN_KEY),
+                now,
+                TOUR_RE_ENGAGE_DURATION,
+            ),
+        );
+        if (!shouldShow) return;
         firedRef.current = true;
         startTour(FIRST_SUGGESTION_SCREEN_KEY);
-        dismiss();
-    }, [
-        state.suggestions.length,
-        hydrated,
-        shouldShow,
-        activeScreen,
-        phase,
-        startTour,
-        dismiss,
-    ]);
+        // Persist BOTH timestamps so the gate returns false until
+        // the next 4-week re-engage window opens. Saving only
+        // `lastDismissedAt` would keep the gate eligible because
+        // the gate's "dismissed but never visited" branch returns
+        // true (a defensive "if state is incoherent, show again").
+        saveTourVisited(FIRST_SUGGESTION_SCREEN_KEY, now);
+        saveTourDismissed(FIRST_SUGGESTION_SCREEN_KEY, now);
+    }, [state.suggestions.length, hydrated, activeScreen, phase, startTour]);
 
     return null;
 }

--- a/src/ui/Clue.tsx
+++ b/src/ui/Clue.tsx
@@ -26,7 +26,7 @@ import { ClueProvider, useClue } from "./state";
 import { TourProvider, useTour } from "./tour/TourProvider";
 import { TourPopover } from "./tour/TourPopover";
 import { useTourGate } from "./tour/useTourGate";
-import { screenKeyForUiMode } from "./tour/screenKey";
+import { screenKeyForUiMode, uiModeForScreenKey } from "./tour/screenKey";
 
 // Non user-facing literals.
 const VARIANT_INITIAL = "initial";
@@ -149,12 +149,27 @@ function CoordinatedShell({
 }: {
     readonly headerRef: React.RefObject<HTMLElement | null>;
 }) {
-    const { hydrated, state } = useClue();
+    const { hydrated, state, dispatch } = useClue();
     const activeScreen = screenKeyForUiMode(state.uiMode);
+    // Translate the coordinator's precedence-redirect request back
+    // into a `setUiMode` dispatch. The coordinator only fires this
+    // when the highest-priority eligible tour belongs to a screen
+    // the user is NOT on (e.g. brand-new user who landed on
+    // `/play?view=checklist` gets sent to `setup`).
+    const handleRedirectToScreen = useCallback(
+        (screen: ReturnType<typeof screenKeyForUiMode>) => {
+            const targetMode = uiModeForScreenKey(screen);
+            if (targetMode === undefined) return;
+            if (targetMode === state.uiMode) return;
+            dispatch({ type: "setUiMode", mode: targetMode });
+        },
+        [dispatch, state.uiMode],
+    );
     return (
         <StartupCoordinatorProvider
             hydrated={hydrated}
             activeScreen={activeScreen}
+            onRedirectToScreen={handleRedirectToScreen}
         >
             <TourProvider>
                 <ClueShell headerRef={headerRef} />

--- a/src/ui/components/BottomNav.tsx
+++ b/src/ui/components/BottomNav.tsx
@@ -91,6 +91,7 @@ export function BottomNav() {
                         shortcut: shortcutSuffix("global.gotoPlay", hasKeyboard),
                     })}
                     active={mode === "suggest"}
+                    tourAnchor="bottom-nav-suggest"
                     onClick={() =>
                         dispatch({ type: "setUiMode", mode: "suggest" })
                     }

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -551,16 +551,26 @@ export function Checklist() {
                             {inSetup || !hasKeyboard ? null : label("global.gotoChecklist")}
                         </th>
                         {owners.flatMap((owner, ownerIdx) => {
-                            // Setup-tour anchor: every player's header
-                            // cell carries `setup-player-column` so the
-                            // spotlight highlights the entire row of
-                            // player names. The Case File header skips
-                            // this anchor since it's not a player.
+                            // Setup-tour anchors for player header cells:
+                            //   - `setup-player-column` (every player
+                            //     header) so the "Add players" step
+                            //     spotlights the row of player names.
+                            //   - `setup-known-cell-header` (FIRST
+                            //     player only) so the "Mark cards"
+                            //     step's popover anchors to the top
+                            //     of the column rather than the full
+                            //     column union (which is too tall to
+                            //     position against on narrow viewports).
+                            // The Case File header skips both since
+                            // it's not a player.
+                            const isFirstPlayer =
+                                owner._tag === "Player" && ownerIdx === 0;
                             const playerHeaderAnchor =
                                 inSetup && owner._tag === "Player"
                                     ? {
-                                          "data-tour-anchor":
-                                              "setup-player-column",
+                                          "data-tour-anchor": isFirstPlayer
+                                              ? "setup-player-column setup-known-cell-header"
+                                              : "setup-player-column",
                                       }
                                     : {};
                             const cell = (

--- a/src/ui/components/SuggestionLogPanel.tsx
+++ b/src/ui/components/SuggestionLogPanel.tsx
@@ -235,6 +235,11 @@ function AddSuggestion() {
 
     return (
         <div
+            // Spotlight target for the wrap-up step of the
+            // checklist+suggest tour. The popover anchors to the
+            // smaller `suggest-add-form-header` (the section title)
+            // so it stays in viewport on tall layouts; the spotlight
+            // unions the two and ends up covering the entire form.
             data-tour-anchor="suggest-add-form"
             onPointerDown={onWrapperActivity}
             onPointerMove={onWrapperActivity}
@@ -345,6 +350,12 @@ function AddSuggestion() {
         return (
             <h3
                 className={`${SECTION_TITLE} leading-[1.5]`}
+                // Tour anchor: the wrap-up step of the
+                // checklist+suggest tour anchors its popover here
+                // (rather than the full form below) so the popover
+                // stays inside the viewport on layouts where the
+                // form sits at the bottom of the panel.
+                data-tour-anchor="suggest-add-form-header"
             >
                 {t.rich("addTitle", {
                     suggestionKey: label("global.gotoPlay"),

--- a/src/ui/onboarding/StartupCoordinator.test.tsx
+++ b/src/ui/onboarding/StartupCoordinator.test.tsx
@@ -14,15 +14,18 @@ import {
     describe,
     expect,
     test,
+    vi,
 } from "vitest";
 import { act, render } from "@testing-library/react";
 import {
     StartupCoordinatorProvider,
     useStartupCoordinator,
 } from "./StartupCoordinator";
+import type { ScreenKey } from "../tour/TourState";
 
 const STORAGE_SPLASH = "effect-clue.splash.v1";
 const STORAGE_TOUR_SETUP = "effect-clue.tour.setup.v1";
+const STORAGE_TOUR_CHECKLIST_SUGGEST = "effect-clue.tour.checklistSuggest.v1";
 const STORAGE_INSTALL = "effect-clue.install-prompt.v1";
 
 const seed = (key: string, value: object): void => {
@@ -47,7 +50,17 @@ const dismissedAtAllGates = (): void => {
         lastVisitedAt: recent,
         lastDismissedAt: recent,
     });
+    // Seed BOTH per-screen tour gates so the precedence sweep across
+    // [setup, checklistSuggest] doesn't pick up an unseeded screen as
+    // eligible. With precedence enabled, leaving any screen unseeded
+    // (i.e. no localStorage entry) makes the coordinator treat that
+    // tour as "fresh, never seen" → eligible.
     seed(STORAGE_TOUR_SETUP, {
+        version: 1,
+        lastVisitedAt: recent,
+        lastDismissedAt: recent,
+    });
+    seed(STORAGE_TOUR_CHECKLIST_SUGGEST, {
         version: 1,
         lastVisitedAt: recent,
         lastDismissedAt: recent,
@@ -70,12 +83,27 @@ function Probe() {
 
 const mount = (
     activeScreen: "setup" | "checklistSuggest" = "setup",
-): void => {
-    render(
-        <StartupCoordinatorProvider hydrated activeScreen={activeScreen}>
+    onRedirectToScreen?: (screen: ScreenKey) => void,
+): { rerender: (nextScreen: ScreenKey) => void } => {
+    // Conditional-spread the redirect callback so TypeScript's
+    // `exactOptionalPropertyTypes` doesn't reject `undefined`. Tests
+    // that omit the callback exercise the fallback (no redirect).
+    const redirectProp = onRedirectToScreen
+        ? { onRedirectToScreen }
+        : {};
+    const Wrapped = ({ screen }: { screen: ScreenKey }) => (
+        <StartupCoordinatorProvider
+            hydrated
+            activeScreen={screen}
+            {...redirectProp}
+        >
             <Probe />
-        </StartupCoordinatorProvider>,
+        </StartupCoordinatorProvider>
     );
+    const utils = render(<Wrapped screen={activeScreen} />);
+    return {
+        rerender: nextScreen => utils.rerender(<Wrapped screen={nextScreen} />),
+    };
 };
 
 beforeEach(() => {
@@ -95,11 +123,17 @@ describe("StartupCoordinator — priority order", () => {
     });
 
     test("only splash eligible → phase becomes splash, then done after dismiss", () => {
+        const recent = new Date().toISOString();
         seed(STORAGE_SPLASH, { version: 1 });
         seed(STORAGE_TOUR_SETUP, {
             version: 1,
-            lastVisitedAt: new Date().toISOString(),
-            lastDismissedAt: new Date().toISOString(),
+            lastVisitedAt: recent,
+            lastDismissedAt: recent,
+        });
+        seed(STORAGE_TOUR_CHECKLIST_SUGGEST, {
+            version: 1,
+            lastVisitedAt: recent,
+            lastDismissedAt: recent,
         });
         seed(STORAGE_INSTALL, { version: 1, visits: 0 });
         mount();
@@ -129,6 +163,11 @@ describe("StartupCoordinator — priority order", () => {
             lastDismissedAt: recent,
         });
         seed(STORAGE_TOUR_SETUP, {
+            version: 1,
+            lastVisitedAt: recent,
+            lastDismissedAt: recent,
+        });
+        seed(STORAGE_TOUR_CHECKLIST_SUGGEST, {
             version: 1,
             lastVisitedAt: recent,
             lastDismissedAt: recent,
@@ -184,6 +223,11 @@ describe("StartupCoordinator — tour suppresses install", () => {
             lastVisitedAt: recent,
             lastDismissedAt: recent,
         });
+        seed(STORAGE_TOUR_CHECKLIST_SUGGEST, {
+            version: 1,
+            lastVisitedAt: recent,
+            lastDismissedAt: recent,
+        });
         seed(STORAGE_INSTALL, { version: 1, visits: 1 });
         mount();
         expect(probe.current?.phase).toBe("splash");
@@ -226,6 +270,144 @@ describe("StartupCoordinator — defensive transitions", () => {
         seed("effect-clue.tour.checklistSuggest.v1", { version: 1 });
         seed(STORAGE_INSTALL, { version: 1, visits: 0 });
         mount("checklistSuggest");
+        expect(probe.current?.phase).toBe("tour");
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Round-4: tour precedence. The coordinator picks the highest-priority
+// eligible tour across all per-screen gates and asks the parent to
+// redirect (via `onRedirectToScreen`) when the user landed on a
+// different screen. Today's precedence list: [setup, checklistSuggest].
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("StartupCoordinator — tour precedence", () => {
+    test("brand-new user lands on checklistSuggest → redirect to setup", () => {
+        // Setup tour eligible (no localStorage entry → first visit).
+        // checklistSuggest also eligible. User landed on
+        // `checklistSuggest`. Setup wins precedence; coordinator asks
+        // parent to redirect.
+        const recent = new Date().toISOString();
+        seed(STORAGE_SPLASH, {
+            version: 1,
+            lastVisitedAt: recent,
+            lastDismissedAt: recent,
+        });
+        seed(STORAGE_INSTALL, { version: 1, visits: 0 });
+        // No tour state seeded → both tours are eligible.
+
+        const onRedirect = vi.fn();
+        const harness = mount("checklistSuggest", onRedirect);
+        // Coordinator dispatched the redirect — phase stays at boot
+        // pending the parent's setUiMode + re-render with the new
+        // screen.
+        expect(onRedirect).toHaveBeenCalledWith("setup");
+        expect(probe.current?.phase).toBe("boot");
+        // Parent dispatches setUiMode("setup") → activeScreen prop
+        // updates → effect re-runs and snapshots eligibility.
+        act(() => harness.rerender("setup"));
+        expect(probe.current?.phase).toBe("tour");
+    });
+
+    test("brand-new user already on setup → no redirect", () => {
+        const recent = new Date().toISOString();
+        seed(STORAGE_SPLASH, {
+            version: 1,
+            lastVisitedAt: recent,
+            lastDismissedAt: recent,
+        });
+        seed(STORAGE_INSTALL, { version: 1, visits: 0 });
+
+        const onRedirect = vi.fn();
+        mount("setup", onRedirect);
+        expect(onRedirect).not.toHaveBeenCalled();
+        expect(probe.current?.phase).toBe("tour");
+    });
+
+    test("returning user (setup completed) on checklistSuggest → no redirect", () => {
+        // Setup completed (lastDismissedAt set). checklistSuggest
+        // eligible. Precedence walks setup first (skipped, not
+        // eligible) then checklistSuggest (eligible, matches the
+        // user's current screen) → no redirect, tour fires.
+        const recent = new Date().toISOString();
+        seed(STORAGE_SPLASH, {
+            version: 1,
+            lastVisitedAt: recent,
+            lastDismissedAt: recent,
+        });
+        seed(STORAGE_TOUR_SETUP, {
+            version: 1,
+            lastVisitedAt: recent,
+            lastDismissedAt: recent,
+        });
+        seed(STORAGE_INSTALL, { version: 1, visits: 0 });
+
+        const onRedirect = vi.fn();
+        mount("checklistSuggest", onRedirect);
+        expect(onRedirect).not.toHaveBeenCalled();
+        expect(probe.current?.phase).toBe("tour");
+    });
+
+    test("no tours eligible → no redirect; phase advances past tour", () => {
+        // All tours dismissed. Coordinator finds no eligible target;
+        // no redirect. Tour eligibility = false; phase falls through
+        // to install (eligible) per the priority order.
+        dismissedAtAllGates();
+        // Re-seed install as eligible.
+        seed(STORAGE_INSTALL, { version: 1, visits: 1 });
+
+        const onRedirect = vi.fn();
+        mount("checklistSuggest", onRedirect);
+        expect(onRedirect).not.toHaveBeenCalled();
+        expect(probe.current?.phase).toBe("install");
+    });
+
+    test("splash-eligible boot defers precedence to splash close", () => {
+        // Splash + setup both eligible; user is on checklistSuggest.
+        // The redirect should NOT fire while splash is on screen.
+        // After splash close, the redirect fires.
+        seed(STORAGE_SPLASH, { version: 1 }); // eligible
+        seed(STORAGE_INSTALL, { version: 1, visits: 0 });
+
+        const onRedirect = vi.fn();
+        const harness = mount("checklistSuggest", onRedirect);
+        // Splash phase first; no redirect yet.
+        expect(probe.current?.phase).toBe("splash");
+        expect(onRedirect).not.toHaveBeenCalled();
+        // Close splash → coordinator re-runs precedence.
+        act(() => probe.current?.reportClosed("splash"));
+        expect(onRedirect).toHaveBeenCalledWith("setup");
+        // Phase advances to tour optimistically (the redirect dispatch
+        // will land + re-render with the new screen, where the
+        // matching tour fires).
+        expect(probe.current?.phase).toBe("tour");
+        // Parent dispatches the redirect; activeScreen prop updates.
+        act(() => harness.rerender("setup"));
+        // Phase stays on tour (snapshot already set; no re-decision).
+        expect(probe.current?.phase).toBe("tour");
+    });
+
+    test("when no onRedirectToScreen is provided, falls back to single-screen eligibility", () => {
+        // Defensive: if a caller doesn't supply the callback, the
+        // coordinator behaves as it did before precedence — checks
+        // ONLY the active screen's eligibility.
+        const recent = new Date().toISOString();
+        seed(STORAGE_SPLASH, {
+            version: 1,
+            lastVisitedAt: recent,
+            lastDismissedAt: recent,
+        });
+        // Setup eligible; user on checklistSuggest with that screen
+        // also eligible (precedence WOULD redirect to setup, but
+        // without the callback, no redirect).
+        seed(STORAGE_INSTALL, { version: 1, visits: 0 });
+
+        // Redirect callback explicitly OMITTED.
+        mount("checklistSuggest");
+        // Tour fires — but for the user's CURRENT screen, not setup.
+        // We can't directly assert which tour fires from here (the
+        // tour content is owned by `TourScreenGate`/`TourProvider`),
+        // but phase=tour confirms the coordinator decided to fire.
         expect(probe.current?.phase).toBe("tour");
     });
 });

--- a/src/ui/onboarding/StartupCoordinator.tsx
+++ b/src/ui/onboarding/StartupCoordinator.tsx
@@ -56,6 +56,23 @@ import { TOUR_RE_ENGAGE_DURATION } from "../tour/useTourGate";
 import { loadTourState, type ScreenKey } from "../tour/TourState";
 
 /**
+ * Priority order for auto-firing tours at boot. The coordinator
+ * picks the highest-priority eligible tour. If that tour belongs to
+ * a screen the user is NOT currently on, it asks the parent to
+ * redirect (via the `onRedirectToScreen` prop) before firing.
+ *
+ * Screens omitted from this list are NOT auto-fired by precedence:
+ *   - `firstSuggestion` is event-triggered (after the user logs
+ *     their first suggestion in any session), not screen-mounted.
+ *   - `account` and `shareImport` are reserved for M7 / M9 — they
+ *     overlay any uiMode rather than redirect.
+ */
+const TOUR_PRECEDENCE: ReadonlyArray<ScreenKey> = [
+    "setup",
+    "checklistSuggest",
+] as const;
+
+/**
  * The slots the coordinator manages. Each maps to one auto-firable
  * surface on /play.
  */
@@ -127,6 +144,21 @@ const isTourEligible = (screen: ScreenKey, now: DateTime.Utc): boolean => {
     );
 };
 
+/**
+ * Walk `TOUR_PRECEDENCE` in order, return the FIRST eligible screen
+ * (or `undefined` when no tour wants to fire). Pure read of
+ * localStorage via `loadTourState` — same reads that
+ * `isTourEligible` does, just done across the priority list.
+ */
+const findHighestPriorityEligibleTour = (
+    now: DateTime.Utc,
+): ScreenKey | undefined => {
+    for (const screen of TOUR_PRECEDENCE) {
+        if (isTourEligible(screen, now)) return screen;
+    }
+    return undefined;
+};
+
 const isInstallEligibleByCounter = (now: DateTime.Utc): boolean => {
     const state = loadInstallPromptState();
     // Account for the visit-bump that happens on this mount. The
@@ -166,6 +198,7 @@ export function StartupCoordinatorProvider({
     children,
     hydrated,
     activeScreen,
+    onRedirectToScreen,
 }: {
     readonly children: ReactNode;
     /**
@@ -182,6 +215,20 @@ export function StartupCoordinatorProvider({
      * re-fire a tour automatically (the user can use ⋯ → Take tour).
      */
     readonly activeScreen: ScreenKey;
+    /**
+     * Optional precedence-redirect callback. When the highest-priority
+     * eligible tour (per `TOUR_PRECEDENCE`) does NOT match
+     * `activeScreen`, the coordinator invokes this with the target
+     * screen. The parent should map the screen back to a `uiMode` and
+     * dispatch `setUiMode` so the user lands on the right pane before
+     * the tour fires.
+     *
+     * When omitted, the precedence redirect is disabled and the
+     * coordinator falls back to single-screen tour eligibility. Useful
+     * for tests and for any caller that doesn't want the redirect
+     * behavior.
+     */
+    readonly onRedirectToScreen?: (screen: ScreenKey) => void;
 }) {
     const [phase, setPhase] = useState<StartupPhase>(PHASE_BOOT);
 
@@ -191,16 +238,63 @@ export function StartupCoordinatorProvider({
     // splash/tour/install gates' own writes during their open path).
     const eligibilityRef = useRef<Eligibility | null>(null);
 
+    // Latest redirect callback in a ref so the boot effect doesn't
+    // need to depend on its identity (the parent often passes an
+    // inline arrow). The redirect only fires inside the effect after
+    // an eligibility decision, which is gated by `eligibilityRef`,
+    // so closure-staleness across renders isn't a concern.
+    const redirectRef = useRef(onRedirectToScreen);
+    redirectRef.current = onRedirectToScreen;
+
     // Compute eligibility once on hydration and decide the first
     // phase. The pure decision lives in `pickNextPhase`.
+    //
+    // Precedence: if a higher-priority tour (per `TOUR_PRECEDENCE`)
+    // is eligible on a screen the user is NOT on, ask the parent to
+    // redirect. The effect short-circuits (returns without writing
+    // the snapshot) so when `activeScreen` updates from the parent's
+    // dispatch, we re-run and fall through to the snapshot branch.
+    //
+    // Splash-first wins regardless of precedence — the precedence
+    // decision is deferred to `reportClosed("splash")`. This avoids
+    // dispatching `setUiMode` while the splash modal is on screen
+    // (which would cause a layout shift behind it).
     useEffect(() => {
         if (!hydrated) return;
         if (phase !== PHASE_BOOT) return;
         if (eligibilityRef.current !== null) return;
         const now = DateTime.nowUnsafe();
+
+        if (isSplashEligible(now)) {
+            const eligibility: Eligibility = {
+                splash: true,
+                // Tour eligibility is recomputed when splash closes;
+                // hold it as `false` here so a stale snapshot can't
+                // accidentally fire the tour for the wrong screen.
+                tour: false,
+                install: isInstallEligibleByCounter(now),
+            };
+            eligibilityRef.current = eligibility;
+            setPhase(SLOT_SPLASH);
+            return;
+        }
+
+        const target = findHighestPriorityEligibleTour(now);
+        if (
+            target !== undefined &&
+            target !== activeScreen &&
+            redirectRef.current
+        ) {
+            // Don't snapshot yet — wait for the parent to dispatch the
+            // redirect, which will update `activeScreen` and re-run
+            // this effect.
+            redirectRef.current(target);
+            return;
+        }
+
         const eligibility: Eligibility = {
-            splash: isSplashEligible(now),
-            tour: isTourEligible(activeScreen, now),
+            splash: false,
+            tour: target !== undefined,
             install: isInstallEligibleByCounter(now),
         };
         eligibilityRef.current = eligibility;
@@ -213,15 +307,48 @@ export function StartupCoordinatorProvider({
         // Only advance when the closing slot matches the active phase.
         // Defensive — guards against a stale onClose from a slot that
         // already advanced, e.g. install snooze + close fired twice.
+        if (slot === SLOT_SPLASH) {
+            // Re-run the precedence decision now that splash is gone.
+            // The user might still be on a non-precedence screen, so
+            // we may need to redirect before phase advances to `tour`.
+            const now = DateTime.nowUnsafe();
+            const target = findHighestPriorityEligibleTour(now);
+            setPhase(prev => {
+                if (prev !== SLOT_SPLASH) return prev;
+                if (target === undefined) {
+                    // No tour wants to fire; fall through to install.
+                    return pickNextPhase({
+                        splash: false,
+                        tour: false,
+                        install: snapshot.install,
+                    });
+                }
+                if (target !== activeScreen && redirectRef.current) {
+                    // Mirror the snapshot to reflect that a tour will
+                    // fire (so the next `reportClosed("tour")` reads
+                    // a consistent snapshot), then redirect. The
+                    // coordinator advances to `tour` immediately —
+                    // when the redirect lands, the right tour will
+                    // fire on the new screen.
+                    eligibilityRef.current = {
+                        splash: false,
+                        tour: true,
+                        install: snapshot.install,
+                    };
+                    redirectRef.current(target);
+                    return SLOT_TOUR;
+                }
+                eligibilityRef.current = {
+                    splash: false,
+                    tour: true,
+                    install: snapshot.install,
+                };
+                return SLOT_TOUR;
+            });
+            return;
+        }
         setPhase(prev => {
             if (prev !== slot) return prev;
-            if (slot === SLOT_SPLASH) {
-                return pickNextPhase({
-                    splash: false,
-                    tour: snapshot.tour,
-                    install: snapshot.install,
-                });
-            }
             if (slot === SLOT_TOUR) {
                 // Tour suppresses install per the spec. Even if the
                 // install gate is otherwise eligible, we do NOT
@@ -233,7 +360,7 @@ export function StartupCoordinatorProvider({
             // install
             return PHASE_DONE;
         });
-    }, []);
+    }, [activeScreen]);
 
     const value = useMemo<CoordinatorValue>(
         () => ({ phase, reportClosed }),

--- a/src/ui/tour/TourPopover.test.tsx
+++ b/src/ui/tour/TourPopover.test.tsx
@@ -363,3 +363,258 @@ describe("TourPopover — M20 interaction rules", () => {
         expect(api.activeScreen).toBeUndefined();
     });
 });
+
+// -----------------------------------------------------------------------
+// Round-4: Veil isolation. While a tour is active, keyboard events that
+// don't target the popover are swallowed in capture phase so app-level
+// shortcuts (⌘K, ⌘Z, etc.) don't fire under the veil. Escape still
+// dismisses the tour. Scroll is left alone — `body.style.overflow`
+// stays unchanged so the user can pan the page to read context.
+// -----------------------------------------------------------------------
+
+describe("TourPopover — veil isolation", () => {
+    test("Escape dismisses the active tour", () => {
+        let api!: ReturnType<typeof useTour>;
+        render(
+            <Harness
+                anchors={[
+                    { testId: "card-pack", anchorAttr: "setup-card-pack" },
+                ]}
+            >
+                {c => {
+                    api = c;
+                    return null;
+                }}
+            </Harness>,
+            { wrapper: TestQueryClientProvider },
+        );
+        act(() => api.startTour("setup"));
+        expect(api.activeScreen).toBe("setup");
+        act(() => {
+            window.dispatchEvent(
+                new KeyboardEvent("keydown", { key: "Escape" }),
+            );
+        });
+        expect(api.activeScreen).toBeUndefined();
+    });
+
+    test("non-Escape keys outside the popover are preventDefault'd + stopPropagation'd", () => {
+        let api!: ReturnType<typeof useTour>;
+        // Bubble-phase listener that simulates an app-level keyboard
+        // shortcut. If our capture-phase isolator works, this should
+        // NOT fire while the tour is active.
+        const bubbleHandler = vi.fn();
+        window.addEventListener("keydown", bubbleHandler);
+        try {
+            render(
+                <Harness
+                    anchors={[
+                        {
+                            testId: "card-pack",
+                            anchorAttr: "setup-card-pack",
+                        },
+                    ]}
+                >
+                    {c => {
+                        api = c;
+                        return null;
+                    }}
+                </Harness>,
+                { wrapper: TestQueryClientProvider },
+            );
+            act(() => api.startTour("setup"));
+            // Dispatch a keydown that targets <body> (outside the
+            // popover content portal). The event's metaKey + key is a
+            // stand-in for ⌘K; the value doesn't matter — our
+            // isolator swallows ALL non-Escape keys whose target
+            // isn't inside the popover.
+            const ev = new KeyboardEvent("keydown", {
+                key: "k",
+                bubbles: true,
+                cancelable: true,
+            });
+            act(() => {
+                document.body.dispatchEvent(ev);
+            });
+            expect(bubbleHandler).not.toHaveBeenCalled();
+            // The tour stays active.
+            expect(api.activeScreen).toBe("setup");
+        } finally {
+            window.removeEventListener("keydown", bubbleHandler);
+        }
+    });
+
+    test("keys targeting the popover content pass through (Tab between buttons)", () => {
+        let api!: ReturnType<typeof useTour>;
+        const bubbleHandler = vi.fn();
+        window.addEventListener("keydown", bubbleHandler);
+        try {
+            render(
+                <Harness
+                    anchors={[
+                        {
+                            testId: "card-pack",
+                            anchorAttr: "setup-card-pack",
+                        },
+                    ]}
+                >
+                    {c => {
+                        api = c;
+                        return null;
+                    }}
+                </Harness>,
+                { wrapper: TestQueryClientProvider },
+            );
+            act(() => api.startTour("setup"));
+            // Find the popover content boundary and dispatch a key
+            // event that fires INSIDE it.
+            const popoverContent = document.querySelector(
+                "[data-tour-popover-content]",
+            );
+            expect(popoverContent).not.toBeNull();
+            const ev = new KeyboardEvent("keydown", {
+                key: "Tab",
+                bubbles: true,
+                cancelable: true,
+            });
+            act(() => {
+                popoverContent!.dispatchEvent(ev);
+            });
+            // Bubble-phase listener fires because the isolator passed
+            // the event through (target is inside the popover).
+            expect(bubbleHandler).toHaveBeenCalled();
+            // Tour stays active.
+            expect(api.activeScreen).toBe("setup");
+        } finally {
+            window.removeEventListener("keydown", bubbleHandler);
+        }
+    });
+
+    test("scroll is not blocked: body.style.overflow stays untouched while tour is active", () => {
+        let api!: ReturnType<typeof useTour>;
+        document.body.style.overflow = "";
+        render(
+            <Harness
+                anchors={[
+                    { testId: "card-pack", anchorAttr: "setup-card-pack" },
+                ]}
+            >
+                {c => {
+                    api = c;
+                    return null;
+                }}
+            </Harness>,
+            { wrapper: TestQueryClientProvider },
+        );
+        const before = document.body.style.overflow;
+        act(() => api.startTour("setup"));
+        expect(document.body.style.overflow).toBe(before);
+        act(() => api.dismissTour("close"));
+        expect(document.body.style.overflow).toBe(before);
+    });
+});
+
+// -----------------------------------------------------------------------
+// Round-4: popoverAnchor + popoverAnchorPriority decouple where the
+// popover binds from where the spotlight unions. Used by:
+//   - the player-column step (popover anchors to the column header)
+//   - the overflow-menu step (popover anchors to the open dropdown,
+//     not the trigger that's earlier in DOM order)
+// -----------------------------------------------------------------------
+
+describe("TourPopover — popoverAnchor + popoverAnchorPriority", () => {
+    test("popoverAnchor token resolves to its OWN element set, distinct from the spotlight token", () => {
+        // The setup tour's `setup-known-cell` step has
+        // `popoverAnchor: "setup-known-cell-header"`. With both tokens
+        // present in the DOM, the popover binds to the header and the
+        // spotlight unions the body cells. We can't assert on
+        // pixel positions in jsdom — but we CAN assert that the
+        // expected DOM nodes exist and the popover renders without
+        // crashing.
+        let api!: ReturnType<typeof useTour>;
+        render(
+            <Harness
+                anchors={[
+                    // Spotlight target: 3 body cells.
+                    { testId: "cell-1", anchorAttr: "setup-known-cell" },
+                    { testId: "cell-2", anchorAttr: "setup-known-cell" },
+                    { testId: "cell-3", anchorAttr: "setup-known-cell" },
+                    // Popover target: 1 header cell.
+                    {
+                        testId: "header",
+                        anchorAttr: "setup-known-cell-header",
+                    },
+                ]}
+            >
+                {c => {
+                    api = c;
+                    return null;
+                }}
+            </Harness>,
+            { wrapper: TestQueryClientProvider },
+        );
+        act(() => api.startTour("setup"));
+        // Advance to step 4 (`setup-known-cell` — index 3, 0-indexed).
+        act(() => api.nextStep()); // → 1
+        act(() => api.nextStep()); // → 2
+        act(() => api.nextStep()); // → 3
+        // The popover renders with the right copy
+        // (`setup.knownCard.title`).
+        expect(
+            screen.getByText("setup.knownCard.title"),
+        ).toBeInTheDocument();
+        // Both anchor sets are queryable via `data-tour-anchor~=`.
+        expect(
+            document.querySelectorAll(
+                "[data-tour-anchor~='setup-known-cell']",
+            ).length,
+        ).toBe(3);
+        expect(
+            document.querySelectorAll(
+                "[data-tour-anchor~='setup-known-cell-header']",
+            ).length,
+        ).toBe(1);
+    });
+
+    test("popoverAnchorPriority='last-visible' resolves to the LAST matched element (overflow-menu trigger + open content)", () => {
+        // The setup tour's `overflow-menu` step uses
+        // `popoverAnchorPriority: "last-visible"` so when both the
+        // trigger button and the portaled menu content are mounted,
+        // the popover binds to the menu content (which is later in
+        // DOM order via the portal).
+        let api!: ReturnType<typeof useTour>;
+        render(
+            <Harness
+                anchors={[
+                    {
+                        testId: "trigger",
+                        anchorAttr: "overflow-menu",
+                    },
+                    {
+                        testId: "menu-content",
+                        anchorAttr: "overflow-menu",
+                    },
+                ]}
+            >
+                {c => {
+                    api = c;
+                    return null;
+                }}
+            </Harness>,
+            { wrapper: TestQueryClientProvider },
+        );
+        act(() => api.startTour("setup"));
+        // Advance to step 5 (`overflow-menu`, 0-indexed = 4).
+        for (let i = 0; i < 4; i++) act(() => api.nextStep());
+        // Both anchored elements are in the DOM.
+        expect(
+            document.querySelectorAll(
+                "[data-tour-anchor~='overflow-menu']",
+            ).length,
+        ).toBe(2);
+        // Popover renders.
+        expect(
+            screen.getByText("setup.overflow.title"),
+        ).toBeInTheDocument();
+    });
+});

--- a/src/ui/tour/TourPopover.tsx
+++ b/src/ui/tour/TourPopover.tsx
@@ -50,6 +50,7 @@ import {
     findAnchorElements,
     pickPopoverRect,
     resolveAnchorToken,
+    resolveHideArrow,
     resolvePopoverAnchorToken,
     resolveSideAndAlign,
     unionRect,
@@ -635,12 +636,14 @@ export function TourPopover() {
                             Tailwind utility classes still target the
                             children directly. */}
                         <div className="contents">
-                        <Popover.Arrow
-                            width={14}
-                            height={8}
-                            className="fill-[var(--color-tour-bg)] stroke-[var(--color-tour-border)]"
-                            strokeWidth={2}
-                        />
+                        {!resolveHideArrow(currentStep) && (
+                            <Popover.Arrow
+                                width={14}
+                                height={8}
+                                className="fill-[var(--color-tour-bg)] stroke-[var(--color-tour-border)]"
+                                strokeWidth={2}
+                            />
+                        )}
                         {/* Header: just the step's own title + the
                             close X. The cross-tour label ("Setup
                             tour" / "Checklist & Suggest tour") was

--- a/src/ui/tour/TourPopover.tsx
+++ b/src/ui/tour/TourPopover.tsx
@@ -46,8 +46,15 @@ import { useTranslations } from "next-intl";
 import { useEffect, useRef, useState } from "react";
 import { XIcon } from "../components/Icons";
 import { useClue } from "../state";
+import {
+    findAnchorElements,
+    pickPopoverRect,
+    resolveAnchorToken,
+    resolvePopoverAnchorToken,
+    resolveSideAndAlign,
+    unionRect,
+} from "./popoverGeometry";
 import { useTour } from "./TourProvider";
-import type { TourStep } from "./tours";
 
 /**
  * Wrapper around `getBoundingClientRect()` that satisfies the shape
@@ -58,13 +65,6 @@ type VirtualElement = {
     readonly getBoundingClientRect: () => DOMRect;
 };
 
-// Module-scope discriminators for `step.popoverAnchorPriority`. Pulled
-// out so the `i18next/no-literal-string` lint rule treats them as
-// wire-format flags rather than user-facing copy.
-const POPOVER_PRIORITY_FIRST = "first-visible" as const;
-const POPOVER_PRIORITY_LAST = "last-visible" as const;
-const POPOVER_SIDE_BOTTOM = "bottom" as const;
-const POPOVER_ALIGN_CENTER = "center" as const;
 // `KeyboardEvent.key` value for Escape. Module-scope so the
 // `i18next/no-literal-string` rule doesn't flag the comparison.
 const KEY_ESCAPE = "Escape" as const;
@@ -75,113 +75,10 @@ const DISMISS_VIA_ESC = "esc" as const;
 // to allow keyboard events that target the popover's own buttons.
 const POPOVER_CONTENT_ATTR = "data-tour-popover-content" as const;
 
-/**
- * Find every on-page element a tour step targets.
- *
- * Uses the `~=` attribute selector so a single DOM element can carry
- * multiple anchor names (space-separated), e.g. the first cell of the
- * checklist grid is both `setup-known-cell` and `checklist-cell`.
- * Returns the empty array when no element matches; the caller falls
- * back to a fixed viewport position.
- */
-const findAnchorElements = (anchor: string): HTMLElement[] => {
-    if (typeof document === "undefined") return [];
-    return Array.from(
-        document.querySelectorAll<HTMLElement>(
-            `[data-tour-anchor~="${anchor}"]`,
-        ),
-    );
-};
-
-/**
- * Resolve a step's anchor token, picking the right one for the
- * current viewport when `anchorByViewport` is set. The mobile
- * breakpoint matches the layout boundary used everywhere else
- * (BottomNav vs desktop Toolbar; PlayLayout's single-pane vs
- * side-by-side render). Falls back to `step.anchor` for SSR / tests
- * where matchMedia hasn't run yet.
- */
-const resolveAnchorToken = (step: TourStep): string => {
-    if (!step.anchorByViewport) return step.anchor;
-    if (typeof window === "undefined") return step.anchor;
-    const isDesktop = window.matchMedia("(min-width: 800px)").matches;
-    return isDesktop
-        ? step.anchorByViewport.desktop
-        : step.anchorByViewport.mobile;
-};
-
-/**
- * Resolve the token used to position the POPOVER specifically. Falls
- * back to the spotlight token when no override is set, so steps that
- * don't care about decoupling the two get today's behavior. Same
- * viewport-conditional + SSR fallback logic as `resolveAnchorToken`.
- */
-const resolvePopoverAnchorToken = (step: TourStep): string =>
-    step.popoverAnchor ?? resolveAnchorToken(step);
-
-type Side = "top" | "right" | "bottom" | "left";
-type Align = "start" | "center" | "end";
-
-/**
- * Resolve the popover's `side` and `align` for the active viewport.
- * `sideByViewport` wins when set; otherwise falls back to the
- * top-level `side`/`align`, then to Radix defaults of
- * `bottom`/`center`. Mirrors `resolveAnchorToken`'s SSR fallback
- * (mobile config when matchMedia isn't available — matches the
- * `useHasKeyboard` / BottomNav default).
- */
-const resolveSideAndAlign = (
-    step: TourStep,
-): { side: Side; align: Align } => {
-    const fallbackSide = step.side ?? POPOVER_SIDE_BOTTOM;
-    const fallbackAlign = step.align ?? POPOVER_ALIGN_CENTER;
-    if (!step.sideByViewport) {
-        return { side: fallbackSide, align: fallbackAlign };
-    }
-    if (typeof window === "undefined") {
-        const m = step.sideByViewport.mobile;
-        return {
-            side: m.side ?? fallbackSide,
-            align: m.align ?? fallbackAlign,
-        };
-    }
-    const isDesktop = window.matchMedia("(min-width: 800px)").matches;
-    const v = isDesktop
-        ? step.sideByViewport.desktop
-        : step.sideByViewport.mobile;
-    return {
-        side: v.side ?? fallbackSide,
-        align: v.align ?? fallbackAlign,
-    };
-};
-
-/**
- * The smallest axis-aligned rect that contains every input rect.
- * Used to highlight a row, a column, or any group of elements as a
- * single spotlight without rendering one per element.
- *
- * Zero-area rects (typically `display: none` siblings — e.g. the
- * Toolbar's ⋯ trigger that's hidden on mobile while the BottomNav's
- * ⋯ trigger carries the same anchor) are filtered out before
- * unioning. Including them would extend the union all the way to
- * the document origin (0,0), making the spotlight cover huge swaths
- * of the page.
- */
-const unionRect = (rects: ReadonlyArray<DOMRect>): DOMRect | null => {
-    const visible = rects.filter(r => r.width > 0 && r.height > 0);
-    if (visible.length === 0) return null;
-    let left = Infinity;
-    let top = Infinity;
-    let right = -Infinity;
-    let bottom = -Infinity;
-    for (const r of visible) {
-        if (r.left < left) left = r.left;
-        if (r.top < top) top = r.top;
-        if (r.right > right) right = r.right;
-        if (r.bottom > bottom) bottom = r.bottom;
-    }
-    return new DOMRect(left, top, right - left, bottom - top);
-};
+// `findAnchorElements`, `resolveAnchorToken`, `resolvePopoverAnchorToken`,
+// `resolveSideAndAlign`, `unionRect`, and `pickPopoverRect` are now in
+// `./popoverGeometry` so they can be unit-tested without mounting the
+// full Radix popover tree.
 
 const fallbackVirtualRect = (): DOMRect => {
     if (typeof window === "undefined") {
@@ -388,29 +285,15 @@ export function TourPopover() {
             const popoverEls = currentStep.popoverAnchor !== undefined
                 ? findAnchorElements(resolvePopoverAnchorToken(currentStep))
                 : els;
-            const popoverPriority =
-                currentStep.popoverAnchorPriority ?? POPOVER_PRIORITY_FIRST;
             const spotlightMeasure = (): DOMRect => {
                 const rects = els.map(el => el.getBoundingClientRect());
                 return unionRect(rects) ?? fallbackVirtualRect();
             };
-            const popoverMeasure = (): DOMRect => {
-                // Iterate forward (`first-visible`) or backward
-                // (`last-visible`). Skip zero-area elements — the
-                // Toolbar + BottomNav both render an OverflowMenu
-                // trigger with the same anchor name; one is hidden
-                // via CSS on the other's breakpoint and reports
-                // 0x0. Skipping it ensures we anchor to the visible
-                // one regardless of priority.
-                const ordered = popoverPriority === POPOVER_PRIORITY_LAST
-                    ? [...popoverEls].reverse()
-                    : popoverEls;
-                for (const el of ordered) {
-                    const r = el.getBoundingClientRect();
-                    if (r.width > 0 && r.height > 0) return r;
-                }
-                return fallbackVirtualRect();
-            };
+            const popoverMeasure = (): DOMRect =>
+                pickPopoverRect(
+                    popoverEls,
+                    currentStep.popoverAnchorPriority,
+                ) ?? fallbackVirtualRect();
             virtualElementRef.current = {
                 getBoundingClientRect: popoverMeasure,
             };

--- a/src/ui/tour/TourPopover.tsx
+++ b/src/ui/tour/TourPopover.tsx
@@ -58,6 +58,23 @@ type VirtualElement = {
     readonly getBoundingClientRect: () => DOMRect;
 };
 
+// Module-scope discriminators for `step.popoverAnchorPriority`. Pulled
+// out so the `i18next/no-literal-string` lint rule treats them as
+// wire-format flags rather than user-facing copy.
+const POPOVER_PRIORITY_FIRST = "first-visible" as const;
+const POPOVER_PRIORITY_LAST = "last-visible" as const;
+const POPOVER_SIDE_BOTTOM = "bottom" as const;
+const POPOVER_ALIGN_CENTER = "center" as const;
+// `KeyboardEvent.key` value for Escape. Module-scope so the
+// `i18next/no-literal-string` rule doesn't flag the comparison.
+const KEY_ESCAPE = "Escape" as const;
+// Analytics discriminator for tour dismissal via Esc keypress.
+const DISMISS_VIA_ESC = "esc" as const;
+// Attribute we add to the Radix Popover.Content so the keyboard
+// isolator can do an O(1) `popoverContent.contains(eventTarget)` check
+// to allow keyboard events that target the popover's own buttons.
+const POPOVER_CONTENT_ATTR = "data-tour-popover-content" as const;
+
 /**
  * Find every on-page element a tour step targets.
  *
@@ -91,6 +108,51 @@ const resolveAnchorToken = (step: TourStep): string => {
     return isDesktop
         ? step.anchorByViewport.desktop
         : step.anchorByViewport.mobile;
+};
+
+/**
+ * Resolve the token used to position the POPOVER specifically. Falls
+ * back to the spotlight token when no override is set, so steps that
+ * don't care about decoupling the two get today's behavior. Same
+ * viewport-conditional + SSR fallback logic as `resolveAnchorToken`.
+ */
+const resolvePopoverAnchorToken = (step: TourStep): string =>
+    step.popoverAnchor ?? resolveAnchorToken(step);
+
+type Side = "top" | "right" | "bottom" | "left";
+type Align = "start" | "center" | "end";
+
+/**
+ * Resolve the popover's `side` and `align` for the active viewport.
+ * `sideByViewport` wins when set; otherwise falls back to the
+ * top-level `side`/`align`, then to Radix defaults of
+ * `bottom`/`center`. Mirrors `resolveAnchorToken`'s SSR fallback
+ * (mobile config when matchMedia isn't available — matches the
+ * `useHasKeyboard` / BottomNav default).
+ */
+const resolveSideAndAlign = (
+    step: TourStep,
+): { side: Side; align: Align } => {
+    const fallbackSide = step.side ?? POPOVER_SIDE_BOTTOM;
+    const fallbackAlign = step.align ?? POPOVER_ALIGN_CENTER;
+    if (!step.sideByViewport) {
+        return { side: fallbackSide, align: fallbackAlign };
+    }
+    if (typeof window === "undefined") {
+        const m = step.sideByViewport.mobile;
+        return {
+            side: m.side ?? fallbackSide,
+            align: m.align ?? fallbackAlign,
+        };
+    }
+    const isDesktop = window.matchMedia("(min-width: 800px)").matches;
+    const v = isDesktop
+        ? step.sideByViewport.desktop
+        : step.sideByViewport.mobile;
+    return {
+        side: v.side ?? fallbackSide,
+        align: v.align ?? fallbackAlign,
+    };
 };
 
 /**
@@ -306,28 +368,44 @@ export function TourPopover() {
             //
             // Spotlight uses the UNION of all matched rects so it
             // can highlight a row/column/group as one cohesive
-            // shape. Popover positioning anchors to JUST THE FIRST
-            // matched element, not the union. Reasoning: for big
-            // unions (e.g. trigger + open menu, or a column tall
-            // enough to fill the viewport), there's nowhere for the
-            // popover to fit if Radix tries to position it against
-            // the whole union — collision detection ends up shoving
-            // the popper off-screen. Anchoring to the first
-            // element keeps the popover near a natural visual hook
-            // while the spotlight communicates the full extent of
-            // the highlighted region.
+            // shape. Popover positioning anchors to a SINGLE element
+            // (not the union). Reasoning: for big unions (e.g. an
+            // entire column or trigger + open menu), there's nowhere
+            // for the popover to fit if Radix tries to position it
+            // against the whole union — collision detection ends up
+            // shoving the popper off-screen.
+            //
+            // Two knobs select the popover's anchor element:
+            //   - `step.popoverAnchor` overrides the token (lets a
+            //     step keep the spotlight on a wide region while
+            //     pinning the popover to a small one — used for the
+            //     player-column step).
+            //   - `step.popoverAnchorPriority` picks `first-visible`
+            //     (default) or `last-visible` from the matched
+            //     elements (used for the overflow-menu step where
+            //     the portaled menu content appears AFTER the trigger
+            //     in DOM order).
+            const popoverEls = currentStep.popoverAnchor !== undefined
+                ? findAnchorElements(resolvePopoverAnchorToken(currentStep))
+                : els;
+            const popoverPriority =
+                currentStep.popoverAnchorPriority ?? POPOVER_PRIORITY_FIRST;
             const spotlightMeasure = (): DOMRect => {
                 const rects = els.map(el => el.getBoundingClientRect());
                 return unionRect(rects) ?? fallbackVirtualRect();
             };
             const popoverMeasure = (): DOMRect => {
-                // Pick the first VISIBLE element. The Toolbar +
-                // BottomNav both render an OverflowMenu trigger
-                // with the same anchor name; one is hidden via CSS
-                // on the other's breakpoint and reports a 0x0 rect.
-                // Skip the zero-area one so the popover anchors to
-                // the visible trigger.
-                for (const el of els) {
+                // Iterate forward (`first-visible`) or backward
+                // (`last-visible`). Skip zero-area elements — the
+                // Toolbar + BottomNav both render an OverflowMenu
+                // trigger with the same anchor name; one is hidden
+                // via CSS on the other's breakpoint and reports
+                // 0x0. Skipping it ensures we anchor to the visible
+                // one regardless of priority.
+                const ordered = popoverPriority === POPOVER_PRIORITY_LAST
+                    ? [...popoverEls].reverse()
+                    : popoverEls;
+                for (const el of ordered) {
                     const r = el.getBoundingClientRect();
                     if (r.width > 0 && r.height > 0) return r;
                 }
@@ -401,12 +479,19 @@ export function TourPopover() {
 
         // ResizeObserver per matched element so we follow internal
         // resizes (e.g. the user typing in a hand-size input that
-        // grows the cell).
-        const els = findAnchorElements(resolveAnchorToken(currentStep));
+        // grows the cell). Observe BOTH the spotlight and popover
+        // anchor sets — the popover anchor may be a different element
+        // than the spotlight when `step.popoverAnchor` is set
+        // (e.g. the player-column step's popover targets just the
+        // header cell while the spotlight covers all body cells).
+        const observedEls = new Set<HTMLElement>([
+            ...findAnchorElements(resolveAnchorToken(currentStep)),
+            ...findAnchorElements(resolvePopoverAnchorToken(currentStep)),
+        ]);
         let observer: ResizeObserver | null = null;
-        if (typeof ResizeObserver !== "undefined" && els.length > 0) {
+        if (typeof ResizeObserver !== "undefined" && observedEls.size > 0) {
             observer = new ResizeObserver(() => recompute());
-            for (const el of els) observer.observe(el);
+            for (const el of observedEls) observer.observe(el);
         }
 
         // MutationObserver on the body to catch anchors that
@@ -449,24 +534,64 @@ export function TourPopover() {
         };
     }, [activeScreen, stepIndex, currentStep, state.uiMode]);
 
-    // Esc dismisses the active tour. Wired at the document level
-    // rather than via Radix's `onOpenChange` because the controlled
-    // `open` Popover would otherwise also fire `onOpenChange(false)`
-    // for outside clicks AND for any sibling modal's interactions —
-    // letting the tour dismiss itself the moment the splash modal
-    // dispatched its own outside-click guard.
+    // While a tour is active, the page beneath the veil should be
+    // keyboard-inert. App-level shortcuts (`⌘K`, `⌘Z`, the per-tab
+    // "go to" shortcuts, etc.) listen at the window in BUBBLE phase;
+    // we install a CAPTURE-phase listener so we run first and can
+    // selectively swallow events.
+    //
+    //   - Escape dismisses the tour (existing behavior, kept as the
+    //     authoritative keyboard-out path).
+    //   - Other keys: if the event target is inside the popover
+    //     content (Tab between Back / Skip / Next, Enter to click),
+    //     pass through. Otherwise stopPropagation + preventDefault so
+    //     the page beneath gets nothing.
+    //
+    // `capture: true` matters for collisions — bubble-phase listeners
+    // we want to suppress fire AFTER us, so our `stopPropagation` is
+    // load-bearing.
     useEffect(() => {
         if (!activeScreen) return;
         const onKey = (e: KeyboardEvent): void => {
-            if (e.key === "Escape") {
+            if (e.key === KEY_ESCAPE) {
                 e.stopPropagation();
-                // eslint-disable-next-line i18next/no-literal-string -- analytics discriminator
-                dismissTour("esc");
+                dismissTour(DISMISS_VIA_ESC);
+                return;
             }
+            const target = e.target;
+            if (target instanceof Node) {
+                const popoverContent = document.querySelector(
+                    `[${POPOVER_CONTENT_ATTR}]`,
+                );
+                if (popoverContent && popoverContent.contains(target)) {
+                    return;
+                }
+            }
+            e.stopPropagation();
+            e.preventDefault();
         };
-        window.addEventListener("keydown", onKey);
-        return () => window.removeEventListener("keydown", onKey);
+        window.addEventListener("keydown", onKey, { capture: true });
+        return () =>
+            window.removeEventListener("keydown", onKey, { capture: true });
     }, [activeScreen, dismissTour]);
+
+    // Pull keyboard focus into the popover's "Next" button each time
+    // a step becomes active. Without this, focus stays on whatever
+    // element initiated the tour (usually a menu item or the document
+    // body), so `Tab` would walk into the page beneath — already
+    // suppressed by the keydown isolator above, but it FEELS off.
+    // Focusing inside the popover anchors the user's keyboard intent
+    // where the visual attention already is.
+    const nextButtonRef = useRef<HTMLButtonElement | null>(null);
+    useEffect(() => {
+        if (!activeScreen || !currentStep) return;
+        // Defer to the next paint so Radix's portal mount completes
+        // before we try to focus.
+        const id = requestAnimationFrame(() => {
+            nextButtonRef.current?.focus();
+        });
+        return () => cancelAnimationFrame(id);
+    }, [activeScreen, stepIndex, currentStep]);
 
     if (!activeScreen || !steps || !currentStep) return null;
 
@@ -485,6 +610,11 @@ export function TourPopover() {
     // Pad the spotlight by a few pixels so the highlight comfortably
     // surrounds the target rather than hugging its edges.
     const SPOTLIGHT_PAD = 6;
+    // Per-step `side` + `align`, with `sideByViewport` overriding the
+    // top-level values when set. Computed during render so it picks
+    // up the active viewport on each remount.
+    const { side: resolvedSide, align: resolvedAlign } =
+        resolveSideAndAlign(currentStep);
 
     return (
         <>
@@ -553,8 +683,8 @@ export function TourPopover() {
                 <Popover.Anchor virtualRef={virtualElementRef} />
                 <Popover.Portal>
                     <Popover.Content
-                        side={currentStep.side ?? "bottom"}
-                        align={currentStep.align ?? "center"}
+                        side={resolvedSide}
+                        align={resolvedAlign}
                         sideOffset={14}
                         collisionPadding={24}
                         // The tour floats above the backdrop (z-40)
@@ -581,11 +711,30 @@ export function TourPopover() {
                         role="dialog"
                         aria-labelledby="tour-step-title"
                         aria-describedby="tour-step-body"
+                        // Boundary marker for the keyboard isolator —
+                        // any keydown whose target is INSIDE this
+                        // element passes through; everything else is
+                        // swallowed.
+                        data-tour-popover-content=""
                         // The anchorTick re-render forces Radix to
                         // recompute its popper position when
                         // virtualElementRef.current swapped.
                         key={anchorTick}
                     >
+                        {/* Single wrapping element so `Popover.Content`
+                            sees ONE child rather than a list. Radix's
+                            DismissableLayer + FocusScope wrap content
+                            via `Slot` (with `asChild`), and `Slot`
+                            calls `React.Children.toArray(children)`
+                            which warns in React 19 about unkeyed
+                            JSX children even when the array isn't
+                            iterated further. Wrapping in a single
+                            `<div>` (or Fragment) is the standard
+                            workaround. The wrapper is `display:
+                            contents` so it doesn't add a layout box —
+                            Tailwind utility classes still target the
+                            children directly. */}
+                        <div className="contents">
                         <Popover.Arrow
                             width={14}
                             height={8}
@@ -601,7 +750,9 @@ export function TourPopover() {
                             tight around its content. The step
                             counter moved to the bottom-left of the
                             footer so it sits next to the Skip link. */}
-                        <div className="flex items-start justify-between gap-3 px-4 pt-3 pb-2">
+                        <div
+                            className="flex items-start justify-between gap-3 px-4 pt-3 pb-2"
+                        >
                             <div
                                 id="tour-step-title"
                                 className="font-semibold text-[15px] leading-snug text-[var(--color-tour-text)]"
@@ -629,7 +780,9 @@ export function TourPopover() {
                                 {bodyText}
                             </div>
                         )}
-                        <div className="flex items-center justify-between gap-3 border-t border-[var(--color-tour-border)] px-4 py-2.5">
+                        <div
+                            className="flex items-center justify-between gap-3 border-t border-[var(--color-tour-border)] px-4 py-2.5"
+                        >
                             <span className="text-[12px] text-[var(--color-tour-accent)]">
                                 {t("stepCounter", {
                                     step: stepNumber,
@@ -654,6 +807,7 @@ export function TourPopover() {
                                     {t("back")}
                                 </button>
                                 <button
+                                    ref={nextButtonRef}
                                     type="button"
                                     onClick={() => nextStep()}
                                     className="cursor-pointer rounded-[var(--tour-radius)] border-2 border-[var(--color-tour-accent)] bg-[var(--color-tour-accent)] px-3 py-1.5 text-[13px] font-semibold text-white hover:bg-[var(--color-tour-accent-hover)]"
@@ -661,6 +815,7 @@ export function TourPopover() {
                                     {isLastStep ? t(finishKey) : t("next")}
                                 </button>
                             </div>
+                        </div>
                         </div>
                     </Popover.Content>
                 </Popover.Portal>

--- a/src/ui/tour/TourPopover.tsx
+++ b/src/ui/tour/TourPopover.tsx
@@ -289,11 +289,28 @@ export function TourPopover() {
                 const rects = els.map(el => el.getBoundingClientRect());
                 return unionRect(rects) ?? fallbackVirtualRect();
             };
-            const popoverMeasure = (): DOMRect =>
-                pickPopoverRect(
+            const popoverMeasure = (): DOMRect => {
+                // Prefer the popover's own anchor target (when set);
+                // fall back to the spotlight elements if nothing
+                // matched. This is what makes a per-viewport
+                // popoverAnchor work — `firstSuggestion`'s
+                // `popoverAnchor: "checklist-case-file"` only
+                // resolves on desktop (the checklist pane is
+                // mounted); on mobile the same token finds nothing
+                // and we drop back to the spotlight elements
+                // (`bottom-nav-checklist`).
+                const fromPopover = pickPopoverRect(
                     popoverEls,
                     currentStep.popoverAnchorPriority,
-                ) ?? fallbackVirtualRect();
+                );
+                if (fromPopover !== null) return fromPopover;
+                return (
+                    pickPopoverRect(
+                        els,
+                        currentStep.popoverAnchorPriority,
+                    ) ?? fallbackVirtualRect()
+                );
+            };
             virtualElementRef.current = {
                 getBoundingClientRect: popoverMeasure,
             };

--- a/src/ui/tour/TourProvider.test.tsx
+++ b/src/ui/tour/TourProvider.test.tsx
@@ -15,11 +15,24 @@
  *     analytics; the persisted timestamp is the same regardless of
  *     `via`.
  */
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { act, render } from "@testing-library/react";
 import { type ReactNode } from "react";
 import { TourProvider, useTour } from "./TourProvider";
 import { loadTourState } from "./TourState";
+
+const stubMatchMedia = (matches: boolean): void => {
+    window.matchMedia = vi.fn().mockImplementation(() => ({
+        matches,
+        media: "",
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+    }));
+};
 
 interface TourApi {
     /** Always returns the LATEST api from the most recent render —
@@ -124,5 +137,65 @@ describe("TourProvider — persistence on close", () => {
         // Per-screen isolation: only the active tour's gate is set.
         expect(loadTourState("checklistSuggest").lastDismissedAt).toBeDefined();
         expect(loadTourState("setup").lastDismissedAt).toBeUndefined();
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Viewport filter — `viewport: "mobile" | "desktop"` steps are filtered
+// out of the active step list per breakpoint. The step counter, the
+// `tour_started` analytics step count, and `isLastStep` all reflect
+// the post-filter list.
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("TourProvider — viewport filter", () => {
+    test("checklistSuggest exposes 4 steps on desktop (mobile-only step filtered)", () => {
+        stubMatchMedia(true); // desktop
+        const api = mount();
+        act(() => api.current().startTour("checklistSuggest"));
+        expect(api.current().steps?.length).toBe(4);
+        // The mobile-only `bottom-nav-suggest` step is excluded.
+        expect(
+            api.current().steps?.map(s => s.anchor),
+        ).not.toContain("bottom-nav-suggest");
+    });
+
+    test("checklistSuggest exposes 5 steps on mobile (mobile-only step included)", () => {
+        stubMatchMedia(false); // mobile
+        const api = mount();
+        act(() => api.current().startTour("checklistSuggest"));
+        expect(api.current().steps?.length).toBe(5);
+        expect(
+            api.current().steps?.map(s => s.anchor),
+        ).toContain("bottom-nav-suggest");
+    });
+
+    test("setup tour has the same 6 steps at both breakpoints (no viewport-locked steps)", () => {
+        stubMatchMedia(true);
+        const api = mount();
+        act(() => api.current().startTour("setup"));
+        expect(api.current().steps?.length).toBe(6);
+
+        stubMatchMedia(false);
+        const api2 = mount();
+        act(() => api2.current().startTour("setup"));
+        expect(api2.current().steps?.length).toBe(6);
+    });
+
+    test("isLastStep is computed from the post-filter list", () => {
+        stubMatchMedia(true); // desktop — 4 steps
+        const api = mount();
+        act(() => api.current().startTour("checklistSuggest"));
+        // Step 0 of 4: not last.
+        expect(api.current().isLastStep).toBe(false);
+        // Walk to step 3 (the wrap-up `suggest-add-form`).
+        act(() => api.current().nextStep());
+        act(() => api.current().nextStep());
+        act(() => api.current().nextStep());
+        // Step 3 of 4 (0-indexed) IS the last on desktop.
+        expect(api.current().isLastStep).toBe(true);
+        // Without the filter, step 3 would be the mobile-only
+        // `bottom-nav-suggest` and isLastStep would be false at this
+        // point — pinning isLastStep at desktop step 3 confirms the
+        // filter is wiring through.
     });
 });

--- a/src/ui/tour/TourProvider.test.tsx
+++ b/src/ui/tour/TourProvider.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * Tour state-machine tests focused on the persistence-touching
+ * transitions. The popover render path and analytics emission are
+ * covered by `TourPopover.test.tsx` + the per-event analytics test
+ * suite; this file pins the localStorage side effects that the
+ * gate logic depends on.
+ *
+ * Specifically:
+ *   - completing a tour (clicking Next on the last step) writes
+ *     `lastDismissedAt` so the per-screen gate doesn't re-fire it on
+ *     every page load (the gate reads "show unless
+ *     dismissed-and-recent").
+ *   - dismissing a tour (Skip / Esc / X) writes `lastDismissedAt`
+ *     with the corresponding `via` discriminator passed through to
+ *     analytics; the persisted timestamp is the same regardless of
+ *     `via`.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { act, render } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { TourProvider, useTour } from "./TourProvider";
+import { loadTourState } from "./TourState";
+
+interface TourApi {
+    /** Always returns the LATEST api from the most recent render —
+     * resists React's closure-staleness across re-renders. Each test
+     * call site does `apiRef().dismissTour(...)` so it grabs the
+     * current useCallback identity (which closes over the current
+     * `activeScreen`). */
+    readonly current: () => ReturnType<typeof useTour>;
+}
+
+function Probe({
+    onApi,
+}: {
+    readonly onApi: (api: ReturnType<typeof useTour>) => void;
+}): null {
+    const api = useTour();
+    onApi(api);
+    return null;
+}
+
+function mount(children?: ReactNode): TourApi {
+    let latest: ReturnType<typeof useTour> | undefined;
+    render(
+        <TourProvider>
+            <Probe onApi={a => (latest = a)} />
+            {children}
+        </TourProvider>,
+    );
+    return {
+        current: () => {
+            if (!latest) throw new Error("api not yet ready");
+            return latest;
+        },
+    };
+}
+
+beforeEach(() => {
+    window.localStorage.clear();
+});
+
+afterEach(() => {
+    window.localStorage.clear();
+});
+
+describe("TourProvider — persistence on close", () => {
+    test("completion: clicking Next past the last step writes lastDismissedAt", () => {
+        const api = mount();
+        act(() => api.current().startTour("setup"));
+        // Setup has 6 steps. Click Next 6 times: steps 0→1, 1→2,
+        // 2→3, 3→4, 4→5, then the 6th call past the last step
+        // triggers the completion path.
+        for (let i = 0; i < 6; i++) {
+            act(() => api.current().nextStep());
+        }
+        expect(api.current().activeScreen).toBeUndefined();
+        const persisted = loadTourState("setup");
+        // The completion path writes lastDismissedAt so the per-screen
+        // gate doesn't re-fire the tour on the next page load (the
+        // gate reads "show unless dismissed-and-recent").
+        expect(persisted.lastDismissedAt).toBeDefined();
+    });
+
+    test("dismissTour('skip') writes lastDismissedAt", () => {
+        const api = mount();
+        act(() => api.current().startTour("setup"));
+        act(() => api.current().dismissTour("skip"));
+        expect(api.current().activeScreen).toBeUndefined();
+        const persisted = loadTourState("setup");
+        expect(persisted.lastDismissedAt).toBeDefined();
+    });
+
+    test("dismissTour('esc') writes lastDismissedAt", () => {
+        const api = mount();
+        act(() => api.current().startTour("setup"));
+        act(() => api.current().dismissTour("esc"));
+        expect(api.current().activeScreen).toBeUndefined();
+        const persisted = loadTourState("setup");
+        expect(persisted.lastDismissedAt).toBeDefined();
+    });
+
+    test("dismissTour('close') writes lastDismissedAt", () => {
+        const api = mount();
+        act(() => api.current().startTour("setup"));
+        act(() => api.current().dismissTour("close"));
+        expect(api.current().activeScreen).toBeUndefined();
+        const persisted = loadTourState("setup");
+        expect(persisted.lastDismissedAt).toBeDefined();
+    });
+
+    test("completion of checklistSuggest tour writes lastDismissedAt for THAT screen only", () => {
+        const api = mount();
+        act(() => api.current().startTour("checklistSuggest"));
+        // Walk until the tour completes. checklistSuggest's step
+        // count is viewport-conditional (mobile gets one extra
+        // "tap Suggest" step), so loop on `activeScreen` rather
+        // than a fixed iteration count.
+        let safety = 20;
+        while (api.current().activeScreen !== undefined && safety-- > 0) {
+            act(() => api.current().nextStep());
+        }
+        expect(api.current().activeScreen).toBeUndefined();
+        // Per-screen isolation: only the active tour's gate is set.
+        expect(loadTourState("checklistSuggest").lastDismissedAt).toBeDefined();
+        expect(loadTourState("setup").lastDismissedAt).toBeUndefined();
+    });
+});

--- a/src/ui/tour/TourProvider.tsx
+++ b/src/ui/tour/TourProvider.tsx
@@ -22,11 +22,12 @@ import {
     createContext,
     useCallback,
     useContext,
+    useEffect,
     useMemo,
     useState,
     type ReactNode,
 } from "react";
-import { Effect } from "effect";
+import { DateTime, Effect } from "effect";
 import {
     tourCompleted,
     tourDismissed,
@@ -39,6 +40,7 @@ import { TelemetryRuntime } from "../../observability/runtime";
 import { TOURS, type TourStep } from "./tours";
 import {
     resetAllTourState,
+    saveTourDismissed,
     type ScreenKey,
 } from "./TourState";
 
@@ -98,19 +100,100 @@ const dismissEffect = Effect.fn("tour.dismiss")(function* (
     return { screen, stepIndex, via };
 });
 
+// Module-scope viewport discriminators so the `i18next/no-literal-string`
+// rule treats them as wire-format flags, not user copy.
+const VIEWPORT_MOBILE = "mobile" as const;
+const VIEWPORT_DESKTOP = "desktop" as const;
+const VIEWPORT_BOTH = "both" as const;
+const DESKTOP_BREAKPOINT_QUERY = "(min-width: 800px)";
+
+/**
+ * Filter `TOURS[screen]` to the steps that match the current viewport
+ * breakpoint. Steps without a `viewport` field (the common case) are
+ * always included; the only steps removed are ones explicitly tagged
+ * `viewport: "mobile"` while running on desktop, or vice versa.
+ *
+ * The filtered list is what drives `currentStep`, `totalSteps`, the
+ * "step N of M" counter, and the analytics event payloads — so a tour
+ * that has 4 steps on desktop and 5 on mobile reports 4 / 5 to
+ * PostHog respectively, rather than reporting 5 and silently
+ * fast-forwarding past the desktop-skipped step.
+ *
+ * The breakpoint matches the rest of the app's mobile/desktop split
+ * (BottomNav vs Toolbar; PlayLayout's single-pane vs side-by-side).
+ */
+const useFilterStepsByViewport = (
+    allSteps: ReadonlyArray<TourStep>,
+): ReadonlyArray<TourStep> => {
+    const [isDesktop, setIsDesktop] = useState<boolean>(() => {
+        if (typeof window === "undefined") return false;
+        return window.matchMedia(DESKTOP_BREAKPOINT_QUERY).matches;
+    });
+    useEffect(() => {
+        if (typeof window === "undefined") return;
+        const mq = window.matchMedia(DESKTOP_BREAKPOINT_QUERY);
+        const onChange = (): void => setIsDesktop(mq.matches);
+        // `addEventListener` is the modern API; fall back to the
+        // deprecated `addListener` for older Safari.
+        if (typeof mq.addEventListener === "function") {
+            mq.addEventListener("change", onChange);
+            return () => mq.removeEventListener("change", onChange);
+        }
+        mq.addListener(onChange);
+        return () => mq.removeListener(onChange);
+    }, []);
+    return useMemo(
+        () =>
+            allSteps.filter(step => {
+                const v = step.viewport ?? VIEWPORT_BOTH;
+                if (v === VIEWPORT_BOTH) return true;
+                if (v === VIEWPORT_DESKTOP) return isDesktop;
+                if (v === VIEWPORT_MOBILE) return !isDesktop;
+                return true;
+            }),
+        [allSteps, isDesktop],
+    );
+};
+
+// Empty array used as the no-active-tour stand-in so the viewport
+// filter hook can run unconditionally (Rules of Hooks). Module-scope
+// so React sees a stable identity across renders.
+const EMPTY_STEPS: ReadonlyArray<TourStep> = [];
+
 export function TourProvider({ children }: { readonly children: ReactNode }) {
     const [activeScreen, setActiveScreen] = useState<ScreenKey | undefined>(
         undefined,
     );
     const [stepIndex, setStepIndex] = useState(0);
 
-    const steps = activeScreen ? TOURS[activeScreen] : undefined;
+    // Filter happens BEFORE we expose `steps` to consumers so the
+    // step counter, analytics, and the wrap-up `isLastStep` flag all
+    // reflect the post-filter list. The filter is reactive — if the
+    // user resizes between mobile and desktop mid-tour, the step
+    // count and (if needed) the current index re-derive.
+    const allSteps: ReadonlyArray<TourStep> =
+        activeScreen ? TOURS[activeScreen] : EMPTY_STEPS;
+    const filteredSteps = useFilterStepsByViewport(allSteps);
+    const steps = activeScreen ? filteredSteps : undefined;
     const currentStep = steps?.[stepIndex];
     const totalSteps = steps?.length ?? 0;
     const isLastStep = totalSteps > 0 && stepIndex === totalSteps - 1;
 
     const startTour = useCallback((screen: ScreenKey) => {
-        const stepsForScreen = TOURS[screen];
+        // Match the filter the live `steps` will go through so the
+        // analytics step count is consistent with what the user
+        // actually sees. We run the same filter logic inline here
+        // because the hook can only run inside the component body.
+        const isDesktop =
+            typeof window !== "undefined" &&
+            window.matchMedia(DESKTOP_BREAKPOINT_QUERY).matches;
+        const stepsForScreen = TOURS[screen].filter(step => {
+            const v = step.viewport ?? VIEWPORT_BOTH;
+            if (v === VIEWPORT_BOTH) return true;
+            if (v === VIEWPORT_DESKTOP) return isDesktop;
+            if (v === VIEWPORT_MOBILE) return !isDesktop;
+            return true;
+        });
         if (stepsForScreen.length === 0) return;
         TelemetryRuntime.runSync(startEffect(screen));
         tourStarted({ screenKey: screen, stepCount: stepsForScreen.length });
@@ -135,7 +218,15 @@ export function TourProvider({ children }: { readonly children: ReactNode }) {
             setStepIndex(next);
             return;
         }
-        // Past the last step — completion path.
+        // Past the last step — completion path. We persist
+        // `lastDismissedAt` here too: the gate logic reads "show
+        // unless dismissed-and-recent", so without this a user who
+        // walked through every step (clicking Next on the closing
+        // CTA) would see the same tour again on every page load.
+        // Completion locks the tour the same way Skip / Esc / X do;
+        // the analytics event still distinguishes the *reason* via
+        // `tourCompleted` vs `tourDismissed`.
+        saveTourDismissed(activeScreen, DateTime.nowUnsafe());
         tourCompleted({
             screenKey: activeScreen,
             totalSteps: steps.length,
@@ -164,6 +255,15 @@ export function TourProvider({ children }: { readonly children: ReactNode }) {
     const dismissTour = useCallback(
         (via: TourDismissVia) => {
             if (!activeScreen) return;
+            // Persist `lastDismissedAt` for the gate. The
+            // first-fire path also writes this eagerly on tour
+            // start (so a same-session refresh doesn't re-fire),
+            // but the "Restart tour" overflow-menu entrypoint wipes
+            // every tour key BEFORE starting, so we have to
+            // re-write here for the close to be locked across page
+            // loads. Idempotent — writing the same key with a
+            // fresher timestamp is fine.
+            saveTourDismissed(activeScreen, DateTime.nowUnsafe());
             TelemetryRuntime.runSync(
                 dismissEffect(activeScreen, stepIndex, via),
             );
@@ -183,7 +283,18 @@ export function TourProvider({ children }: { readonly children: ReactNode }) {
         (screen: ScreenKey) => {
             resetAllTourState();
             tourRestarted({ screenKey: screen });
-            const stepsForScreen = TOURS[screen];
+            // Same viewport filter as `startTour` so the analytics
+            // step count matches the live `steps` list.
+            const isDesktop =
+                typeof window !== "undefined" &&
+                window.matchMedia(DESKTOP_BREAKPOINT_QUERY).matches;
+            const stepsForScreen = TOURS[screen].filter(step => {
+                const v = step.viewport ?? VIEWPORT_BOTH;
+                if (v === VIEWPORT_BOTH) return true;
+                if (v === VIEWPORT_DESKTOP) return isDesktop;
+                if (v === VIEWPORT_MOBILE) return !isDesktop;
+                return true;
+            });
             if (stepsForScreen.length === 0) {
                 setActiveScreen(undefined);
                 setStepIndex(0);

--- a/src/ui/tour/popoverGeometry.test.ts
+++ b/src/ui/tour/popoverGeometry.test.ts
@@ -29,6 +29,7 @@ import {
     isDesktopViewport,
     pickPopoverRect,
     resolveAnchorToken,
+    resolveHideArrow,
     resolvePopoverAnchorToken,
     resolveSideAndAlign,
     unionRect,
@@ -213,6 +214,46 @@ describe("resolveSideAndAlign", () => {
                 },
             }),
         ).toEqual({ side: "right", align: "end" });
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// resolveHideArrow
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("resolveHideArrow", () => {
+    test("default (no hideArrow): arrow is shown on both viewports", () => {
+        stubMatchMedia(true);
+        expect(resolveHideArrow(baseStep)).toBe(false);
+        stubMatchMedia(false);
+        expect(resolveHideArrow(baseStep)).toBe(false);
+    });
+
+    test("hideArrow.desktop: arrow hidden on desktop, shown on mobile", () => {
+        const step: TourStep = { ...baseStep, hideArrow: { desktop: true } };
+        stubMatchMedia(true);
+        expect(resolveHideArrow(step)).toBe(true);
+        stubMatchMedia(false);
+        expect(resolveHideArrow(step)).toBe(false);
+    });
+
+    test("hideArrow.mobile: arrow hidden on mobile, shown on desktop", () => {
+        const step: TourStep = { ...baseStep, hideArrow: { mobile: true } };
+        stubMatchMedia(true);
+        expect(resolveHideArrow(step)).toBe(false);
+        stubMatchMedia(false);
+        expect(resolveHideArrow(step)).toBe(true);
+    });
+
+    test("hideArrow set on both: arrow hidden everywhere", () => {
+        const step: TourStep = {
+            ...baseStep,
+            hideArrow: { mobile: true, desktop: true },
+        };
+        stubMatchMedia(true);
+        expect(resolveHideArrow(step)).toBe(true);
+        stubMatchMedia(false);
+        expect(resolveHideArrow(step)).toBe(true);
     });
 });
 

--- a/src/ui/tour/popoverGeometry.test.ts
+++ b/src/ui/tour/popoverGeometry.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Pure-function tests for the popover-geometry helpers. These
+ * functions don't render any React or use Radix — they're the
+ * deterministic config + math that Radix's positioning relies on.
+ *
+ * What this file catches that the manual `next-dev` walk doesn't
+ * (cheaper feedback loop):
+ *
+ *   - `sideByViewport` typo / missing branch — would surface as a
+ *     wrong popover side at one breakpoint without you noticing
+ *     until you walk that breakpoint.
+ *   - `popoverAnchorPriority` regression — `last-visible` accidentally
+ *     resolving to first.
+ *   - `unionRect` accidentally including a zero-area rect (would
+ *     stretch the spotlight to the document origin).
+ *   - `pickPopoverRect` accidentally returning a rect for a hidden
+ *     element (would anchor the popover at 0,0).
+ *
+ * What it CAN'T catch (needs a real browser):
+ *   - Whether the resulting popover ends up on-screen given the
+ *     actual viewport + Radix's positioning. Floating UI's collision
+ *     detection runs in jsdom but it needs the popover's own
+ *     bounding rect, which is 0×0 in jsdom. CLAUDE.md's manual
+ *     verification covers this.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+    findAnchorElements,
+    isDesktopViewport,
+    pickPopoverRect,
+    resolveAnchorToken,
+    resolvePopoverAnchorToken,
+    resolveSideAndAlign,
+    unionRect,
+} from "./popoverGeometry";
+import type { TourStep } from "./tours";
+
+const stubMatchMedia = (matches: boolean): void => {
+    window.matchMedia = vi.fn().mockImplementation(() => ({
+        matches,
+        media: "",
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+    }));
+};
+
+const baseStep: TourStep = {
+    anchor: "any-anchor",
+    titleKey: "any.title",
+};
+
+beforeEach(() => {
+    // Default to mobile so each test explicitly opts in to desktop
+    // by stubbing matchMedia.
+    stubMatchMedia(false);
+});
+
+afterEach(() => {
+    document.body.innerHTML = "";
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// isDesktopViewport
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("isDesktopViewport", () => {
+    test("matches desktop when matchMedia('(min-width: 800px)') matches", () => {
+        stubMatchMedia(true);
+        expect(isDesktopViewport()).toBe(true);
+    });
+
+    test("falls back to mobile when matchMedia returns false", () => {
+        stubMatchMedia(false);
+        expect(isDesktopViewport()).toBe(false);
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// resolveAnchorToken
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("resolveAnchorToken", () => {
+    test("returns step.anchor when no anchorByViewport", () => {
+        expect(resolveAnchorToken({ ...baseStep, anchor: "plain" })).toBe(
+            "plain",
+        );
+    });
+
+    test("desktop branch on desktop viewport", () => {
+        stubMatchMedia(true);
+        expect(
+            resolveAnchorToken({
+                ...baseStep,
+                anchor: "fallback",
+                anchorByViewport: { mobile: "m", desktop: "d" },
+            }),
+        ).toBe("d");
+    });
+
+    test("mobile branch on mobile viewport", () => {
+        stubMatchMedia(false);
+        expect(
+            resolveAnchorToken({
+                ...baseStep,
+                anchor: "fallback",
+                anchorByViewport: { mobile: "m", desktop: "d" },
+            }),
+        ).toBe("m");
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// resolvePopoverAnchorToken
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("resolvePopoverAnchorToken", () => {
+    test("falls through to spotlight anchor when popoverAnchor is unset", () => {
+        expect(
+            resolvePopoverAnchorToken({ ...baseStep, anchor: "x" }),
+        ).toBe("x");
+    });
+
+    test("popoverAnchor overrides regardless of viewport", () => {
+        stubMatchMedia(true);
+        expect(
+            resolvePopoverAnchorToken({
+                ...baseStep,
+                anchor: "spotlight",
+                popoverAnchor: "popover-only",
+            }),
+        ).toBe("popover-only");
+    });
+
+    test("popoverAnchor overrides even when anchorByViewport is set", () => {
+        stubMatchMedia(true);
+        expect(
+            resolvePopoverAnchorToken({
+                ...baseStep,
+                anchor: "fallback",
+                anchorByViewport: { mobile: "m", desktop: "d" },
+                popoverAnchor: "popover-only",
+            }),
+        ).toBe("popover-only");
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// resolveSideAndAlign
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("resolveSideAndAlign", () => {
+    test("Radix defaults when nothing is set", () => {
+        expect(resolveSideAndAlign(baseStep)).toEqual({
+            side: "bottom",
+            align: "center",
+        });
+    });
+
+    test("top-level side / align passes through when sideByViewport is unset", () => {
+        expect(
+            resolveSideAndAlign({
+                ...baseStep,
+                side: "top",
+                align: "end",
+            }),
+        ).toEqual({ side: "top", align: "end" });
+    });
+
+    test("sideByViewport.desktop wins on desktop", () => {
+        stubMatchMedia(true);
+        expect(
+            resolveSideAndAlign({
+                ...baseStep,
+                side: "bottom",
+                align: "center",
+                sideByViewport: {
+                    desktop: { side: "right", align: "start" },
+                    mobile: { side: "top", align: "end" },
+                },
+            }),
+        ).toEqual({ side: "right", align: "start" });
+    });
+
+    test("sideByViewport.mobile wins on mobile", () => {
+        stubMatchMedia(false);
+        expect(
+            resolveSideAndAlign({
+                ...baseStep,
+                side: "bottom",
+                align: "center",
+                sideByViewport: {
+                    desktop: { side: "right", align: "start" },
+                    mobile: { side: "top", align: "end" },
+                },
+            }),
+        ).toEqual({ side: "top", align: "end" });
+    });
+
+    test("sideByViewport partial overrides fall back to top-level side / align", () => {
+        stubMatchMedia(true);
+        expect(
+            resolveSideAndAlign({
+                ...baseStep,
+                side: "left",
+                align: "end",
+                sideByViewport: {
+                    desktop: { side: "right" }, // align falls back to "end"
+                    mobile: { align: "start" }, // side falls back to "left"
+                },
+            }),
+        ).toEqual({ side: "right", align: "end" });
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// findAnchorElements
+// ─────────────────────────────────────────────────────────────────────────
+
+describe("findAnchorElements", () => {
+    test("returns elements with matching `data-tour-anchor`", () => {
+        document.body.innerHTML = `
+            <div data-tour-anchor="alpha"></div>
+            <div data-tour-anchor="beta"></div>
+            <div data-tour-anchor="alpha"></div>
+        `;
+        expect(findAnchorElements("alpha")).toHaveLength(2);
+        expect(findAnchorElements("beta")).toHaveLength(1);
+        expect(findAnchorElements("gamma")).toHaveLength(0);
+    });
+
+    test("matches space-separated tokens via the `~=` selector", () => {
+        document.body.innerHTML = `<div data-tour-anchor="alpha beta"></div>`;
+        expect(findAnchorElements("alpha")).toHaveLength(1);
+        expect(findAnchorElements("beta")).toHaveLength(1);
+        expect(findAnchorElements("alphabeta")).toHaveLength(0);
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// unionRect
+// ─────────────────────────────────────────────────────────────────────────
+
+const rect = (x: number, y: number, w: number, h: number): DOMRect =>
+    new DOMRect(x, y, w, h);
+
+describe("unionRect", () => {
+    test("returns null for empty input", () => {
+        expect(unionRect([])).toBeNull();
+    });
+
+    test("filters out zero-area rects (display:none siblings)", () => {
+        // The hidden sibling is at (0,0) with zero size — including
+        // it would extend the union all the way to the document
+        // origin. The visible rect is far from origin.
+        const u = unionRect([rect(0, 0, 0, 0), rect(500, 200, 100, 50)]);
+        expect(u).not.toBeNull();
+        expect(u!.left).toBe(500);
+        expect(u!.top).toBe(200);
+        expect(u!.right).toBe(600);
+        expect(u!.bottom).toBe(250);
+    });
+
+    test("returns the bounding box of multiple visible rects", () => {
+        const u = unionRect([
+            rect(100, 100, 50, 50), // 100,100 → 150,150
+            rect(300, 200, 50, 100), // 300,200 → 350,300
+        ]);
+        expect(u).not.toBeNull();
+        expect(u!.left).toBe(100);
+        expect(u!.top).toBe(100);
+        expect(u!.right).toBe(350);
+        expect(u!.bottom).toBe(300);
+    });
+
+    test("returns null when ALL rects are zero-area", () => {
+        expect(unionRect([rect(0, 0, 0, 0), rect(100, 100, 0, 0)])).toBeNull();
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// pickPopoverRect
+// ─────────────────────────────────────────────────────────────────────────
+
+const mockEl = (
+    rectArgs: { x: number; y: number; w: number; h: number },
+): HTMLElement => {
+    const el = document.createElement("div");
+    el.getBoundingClientRect = () =>
+        new DOMRect(rectArgs.x, rectArgs.y, rectArgs.w, rectArgs.h);
+    return el;
+};
+
+describe("pickPopoverRect", () => {
+    test("first-visible (default): returns the first non-zero element's rect", () => {
+        const els = [
+            mockEl({ x: 0, y: 0, w: 0, h: 0 }), // hidden
+            mockEl({ x: 100, y: 50, w: 40, h: 30 }), // visible
+            mockEl({ x: 200, y: 60, w: 50, h: 25 }), // visible
+        ];
+        const r = pickPopoverRect(els, undefined);
+        expect(r).not.toBeNull();
+        expect(r!.left).toBe(100);
+        expect(r!.top).toBe(50);
+    });
+
+    test('"first-visible" explicit: same as default', () => {
+        const els = [
+            mockEl({ x: 100, y: 50, w: 40, h: 30 }),
+            mockEl({ x: 200, y: 60, w: 50, h: 25 }),
+        ];
+        const r = pickPopoverRect(els, "first-visible");
+        expect(r!.left).toBe(100);
+    });
+
+    test('"last-visible": returns the last non-zero element\'s rect', () => {
+        const els = [
+            mockEl({ x: 100, y: 50, w: 40, h: 30 }), // trigger
+            mockEl({ x: 200, y: 60, w: 50, h: 25 }), // open menu (later in DOM order)
+        ];
+        const r = pickPopoverRect(els, "last-visible");
+        expect(r!.left).toBe(200);
+    });
+
+    test('"last-visible" with hidden trailing element: skips zero-area, returns last visible', () => {
+        const els = [
+            mockEl({ x: 100, y: 50, w: 40, h: 30 }), // visible
+            mockEl({ x: 200, y: 60, w: 50, h: 25 }), // visible
+            mockEl({ x: 0, y: 0, w: 0, h: 0 }), // hidden (CSS-hidden alternate)
+        ];
+        const r = pickPopoverRect(els, "last-visible");
+        expect(r!.left).toBe(200); // last VISIBLE, not last in array
+    });
+
+    test("returns null when no element has a non-zero area", () => {
+        const els = [mockEl({ x: 0, y: 0, w: 0, h: 0 })];
+        expect(pickPopoverRect(els, "first-visible")).toBeNull();
+        expect(pickPopoverRect(els, "last-visible")).toBeNull();
+    });
+
+    test("returns null for an empty element list", () => {
+        expect(pickPopoverRect([], "first-visible")).toBeNull();
+    });
+});

--- a/src/ui/tour/popoverGeometry.ts
+++ b/src/ui/tour/popoverGeometry.ts
@@ -142,6 +142,21 @@ export const unionRect = (rects: ReadonlyArray<DOMRect>): DOMRect | null => {
 };
 
 /**
+ * Resolve whether the popover's pointer arrow should be HIDDEN for
+ * the active viewport. `hideArrow.desktop` / `.mobile` opt out of
+ * the arrow on each breakpoint; missing keys default to `false`
+ * (arrow shown). Most steps don't set `hideArrow` at all and the
+ * arrow renders as a normal Radix Popover.Arrow.
+ */
+export const resolveHideArrow = (step: TourStep): boolean => {
+    if (!step.hideArrow) return false;
+    const isDesktop = isDesktopViewport();
+    return isDesktop
+        ? step.hideArrow.desktop ?? false
+        : step.hideArrow.mobile ?? false;
+};
+
+/**
  * Pick the rect of the visible element that should drive the popover
  * position, honouring `step.popoverAnchorPriority`:
  *

--- a/src/ui/tour/popoverGeometry.ts
+++ b/src/ui/tour/popoverGeometry.ts
@@ -1,0 +1,170 @@
+/**
+ * Pure geometry / config-resolution helpers for the tour popover.
+ *
+ * These live separately from `TourPopover.tsx` so they can be unit-
+ * tested in jsdom (no Radix portal mount, no `motion/react` mock,
+ * no client-side React tree) — the kind of drift this catches:
+ *
+ *   - A step's `sideByViewport` was added but the desktop branch
+ *     resolves to the wrong side because of a typo in the helper.
+ *   - `popoverAnchorPriority: "last-visible"` accidentally gets
+ *     treated as "first-visible" because of a string-discriminator
+ *     refactor.
+ *   - `unionRect` accidentally includes a zero-area rect and the
+ *     spotlight stretches to the document origin.
+ *
+ * jsdom can't verify the popover's *final* on-screen position
+ * (Radix's positioning runs Floating UI which needs the popover's
+ * own bounding rect — and the popover renders into a portal where
+ * jsdom returns 0×0). For that, walk the tour in `next-dev` per
+ * the Tour-popover verification section in CLAUDE.md.
+ */
+import type { TourStep } from "./tours";
+
+type PopoverSide = "top" | "right" | "bottom" | "left";
+type PopoverAlign = "start" | "center" | "end";
+
+const DEFAULT_SIDE: PopoverSide = "bottom";
+const DEFAULT_ALIGN: PopoverAlign = "center";
+const DESKTOP_BREAKPOINT_QUERY = "(min-width: 800px)";
+
+/**
+ * Read the active breakpoint from `window.matchMedia`. Falls back to
+ * `false` (mobile) for SSR / tests where matchMedia isn't available.
+ * Tests can stub `window.matchMedia` to flip this synchronously.
+ */
+export const isDesktopViewport = (): boolean => {
+    if (typeof window === "undefined") return false;
+    return window.matchMedia(DESKTOP_BREAKPOINT_QUERY).matches;
+};
+
+/**
+ * Find every on-page element a tour step targets.
+ *
+ * Uses the `~=` attribute selector so a single DOM element can carry
+ * multiple anchor names (space-separated), e.g. the first cell of the
+ * checklist grid is both `setup-known-cell` and `checklist-cell`.
+ * Returns the empty array when no element matches; the caller falls
+ * back to a fixed viewport position.
+ */
+export const findAnchorElements = (anchor: string): HTMLElement[] => {
+    if (typeof document === "undefined") return [];
+    return Array.from(
+        document.querySelectorAll<HTMLElement>(
+            `[data-tour-anchor~="${anchor}"]`,
+        ),
+    );
+};
+
+/**
+ * Resolve a step's anchor token, picking the right one for the
+ * current viewport when `anchorByViewport` is set. The mobile
+ * breakpoint matches the layout boundary used everywhere else
+ * (BottomNav vs desktop Toolbar; PlayLayout's single-pane vs
+ * side-by-side render). Falls back to `step.anchor` for SSR / tests
+ * where matchMedia hasn't run yet.
+ */
+export const resolveAnchorToken = (step: TourStep): string => {
+    if (!step.anchorByViewport) return step.anchor;
+    if (typeof window === "undefined") return step.anchor;
+    return isDesktopViewport()
+        ? step.anchorByViewport.desktop
+        : step.anchorByViewport.mobile;
+};
+
+/**
+ * Resolve the token used to position the POPOVER specifically. Falls
+ * back to the spotlight token when no override is set, so steps that
+ * don't care about decoupling the two get today's behavior. Same
+ * viewport-conditional + SSR fallback logic as `resolveAnchorToken`.
+ */
+export const resolvePopoverAnchorToken = (step: TourStep): string =>
+    step.popoverAnchor ?? resolveAnchorToken(step);
+
+/**
+ * Resolve the popover's `side` and `align` for the active viewport.
+ * `sideByViewport` wins when set; otherwise falls back to the
+ * top-level `side`/`align`, then to Radix defaults of
+ * `bottom`/`center`. Mirrors `resolveAnchorToken`'s SSR fallback
+ * (mobile config when matchMedia isn't available — matches the
+ * `useHasKeyboard` / BottomNav default).
+ */
+export const resolveSideAndAlign = (
+    step: TourStep,
+): { side: PopoverSide; align: PopoverAlign } => {
+    const fallbackSide = step.side ?? DEFAULT_SIDE;
+    const fallbackAlign = step.align ?? DEFAULT_ALIGN;
+    if (!step.sideByViewport) {
+        return { side: fallbackSide, align: fallbackAlign };
+    }
+    if (typeof window === "undefined") {
+        const m = step.sideByViewport.mobile;
+        return {
+            side: m.side ?? fallbackSide,
+            align: m.align ?? fallbackAlign,
+        };
+    }
+    const v = isDesktopViewport()
+        ? step.sideByViewport.desktop
+        : step.sideByViewport.mobile;
+    return {
+        side: v.side ?? fallbackSide,
+        align: v.align ?? fallbackAlign,
+    };
+};
+
+/**
+ * The smallest axis-aligned rect that contains every input rect.
+ * Used to highlight a row, a column, or any group of elements as a
+ * single spotlight without rendering one per element.
+ *
+ * Zero-area rects (typically `display: none` siblings — e.g. the
+ * Toolbar's ⋯ trigger that's hidden on mobile while the BottomNav's
+ * ⋯ trigger carries the same anchor) are filtered out before
+ * unioning. Including them would extend the union all the way to
+ * the document origin (0,0), making the spotlight cover huge swaths
+ * of the page.
+ */
+export const unionRect = (rects: ReadonlyArray<DOMRect>): DOMRect | null => {
+    const visible = rects.filter(r => r.width > 0 && r.height > 0);
+    if (visible.length === 0) return null;
+    let left = Infinity;
+    let top = Infinity;
+    let right = -Infinity;
+    let bottom = -Infinity;
+    for (const r of visible) {
+        if (r.left < left) left = r.left;
+        if (r.top < top) top = r.top;
+        if (r.right > right) right = r.right;
+        if (r.bottom > bottom) bottom = r.bottom;
+    }
+    return new DOMRect(left, top, right - left, bottom - top);
+};
+
+/**
+ * Pick the rect of the visible element that should drive the popover
+ * position, honouring `step.popoverAnchorPriority`:
+ *
+ *   - `"first-visible"` (default) — first non-zero-area element in
+ *     DOM order. Right for the common case where multiple matches
+ *     are CSS-hidden alternates (Toolbar / BottomNav variants).
+ *   - `"last-visible"` — last non-zero-area element. Right for
+ *     portaled overlays where the trigger is in DOM order before
+ *     the open menu content but the popover should anchor against
+ *     the open content.
+ *
+ * Returns `null` when no element has a non-zero area; the caller
+ * uses a fallback viewport-corner rect.
+ */
+export const pickPopoverRect = (
+    elements: ReadonlyArray<HTMLElement>,
+    priority: TourStep["popoverAnchorPriority"],
+): DOMRect | null => {
+    const ordered =
+        priority === "last-visible" ? [...elements].reverse() : elements;
+    for (const el of ordered) {
+        const r = el.getBoundingClientRect();
+        if (r.width > 0 && r.height > 0) return r;
+    }
+    return null;
+};

--- a/src/ui/tour/screenKey.test.ts
+++ b/src/ui/tour/screenKey.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Round-trip tests for the uiMode ↔ ScreenKey mapping. Both halves
+ * are pure and synchronous; the tests pin the mapping so a future
+ * refactor can't silently introduce a uiMode that has no tour
+ * `ScreenKey` (or a `ScreenKey` that maps to the wrong uiMode and
+ * thereby breaks `StartupCoordinator`'s precedence redirect).
+ */
+import { describe, expect, test } from "vitest";
+import { screenKeyForUiMode, uiModeForScreenKey } from "./screenKey";
+import type { ScreenKey } from "./TourState";
+import type { UiMode } from "../../logic/ClueState";
+
+describe("screenKeyForUiMode", () => {
+    test("setup uiMode → setup screen", () => {
+        expect(screenKeyForUiMode("setup")).toBe("setup");
+    });
+
+    test("checklist uiMode → checklistSuggest screen (combined tour)", () => {
+        expect(screenKeyForUiMode("checklist")).toBe("checklistSuggest");
+    });
+
+    test("suggest uiMode → checklistSuggest screen (combined tour)", () => {
+        expect(screenKeyForUiMode("suggest")).toBe("checklistSuggest");
+    });
+});
+
+describe("uiModeForScreenKey", () => {
+    test("setup screen → setup uiMode (canonical)", () => {
+        expect(uiModeForScreenKey("setup")).toBe("setup");
+    });
+
+    test("checklistSuggest screen → checklist uiMode (canonical)", () => {
+        // The combined tour starts on the checklist pane on mobile;
+        // `checklist` is the default of the two share-a-tour modes.
+        expect(uiModeForScreenKey("checklistSuggest")).toBe("checklist");
+    });
+
+    test("firstSuggestion screen → undefined (event-triggered, not screen-mounted)", () => {
+        expect(uiModeForScreenKey("firstSuggestion")).toBeUndefined();
+    });
+
+    test("account screen → undefined (reserved overlay)", () => {
+        expect(uiModeForScreenKey("account")).toBeUndefined();
+    });
+
+    test("shareImport screen → undefined (reserved overlay)", () => {
+        expect(uiModeForScreenKey("shareImport")).toBeUndefined();
+    });
+});
+
+describe("uiMode ↔ ScreenKey round-trip", () => {
+    // For every uiMode the user can be in, dispatching to its
+    // corresponding screen and back lands on a uiMode that
+    // `screenKeyForUiMode` maps to the same screen. This is what
+    // makes the precedence redirect idempotent — once redirected to
+    // the canonical uiMode, the next render's screenKey matches.
+    const uiModes: ReadonlyArray<UiMode> = ["setup", "checklist", "suggest"];
+    for (const mode of uiModes) {
+        test(`${mode}: round-trip stays on the same screen`, () => {
+            const screen = screenKeyForUiMode(mode);
+            const canonicalMode = uiModeForScreenKey(screen);
+            expect(canonicalMode).toBeDefined();
+            expect(screenKeyForUiMode(canonicalMode!)).toBe(screen);
+        });
+    }
+
+    // The reverse direction: every screen with a uiMode maps back to
+    // its own ScreenKey via screenKeyForUiMode. (Screens without a
+    // uiMode return undefined and are excluded — they're event-fired
+    // overlays, never landing-screen tours.)
+    const mappedScreens: ReadonlyArray<ScreenKey> = [
+        "setup",
+        "checklistSuggest",
+    ];
+    for (const screen of mappedScreens) {
+        test(`${screen}: canonical uiMode maps back to itself`, () => {
+            const mode = uiModeForScreenKey(screen);
+            expect(mode).toBeDefined();
+            expect(screenKeyForUiMode(mode!)).toBe(screen);
+        });
+    }
+});

--- a/src/ui/tour/screenKey.ts
+++ b/src/ui/tour/screenKey.ts
@@ -15,6 +15,12 @@ import type { ScreenKey } from "./TourState";
 const SETUP: ScreenKey = "setup";
 const CHECKLIST_SUGGEST: ScreenKey = "checklistSuggest";
 
+/** Module-scope `uiMode` discriminators. The `i18next/no-literal-string`
+ * lint rule treats inline string literals as user-facing copy; pulling
+ * these out keeps it quiet without per-call eslint-disable. */
+const UI_MODE_SETUP: UiMode = "setup";
+const UI_MODE_CHECKLIST: UiMode = "checklist";
+
 /**
  * Map the live `uiMode` to its corresponding tour `ScreenKey`. Both
  * `checklist` and `suggest` modes share the combined
@@ -22,6 +28,26 @@ const CHECKLIST_SUGGEST: ScreenKey = "checklistSuggest";
  * panes on mobile when individual steps require it.
  */
 export const screenKeyForUiMode = (mode: UiMode): ScreenKey => {
-    if (mode === "setup") return SETUP;
+    if (mode === UI_MODE_SETUP) return SETUP;
     return CHECKLIST_SUGGEST;
+};
+
+/**
+ * Inverse of `screenKeyForUiMode`: the canonical `uiMode` to land on
+ * for a given tour `ScreenKey`. Used by `StartupCoordinator`'s
+ * precedence redirect to bring a brand-new user to the screen whose
+ * tour should fire first (e.g. someone who lands on `/play?view=
+ * checklist` gets dispatched to `setup` so the setup tour fires
+ * before the checklist tour).
+ *
+ * Returns `undefined` for screens that don't correspond to a uiMode:
+ *   - `firstSuggestion` is event-triggered (after the user logs their
+ *     first suggestion), not screen-mounted.
+ *   - `account` and `shareImport` are reserved for M7 / M9 — they
+ *     overlay any uiMode rather than redirect.
+ */
+export const uiModeForScreenKey = (screen: ScreenKey): UiMode | undefined => {
+    if (screen === SETUP) return UI_MODE_SETUP;
+    if (screen === CHECKLIST_SUGGEST) return UI_MODE_CHECKLIST;
+    return undefined;
 };

--- a/src/ui/tour/tours.test.ts
+++ b/src/ui/tour/tours.test.ts
@@ -180,6 +180,15 @@ describe("TOURS — firstSuggestion tour", () => {
             align: "center",
         });
     });
+
+    test("hideArrow on desktop only (popover sits inside spotlight on desktop; arrow is useful on mobile)", () => {
+        // Desktop: arrow has nothing meaningful to point at (popover
+        // is inside the spotlight). Mobile: arrow points down at the
+        // BottomNav Checklist tab, which is genuinely a different
+        // element than the popover.
+        expect(TOURS.firstSuggestion[0]!.hideArrow?.desktop).toBe(true);
+        expect(TOURS.firstSuggestion[0]!.hideArrow?.mobile).toBeUndefined();
+    });
 });
 
 describe("TOURS — placeholder tours", () => {

--- a/src/ui/tour/tours.test.ts
+++ b/src/ui/tour/tours.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Config-drift tests for the tour registry. The values pinned here
+ * MUST match what the manual `next-dev` walk verified for every
+ * positioning fix — when those values drift (someone removes
+ * `sideByViewport` from a step, or a tour gains a step without a
+ * `viewport` flag where it should have one), this catches it before
+ * the change ships.
+ *
+ * What this file does NOT test:
+ *
+ *   - Whether the resulting popover ends up on-screen (jsdom can't
+ *     run Radix's positioning math on a portaled element). Walk the
+ *     `next-dev` preview for that — see the Tour-popover verification
+ *     section in CLAUDE.md.
+ *   - Whether the spotlight visually rings the right element. Same
+ *     reason — DOM positioning is a layout concern.
+ *
+ * What it DOES catch (cheap & deterministic):
+ *
+ *   - A step's `popoverAnchor` getting silently dropped.
+ *   - The mobile-only Suggest-tab step losing its `viewport: "mobile"`
+ *     flag (which would make it render on desktop too).
+ *   - `sideByViewport` keys flipped (mobile config landing on
+ *     desktop).
+ *   - The `firstSuggestion` step's `desktop` anchor being changed
+ *     back to a tall element (which previously caused the off-top
+ *     popover bug).
+ */
+import { describe, expect, test } from "vitest";
+import { TOURS, type TourStep } from "./tours";
+
+const findStep = (
+    tour: ReadonlyArray<TourStep>,
+    anchor: string,
+): TourStep => {
+    const step = tour.find(s => s.anchor === anchor);
+    if (!step) {
+        throw new Error(`No step with anchor "${anchor}" in this tour`);
+    }
+    return step;
+};
+
+describe("TOURS — setup tour", () => {
+    test("has 6 steps in declaration order", () => {
+        expect(TOURS.setup.map(s => s.anchor)).toEqual([
+            "setup-card-pack",
+            "setup-player-column",
+            "setup-hand-size",
+            "setup-known-cell",
+            "overflow-menu",
+            "setup-start-playing",
+        ]);
+    });
+
+    test("setup-known-cell uses popoverAnchor + sideByViewport", () => {
+        const step = findStep(TOURS.setup, "setup-known-cell");
+        // Spotlight covers all body cells; popover anchors to the
+        // header so it doesn't pin against an 800-px-tall column.
+        expect(step.popoverAnchor).toBe("setup-known-cell-header");
+        // Desktop: popover sits to the RIGHT (column visible).
+        // Mobile: side: bottom; column too narrow horizontally for
+        // a side popover.
+        expect(step.sideByViewport?.desktop).toEqual({
+            side: "right",
+            align: "start",
+        });
+        expect(step.sideByViewport?.mobile).toEqual({
+            side: "bottom",
+            align: "center",
+        });
+    });
+
+    test("overflow-menu uses popoverAnchorPriority + sideByViewport", () => {
+        const step = findStep(TOURS.setup, "overflow-menu");
+        // Trigger is in DOM order before the portaled menu content;
+        // last-visible resolves to the open dropdown.
+        expect(step.popoverAnchorPriority).toBe("last-visible");
+        // Desktop: popover left of menu (menu opens DOWN from
+        // top-right trigger). Mobile: popover above menu (menu opens
+        // UP from bottom-right trigger).
+        expect(step.sideByViewport?.desktop.side).toBe("left");
+        expect(step.sideByViewport?.mobile.side).toBe("top");
+    });
+});
+
+describe("TOURS — checklistSuggest tour", () => {
+    test("has the expected step list including the mobile-only Suggest-tab step", () => {
+        expect(TOURS.checklistSuggest.map(s => s.anchor)).toEqual([
+            "checklist-cell",
+            "checklist-case-file",
+            "bottom-nav-suggest", // mobile-only — `viewport: "mobile"` filters it on desktop
+            "suggest-prior-log",
+            "suggest-add-form",
+        ]);
+    });
+
+    test("bottom-nav-suggest is mobile-only (filtered out on desktop)", () => {
+        const step = findStep(TOURS.checklistSuggest, "bottom-nav-suggest");
+        expect(step.viewport).toBe("mobile");
+        // The step requires `checklist` uiMode so the BottomNav's
+        // Suggest tab is the natural CTA — switching to suggest is
+        // the user's next action.
+        expect(step.requiredUiMode).toBe("checklist");
+    });
+
+    test("no other step is viewport-locked", () => {
+        // Only the Suggest-tab step is viewport-conditional today.
+        // If you add another viewport-locked step, update this
+        // assertion AND walk both breakpoints.
+        const lockedSteps = TOURS.checklistSuggest.filter(
+            s => s.viewport !== undefined && s.viewport !== "both",
+        );
+        expect(lockedSteps.map(s => s.anchor)).toEqual(["bottom-nav-suggest"]);
+    });
+
+    test("suggest-add-form spotlight covers the whole form, popover sits outside via sideByViewport", () => {
+        const step = findStep(TOURS.checklistSuggest, "suggest-add-form");
+        // The wrap-up step: spotlight covers the whole form (header
+        // + tabs + pill row); popover sits ABOVE on desktop and
+        // BELOW on mobile to avoid covering the form.
+        expect(step.popoverAnchor).toBeUndefined(); // popover anchors to the same wide form
+        expect(step.sideByViewport?.desktop).toEqual({
+            side: "top",
+            align: "end",
+        });
+        expect(step.sideByViewport?.mobile).toEqual({
+            side: "bottom",
+            align: "center",
+        });
+        expect(step.finishLabelKey).toBe("startPlaying");
+    });
+
+    test("every step except the mobile-only one has a requiredUiMode", () => {
+        // The driver dispatches `setUiMode` to land on the right pane
+        // before each step renders on mobile (since panes don't
+        // co-exist on mobile). The mobile-only Suggest-tab step
+        // explicitly stays on the checklist pane (the user is about
+        // to switch panes themselves).
+        for (const step of TOURS.checklistSuggest) {
+            expect(step.requiredUiMode).toBeDefined();
+        }
+    });
+});
+
+describe("TOURS — firstSuggestion tour", () => {
+    test("has exactly one step", () => {
+        expect(TOURS.firstSuggestion).toHaveLength(1);
+    });
+
+    test("desktop anchor is the case-file summary, NOT the full deduction grid", () => {
+        // Earlier the desktop anchor was `desktop-checklist-area`
+        // which is ~880 px tall and exceeded the viewport — Radix
+        // had nowhere to fit the popover above or below and clamped
+        // it past the top of the screen. Now anchored to the
+        // small case-file summary box so the popover sits below it
+        // safely.
+        const step = TOURS.firstSuggestion[0]!;
+        expect(step.anchorByViewport?.desktop).toBe("checklist-case-file");
+        expect(step.anchorByViewport?.mobile).toBe("bottom-nav-checklist");
+    });
+
+    test("desktop side flips to bottom (popover sits below the case-file summary)", () => {
+        const step = TOURS.firstSuggestion[0]!;
+        // Mobile: side="top" → popover above the BottomNav tab.
+        // Desktop: side="bottom" → popover below the case-file box.
+        expect(step.sideByViewport?.desktop).toEqual({
+            side: "bottom",
+            align: "start",
+        });
+        expect(step.sideByViewport?.mobile).toEqual({
+            side: "top",
+            align: "center",
+        });
+    });
+});
+
+describe("TOURS — placeholder tours", () => {
+    test("account is reserved (empty step list)", () => {
+        expect(TOURS.account).toEqual([]);
+    });
+
+    test("shareImport is reserved (empty step list)", () => {
+        expect(TOURS.shareImport).toEqual([]);
+    });
+});

--- a/src/ui/tour/tours.test.ts
+++ b/src/ui/tour/tours.test.ts
@@ -147,22 +147,30 @@ describe("TOURS — firstSuggestion tour", () => {
         expect(TOURS.firstSuggestion).toHaveLength(1);
     });
 
-    test("desktop anchor is the case-file summary, NOT the full deduction grid", () => {
-        // Earlier the desktop anchor was `desktop-checklist-area`
-        // which is ~880 px tall and exceeded the viewport — Radix
-        // had nowhere to fit the popover above or below and clamped
-        // it past the top of the screen. Now anchored to the
-        // small case-file summary box so the popover sits below it
-        // safely.
+    test("desktop spotlight covers the WHOLE checklist; mobile points at the BottomNav Checklist tab", () => {
+        // The exact details inside the deduction grid don't matter
+        // for this step — the user just needs a "look here after
+        // dismissing" cue. Spotlight covers the whole grid on
+        // desktop; popover anchors to a smaller element so it
+        // actually fits.
         const step = TOURS.firstSuggestion[0]!;
-        expect(step.anchorByViewport?.desktop).toBe("checklist-case-file");
+        expect(step.anchorByViewport?.desktop).toBe("desktop-checklist-area");
         expect(step.anchorByViewport?.mobile).toBe("bottom-nav-checklist");
     });
 
-    test("desktop side flips to bottom (popover sits below the case-file summary)", () => {
+    test("popover anchors to the case-file summary on desktop; falls back to the spotlight on mobile", () => {
+        // The popoverAnchor token resolves to an element on desktop
+        // (the case-file summary box at the top of the checklist)
+        // but to nothing on mobile (the checklist pane isn't
+        // mounted in the suggest viewport). The popover-measurement
+        // fallback in TourPopover.tsx handles that by reverting to
+        // the spotlight elements (`bottom-nav-checklist`).
         const step = TOURS.firstSuggestion[0]!;
-        // Mobile: side="top" → popover above the BottomNav tab.
-        // Desktop: side="bottom" → popover below the case-file box.
+        expect(step.popoverAnchor).toBe("checklist-case-file");
+    });
+
+    test("sideByViewport pins desktop=bottom (below case-file box), mobile=top (above BottomNav tab)", () => {
+        const step = TOURS.firstSuggestion[0]!;
         expect(step.sideByViewport?.desktop).toEqual({
             side: "bottom",
             align: "start",

--- a/src/ui/tour/tours.ts
+++ b/src/ui/tour/tours.ts
@@ -70,6 +70,29 @@ export interface TourStep {
     /** Defaults to `"center"`. */
     readonly align?: "start" | "center" | "end";
     /**
+     * Viewport-conditional override for `side` + `align`. Like
+     * `anchorByViewport` (which selects a different anchor *element*
+     * per breakpoint), this picks a different side/align per
+     * breakpoint when the natural anchor sits in different parts of
+     * the layout on mobile vs desktop. Used by the `overflow-menu`
+     * step where the menu opens DOWN on desktop and UP on mobile.
+     *
+     * When set, takes precedence over `side` + `align` once the
+     * client knows which breakpoint is active (`window.matchMedia
+     * ("(min-width: 800px)")`). On SSR / tests where matchMedia
+     * isn't available, falls back to the top-level `side` / `align`.
+     */
+    readonly sideByViewport?: {
+        readonly mobile: {
+            readonly side?: "top" | "right" | "bottom" | "left";
+            readonly align?: "start" | "center" | "end";
+        };
+        readonly desktop: {
+            readonly side?: "top" | "right" | "bottom" | "left";
+            readonly align?: "start" | "center" | "end";
+        };
+    };
+    /**
      * If set, the driver dispatches `setUiMode` to this mode before
      * the step renders so the anchor is mounted in the visible pane.
      */
@@ -82,6 +105,42 @@ export interface TourStep {
      * Checklist & Suggest tour's wrap-up step.
      */
     readonly finishLabelKey?: string;
+    /**
+     * When set, the popover anchors to elements matching THIS token
+     * instead of `anchor`. The spotlight still resolves `anchor` (so
+     * the highlight region is unchanged) — only the popover binding
+     * moves. Useful when the spotlight covers a tall / wide region
+     * (e.g. an entire column) and anchoring the popover to the first
+     * cell would push it off-screen on narrow viewports.
+     */
+    readonly popoverAnchor?: string;
+    /**
+     * Among matched elements, which one drives popover position.
+     * Defaults to `"first-visible"` — the natural "anchor to the first
+     * visible element" rule that handles ordinary single-element
+     * anchors and same-token-on-multiple-breakpoints (Toolbar +
+     * BottomNav both carrying the same token; we pick the visible
+     * one).
+     *
+     * `"last-visible"` is needed for portaled overlays — the overflow
+     * menu's portaled content appears AFTER the trigger button in
+     * DOM order, so picking the LAST visible element resolves to the
+     * open dropdown when present, falling back to the trigger when
+     * not.
+     */
+    readonly popoverAnchorPriority?: "first-visible" | "last-visible";
+    /**
+     * Limits this step to a single viewport breakpoint. Steps with a
+     * non-matching `viewport` value are FILTERED OUT of the tour
+     * before it starts — the step counter ("3 of 5") and the
+     * `tour_started.stepCount` analytics property both reflect the
+     * post-filter list. Use this for steps that only make sense on
+     * one layout (e.g. "Tap the Suggest tab" makes no sense on
+     * desktop where both panes are side-by-side).
+     *
+     * Defaults to `"both"` — step renders on every viewport.
+     */
+    readonly viewport?: "mobile" | "desktop" | "both";
 }
 
 /**
@@ -117,28 +176,57 @@ export const TOURS: Record<ScreenKey, ReadonlyArray<TourStep>> = {
             align: "center",
         },
         {
+            // Spotlight unions every cell in the first player column
+            // (header + body cells). Popover anchors to the column
+            // HEADER only — pinning to the full column would put the
+            // popover off-screen on narrow viewports because Radix
+            // tries to anchor against a tall rect.
             anchor: "setup-known-cell",
+            popoverAnchor: "setup-known-cell-header",
             titleKey: "setup.knownCard.title",
             bodyKey: "setup.knownCard.body",
-            // The first-player column extends from the top to the
-            // bottom of the table. Putting the popover to the right
-            // keeps the column itself unobscured so the user can
-            // see the cells they're being introduced to.
-            side: "right",
-            align: "start",
+            // Per-viewport positioning:
+            //   - desktop: sit to the RIGHT of the column header so
+            //     the entire column stays visible. The setup table
+            //     is wide enough on desktop that there's room.
+            //   - mobile: sit BELOW the header (popover hangs into
+            //     the column body, covering the top 2-3 rows). Side
+            //     "right" doesn't fit on mobile because the column
+            //     pushes near the right edge.
+            side: "bottom",
+            align: "center",
+            sideByViewport: {
+                desktop: { side: "right", align: "start" },
+                mobile: { side: "bottom", align: "center" },
+            },
         },
         {
             anchor: "overflow-menu",
             titleKey: "setup.overflow.title",
             bodyKey: "setup.overflow.body",
-            // The overflow menu opens vertically from the trigger
-            // (downward on desktop, upward on mobile). Anchoring the
-            // popover to the LEFT of the trigger keeps the menu
-            // contents visible — Radix's collision detection will
-            // flip to bottom/top if the left edge runs out of room
-            // on a small viewport.
+            // The trigger is in DOM order before the portaled menu
+            // content; `last-visible` resolves to the OPEN dropdown
+            // when it's present (which it is during this step, via
+            // forceOpen). The popover lands beside the dropdown,
+            // leaving both the trigger AND the menu items unobscured.
+            //
+            // The popover is too wide (~360px) to fit in the gap on
+            // either SIDE of the menu on mobile (where the menu fills
+            // most of the right column), so the side flips per
+            // viewport:
+            //   - desktop: menu opens DOWN from a TOP-right trigger;
+            //     plenty of room to the LEFT → side:"left".
+            //   - mobile: menu opens UP from a BOTTOM-right trigger;
+            //     plenty of room ABOVE → side:"top", align:"end" so
+            //     the popover hugs the menu's right edge and stays
+            //     in-viewport on a 375 px viewport.
+            popoverAnchorPriority: "last-visible",
             side: "left",
             align: "start",
+            sideByViewport: {
+                mobile: { side: "top", align: "end" },
+                desktop: { side: "left", align: "start" },
+            },
         },
         {
             anchor: "setup-start-playing",
@@ -166,6 +254,21 @@ export const TOURS: Record<ScreenKey, ReadonlyArray<TourStep>> = {
             requiredUiMode: "checklist",
         },
         {
+            // Mobile-only: on a narrow layout the checklist and
+            // suggest panes don't co-exist, so we have to hand the
+            // user the wayfinding cue ("tap Suggest to log a
+            // suggestion") before the next step actually flips
+            // them over to that pane. Skipped on desktop where
+            // both panes are visible at the same time.
+            anchor: "bottom-nav-suggest",
+            titleKey: "checklist.gotoSuggest.title",
+            bodyKey: "checklist.gotoSuggest.body",
+            side: "top",
+            align: "center",
+            requiredUiMode: "checklist",
+            viewport: "mobile",
+        },
+        {
             // The user sees the suggestion log BEFORE we point at
             // the form to add the first one. Order matters —
             // landing on the form last lets the wrap-up step's
@@ -184,11 +287,23 @@ export const TOURS: Record<ScreenKey, ReadonlyArray<TourStep>> = {
             // override flips the next-button copy from generic
             // "Finish" to "Start playing" so the user reads it as
             // a continuation, not a chore.
+            //
+            // Spotlight + popover both anchor to the whole form so
+            // the spotlight rings the user's target while the
+            // popover stays OUTSIDE that target. On desktop the
+            // form sits high in the right column so popover goes
+            // above it; on mobile the form sits at the top of the
+            // pane, so popover goes below it. Either way the
+            // spotlight + popover don't overlap.
             anchor: "suggest-add-form",
             titleKey: "suggest.addForm.title",
             bodyKey: "suggest.addForm.body",
-            side: "bottom",
-            align: "start",
+            side: "top",
+            align: "end",
+            sideByViewport: {
+                desktop: { side: "top", align: "end" },
+                mobile: { side: "bottom", align: "center" },
+            },
             requiredUiMode: "suggest",
             finishLabelKey: "startPlaying",
         },

--- a/src/ui/tour/tours.ts
+++ b/src/ui/tour/tours.ts
@@ -310,22 +310,29 @@ export const TOURS: Record<ScreenKey, ReadonlyArray<TourStep>> = {
     ],
     /**
      * One-step popover that fires the first time the user logs a
-     * suggestion in any game. The anchor is viewport-conditional:
+     * suggestion in any game.
      *
-     *   - mobile: BottomNav's Checklist tab (small, at the bottom of
-     *     the screen). Popover above it. The user is on the suggest
-     *     pane post-submit; the popover tells them to tap over to
-     *     the checklist.
-     *   - desktop: the case-file summary box at the top of the
-     *     checklist (small, well-positioned). Popover below it. Both
-     *     panes are visible at this breakpoint, so pointing at the
-     *     summary is enough to direct the user's attention.
+     * Spotlight (`anchorByViewport`):
+     *   - mobile: the BottomNav Checklist tab. The user is on the
+     *     suggest pane post-submit; spotlight + popover prompt them
+     *     to tap over to the checklist.
+     *   - desktop: the WHOLE deduction grid wrapper
+     *     (`desktop-checklist-area`). Both panes are visible; the
+     *     spotlight rings the entire area where the user's
+     *     attention should land. The exact details inside the grid
+     *     don't matter — the user just needs a "look here" cue.
      *
-     * Anchoring desktop to the WHOLE deduction grid (its predecessor
-     * `desktop-checklist-area`) sized the spotlight at ~880 px tall,
-     * which exceeded the viewport. Radix had nowhere to fit the
-     * popover above or below and clamped it past the top of the
-     * screen. Per-viewport `side`/`align` keeps both layouts safe.
+     * Popover (`popoverAnchor`):
+     *   - desktop: anchored to the case-file summary box
+     *     (`checklist-case-file`) — small + well-positioned at the
+     *     top of the checklist, so the popover sits below it
+     *     comfortably. The popover lives INSIDE the spotlight area
+     *     which is fine: nothing important is being obscured (the
+     *     summary itself remains visible above the popover).
+     *   - mobile: `checklist-case-file` doesn't exist on mobile
+     *     (the checklist pane isn't mounted), so the popover falls
+     *     back to the spotlight anchor — the BottomNav tab. Popover
+     *     sits above the tab.
      *
      * Same 4-week re-engage cadence as the other tours via
      * `useTourGate`.
@@ -337,8 +344,14 @@ export const TOURS: Record<ScreenKey, ReadonlyArray<TourStep>> = {
             anchor: "first-suggestion-checklist",
             anchorByViewport: {
                 mobile: "bottom-nav-checklist",
-                desktop: "checklist-case-file",
+                desktop: "desktop-checklist-area",
             },
+            // Popover anchors to the case-file summary on desktop
+            // (small, top of the checklist). On mobile this token
+            // resolves to no element, so the popover falls back to
+            // the spotlight anchor (the BottomNav tab) via
+            // `popoverMeasure`'s fallback path.
+            popoverAnchor: "checklist-case-file",
             titleKey: "firstSuggestion.checklist.title",
             bodyKey: "firstSuggestion.checklist.body",
             side: "top",

--- a/src/ui/tour/tours.ts
+++ b/src/ui/tour/tours.ts
@@ -141,6 +141,26 @@ export interface TourStep {
      * Defaults to `"both"` — step renders on every viewport.
      */
     readonly viewport?: "mobile" | "desktop" | "both";
+    /**
+     * Suppress the popover's pointer arrow per breakpoint. Useful
+     * when the popover sits INSIDE the spotlit area on one
+     * viewport but BESIDE it on another — the arrow's job is
+     * "this popover is talking about that element over there", so
+     * it only makes sense when the popover is outside the
+     * spotlight. The `firstSuggestion` step is the example: on
+     * desktop the popover sits inside the wide checklist
+     * spotlight, so the arrow has nothing meaningful to point at;
+     * on mobile the popover sits above the BottomNav Checklist
+     * tab, so the arrow IS pointing at something useful.
+     *
+     * Defaults to `{ mobile: false, desktop: false }` — arrow
+     * shown on both viewports. Either key is independently
+     * optional.
+     */
+    readonly hideArrow?: {
+        readonly mobile?: boolean;
+        readonly desktop?: boolean;
+    };
 }
 
 /**
@@ -363,6 +383,13 @@ export const TOURS: Record<ScreenKey, ReadonlyArray<TourStep>> = {
             // Single-step tour ends with a "Got it" CTA — no
             // back-button context, just an acknowledgement.
             finishLabelKey: "gotIt",
+            // Desktop: the popover sits INSIDE the wide checklist
+            // spotlight, so the arrow has nothing meaningful to
+            // point at — hide it. Mobile: the popover sits ABOVE
+            // the BottomNav Checklist tab (outside the small
+            // spotlight on the tab), so the arrow IS pointing at
+            // something useful — keep it.
+            hideArrow: { desktop: true },
         },
     ],
     // Reserved for M7 / M9 — no content yet.

--- a/src/ui/tour/tours.ts
+++ b/src/ui/tour/tours.ts
@@ -311,10 +311,24 @@ export const TOURS: Record<ScreenKey, ReadonlyArray<TourStep>> = {
     /**
      * One-step popover that fires the first time the user logs a
      * suggestion in any game. The anchor is viewport-conditional:
-     * mobile points at the BottomNav's Checklist tab; desktop points
-     * at the wrapping section of the deduction grid (where the
-     * solver's updates show up). Same 4-week re-engage cadence as
-     * the other tours via `useTourGate`.
+     *
+     *   - mobile: BottomNav's Checklist tab (small, at the bottom of
+     *     the screen). Popover above it. The user is on the suggest
+     *     pane post-submit; the popover tells them to tap over to
+     *     the checklist.
+     *   - desktop: the case-file summary box at the top of the
+     *     checklist (small, well-positioned). Popover below it. Both
+     *     panes are visible at this breakpoint, so pointing at the
+     *     summary is enough to direct the user's attention.
+     *
+     * Anchoring desktop to the WHOLE deduction grid (its predecessor
+     * `desktop-checklist-area`) sized the spotlight at ~880 px tall,
+     * which exceeded the viewport. Radix had nowhere to fit the
+     * popover above or below and clamped it past the top of the
+     * screen. Per-viewport `side`/`align` keeps both layouts safe.
+     *
+     * Same 4-week re-engage cadence as the other tours via
+     * `useTourGate`.
      */
     firstSuggestion: [
         {
@@ -323,12 +337,16 @@ export const TOURS: Record<ScreenKey, ReadonlyArray<TourStep>> = {
             anchor: "first-suggestion-checklist",
             anchorByViewport: {
                 mobile: "bottom-nav-checklist",
-                desktop: "desktop-checklist-area",
+                desktop: "checklist-case-file",
             },
             titleKey: "firstSuggestion.checklist.title",
             bodyKey: "firstSuggestion.checklist.body",
             side: "top",
             align: "center",
+            sideByViewport: {
+                mobile: { side: "top", align: "center" },
+                desktop: { side: "bottom", align: "start" },
+            },
             // Single-step tour ends with a "Got it" CTA — no
             // back-button context, just an acknowledgement.
             finishLabelKey: "gotIt",


### PR DESCRIPTION
## Summary

This PR (M27) lands a comprehensive round of fixes to the per-screen onboarding tour system. After living with the tours from M4 / M22, four classes of bugs surfaced (PLAN-02 / 03 / 04 / 05 in the original plan) — all resolved here. Also restructures the tour-verification docs in CLAUDE.md to be drift-resistant.

### User-visible behavior

- **Every tour popover lands fully on-screen at every supported breakpoint.** The off-top "Add the first suggestion" wrap-up, the off-left "Mark cards you've seen" column step, and the overflow-menu step that used to cover its own dropdown all now position correctly on desktop (1280×800) and mobile (375×812).
- **Brand-new users get the right tour.** A user landing on `/play?view=checklist` (e.g. via a shared link) used to see the checklist tour fire — they hadn't done setup yet. Now `StartupCoordinator` walks `TOUR_PRECEDENCE = [setup, checklistSuggest]`, finds setup eligible, and dispatches `setUiMode("setup")` so the setup tour fires first.
- **Mobile gets a new "Tap Suggest to log a suggestion" step** between the Checklist case-file step and the Suggest log step, since mobile doesn't show both panes simultaneously. Skipped on desktop. The "step N of M" counter and analytics step counts reflect the post-filter list per viewport.
- **Completing a tour locks it for 4 weeks** (same as Skip / Esc / X). Previously, finishing by clicking through every step left the gate open and the tour re-fired on every page load.
- **Tour active = page is keyboard-inert.** Capture-phase keydown listener swallows app-level shortcuts (⌘K, ⌘Z, etc.) outside the popover, preserving Esc to dismiss and Tab cycling within Back / Skip / Next. Veil click never dismisses. Scroll is explicitly allowed in any direction so the user can pan to read context.
- **The post-suggestion ("first-suggestion") tour fires on the next add after a fresh gate** — not specifically on the 0 → 1+ transition. So when the user clicks ⋯ → "Take tour" mid-game (which wipes every tour gate), the next suggestion they log re-fires the tour without a page refresh. Spotlight covers the whole checklist (including case-file summary); popover sits inside the spotlight on desktop with the arrow hidden, and above the BottomNav Checklist tab on mobile with the arrow pointing down.

### Verification

- **All five pre-commit checks green**: `pnpm typecheck`, `pnpm lint`, `pnpm test` (845 / 845 — was 767, +78 new tests), `pnpm knip`, `pnpm i18n:check` (323 keys, 194 source files).
- **Manual walk** at desktop 1280×800 + mobile 375×812 for setup / checklistSuggest / firstSuggestion. Findings + per-step rect measurements collected during development; popover on-screen at every step, no console warnings, no React 19 key-prop warning.

### CLAUDE.md verification section

The "Tour-popover verification" subsection is rewritten to be drift-resistant. Instead of a hardcoded matrix of "the setup tour has 6 steps, the checklistSuggest tour has 4/5 steps, the firstSuggestion tour has 1 step", it now describes the verification *rule* (popover visible always > popover doesn't cover spotlight when possible > no console warnings) and tells the reader how to enumerate tours from the live `TOURS` registry, how to launch each one, and the four common drift signals to look for. Adding a new tour means walking it under the same rule, not editing a static table.

### Observability

No new analytics events. Existing `tour_started`, `tour_step_advanced`, `tour_completed`, `tour_dismissed`, `tour_restarted` continue firing. The `tour_started.stepCount` payload reflects the post-viewport-filter step count, which is a behavioral change worth noting in the PostHog tour funnel definitions: `checklistSuggest` now reports `stepCount: 4` on desktop and `stepCount: 5` on mobile.

## Commit log

1. **`8a0d42e`** — Tour popover round 4: positioning, isolation, precedence
   - Step config knobs: `popoverAnchor`, `popoverAnchorPriority` (first-visible / last-visible), `sideByViewport`, `viewport` filter
   - `StartupCoordinator` precedence redirect via `onRedirectToScreen` callback
   - Tour completion writes `lastDismissedAt`; capture-phase keydown isolator; focus into Next button
   - Wrapping `<div className="contents">` inside Popover.Content silences the React 19 `Children.toArray` key warning
   - +30 new tests across `screenKey.test.ts` (new), `TourProvider.test.tsx` (new), `TourPopover.test.tsx`, `StartupCoordinator.test.tsx`

2. **`378d997`** — Fix firstSuggestion tour off-top popover; rewrite tour-verification docs
   - Initial fix anchoring the desktop popover to the case-file summary
   - CLAUDE.md verification section rewritten to enumerate tours from `TOURS` registry with a generic rule

3. **`42b9685`** — Add jsdom-friendly tour-config + geometry tests
   - Extracted geometry helpers (`resolveAnchorToken`, `resolvePopoverAnchorToken`, `resolveSideAndAlign`, `unionRect`, `pickPopoverRect`) into `popoverGeometry.ts` for unit testability
   - +42 tests across new `popoverGeometry.test.ts`, new `tours.test.ts`, extended `TourProvider.test.tsx` (viewport filter)

4. **`a336565`** — firstSuggestion tour: spotlight whole checklist, popover overlap is OK
   - Restored desktop spotlight to the wide `desktop-checklist-area`
   - Popover anchors to `checklist-case-file` inside the spotlight; falls back to spotlight elements on mobile (where the checklist pane isn't mounted)

5. **`bf5e902`** — firstSuggestion tour: fire on next add, drop arrow on desktop only
   - Trigger changed to "any suggestion-count increase since mount" with a fresh gate read at trigger time (so "Take tour" mid-session takes effect on the next add)
   - New per-viewport `hideArrow` field; arrow hidden on desktop where popover sits inside spotlight, shown on mobile where it points at the BottomNav tab

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (845 / 845)
- [x] `pnpm knip`
- [x] `pnpm i18n:check`
- [x] Walked setup tour end-to-end at desktop + mobile
- [x] Walked checklistSuggest tour end-to-end at desktop (4 steps) + mobile (5 steps)
- [x] Triggered firstSuggestion tour on desktop + mobile by submitting an actual suggestion in the preview
- [x] Confirmed precedence redirect: brand-new user landing on `/play?view=checklist` gets dispatched to `/play?view=setup`
- [x] Confirmed React 19 key warning is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)