### PR TITLE
Onboarding analytics: splash, install, and tour metrics

### DIFF
--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -20,7 +20,19 @@
  *                         languageChanged, localstorageCleared
  *   Onboarding / splash : splashScreenViewed, splashScreenDismissed,
  *                         youtubeEmbedPlayed, aboutLinkClicked
+ *   Onboarding tour     : tourStarted, tourStepAdvanced, tourStepViewed,
+ *                         tourCompleted, tourDismissed, tourAbandoned,
+ *                         tourRestarted
+ *   PWA install         : installPrompted, installAccepted,
+ *                         installDismissed, installCompleted,
+ *                         appLaunchedStandalone
  *   Performance signals : webVital, deducerRun
+ *
+ * Several of the splash / install / tour emitters layer PostHog
+ * person-property updates (`$set` / `$set_once`) onto the event
+ * payload via `withPersonProperties()` — this powers cross-funnel
+ * cohort filtering ("did dismissing splash affect setup completion?")
+ * without separate identify calls. See `personProperties.ts`.
  *
  * Note: this app is a Clue *solver*, not a Clue *game* — the user records
  * what other players suggested in their physical game, and the deducer
@@ -34,13 +46,26 @@
  */
 "use client";
 
+import { DateTime } from "effect";
 import { posthog } from "./posthog";
+import {
+    personIso,
+    withPersonProperties,
+    type InstallStatus,
+    type SplashStatus,
+    type TourStatus,
+} from "./personProperties";
 
 const capture = (event: string, props?: Record<string, unknown>): void => {
     if (typeof window === "undefined") return;
     if (!posthog.__loaded) return;
     posthog.capture(event, props);
 };
+
+/** Capture-time clock for the `last_*_at` person properties. The
+ *  emitter owns its own timestamp — it's strictly an analytics signal,
+ *  not a domain timestamp, so we don't take it as a parameter. */
+const nowIso = (): string => personIso(DateTime.nowUnsafe());
 
 // ── Lifecycle ─────────────────────────────────────────────────────────────
 
@@ -213,15 +238,55 @@ export const localstorageCleared = (props: { hadActiveGame: boolean }): void =>
 
 // ── Onboarding / splash ───────────────────────────────────────────────────
 
+/**
+ * Fires the moment the splash modal becomes visible. Carries enough
+ * context that PostHog dashboards can answer view-rate, reengagement,
+ * and "did the user opt out earlier?" questions without joining
+ * across separate events.
+ *
+ * `reengaged` flips true when the user is seeing the splash again
+ * after a previous dismissal *and* their `lastVisitedAt` was older
+ * than the gate's re-engagement window — i.e. the splash re-fired on
+ * its own after the snooze expired. Lets a Trends insight read
+ * reengagement view-rate by filtering `reengaged: true`.
+ */
 export const splashScreenViewed = (props: {
     dismissedBefore: boolean;
     daysSinceLastVisit: number | null;
-}): void => capture("splash_screen_viewed", props);
+    reengaged: boolean;
+    daysSinceLastDismissal: number | null;
+}): void => {
+    const at = nowIso();
+    const status: SplashStatus = "viewed";
+    capture("splash_screen_viewed", {
+        ...props,
+        ...withPersonProperties(
+            {
+                splash_status: status,
+                last_splash_viewed_at: at,
+            },
+            { first_splash_viewed_at: at },
+        ),
+    });
+};
 
 export const splashScreenDismissed = (props: {
     method: "start_playing" | "x_button";
     dontShowAgainChecked: boolean;
-}): void => capture("splash_screen_dismissed", props);
+}): void => {
+    const status: SplashStatus = props.dontShowAgainChecked
+        ? "dismissed_with_dontshow"
+        : "dismissed_no_dontshow";
+    capture("splash_screen_dismissed", {
+        ...props,
+        ...withPersonProperties({
+            splash_status: status,
+            splash_dont_show_again: props.dontShowAgainChecked,
+            last_splash_dismiss_method: props.method,
+            last_splash_dismissed_at: nowIso(),
+        }),
+    });
+};
 
 export const youtubeEmbedPlayed = (props: {
     context: "page" | "modal";
@@ -257,10 +322,53 @@ export type TourDismissVia =
     | "close"
     | "anchor_missing";
 
+/** Build the `tour_<screenKey>_status` person-property key for a
+ *  given screen. Centralized here so the wire-format string is built
+ *  the same way at every emission site. */
+const tourStatusKey = (screenKey: TourScreenKey): string =>
+    `tour_${screenKey}_status`;
+
+const lastTourStartedAtKey = (screenKey: TourScreenKey): string =>
+    `last_tour_${screenKey}_started_at`;
+
+const firstTourStartedAtKey = (screenKey: TourScreenKey): string =>
+    `first_tour_${screenKey}_started_at`;
+
+const lastTourCompletedAtKey = (screenKey: TourScreenKey): string =>
+    `last_tour_${screenKey}_completed_at`;
+
+const lastTourDismissedAtKey = (screenKey: TourScreenKey): string =>
+    `last_tour_${screenKey}_dismissed_at`;
+
+const lastTourStepIndexKey = (screenKey: TourScreenKey): string =>
+    `last_tour_${screenKey}_step_index`;
+
+const lastTourAbandonedAtKey = (screenKey: TourScreenKey): string =>
+    `last_tour_${screenKey}_abandoned_at`;
+
 export const tourStarted = (props: {
     screenKey: TourScreenKey;
     stepCount: number;
-}): void => capture("tour_started", props);
+    /** `true` when the user has previously dismissed this tour and
+     *  is now seeing it again after the re-engage window. */
+    reengaged: boolean;
+    /** Days since the previous dismissal, or `null` if the user has
+     *  never dismissed this tour before. */
+    daysSinceLastDismissal: number | null;
+}): void => {
+    const at = nowIso();
+    const status: TourStatus = "started";
+    capture("tour_started", {
+        ...props,
+        ...withPersonProperties(
+            {
+                [tourStatusKey(props.screenKey)]: status,
+                [lastTourStartedAtKey(props.screenKey)]: at,
+            },
+            { [firstTourStartedAtKey(props.screenKey)]: at },
+        ),
+    });
+};
 
 export const tourStepAdvanced = (props: {
     screenKey: TourScreenKey;
@@ -270,17 +378,91 @@ export const tourStepAdvanced = (props: {
     direction: "forward" | "back";
 }): void => capture("tour_step_advanced", props);
 
+/**
+ * Fires once per step the user actually sees, in addition to
+ * `tour_step_advanced` which fires on the navigation moment. The
+ * step-viewed event is what powers the histogram funnel: a Trends
+ * insight grouped by `stepIndex` (and filterable by `screenKey`)
+ * auto-discovers new steps as tours change in code, with no
+ * dashboard re-config needed.
+ */
+export const tourStepViewed = (props: {
+    screenKey: TourScreenKey;
+    stepIndex: number;
+    /** The step's `data-tour-anchor` token. Free-form; the histogram
+     *  insight slices by `stepIndex`, but `stepId` is what makes
+     *  individual rows readable in the PostHog UI. */
+    stepId: string;
+    totalSteps: number;
+    isFirstStep: boolean;
+    isLastStep: boolean;
+}): void => {
+    capture("tour_step_viewed", {
+        ...props,
+        ...withPersonProperties({
+            [lastTourStepIndexKey(props.screenKey)]: props.stepIndex,
+        }),
+    });
+};
+
 export const tourCompleted = (props: {
     screenKey: TourScreenKey;
     totalSteps: number;
-}): void => capture("tour_completed", props);
+}): void => {
+    const status: TourStatus = "completed";
+    capture("tour_completed", {
+        ...props,
+        ...withPersonProperties({
+            [tourStatusKey(props.screenKey)]: status,
+            [lastTourCompletedAtKey(props.screenKey)]: nowIso(),
+        }),
+    });
+};
 
 export const tourDismissed = (props: {
     screenKey: TourScreenKey;
     stepIndex: number;
     totalSteps: number;
     via: TourDismissVia;
-}): void => capture("tour_dismissed", props);
+}): void => {
+    const status: TourStatus =
+        props.via === "skip"
+            ? "dismissed_skip"
+            : props.via === "close"
+              ? "dismissed_close"
+              : props.via === "esc"
+                ? "dismissed_esc"
+                : "dismissed_anchor_missing";
+    capture("tour_dismissed", {
+        ...props,
+        ...withPersonProperties({
+            [tourStatusKey(props.screenKey)]: status,
+            [lastTourDismissedAtKey(props.screenKey)]: nowIso(),
+            [lastTourStepIndexKey(props.screenKey)]: props.stepIndex,
+        }),
+    });
+};
+
+/** Fires when a tour is active and the page is unloaded (tab close,
+ *  browser back) without the user reaching `tour_completed` /
+ *  `tour_dismissed`. Lets the dropoff dashboard cleanly bucket "left
+ *  the site" as a third class alongside Skip / Close / Esc. */
+export const tourAbandoned = (props: {
+    screenKey: TourScreenKey;
+    lastStepIndex: number;
+    lastStepId: string;
+    totalSteps: number;
+}): void => {
+    const status: TourStatus = "abandoned";
+    capture("tour_abandoned", {
+        ...props,
+        ...withPersonProperties({
+            [tourStatusKey(props.screenKey)]: status,
+            [lastTourAbandonedAtKey(props.screenKey)]: nowIso(),
+            [lastTourStepIndexKey(props.screenKey)]: props.lastStepIndex,
+        }),
+    });
+};
 
 /** Fires on "Restart tour" overflow-menu click before `tourStarted`. */
 export const tourRestarted = (props: {
@@ -303,27 +485,86 @@ export type InstallDismissVia =
     | "snooze"
     | "native_decline";
 
+/**
+ * Fires when our in-app install modal opens. `reengaged` flips true
+ * when the modal is re-firing after a previous dismissal whose snooze
+ * has now elapsed — the same definition the splash uses, so the two
+ * dashboards read symmetrically.
+ *
+ * `visitCount` mirrors the localStorage `visits` counter at the time
+ * the modal opens, so the team can read "what fraction of users on
+ * their N-th visit see the prompt?" without joining events.
+ */
 export const installPrompted = (props: {
     trigger: InstallPromptTrigger;
-}): void => capture("install_prompted", props);
+    reengaged: boolean;
+    daysSinceLastDismissal: number | null;
+    visitCount: number;
+}): void => {
+    const at = nowIso();
+    const status: InstallStatus = "prompted";
+    capture("install_prompted", {
+        ...props,
+        ...withPersonProperties(
+            {
+                install_status: status,
+                last_install_prompted_at: at,
+            },
+            { first_install_prompted_at: at },
+        ),
+    });
+};
 
 export const installAccepted = (props: {
     trigger: InstallPromptTrigger;
-}): void => capture("install_accepted", props);
+}): void => {
+    const status: InstallStatus = "accepted";
+    capture("install_accepted", {
+        ...props,
+        ...withPersonProperties({
+            install_status: status,
+            last_install_accepted_at: nowIso(),
+        }),
+    });
+};
 
 export const installDismissed = (props: {
     trigger: InstallPromptTrigger;
     via: InstallDismissVia;
-}): void => capture("install_dismissed", props);
+}): void => {
+    const status: InstallStatus =
+        props.via === "native_decline"
+            ? "dismissed_native_decline"
+            : "dismissed_snoozed";
+    capture("install_dismissed", {
+        ...props,
+        ...withPersonProperties({
+            install_status: status,
+            last_install_dismiss_via: props.via,
+            last_install_dismissed_at: nowIso(),
+        }),
+    });
+};
 
 /** Fires when the browser confirms a successful install (`appinstalled` event). */
