### PR TITLE
Lock local Postgres Docker image to Neon's production major

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,5 +2,6 @@
     $schema: "https://docs.renovatebot.com/renovate-schema.json",
     extends: [
         "github>StoryCut/renovate-config:js-app.json5",
+        "github>StoryCut/renovate-config:neon-local-postgres.json5",
     ],
 }


### PR DESCRIPTION
## Summary

Local-dev Postgres (`docker-compose.yml`, behind `pnpm db:up`) is meant to track whatever major version Neon runs in production, so "works locally" continues to mean "works on Vercel". Without a lock, Renovate would happily propose upgrades past Neon's current major and silently drift local dev ahead of prod.

This PR extends the shared `StoryCut/renovate-config:neon-local-postgres.json5` preset, which caps the docker-compose-managed `postgres` image at the Neon production major (currently 17). When Neon advances, the StoryCut preset gets bumped once and every consuming repo inherits the new ceiling — no per-repo config churn.

The local image stays at `postgres:16-alpine` for now; Renovate will open a follow-up PR to bump 16 → 17 on its next scheduled run.

## Commits

- **Lock local Postgres Docker image to Neon's production major** — adds `"github>StoryCut/renovate-config:neon-local-postgres.json5"` to the `extends` array in `renovate.json5`. One-line config change; no runtime impact.

## Test plan

- [ ] Renovate's next run either opens a `postgres` 16 → 17 bump PR or shows the image as version-capped on the Dependency Dashboard
- [ ] No unexpected new Renovate PRs appear (preset only matches `postgres` under the `docker-compose` manager)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F8J8GG4UPAkXVaDadgKUwk)_