-export const installCompleted = (): void =>
-    capture("install_completed");
+export const installCompleted = (): void => {
+    const status: InstallStatus = "completed";
+    capture("install_completed", {
+        ...withPersonProperties({
+            install_status: status,
+            app_installed: true,
+            last_install_completed_at: nowIso(),
+        }),
+    });
+};
 
 /** Fires on every load when `display-mode: standalone` matches — the user
  *  has installed and is launching from the home screen / dock. */
-export const appLaunchedStandalone = (): void =>
-    capture("app_launched_standalone");
+export const appLaunchedStandalone = (): void => {
+    capture("app_launched_standalone", {
+        ...withPersonProperties({ app_installed: true }),
+    });
+};
 
 // ── Auth (M7) ─────────────────────────────────────────────────────────────
 //

--- a/src/analytics/personProperties.test.ts
+++ b/src/analytics/personProperties.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests for the person-properties helper. Pins the empty-bag drop
+ * (so spread-into-payload doesn't bloat the wire format with
+ * `$set: {}`) and the ISO conversion at the DateTime → string edge.
+ */
+import { describe, expect, test } from "vitest";
+import { DateTime } from "effect";
+import { personIso, withPersonProperties } from "./personProperties";
+
+describe("withPersonProperties", () => {
+    test("returns an empty object when both bags are missing", () => {
+        expect(withPersonProperties()).toEqual({});
+    });
+
+    test("returns an empty object when both bags are empty", () => {
+        expect(withPersonProperties({}, {})).toEqual({});
+    });
+
+    test("includes $set when set has at least one key", () => {
+        expect(withPersonProperties({ a: 1 })).toEqual({
+            $set: { a: 1 },
+        });
+    });
+
+    test("includes $set_once when only setOnce is provided", () => {
+        expect(withPersonProperties(undefined, { first_seen: "x" })).toEqual({
+            $set_once: { first_seen: "x" },
+        });
+    });
+
+    test("includes both keys when both bags have entries", () => {
+        expect(
+            withPersonProperties(
+                { status: "ready" },
+                { first_at: "2026-01-01T00:00:00.000Z" },
+            ),
+        ).toEqual({
+            $set: { status: "ready" },
+            $set_once: { first_at: "2026-01-01T00:00:00.000Z" },
+        });
+    });
+
+    test("drops an empty $set even if setOnce has entries", () => {
+        expect(
+            withPersonProperties({}, { first_at: "x" }),
+        ).toEqual({ $set_once: { first_at: "x" } });
+    });
+});
+
+describe("personIso", () => {
+    test("formats a DateTime.Utc as an ISO-8601 string", () => {
+        const dt = DateTime.makeUnsafe("2026-04-25T12:34:56.789Z");
+        expect(personIso(dt)).toBe("2026-04-25T12:34:56.789Z");
+    });
+});

--- a/src/analytics/personProperties.ts
+++ b/src/analytics/personProperties.ts
@@ -1,0 +1,82 @@
+/**
+ * Helpers for layering PostHog person-property updates onto the
+ * typed event emitters in `events.ts`.
+ *
+ * PostHog reads two reserved keys from any event payload:
+ *
+ *   `$set`       — overwrites the named person properties every time.
+ *                  Use for state whose *latest* value matters (e.g.
+ *                  `install_status`, `tour_<screenKey>_status`).
+ *   `$set_once`  — write-once. Subsequent writes from the SDK are
+ *                  ignored. Use for first-touch timestamps so a
+ *                  returning user's `first_splash_viewed_at` doesn't
+ *                  drift forward.
+ *
+ * The `withPersonProperties` helper returns the `$set` / `$set_once`
+ * shape the existing `capture()` wrapper in `events.ts` already
+ * passes through to PostHog verbatim — no infrastructure change.
+ *
+ * The status-string type aliases below pin the discriminator values
+ * we set. Free-form strings would also work, but typing them at the
+ * source means a typo in an emitter is a TypeScript error rather
+ * than a silent dashboard drift.
+ */
+"use client";
+
+import { DateTime } from "effect";
+
+/** Splash modal lifecycle status, kept as a per-user latest value. */
+export type SplashStatus =
+    | "viewed"
+    | "dismissed_with_dontshow"
+    | "dismissed_no_dontshow";
+
+/** PWA install-prompt lifecycle status. */
+export type InstallStatus =
+    | "prompted"
+    | "accepted"
+    | "completed"
+    | "dismissed_snoozed"
+    | "dismissed_native_decline";
+
+/** Per-tour lifecycle status, written under `tour_<screenKey>_status`. */
+export type TourStatus =
+    | "started"
+    | "completed"
+    | "dismissed_skip"
+    | "dismissed_close"
+    | "dismissed_esc"
+    | "dismissed_anchor_missing"
+    | "abandoned";
+
+/** Convert a `DateTime.Utc` to the ISO-8601 string PostHog stores. */
+export const personIso = (dt: DateTime.Utc): string =>
+    new Date(DateTime.toEpochMillis(dt)).toISOString();
+
+interface PersonPropertyPatch {
+    readonly $set?: Readonly<Record<string, unknown>>;
+    readonly $set_once?: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Build the `$set` / `$set_once` keys PostHog reads from an event
+ * payload. Drops empty bags so we don't send `$set: {}` and bloat the
+ * wire format. Designed to be spread into the emitter's capture
+ * payload alongside the event-specific properties.
+ */
+export const withPersonProperties = (
+    set?: Readonly<Record<string, unknown>>,
+    setOnce?: Readonly<Record<string, unknown>>,
+): PersonPropertyPatch => {
+    const patch: {
+        $set?: Readonly<Record<string, unknown>>;
+        $set_once?: Readonly<Record<string, unknown>>;
+    } = {};
+    if (set !== undefined && Object.keys(set).length > 0) {
+        patch.$set = set;
+    }
+    if (setOnce !== undefined && Object.keys(setOnce).length > 0) {
+        patch.$set_once = setOnce;
+    }
+    return patch;
+};

--- a/src/logic/InstallPromptState.ts
+++ b/src/logic/InstallPromptState.ts
@@ -134,3 +134,50 @@ export const computeShouldShowInstallPrompt = (
     const elapsed = DateTime.distance(state.lastDismissedAt, now);
     return Duration.isGreaterThan(elapsed, snoozeDuration);
 };
+
+/**
+ * Reengagement context for the `install_prompted` analytics payload.
+ *
+ * `reengaged` flips true when the user is seeing the prompt again
+ * after a previous dismissal whose snooze has elapsed — same
+ * definition as the splash gate so the two dashboards read
+ * symmetrically.
+ *
+ * `daysSinceLastDismissal` is `null` when the user has never
+ * dismissed before (first-time prompt). `visitCount` mirrors the
+ * `visits` counter in localStorage so the dashboard can answer
+ * "what visit number is the install prompt landing on?".
+ */
+interface InstallPromptAnalyticsContext {
+    readonly reengaged: boolean;
+    readonly daysSinceLastDismissal: number | null;
+    readonly visitCount: number;
+}
+
+const daysBetween = (from: DateTime.Utc, to: DateTime.Utc): number => {
+    const ms = Duration.toMillis(DateTime.distance(from, to));
+    return Math.floor(ms / Duration.toMillis(Duration.days(1)));
+};
+
+export const computeInstallPromptAnalyticsContext = (
+    state: InstallPromptState,
+    now: DateTime.Utc,
+    snoozeDuration: Duration.Duration = INSTALL_PROMPT_SNOOZE_DURATION,
+): InstallPromptAnalyticsContext => {
+    const lastDismissedAt = state.lastDismissedAt;
+    if (lastDismissedAt === undefined) {
+        return {
+            reengaged: false,
+            daysSinceLastDismissal: null,
+            visitCount: state.visits,
+        };
+    }
+    return {
+        reengaged: Duration.isGreaterThan(
+            DateTime.distance(lastDismissedAt, now),
+            snoozeDuration,
+        ),
+        daysSinceLastDismissal: daysBetween(lastDismissedAt, now),
+        visitCount: state.visits,
+    };
+};

--- a/src/ui/components/InstallPromptModal.test.tsx
+++ b/src/ui/components/InstallPromptModal.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * Pins the install-prompt modal's analytics emission, including the
+ * reengagement context (`reengaged`, `daysSinceLastDismissal`,
+ * `visitCount`) read from `InstallPromptState` localStorage at the
+ * moment the user clicks Install / Snooze / X.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { DateTime } from "effect";
+
+const captureCalls: Array<{
+    event: string;
+    props: Record<string, unknown> | undefined;
+}> = [];
+
+vi.mock("../../analytics/posthog", () => ({
+    posthog: {
+        __loaded: true,
+        capture: (event: string, props?: Record<string, unknown>) => {
+            captureCalls.push({ event, props });
+        },
+    },
+}));
+
+vi.mock("next-intl", () => ({
+    useTranslations: (ns?: string) => (key: string) =>
+        ns ? `${ns}.${key}` : key,
+}));
+
+beforeEach(() => {
+    window.localStorage.clear();
+    captureCalls.length = 0;
+});
+
+afterEach(() => {
+    window.localStorage.clear();
+});
+
+const importModal = async () => {
+    const mod = await import("./InstallPromptModal");
+    return mod.InstallPromptModal;
+};
+
+const seedState = (state: {
+    visits: number;
+    lastDismissedAt?: DateTime.Utc;
+}): void => {
+    const payload: {
+        version: 1;
+        visits: number;
+        lastDismissedAt?: string;
+    } = { version: 1, visits: state.visits };
+    if (state.lastDismissedAt) {
+        payload.lastDismissedAt = new Date(
+            DateTime.toEpochMillis(state.lastDismissedAt),
+        ).toISOString();
+    }
+    window.localStorage.setItem(
+        "effect-clue.install-prompt.v1",
+        JSON.stringify(payload),
+    );
+};
+
+describe("InstallPromptModal — analytics", () => {
+    test("Install with no prior dismissal sends reengaged: false, visitCount from state", async () => {
+        seedState({ visits: 3 });
+        const InstallPromptModal = await importModal();
+        const onInstall = vi.fn().mockResolvedValue(true);
+        render(
+            <InstallPromptModal
+                open
+                trigger="auto"
+                onInstall={onInstall}
+                onSnooze={() => {}}
+                onClose={() => {}}
+            />,
+        );
+        fireEvent.click(
+            screen.getByRole("button", { name: "installPrompt.install" }),
+        );
+        // Wait the microtask for the awaited onInstall.
+        await Promise.resolve();
+        await Promise.resolve();
+        const prompted = captureCalls.find(c => c.event === "install_prompted");
+        expect(prompted).toMatchObject({
+            event: "install_prompted",
+            props: {
+                trigger: "auto",
+                reengaged: false,
+                daysSinceLastDismissal: null,
+                visitCount: 3,
+                $set: { install_status: "prompted" },
+            },
+        });
+    });
+
+    test("Install with stale dismissal reports reengaged: true and the day count", async () => {
+        const dismissedAt = DateTime.makeUnsafe("2026-01-01T00:00:00Z");
+        seedState({ visits: 5, lastDismissedAt: dismissedAt });
+        const InstallPromptModal = await importModal();
+        render(
+            <InstallPromptModal
+                open
+                trigger="menu"
+                onInstall={vi.fn().mockResolvedValue(false)}
+                onSnooze={() => {}}
+                onClose={() => {}}
+            />,
+        );
+        fireEvent.click(
+            screen.getByRole("button", { name: "installPrompt.install" }),
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+        const prompted = captureCalls.find(c => c.event === "install_prompted");
+        expect(prompted).toMatchObject({
+            event: "install_prompted",
+            props: {
+                trigger: "menu",
+                reengaged: true,
+                visitCount: 5,
+            },
+        });
+        // Day count is "today minus dismissedAt" — depends on `Date.now()`,
+        // so we just assert it's a non-negative number.
+        const days = (prompted!.props as { daysSinceLastDismissal: number })
+            .daysSinceLastDismissal;
+        expect(typeof days).toBe("number");
+        expect(days).toBeGreaterThanOrEqual(0);
+    });
+
+    test("Snooze fires install_dismissed with via=snooze and the dismiss-snoozed status", async () => {
+        seedState({ visits: 2 });
+        const InstallPromptModal = await importModal();
+        const onSnooze = vi.fn();
+        render(
+            <InstallPromptModal
+                open
+                trigger="auto"
+                onInstall={vi.fn().mockResolvedValue(false)}
+                onSnooze={onSnooze}
+                onClose={() => {}}
+            />,
+        );
+        fireEvent.click(
+            screen.getByRole("button", { name: "installPrompt.notNow" }),
+        );
+        expect(onSnooze).toHaveBeenCalled();
+        expect(captureCalls).toHaveLength(1);
+        expect(captureCalls[0]).toMatchObject({
+            event: "install_dismissed",
+            props: {
+                trigger: "auto",
+                via: "snooze",
+                $set: {
+                    install_status: "dismissed_snoozed",
+                    last_install_dismiss_via: "snooze",
+                },
+            },
+        });
+    });
+
+    test("Native decline (user accepts our modal but declines OS dialog) reports dismissed_native_decline", async () => {
+        seedState({ visits: 2 });
+        const InstallPromptModal = await importModal();
+        render(
+            <InstallPromptModal
+                open
+                trigger="auto"
+                onInstall={vi.fn().mockResolvedValue(false)}
+                onSnooze={() => {}}
+                onClose={() => {}}
+            />,
+        );
+        fireEvent.click(
+            screen.getByRole("button", { name: "installPrompt.install" }),
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+        const dismissed = captureCalls.find(c => c.event === "install_dismissed");
+        expect(dismissed).toMatchObject({
+            event: "install_dismissed",
+            props: {
+                trigger: "auto",
+                via: "native_decline",
+                $set: {
+                    install_status: "dismissed_native_decline",
+                    last_install_dismiss_via: "native_decline",
+                },
+            },
+        });
+    });
+
+    test("Successful install fires install_accepted with the accepted status", async () => {
+        seedState({ visits: 2 });
+        const InstallPromptModal = await importModal();
+        render(
+            <InstallPromptModal
+                open
+                trigger="menu"
+                onInstall={vi.fn().mockResolvedValue(true)}
+                onSnooze={() => {}}
+                onClose={() => {}}
+            />,
+        );
+        fireEvent.click(
+            screen.getByRole("button", { name: "installPrompt.install" }),
+        );
+        await Promise.resolve();
+        await Promise.resolve();
+        const accepted = captureCalls.find(c => c.event === "install_accepted");
+        expect(accepted).toMatchObject({
+            event: "install_accepted",
+            props: {
+                trigger: "menu",
+                $set: { install_status: "accepted" },
+            },
+        });
+    });
+});

--- a/src/ui/components/InstallPromptModal.tsx
+++ b/src/ui/components/InstallPromptModal.tsx
@@ -19,6 +19,7 @@
 
 import * as Dialog from "@radix-ui/react-dialog";
 import { useTranslations } from "next-intl";
+import { DateTime } from "effect";
 import {
     installAccepted,
     installDismissed,
@@ -26,6 +27,10 @@ import {
     type InstallDismissVia,
     type InstallPromptTrigger,
 } from "../../analytics/events";
+import {
+    computeInstallPromptAnalyticsContext,
+    loadInstallPromptState,
+} from "../../logic/InstallPromptState";
 import { ArrowRightIcon, XIcon } from "./Icons";
 
 // Module-scope discriminator constants for the analytics payload —
@@ -56,7 +61,11 @@ export function InstallPromptModal({
     const tCommon = useTranslations("common");
 
     const handleInstall = async (): Promise<void> => {
-        installPrompted({ trigger });
+        const ctx = computeInstallPromptAnalyticsContext(
+            loadInstallPromptState(),
+            DateTime.nowUnsafe(),
+        );
+        installPrompted({ trigger, ...ctx });
         const accepted = await onInstall();
         if (accepted) {
             installAccepted({ trigger });

--- a/src/ui/components/SplashModal.test.tsx
+++ b/src/ui/components/SplashModal.test.tsx
@@ -57,14 +57,24 @@ describe("SplashModal", () => {
         render(<SplashModal open onDismiss={onDismiss} />);
         fireEvent.click(screen.getByRole("button", { name: "splash.startPlaying" }));
         expect(onDismiss).toHaveBeenCalledWith(false);
-        expect(captureCalls).toEqual([
-            {
-                event: "splash_screen_dismissed",
-                props: {
-                    method: "start_playing",
-                    dontShowAgainChecked: false,
+        expect(captureCalls).toHaveLength(1);
+        expect(captureCalls[0]).toMatchObject({
+            event: "splash_screen_dismissed",
+            props: {
+                method: "start_playing",
+                dontShowAgainChecked: false,
+                $set: {
+                    splash_status: "dismissed_no_dontshow",
+                    splash_dont_show_again: false,
+                    last_splash_dismiss_method: "start_playing",
                 },
             },
+        });
+        // Timestamp shape isn't pinned but presence is — it powers
+        // the dashboard's "last dismissed" cohort.
+        expect(captureCalls[0]?.props).toHaveProperty([
+            "$set",
+            "last_splash_dismissed_at",
         ]);
     });
 
@@ -74,15 +84,19 @@ describe("SplashModal", () => {
         render(<SplashModal open onDismiss={onDismiss} />);
         fireEvent.click(screen.getByRole("button", { name: "splash.close" }));
         expect(onDismiss).toHaveBeenCalledWith(false);
-        expect(captureCalls).toEqual([
-            {
-                event: "splash_screen_dismissed",
-                props: {
-                    method: "x_button",
-                    dontShowAgainChecked: false,
+        expect(captureCalls).toHaveLength(1);
+        expect(captureCalls[0]).toMatchObject({
+            event: "splash_screen_dismissed",
+            props: {
+                method: "x_button",
+                dontShowAgainChecked: false,
+                $set: {
+                    splash_status: "dismissed_no_dontshow",
+                    splash_dont_show_again: false,
+                    last_splash_dismiss_method: "x_button",
                 },
             },
-        ]);
+        });
     });
 
     test("checkbox toggle propagates into the dismiss event and onDismiss arg", async () => {
@@ -93,14 +107,18 @@ describe("SplashModal", () => {
         await user.click(screen.getByRole("checkbox"));
         await user.click(screen.getByRole("button", { name: "splash.startPlaying" }));
         expect(onDismiss).toHaveBeenCalledWith(true);
-        expect(captureCalls).toEqual([
-            {
-                event: "splash_screen_dismissed",
-                props: {
-                    method: "start_playing",
-                    dontShowAgainChecked: true,
+        expect(captureCalls).toHaveLength(1);
+        expect(captureCalls[0]).toMatchObject({
+            event: "splash_screen_dismissed",
+            props: {
+                method: "start_playing",
+                dontShowAgainChecked: true,
+                $set: {
+                    splash_status: "dismissed_with_dontshow",
+                    splash_dont_show_again: true,
+                    last_splash_dismiss_method: "start_playing",
                 },
             },
-        ]);
+        });
     });
 });

--- a/src/ui/hooks/useSplashGate.tsx
+++ b/src/ui/hooks/useSplashGate.tsx
@@ -103,12 +103,33 @@ export function useSplashGate(): {
                 ABOUT_APP_SPLASH_SCREEN_DISMISSAL_DURATION,
             ),
         );
+        const dismissedBefore = state.lastDismissedAt !== undefined;
+        const daysSinceLastVisit =
+            state.lastVisitedAt !== undefined
+                ? daysBetween(state.lastVisitedAt, now)
+                : null;
+        const daysSinceLastDismissal =
+            state.lastDismissedAt !== undefined
+                ? daysBetween(state.lastDismissedAt, now)
+                : null;
+        // `reengaged` is true when the user previously dismissed the
+        // splash AND the snooze window has elapsed — i.e. the splash
+        // re-fired on its own after a dormant stretch. Mirrors the
+        // gate condition in `computeShouldShowSplash` so the
+        // dashboard's "reengaged" filter matches the code's gate
+        // exactly.
+        const reengaged =
+            dismissedBefore &&
+            state.lastVisitedAt !== undefined &&
+            Duration.isGreaterThan(
+                DateTime.distance(state.lastVisitedAt, now),
+                ABOUT_APP_SPLASH_SCREEN_DISMISSAL_DURATION,
+            );
         splashScreenViewed({
-            dismissedBefore: state.lastDismissedAt !== undefined,
-            daysSinceLastVisit:
-                state.lastVisitedAt !== undefined
-                    ? daysBetween(state.lastVisitedAt, now)
-                    : null,
+            dismissedBefore,
+            daysSinceLastVisit,
+            reengaged,
+            daysSinceLastDismissal,
         });
     }, [phase]);
 

--- a/src/ui/tour/TourProvider.test.tsx
+++ b/src/ui/tour/TourProvider.test.tsx
@@ -18,8 +18,23 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { act, render } from "@testing-library/react";
 import { type ReactNode } from "react";
+import { DateTime } from "effect";
 import { TourProvider, useTour } from "./TourProvider";
-import { loadTourState } from "./TourState";
+import { loadTourState, saveTourDismissed } from "./TourState";
+
+const captureCalls: Array<{
+    event: string;
+    props: Record<string, unknown> | undefined;
+}> = [];
+
+vi.mock("../../analytics/posthog", () => ({
+    posthog: {
+        __loaded: true,
+        capture: (event: string, props?: Record<string, unknown>) => {
+            captureCalls.push({ event, props });
+        },
+    },
+}));
 
 const stubMatchMedia = (matches: boolean): void => {
     window.matchMedia = vi.fn().mockImplementation(() => ({
@@ -71,6 +86,7 @@ function mount(children?: ReactNode): TourApi {
 
 beforeEach(() => {
     window.localStorage.clear();
+    captureCalls.length = 0;
 });
 
 afterEach(() => {
@@ -197,5 +213,134 @@ describe("TourProvider — viewport filter", () => {
         // `bottom-nav-suggest` and isLastStep would be false at this
         // point — pinning isLastStep at desktop step 3 confirms the
         // filter is wiring through.
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Analytics — generic per-step view event powers a histogram funnel that
+// auto-discovers steps as tours change in code. We pin the exact event
+// sequence walking through a tour so a regression in the wiring (e.g.
+// dropping step-0's view event) shows up as a failing test.
+// ─────────────────────────────────────────────────────────────────────────
+
+const eventNames = (): ReadonlyArray<string> =>
+    captureCalls.map(c => c.event);
+
+describe("TourProvider — analytics events", () => {
+    test("startTour fires tour_started then tour_step_viewed for step 0", () => {
+        stubMatchMedia(true);
+        const api = mount();
+        act(() => api.current().startTour("setup"));
+        expect(eventNames()).toEqual(["tour_started", "tour_step_viewed"]);
+        expect(captureCalls[0]).toMatchObject({
+            event: "tour_started",
+            props: {
+                screenKey: "setup",
+                stepCount: 6,
+                reengaged: false,
+                daysSinceLastDismissal: null,
+            },
+        });
+        expect(captureCalls[1]).toMatchObject({
+            event: "tour_step_viewed",
+            props: {
+                screenKey: "setup",
+                stepIndex: 0,
+                stepId: "setup-card-pack",
+                totalSteps: 6,
+                isFirstStep: true,
+                isLastStep: false,
+            },
+        });
+    });
+
+    test("nextStep emits tour_step_advanced then tour_step_viewed for the new step", () => {
+        stubMatchMedia(true);
+        const api = mount();
+        act(() => api.current().startTour("setup"));
+        captureCalls.length = 0; // discard start events
+        act(() => api.current().nextStep());
+        expect(eventNames()).toEqual([
+            "tour_step_advanced",
+            "tour_step_viewed",
+        ]);
+        expect(captureCalls[1]).toMatchObject({
+            event: "tour_step_viewed",
+            props: {
+                screenKey: "setup",
+                stepIndex: 1,
+                stepId: "setup-player-column",
+                isFirstStep: false,
+                isLastStep: false,
+            },
+        });
+    });
+
+    test("completing a tour fires tour_completed (no extra step_viewed)", () => {
+        stubMatchMedia(true);
+        const api = mount();
+        act(() => api.current().startTour("setup"));
+        captureCalls.length = 0;
+        for (let i = 0; i < 6; i++) {
+            act(() => api.current().nextStep());
+        }
+        // 5 advances + 5 step_views (steps 1..5) + 1 completion.
+        const last = captureCalls[captureCalls.length - 1];
+        expect(last?.event).toBe("tour_completed");
+        expect(last).toMatchObject({
+            props: {
+                screenKey: "setup",
+                totalSteps: 6,
+                $set: { tour_setup_status: "completed" },
+            },
+        });
+    });
+
+    test("dismissTour fires tour_dismissed with the via-keyed status", () => {
+        stubMatchMedia(true);
+        const api = mount();
+        act(() => api.current().startTour("setup"));
+        captureCalls.length = 0;
+        act(() => api.current().dismissTour("skip"));
+        expect(captureCalls).toHaveLength(1);
+        expect(captureCalls[0]).toMatchObject({
+            event: "tour_dismissed",
+            props: {
+                screenKey: "setup",
+                stepIndex: 0,
+                via: "skip",
+                $set: {
+                    tour_setup_status: "dismissed_skip",
+                    last_tour_setup_step_index: 0,
+                },
+            },
+        });
+    });
+
+    test("tour_started carries reengaged: true after a previous dismissal", () => {
+        stubMatchMedia(true);
+        // Pre-seed a dismissal so loadTourState reports lastDismissedAt.
+        saveTourDismissed("setup", DateTime.nowUnsafe());
+        const api = mount();
+        act(() => api.current().startTour("setup"));
+        expect(captureCalls[0]).toMatchObject({
+            event: "tour_started",
+            props: { screenKey: "setup", reengaged: true },
+        });
+        expect(captureCalls[0]?.props).toHaveProperty(
+            "daysSinceLastDismissal",
+            0,
+        );
+    });
+
+    test("restartTourForScreen reports reengaged from BEFORE wiping state", () => {
+        stubMatchMedia(true);
+        saveTourDismissed("setup", DateTime.nowUnsafe());
+        const api = mount();
+        act(() => api.current().restartTourForScreen("setup"));
+        const startedEvent = captureCalls.find(c => c.event === "tour_started");
+        expect(startedEvent).toMatchObject({
+            props: { screenKey: "setup", reengaged: true },
+        });
     });
 });

--- a/src/ui/tour/TourProvider.tsx
+++ b/src/ui/tour/TourProvider.tsx
@@ -24,25 +24,29 @@ import {
     useContext,
     useEffect,
     useMemo,
+    useRef,
     useState,
     type ReactNode,
 } from "react";
-import { DateTime, Effect } from "effect";
+import { DateTime, Duration, Effect } from "effect";
 import {
     tourCompleted,
     tourDismissed,
     tourRestarted,
     tourStarted,
     tourStepAdvanced,
+    tourStepViewed,
     type TourDismissVia,
 } from "../../analytics/events";
 import { TelemetryRuntime } from "../../observability/runtime";
 import { TOURS, type TourStep } from "./tours";
 import {
+    loadTourState,
     resetAllTourState,
     saveTourDismissed,
     type ScreenKey,
 } from "./TourState";
+import { useTourAbandonReporter } from "./useTourAbandonReporter";
 
 interface TourContextValue {
     /** The currently-active tour, or undefined when no tour is showing. */
@@ -160,6 +164,32 @@ const useFilterStepsByViewport = (
 // so React sees a stable identity across renders.
 const EMPTY_STEPS: ReadonlyArray<TourStep> = [];
 
+const daysBetween = (from: DateTime.Utc, to: DateTime.Utc): number => {
+    const ms = Duration.toMillis(DateTime.distance(from, to));
+    return Math.floor(ms / Duration.toMillis(Duration.days(1)));
+};
+
+/**
+ * Compute the reengagement context for `tourStarted` from a screen's
+ * persisted state. Pulled out so both auto-fire (`startTour`) and
+ * manual restart (`restartTourForScreen`) can use it — manual
+ * restart reads state BEFORE wiping it, so the analytics still
+ * reflect the user's history.
+ */
+const tourReengagementContext = (
+    state: { lastDismissedAt?: DateTime.Utc },
+    now: DateTime.Utc,
+): { reengaged: boolean; daysSinceLastDismissal: number | null } => {
+    const lastDismissedAt = state.lastDismissedAt;
+    if (lastDismissedAt === undefined) {
+        return { reengaged: false, daysSinceLastDismissal: null };
+    }
+    return {
+        reengaged: true,
+        daysSinceLastDismissal: daysBetween(lastDismissedAt, now),
+    };
+};
+
 export function TourProvider({ children }: { readonly children: ReactNode }) {
     const [activeScreen, setActiveScreen] = useState<ScreenKey | undefined>(
         undefined,
@@ -196,7 +226,15 @@ export function TourProvider({ children }: { readonly children: ReactNode }) {
         });
         if (stepsForScreen.length === 0) return;
         TelemetryRuntime.runSync(startEffect(screen));
-        tourStarted({ screenKey: screen, stepCount: stepsForScreen.length });
+        const reengage = tourReengagementContext(
+            loadTourState(screen),
+            DateTime.nowUnsafe(),
+        );
+        tourStarted({
+            screenKey: screen,
+            stepCount: stepsForScreen.length,
+            ...reengage,
+        });
         setActiveScreen(screen);
         setStepIndex(0);
     }, []);
@@ -281,6 +319,15 @@ export function TourProvider({ children }: { readonly children: ReactNode }) {
 
     const restartTourForScreen = useCallback(
         (screen: ScreenKey) => {
+            // Read the dismissal state BEFORE wiping, so the analytics
+            // payload reflects the user's actual history. After
+            // `resetAllTourState()` runs, `lastDismissedAt` is gone —
+            // but the user did dismiss it before, and a manual restart
+            // is a reengagement signal worth preserving.
+            const reengage = tourReengagementContext(
+                loadTourState(screen),
+                DateTime.nowUnsafe(),
+            );
             resetAllTourState();
             tourRestarted({ screenKey: screen });
             // Same viewport filter as `startTour` so the analytics
@@ -304,12 +351,83 @@ export function TourProvider({ children }: { readonly children: ReactNode }) {
             tourStarted({
                 screenKey: screen,
                 stepCount: stepsForScreen.length,
+                ...reengage,
             });
             setActiveScreen(screen);
             setStepIndex(0);
         },
         [],
     );
+
+    // Abandon reporter: fires `tour_abandoned` if the user closes
+    // the tab while the tour is open. Returns `markTerminated` so
+    // the dismiss / completion paths can prevent a same-tick
+    // `pagehide` from firing a redundant abandon event.
+    const { markTerminated } = useTourAbandonReporter({
+        activeScreen,
+        stepIndex,
+        currentStep,
+        totalSteps,
+    });
+
+    // The original nextStep / dismissTour callbacks are wrapped so
+    // they call `markTerminated` after dispatching their terminal
+    // event. Wrappers don't change behavior; they just notify the
+    // abandon reporter.
+    const nextStepWrapped = useCallback(() => {
+        const wasLastStep =
+            activeScreen !== undefined &&
+            steps !== undefined &&
+            stepIndex >= steps.length - 1;
+        nextStep();
+        if (wasLastStep) markTerminated();
+    }, [nextStep, activeScreen, steps, stepIndex, markTerminated]);
+
+    const dismissTourWrapped = useCallback(
+        (via: TourDismissVia) => {
+            dismissTour(via);
+            markTerminated();
+        },
+        [dismissTour, markTerminated],
+    );
+
+    // Per-step view event for the histogram funnel. Fires once per
+    // (activeScreen, stepIndex) combination — one event when a tour
+    // starts (step 0), one event on each Next/Back navigation. The
+    // ref dedup ensures React StrictMode's double-invocation in dev
+    // doesn't fire two events for the same step.
+    const lastStepViewedRef = useRef<{
+        screen: ScreenKey;
+        index: number;
+    } | null>(null);
+    useEffect(() => {
+        if (
+            activeScreen === undefined ||
+            currentStep === undefined ||
+            steps === undefined
+        ) {
+            // Tour closed — clear the ref so the next start fires
+            // step 0's event again.
+            lastStepViewedRef.current = null;
+            return;
+        }
+        const last = lastStepViewedRef.current;
+        if (last?.screen === activeScreen && last.index === stepIndex) {
+            return;
+        }
+        lastStepViewedRef.current = {
+            screen: activeScreen,
+            index: stepIndex,
+        };
+        tourStepViewed({
+            screenKey: activeScreen,
+            stepIndex,
+            stepId: currentStep.anchor,
+            totalSteps,
+            isFirstStep: stepIndex === 0,
+            isLastStep,
+        });
+    }, [activeScreen, stepIndex, currentStep, steps, totalSteps, isLastStep]);
 
     const value = useMemo<TourContextValue>(
         () => ({
@@ -319,9 +437,9 @@ export function TourProvider({ children }: { readonly children: ReactNode }) {
             currentStep,
             isLastStep,
             startTour,
-            nextStep,
+            nextStep: nextStepWrapped,
             prevStep,
-            dismissTour,
+            dismissTour: dismissTourWrapped,
             restartTourForScreen,
         }),
         [
@@ -331,9 +449,9 @@ export function TourProvider({ children }: { readonly children: ReactNode }) {
             currentStep,
             isLastStep,
             startTour,
-            nextStep,
+            nextStepWrapped,
             prevStep,
-            dismissTour,
+            dismissTourWrapped,
             restartTourForScreen,
         ],
     );

--- a/src/ui/tour/useTourAbandonReporter.test.tsx
+++ b/src/ui/tour/useTourAbandonReporter.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * Tests for the tour-abandonment reporter. Pins:
+ *   - `pagehide` while a tour is active fires `tour_abandoned` with
+ *     the latest step index.
+ *   - `markTerminated()` (called from completion / dismissal paths)
+ *     suppresses the abandon event for the rest of the page load.
+ *   - When `activeScreen` flips to `undefined`, the listener is
+ *     removed (no abandon event after the tour closes).
+ *   - The listener reads the LATEST step index (ref pattern) — a
+ *     mid-tour `pagehide` reports the user's actual step, not the
+ *     one they started on.
+ */
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { useTourAbandonReporter } from "./useTourAbandonReporter";
+import type { ScreenKey } from "./TourState";
+import type { TourStep } from "./tours";
+
+const captureCalls: Array<{
+    event: string;
+    props: Record<string, unknown> | undefined;
+}> = [];
+
+vi.mock("../../analytics/posthog", () => ({
+    posthog: {
+        __loaded: true,
+        capture: (event: string, props?: Record<string, unknown>) => {
+            captureCalls.push({ event, props });
+        },
+    },
+}));
+
+afterEach(() => {
+    captureCalls.length = 0;
+});
+
+const stepFromAnchor = (anchor: string): TourStep => ({
+    anchor,
+    titleKey: "x",
+});
+
+interface ProbeProps {
+    readonly activeScreen: ScreenKey | undefined;
+    readonly stepIndex: number;
+    readonly currentStep: TourStep | undefined;
+    readonly totalSteps: number;
+    readonly onApi?: (
+        api: ReturnType<typeof useTourAbandonReporter>,
+    ) => void;
+}
+
+function Probe({
+    activeScreen,
+    stepIndex,
+    currentStep,
+    totalSteps,
+    onApi,
+}: ProbeProps): null {
+    const api = useTourAbandonReporter({
+        activeScreen,
+        stepIndex,
+        currentStep,
+        totalSteps,
+    });
+    onApi?.(api);
+    return null;
+}
+
+const firePageHide = (): void => {
+    window.dispatchEvent(new Event("pagehide"));
+};
+
+describe("useTourAbandonReporter", () => {
+    test("does nothing when no tour is active", () => {
+        render(
+            <Probe
+                activeScreen={undefined}
+                stepIndex={0}
+                currentStep={undefined}
+                totalSteps={0}
+            />,
+        );
+        firePageHide();
+        expect(captureCalls).toEqual([]);
+    });
+
+    test("fires tour_abandoned when pagehide fires mid-tour", () => {
+        render(
+            <Probe
+                activeScreen="setup"
+                stepIndex={2}
+                currentStep={stepFromAnchor("setup-known-cell")}
+                totalSteps={6}
+            />,
+        );
+        firePageHide();
+        expect(captureCalls).toHaveLength(1);
+        expect(captureCalls[0]).toMatchObject({
+            event: "tour_abandoned",
+            props: {
+                screenKey: "setup",
+                lastStepIndex: 2,
+                lastStepId: "setup-known-cell",
+                totalSteps: 6,
+            },
+        });
+    });
+
+    test("does not fire after markTerminated() is called", () => {
+        let api: ReturnType<typeof useTourAbandonReporter> | undefined;
+        render(
+            <Probe
+                activeScreen="setup"
+                stepIndex={3}
+                currentStep={stepFromAnchor("overflow-menu")}
+                totalSteps={6}
+                onApi={a => (api = a)}
+            />,
+        );
+        api!.markTerminated();
+        firePageHide();
+        expect(captureCalls).toEqual([]);
+    });
+
+    test("does not fire after the tour closes (activeScreen=undefined)", () => {
+        const { rerender } = render(
+            <Probe
+                activeScreen="setup"
+                stepIndex={1}
+                currentStep={stepFromAnchor("setup-player-column")}
+                totalSteps={6}
+            />,
+        );
+        rerender(
+            <Probe
+                activeScreen={undefined}
+                stepIndex={0}
+                currentStep={undefined}
+                totalSteps={0}
+            />,
+        );
+        firePageHide();
+        expect(captureCalls).toEqual([]);
+    });
+
+    test("reads the latest step index, not the one at mount time", () => {
+        const { rerender } = render(
+            <Probe
+                activeScreen="checklistSuggest"
+                stepIndex={0}
+                currentStep={stepFromAnchor("checklist-cell")}
+                totalSteps={4}
+            />,
+        );
+        rerender(
+            <Probe
+                activeScreen="checklistSuggest"
+                stepIndex={3}
+                currentStep={stepFromAnchor("suggest-add-form")}
+                totalSteps={4}
+            />,
+        );
+        firePageHide();
+        expect(captureCalls).toHaveLength(1);
+        expect(captureCalls[0]?.props).toMatchObject({
+            screenKey: "checklistSuggest",
+            lastStepIndex: 3,
+            lastStepId: "suggest-add-form",
+            totalSteps: 4,
+        });
+    });
+
+    test("fires only once even if pagehide repeats", () => {
+        render(
+            <Probe
+                activeScreen="setup"
+                stepIndex={0}
+                currentStep={stepFromAnchor("setup-card-pack")}
+                totalSteps={6}
+            />,
+        );
+        firePageHide();
+        firePageHide();
+        firePageHide();
+        expect(captureCalls).toHaveLength(1);
+    });
+});

--- a/src/ui/tour/useTourAbandonReporter.ts
+++ b/src/ui/tour/useTourAbandonReporter.ts
@@ -1,0 +1,97 @@
+/**
+ * Hook that fires `tour_abandoned` when the user closes the tab /
+ * navigates away while a tour is still open. Without this, dropoffs
+ * by site-leave look identical to dropoffs that never started — the
+ * dashboard can't tell them apart from "we never showed the tour".
+ *
+ * Wiring:
+ *   - Caller passes the latest tour state (active screen, step
+ *     index, current step, total steps).
+ *   - While `activeScreen` is defined, a `pagehide` listener is
+ *     installed.
+ *   - When the user dismisses or completes the tour through the UI,
+ *     the caller invokes `markTerminated()` so a later `pagehide`
+ *     doesn't fire a redundant `tour_abandoned`. This is belt-and-
+ *     suspenders: when the tour closes the cleanup also removes the
+ *     listener, but `markTerminated` covers the same-tick race
+ *     between firing the terminal event and React running cleanup.
+ *
+ * Why `pagehide` and not `beforeunload`: `pagehide` is the modern
+ * recommended event, fires reliably on tab close + back-navigation
+ * + browser-level navigation, and works on iOS Safari (where
+ * `beforeunload` does not).
+ */
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { tourAbandoned } from "../../analytics/events";
+import type { TourStep } from "./tours";
+import type { ScreenKey } from "./TourState";
+
+interface UseTourAbandonReporterArgs {
+    readonly activeScreen: ScreenKey | undefined;
+    readonly stepIndex: number;
+    readonly currentStep: TourStep | undefined;
+    readonly totalSteps: number;
+}
+
+interface UseTourAbandonReporterApi {
+    /** Mark the tour as terminated so a subsequent `pagehide` does
+     *  not fire `tour_abandoned`. Call from completion / dismissal
+     *  paths. */
+    readonly markTerminated: () => void;
+}
+
+export function useTourAbandonReporter(
+    args: UseTourAbandonReporterArgs,
+): UseTourAbandonReporterApi {
+    // Snapshot the latest props in a ref so the `pagehide` listener
+    // — installed once when a tour starts — always reads the current
+    // step index instead of a stale closure value. Only `activeScreen`
+    // gates listener install/removal; everything else flows through
+    // the ref.
+    const stateRef = useRef(args);
+    stateRef.current = args;
+    const activeScreen = args.activeScreen;
+
+    // True once the tour ended via UI (Skip / Esc / X / completion).
+    // Prevents a same-tick `pagehide` from firing a redundant
+    // `tour_abandoned` after the terminal UI event.
+    const terminatedRef = useRef(false);
+
+    useEffect(() => {
+        if (typeof window === "undefined") return;
+        if (activeScreen === undefined) return;
+        // A new tour just started — re-arm the dedup flag so the
+        // listener can fire if the user closes the tab now.
+        terminatedRef.current = false;
+
+        const onPageHide = (): void => {
+            if (terminatedRef.current) return;
+            const snapshot = stateRef.current;
+            if (snapshot.activeScreen === undefined) return;
+            if (snapshot.currentStep === undefined) return;
+            terminatedRef.current = true;
+            tourAbandoned({
+                screenKey: snapshot.activeScreen,
+                lastStepIndex: snapshot.stepIndex,
+                lastStepId: snapshot.currentStep.anchor,
+                totalSteps: snapshot.totalSteps,
+            });
+        };
+
+        window.addEventListener("pagehide", onPageHide);
+        return () => {
+            window.removeEventListener("pagehide", onPageHide);
+        };
+        // The listener intentionally only re-installs when
+        // `activeScreen` changes. Step-index updates flow through
+        // the ref so we don't churn the listener every step.
+    }, [activeScreen]);
+
+    const markTerminated = useCallback((): void => {
+        terminatedRef.current = true;
+    }, []);
+
+    return { markTerminated };
+}


### PR DESCRIPTION
## Summary

Fills the gaps in onboarding analytics so dashboards can answer view rate, dismissal rate, reengagement, cross-funnel impact, and per-step tour dropoff for the splash modal, install prompt, and tour system.

Most events already existed in `src/analytics/events.ts`; this layer adds:

- **Reengagement signals** on splash, install, and tour-started events (`reengaged`, `daysSinceLastDismissal`, plus install's `visitCount`).
- **Person properties** via PostHog's \`\$set\` / \`\$set_once\` mechanism, so cross-funnel cohort filtering ("did dismissing splash hurt setup completion?") needs zero new events.
- **`tour_step_viewed`** — generic per-step view event that powers a Trends histogram by `stepIndex`. New steps in code show up as new bars without any PostHog UI edits.
- **`tour_abandoned`** — fires from `pagehide` when the user closes the tab mid-tour, so dropoffs cleanly bucket into Skip / Close / Esc / Abandoned.

User-facing behavior is unchanged. No new UI; the install modal stays snooze-only; splash reengagement is the natural 4-week re-fire.

## What you need to do in PostHog after this deploys

The new events fire from deploy forward — historical data is what it is. Configure these once in the PostHog UI:

### 1. Splash dashboards

**View rate (first-time vs reengaged):**
- Trends → event: `splash_screen_viewed`
- Filter: \`reengaged\` = `false` for first-touch view rate
- Duplicate the insight with \`reengaged\` = `true` for reengagement view rate

**Dismissal breakdown:**
- Trends → event: `splash_screen_dismissed`
- Breakdown by: \`method\` (`x_button` vs `start_playing`) and by \`dontShowAgainChecked\` (true vs false)

**Cross-funnel: did dismissing splash affect setup completion?**
- Open the existing onboarding funnel (\`game_setup_started → cards_dealt → game_started\`)
- Add a global filter on the person property \`splash_dont_show_again\`. Compare the two cohorts.

### 2. Install prompt dashboards

**Install funnel:**
- Funnel: \`install_prompted → install_accepted → install_completed → app_launched_standalone\`
- Breakdown by: \`trigger\` (\`auto\` / \`menu\` / \`tour\`)

**Snooze vs decline split:**
- Trends → event: \`install_dismissed\`
- Breakdown by: \`via\` (\`snooze\` / \`x_button\` / \`native_decline\`)

**PWA cohort filter (use anywhere):**
- Person property \`app_installed\` is set to \`true\` on \`install_completed\` AND \`app_launched_standalone\`. Use it to filter any insight to "users who actually run the PWA."

### 3. Tour dashboards (auto-syncing histogram funnel)

**Per-step dropoff (the funnel that doesn't fall out of sync with code):**
- Trends → event: \`tour_step_viewed\`
- Series → group by: \`stepIndex\`
- Breakdown by: \`screenKey\` so each tour gets its own line / segment
- Result: a histogram of "users who reached step N", auto-discovers new steps when tours change in code. For a single tour, add a global filter \`screenKey = setup\` (or whichever).

**Tour completion rate per tour:**
- Funnel: \`tour_started → tour_completed\`
- Breakdown by: \`screenKey\`

**Dropoff classification (Skip / Close / Esc / Abandoned):**
- Insights → table or pivot
- Rows: \`screenKey\`
- Columns: counts of \`tour_completed\`, \`tour_dismissed\` (with \`via\` breakdown), \`tour_abandoned\`

**Cross-funnel cohorts:**
- Each tour writes \`tour_<screenKey>_status\` as a person property (\`completed\` / \`dismissed_skip\` / \`dismissed_close\` / \`dismissed_esc\` / \`abandoned\`). Use these in any insight's filters to compare "users who completed the setup tour" vs "users who skipped it."

### 4. Quick sanity check after deploy

In Live Events, confirm the new events appear:
- \`tour_step_viewed\` — fires on every tour step entry
- \`tour_abandoned\` — fires when a user closes a tab mid-tour
- \`splash_screen_viewed\` — now carries \`reengaged\`, \`daysSinceLastDismissal\`
- \`install_prompted\` — now carries \`reengaged\`, \`daysSinceLastDismissal\`, \`visitCount\`
- \`tour_started\` — now carries \`reengaged\`, \`daysSinceLastDismissal\`

Open a user's profile and confirm person properties appear: \`splash_status\`, \`install_status\`, \`tour_setup_status\`, etc.

## Test plan
- [x] \`pnpm typecheck\` passes
- [x] \`pnpm lint\` passes
- [x] \`pnpm test\` — all 948 tests pass (added 6 unit tests for personProperties, 6 for useTourAbandonReporter, 5 for InstallPromptModal, 6 analytics-event assertions in TourProvider, updated SplashModal tests)
- [x] \`pnpm knip\` — no unused exports
- [x] \`pnpm i18n:check\` — no orphan keys
- [x] Manual walkthrough at desktop (1280×800) and mobile (375×812): splash → setup tour walks all 6 steps cleanly; "Take tour" overflow item restarts; simulated \`pagehide\` mid-tour produces no console errors
- [ ] After deploy: confirm Live Events in PostHog show the new event names + person properties on a user profile

## Commits
- \`Onboarding analytics: splash, install, and tour metrics\` — adds \`personProperties.ts\` helper and the events surface; wires reengagement context into useSplashGate, the install modal, and TourProvider; adds \`useTourAbandonReporter\` for tab-close detection; updates / adds tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)