### PR TITLE
Bias modal focus to cancel actions; prompt to abandon stale games

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -358,6 +358,16 @@
         "notNow": "Not now",
         "menuItem": "Install app"
     },
+    "staleGame": {
+        "title": "Pick up where you left off?",
+        "descriptionStarted": "You haven't touched this game in {humanDuration}. Want to set up a new one?",
+        "descriptionUnstarted": "This game has been sitting empty for {humanDuration}. Want to set up a new one?",
+        "durationDays": "{count, plural, one {# day} other {# days}}",
+        "durationHours": "{count, plural, one {# hour} other {# hours}}",
+        "durationMinutes": "{count, plural, one {# minute} other {# minutes}}",
+        "keepWorking": "Keep working",
+        "setupNew": "Set up new game"
+    },
     "onboarding": {
         "next": "Next",
         "back": "Back",

--- a/src/logic/GameLifecycleState.test.ts
+++ b/src/logic/GameLifecycleState.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { DateTime, Duration } from "effect";
+import {
+    clearGameLifecycle,
+    isStaleGameEligible,
+    loadGameLifecycleState,
+    markGameCreated,
+    markGameTouched,
+    markStaleGameSnoozed,
+    STALE_GAME_SNOOZE,
+    STALE_GAME_THRESHOLD_STARTED,
+    STALE_GAME_THRESHOLD_UNSTARTED,
+} from "./GameLifecycleState";
+
+const STORAGE_KEY = "effect-clue.gameLifecycle.v1";
+
+afterEach(() => {
+    window.localStorage.clear();
+});
+
+describe("GameLifecycleState", () => {
+    test("returns empty state when nothing is stored", () => {
+        expect(loadGameLifecycleState()).toEqual({});
+    });
+
+    test("returns empty state when payload is malformed", () => {
+        window.localStorage.setItem(STORAGE_KEY, "not json");
+        expect(loadGameLifecycleState()).toEqual({});
+    });
+
+    test("returns empty state when schema rejects payload", () => {
+        window.localStorage.setItem(
+            STORAGE_KEY,
+            JSON.stringify({ version: 99, createdAt: "garbage" }),
+        );
+        expect(loadGameLifecycleState()).toEqual({});
+    });
+
+    test("markGameCreated sets createdAt and lastModifiedAt", () => {
+        const now = DateTime.makeUnsafe("2026-04-25T12:00:00Z");
+        markGameCreated(now);
+        const state = loadGameLifecycleState();
+        expect(state.createdAt).toEqual(now);
+        expect(state.lastModifiedAt).toEqual(now);
+        expect(state.lastSnoozedAt).toBeUndefined();
+    });
+
+    test("markGameCreated clears a prior snooze", () => {
+        const snoozeAt = DateTime.makeUnsafe("2026-04-20T00:00:00Z");
+        const createdAt = DateTime.makeUnsafe("2026-04-25T00:00:00Z");
+        markStaleGameSnoozed(snoozeAt);
+        markGameCreated(createdAt);
+        const state = loadGameLifecycleState();
+        expect(state.lastSnoozedAt).toBeUndefined();
+        expect(state.createdAt).toEqual(createdAt);
+    });
+
+    test("markGameTouched bumps lastModifiedAt without clobbering createdAt", () => {
+        const createdAt = DateTime.makeUnsafe("2026-04-20T00:00:00Z");
+        const touchedAt = DateTime.makeUnsafe("2026-04-25T12:00:00Z");
+        markGameCreated(createdAt);
+        markGameTouched(touchedAt);
+        const state = loadGameLifecycleState();
+        expect(state.createdAt).toEqual(createdAt);
+        expect(state.lastModifiedAt).toEqual(touchedAt);
+    });
+
+    test("markStaleGameSnoozed records the snooze without touching the rest", () => {
+        const createdAt = DateTime.makeUnsafe("2026-04-20T00:00:00Z");
+        const touchedAt = DateTime.makeUnsafe("2026-04-21T00:00:00Z");
+        const snoozedAt = DateTime.makeUnsafe("2026-04-25T00:00:00Z");
+        markGameCreated(createdAt);
+        markGameTouched(touchedAt);
+        markStaleGameSnoozed(snoozedAt);
+        const state = loadGameLifecycleState();
+        expect(state.createdAt).toEqual(createdAt);
+        expect(state.lastModifiedAt).toEqual(touchedAt);
+        expect(state.lastSnoozedAt).toEqual(snoozedAt);
+    });
+
+    test("clearGameLifecycle wipes the storage key", () => {
+        markGameCreated(DateTime.makeUnsafe("2026-04-20T00:00:00Z"));
+        clearGameLifecycle();
+        expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+        expect(loadGameLifecycleState()).toEqual({});
+    });
+});
+
+describe("isStaleGameEligible", () => {
+    const now = DateTime.makeUnsafe("2026-04-25T12:00:00Z");
+
+    test("returns false on an empty state regardless of started flag", () => {
+        expect(
+            isStaleGameEligible({ state: {}, gameStarted: false, now }),
+        ).toBe(false);
+        expect(
+            isStaleGameEligible({ state: {}, gameStarted: true, now }),
+        ).toBe(false);
+    });
+
+    test("started game: fires when idle longer than the started threshold", () => {
+        const lastModifiedAt = DateTime.subtractDuration(
+            now,
+            Duration.sum(STALE_GAME_THRESHOLD_STARTED, Duration.minutes(1)),
+        );
+        expect(
+            isStaleGameEligible({
+                state: { lastModifiedAt },
+                gameStarted: true,
+                now,
+            }),
+        ).toBe(true);
+    });
+
+    test("started game: does NOT fire within the started threshold", () => {
+        const lastModifiedAt = DateTime.subtractDuration(
+            now,
+            Duration.minutes(5),
+        );
+        expect(
+            isStaleGameEligible({
+                state: { lastModifiedAt },
+                gameStarted: true,
+                now,
+            }),
+        ).toBe(false);
+    });
+
+    test("unstarted game: fires when older than the unstarted threshold", () => {
+        const createdAt = DateTime.subtractDuration(
+            now,
+            Duration.sum(STALE_GAME_THRESHOLD_UNSTARTED, Duration.minutes(1)),
+        );
+        expect(
+            isStaleGameEligible({
+                state: { createdAt },
+                gameStarted: false,
+                now,
+            }),
+        ).toBe(true);
+    });
+
+    test("unstarted game: does NOT fire within the unstarted threshold", () => {
+        const createdAt = DateTime.subtractDuration(
+            now,
+            Duration.minutes(5),
+        );
+        expect(
+            isStaleGameEligible({
+                state: { createdAt },
+                gameStarted: false,
+                now,
+            }),
+        ).toBe(false);
+    });
+
+    test("snoozed within window: never fires regardless of age", () => {
+        const lastModifiedAt = DateTime.subtractDuration(
+            now,
+            Duration.weeks(4),
+        );
+        const lastSnoozedAt = DateTime.subtractDuration(
+            now,
+            Duration.hours(1),
+        );
+        expect(
+            isStaleGameEligible({
+                state: { lastModifiedAt, lastSnoozedAt },
+                gameStarted: true,
+                now,
+            }),
+        ).toBe(false);
+    });
+
+    test("snooze older than window: gate falls back to age check", () => {
+        const lastModifiedAt = DateTime.subtractDuration(
+            now,
+            Duration.weeks(4),
+        );
+        const lastSnoozedAt = DateTime.subtractDuration(
+            now,
+            Duration.sum(STALE_GAME_SNOOZE, Duration.minutes(1)),
+        );
+        expect(
+            isStaleGameEligible({
+                state: { lastModifiedAt, lastSnoozedAt },
+                gameStarted: true,
+                now,
+            }),
+        ).toBe(true);
+    });
+});

--- a/src/logic/GameLifecycleState.ts
+++ b/src/logic/GameLifecycleState.ts
@@ -1,0 +1,185 @@
+/**
+ * Persisted "when did this game come into being / last get touched"
+ * timestamps for the active session. Drives the stale-game prompt
+ * that fires on Checklist or Suggest when the user lands on a game
+ * they haven't touched in a while (or never started in the first
+ * place).
+ *
+ * Three timestamps live in localStorage:
+ *
+ * - `createdAt` — set when a session is first hydrated or when the
+ *   user dispatches `newGame`. Used to gate the "unstarted game" flavor
+ *   of the prompt (game has no known cards / suggestions / accusations
+ *   AND was created more than `STALE_GAME_THRESHOLD_UNSTARTED` ago).
+ *
+ * - `lastModifiedAt` — bumped whenever a state-mutating action lands.
+ *   Used to gate the "started game" flavor (game has any progress
+ *   AND has been idle for more than `STALE_GAME_THRESHOLD_STARTED`).
+ *
+ * - `lastSnoozedAt` — set when the user dismisses the prompt. Until
+ *   `STALE_GAME_SNOOZE` passes we suppress the prompt so the user
+ *   isn't re-asked on every page load.
+ *
+ * Mirrors `SplashState`: ISO-8601 strings on disk, `DateTime.Utc` at
+ * the API boundary, silent fallback to `{}` on a malformed payload.
+ */
+import { DateTime, Duration, Result, Schema } from "effect";
+
+const PersistedGameLifecycleSchema = Schema.Struct({
+    version: Schema.Literal(1),
+    createdAt: Schema.optional(Schema.String),
+    lastModifiedAt: Schema.optional(Schema.String),
+    lastSnoozedAt: Schema.optional(Schema.String),
+});
+
+const decodeUnknown = Schema.decodeUnknownResult(
+    PersistedGameLifecycleSchema,
+);
+const encode = Schema.encodeSync(PersistedGameLifecycleSchema);
+
+const STORAGE_KEY = "effect-clue.gameLifecycle.v1";
+
+interface GameLifecycleState {
+    readonly createdAt?: DateTime.Utc;
+    readonly lastModifiedAt?: DateTime.Utc;
+    readonly lastSnoozedAt?: DateTime.Utc;
+}
+
+export const STALE_GAME_THRESHOLD_STARTED: Duration.Duration = Duration.days(3);
+export const STALE_GAME_THRESHOLD_UNSTARTED: Duration.Duration = Duration.days(1);
+export const STALE_GAME_SNOOZE: Duration.Duration = Duration.days(1);
+
+const parseIso = (iso: string): DateTime.Utc | undefined => {
+    const date = new Date(iso);
+    if (Number.isNaN(date.getTime())) return undefined;
+    return DateTime.makeUnsafe(date);
+};
+
+const formatIso = (dt: DateTime.Utc): string =>
+    new Date(DateTime.toEpochMillis(dt)).toISOString();
+
+export const loadGameLifecycleState = (): GameLifecycleState => {
+    if (typeof window === "undefined") return {};
+    try {
+        const raw = window.localStorage.getItem(STORAGE_KEY);
+        if (!raw) return {};
+        const decoded = decodeUnknown(JSON.parse(raw));
+        if (Result.isFailure(decoded)) return {};
+        const out: {
+            -readonly [K in keyof GameLifecycleState]: GameLifecycleState[K];
+        } = {};
+        if (decoded.success.createdAt !== undefined) {
+            const parsed = parseIso(decoded.success.createdAt);
+            if (parsed !== undefined) out.createdAt = parsed;
+        }
+        if (decoded.success.lastModifiedAt !== undefined) {
+            const parsed = parseIso(decoded.success.lastModifiedAt);
+            if (parsed !== undefined) out.lastModifiedAt = parsed;
+        }
+        if (decoded.success.lastSnoozedAt !== undefined) {
+            const parsed = parseIso(decoded.success.lastSnoozedAt);
+            if (parsed !== undefined) out.lastSnoozedAt = parsed;
+        }
+        return out;
+    } catch {
+        return {};
+    }
+};
+
+const writeMerged = (
+    patch: Partial<GameLifecycleState>,
+    options?: { readonly clear?: ReadonlyArray<keyof GameLifecycleState> },
+): void => {
+    if (typeof window === "undefined") return;
+    try {
+        const current = loadGameLifecycleState();
+        const cleared = new Set<keyof GameLifecycleState>(options?.clear ?? []);
+        const pickField = (
+            field: keyof GameLifecycleState,
+        ): DateTime.Utc | undefined => {
+            if (cleared.has(field)) return undefined;
+            return patch[field] ?? current[field];
+        };
+        const createdAt = pickField("createdAt");
+        const lastModifiedAt = pickField("lastModifiedAt");
+        const lastSnoozedAt = pickField("lastSnoozedAt");
+        const merged: {
+            version: 1;
+            createdAt?: string;
+            lastModifiedAt?: string;
+            lastSnoozedAt?: string;
+        } = { version: 1 };
+        if (createdAt !== undefined) {
+            merged.createdAt = formatIso(createdAt);
+        }
+        if (lastModifiedAt !== undefined) {
+            merged.lastModifiedAt = formatIso(lastModifiedAt);
+        }
+        if (lastSnoozedAt !== undefined) {
+            merged.lastSnoozedAt = formatIso(lastSnoozedAt);
+        }
+        const encoded = encode(merged);
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(encoded));
+    } catch {
+        // Quota exceeded, private mode, etc. — non-fatal.
+    }
+};
+
+/** Stamp the moment a fresh game came into being. Resets snooze too. */
+export const markGameCreated = (now: DateTime.Utc): void =>
+    writeMerged(
+        { createdAt: now, lastModifiedAt: now },
+        { clear: ["lastSnoozedAt"] },
+    );
+
+/** Bump the touched timestamp without changing creation or snooze. */
+export const markGameTouched = (now: DateTime.Utc): void =>
+    writeMerged({ lastModifiedAt: now });
+
+/** Record that the user just dismissed the stale-game prompt. */
+export const markStaleGameSnoozed = (now: DateTime.Utc): void =>
+    writeMerged({ lastSnoozedAt: now });
+
+/** Wipe lifecycle state — used after `newGame` followed by markGameCreated. */
+export const clearGameLifecycle = (): void => {
+    if (typeof window === "undefined") return;
+    try {
+        window.localStorage.removeItem(STORAGE_KEY);
+    } catch {
+        // Non-fatal.
+    }
+};
+
+/**
+ * Pure decision helper. Given lifecycle state, "is the game started"
+ * (any progress on the board), and the current time, returns whether
+ * the stale-game prompt should fire.
+ *
+ * Eligibility rules:
+ *  - If the user snoozed less than `STALE_GAME_SNOOZE` ago, never fire.
+ *  - If the game is started, fire when `now - lastModifiedAt > STARTED`.
+ *  - If the game is unstarted, fire when `now - createdAt > UNSTARTED`.
+ *  - Missing timestamps are treated as "no signal yet" (don't fire).
+ */
+export const isStaleGameEligible = ({
+    state,
+    gameStarted,
+    now,
+}: {
+    readonly state: GameLifecycleState;
+    readonly gameStarted: boolean;
+    readonly now: DateTime.Utc;
+}): boolean => {
+    if (state.lastSnoozedAt !== undefined) {
+        const snoozeAge = DateTime.distance(state.lastSnoozedAt, now);
+        if (!Duration.isGreaterThan(snoozeAge, STALE_GAME_SNOOZE)) return false;
+    }
+    if (gameStarted) {
+        if (state.lastModifiedAt === undefined) return false;
+        const idleFor = DateTime.distance(state.lastModifiedAt, now);
+        return Duration.isGreaterThan(idleFor, STALE_GAME_THRESHOLD_STARTED);
+    }
+    if (state.createdAt === undefined) return false;
+    const ageOf = DateTime.distance(state.createdAt, now);
+    return Duration.isGreaterThan(ageOf, STALE_GAME_THRESHOLD_UNSTARTED);
+};

--- a/src/ui/Clue.tsx
+++ b/src/ui/Clue.tsx
@@ -22,6 +22,8 @@ import { T_STANDARD, useReducedTransition } from "./motion";
 import type { UiMode } from "../logic/ClueState";
 import { StartupCoordinatorProvider, useStartupCoordinator } from "./onboarding/StartupCoordinator";
 import { SplashModal } from "./components/SplashModal";
+import { StaleGameModal } from "./components/StaleGameModal";
+import { useStaleGameGate } from "./hooks/useStaleGameGate";
 import { ClueProvider, useClue } from "./state";
 import { TourProvider, useTour } from "./tour/TourProvider";
 import { TourPopover } from "./tour/TourPopover";
@@ -167,6 +169,12 @@ function CoordinatedShell({
 }) {
     const { hydrated, state, dispatch } = useClue();
     const activeScreen = screenKeyForUiMode(state.uiMode);
+    // Whether the hydrated game has any progress. Drives the
+    // staleGame slot's threshold choice in the coordinator.
+    const gameStarted =
+        state.knownCards.length > 0
+        || state.suggestions.length > 0
+        || state.accusations.length > 0;
     // Translate the coordinator's precedence-redirect request back
     // into a `setUiMode` dispatch. The coordinator only fires this
     // when the highest-priority eligible tour belongs to a screen
@@ -185,6 +193,7 @@ function CoordinatedShell({
         <StartupCoordinatorProvider
             hydrated={hydrated}
             activeScreen={activeScreen}
+            gameStarted={gameStarted}
             onRedirectToScreen={handleRedirectToScreen}
         >
             <TourProvider>
@@ -207,6 +216,7 @@ function ClueShell({
 }) {
     const t = useTranslations("app");
     const { showSplash, dismiss: dismissSplash } = useSplashGate();
+    const staleGame = useStaleGameGate();
     return (
         <InstallPromptProvider>
         <AccountProvider>
@@ -236,6 +246,14 @@ function ClueShell({
             </main>
             <BottomNav />
             <SplashModal open={showSplash} onDismiss={dismissSplash} />
+            <StaleGameModal
+                open={staleGame.open}
+                variant={staleGame.variant}
+                referenceTimestamp={staleGame.referenceTimestamp}
+                now={staleGame.now}
+                onSetupNewGame={staleGame.setupNewGame}
+                onKeepWorking={staleGame.keepWorking}
+            />
         </ShareProvider>
         </AccountProvider>
         </InstallPromptProvider>

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -286,6 +286,61 @@ export function Checklist() {
         maxCol: totalCols - 1,
     };
 
+    // Expand-in animation for newly added Checklist rows (cards,
+    // categories) and columns (players). Each cell content is
+    // wrapped in a `<motion.div>` keyed by entry id inside its own
+    // per-cell `<AnimatePresence>`. The motion.div animates
+    // `maxHeight` / `maxWidth` from 0 to a generous cap (plus
+    // opacity) so the row visually grows into place rather than
+    // blinking in.
+    //
+    // Notes on the design:
+    //
+    //  - **`cellAnimateInitial` flag**: defaults `false` and flips
+    //    `true` a tick after mount. With `initial={false}` on first
+    //    paint, the post-hydration state from localStorage doesn't
+    //    shimmer in. Once the flag flips, AnimatePresence instances
+    //    created *after* mount (inside a brand-new card / category
+    //    / player row) mount with `initial=true` and run the entry
+    //    animation.
+    //
+    //  - **No `<motion.tr>` / `<motion.th>`**: those components,
+    //    when placed inside `<AnimatePresence>`, wrap the row/cell
+    //    in `<PopChild>` / `<PopChildMeasure>` helpers that
+    //    swallowed click events on the row's own buttons in this
+    //    codebase (e.g. `Remove Miss Scarlet` × stopped firing).
+    //    Animating cell content via `<motion.div>` inside the cell
+    //    avoids that.
+    //
+    //  - **`maxHeight` / `maxWidth` rather than `height/width:
+    //    auto`**: Framer Motion v12's `auto` keyword measurement
+    //    is unreliable inside table cells — newly-mounted rows
+    //    would stay stuck at `height: 0`. `max-*` doesn't need
+    //    measurement: the cell takes its natural size up to the
+    //    cap, so a generous cap (200px) gives a real expand-in.
+    //
+    //  - **No exit animation**: the `<AnimatePresence>` lives
+    //    *inside* each row's `<th>` cell, so when dispatch removes
+    //    the row the `<tr>` and its descendants (including the
+    //    AnimatePresence) all unmount synchronously. Framer's exit
+    //    lifecycle needs the AnimatePresence to stay in the DOM
+    //    during the exit, which would require `<motion.tr>` direct
+    //    children of an outer AnimatePresence — and that breaks
+    //    click dispatch in this codebase. Removes therefore snap
+    //    cleanly; we accept the trade-off for reliable dispatches.
+    //
+    // Honors `prefers-reduced-motion` via `useReducedTransition`.
+    // Use 220ms (slower than the 120ms `T_FAST` we use for value
+    // glyph swaps) so the expand reads as deliberate motion. At
+    // 120ms the change scans as a flicker rather than an animation.
+    const cellEntryTransition = useReducedTransition({ duration: 0.22 });
+    const [cellAnimateInitial, setCellAnimateInitial] = useState(false);
+    useEffect(() => {
+        const id = window.setTimeout(() => {
+            setCellAnimateInitial(true);
+        }, 0);
+        return () => window.clearTimeout(id);
+    }, []);
 
     // Handle ⌘J / ⌘H focus requests: locate a cell by (row,col) and
     // focus it. "first" falls back to the first interactive cell.
@@ -594,16 +649,26 @@ export function Checklist() {
                                     className="border-r border-b border-border bg-row-header px-2 py-1 text-center align-top font-semibold"
                                     {...playerHeaderAnchor}
                                 >
-                                    {inSetup && owner._tag === "Player" ? (
-                                        <PlayerNameInput
-                                            player={owner.player}
-                                            allPlayers={setup.players}
-                                            colIdx={ownerIdx}
-                                            bounds={bounds}
-                                        />
-                                    ) : (
-                                        ownerLabel(owner)
-                                    )}
+                                    <AnimatePresence>
+                                        <motion.div
+                                            key={ownerKey(owner)}
+                                            initial={cellAnimateInitial ? ANIM_HIDDEN_COL : false}
+                                            animate={ANIM_VISIBLE_COL}
+                                            transition={cellEntryTransition}
+                                            style={STYLE_OVERFLOW_HIDDEN}
+                                        >
+                                            {inSetup && owner._tag === "Player" ? (
+                                                <PlayerNameInput
+                                                    player={owner.player}
+                                                    allPlayers={setup.players}
+                                                    colIdx={ownerIdx}
+                                                    bounds={bounds}
+                                                />
+                                            ) : (
+                                                ownerLabel(owner)
+                                            )}
+                                        </motion.div>
+                                    </AnimatePresence>
                                 </th>
                             );
                             return inSetup && owner._tag === "CaseFile"
@@ -708,7 +773,15 @@ export function Checklist() {
                                     className="border-r border-b border-border bg-category-header px-2 py-1.5 text-left text-[11px] uppercase tracking-[0.05em] text-white"
                                 >
                                     {inSetup ? (
-                                        <div className="flex items-center justify-between gap-2">
+                                        <AnimatePresence>
+                                        <motion.div
+                                            key={`cat-${String(category.id)}`}
+                                            className="flex items-center justify-between gap-2"
+                                            initial={cellAnimateInitial ? ANIM_HIDDEN_ROW : false}
+                                            animate={ANIM_VISIBLE_ROW}
+                                            transition={cellEntryTransition}
+                                            style={STYLE_OVERFLOW_HIDDEN}
+                                            >
                                             <InlineTextEdit
                                                 value={category.name}
                                                 className="min-w-0 flex-1 rounded border border-white/30 bg-transparent px-1 py-0.5 text-[11px] font-semibold uppercase tracking-[0.05em] text-white focus:bg-white/10 focus:outline-none"
@@ -770,7 +843,8 @@ export function Checklist() {
                                             >
                                                 &times;
                                             </button>
-                                        </div>
+                                        </motion.div>
+                                        </AnimatePresence>
                                     ) : (
                                         category.name
                                     )}
@@ -782,10 +856,18 @@ export function Checklist() {
                                 return (
                                 <tr
                                     key={String(entry.id)}
-                                                                    >
+                                >
                                     <th className="w-px whitespace-nowrap border-r border-b border-border px-2 py-1 text-left font-normal">
                                         {inSetup ? (
-                                            <div className="flex items-center justify-between gap-2">
+                                            <AnimatePresence>
+                                            <motion.div
+                                                key={String(entry.id)}
+                                                className="flex items-center justify-between gap-2"
+                                                initial={cellAnimateInitial ? ANIM_HIDDEN_ROW : false}
+                                                animate={ANIM_VISIBLE_ROW}
+                                                transition={cellEntryTransition}
+                                                style={STYLE_OVERFLOW_HIDDEN}
+                                                >
                                                 <InlineTextEdit
                                                     value={entry.name}
                                                     className="min-w-0 flex-1 rounded border border-border/60 bg-transparent px-1 py-0.5 text-[12px] focus:border-accent focus:outline-none"
@@ -846,7 +928,8 @@ export function Checklist() {
                                                 >
                                                     &times;
                                                 </button>
-                                            </div>
+                                            </motion.div>
+                                            </AnimatePresence>
                                         ) : (
                                             entry.name
                                         )}
@@ -1721,6 +1804,23 @@ const CSS_WHITE = "#ffffff";
 const CSS_INK = "#2a1f12";
 const MOTION_WAIT: "wait" = "wait";
 const MOTION_POP_LAYOUT: "popLayout" = "popLayout";
+// Animation target values for the cell-content expand/collapse. Pulled
+// out so the i18next/no-literal-string rule treats them as wire-format
+// CSS keywords rather than user-facing copy.
+// Animate `maxHeight` / `maxWidth` from 0 to a generous cap rather
+// than `height/width: auto`. Framer Motion v12's `auto` keyword
+// measurement is unreliable inside table cells — newly-mounted
+// rows would stay stuck at `height: 0`. `max-height` / `max-width`
+// don't have that measurement step: the cell takes its natural
+// size up to the cap, so the cap just needs to be larger than any
+// row / column will ever be. Combined with `overflow: hidden` on
+// the wrapper this gives a clean expand-in.
+const CELL_EXPAND_CAP_PX = 200;
+const ANIM_HIDDEN_ROW = { maxHeight: 0, opacity: 0 } as const;
+const ANIM_VISIBLE_ROW = { maxHeight: CELL_EXPAND_CAP_PX, opacity: 1 } as const;
+const ANIM_HIDDEN_COL = { maxWidth: 0, opacity: 0 } as const;
+const ANIM_VISIBLE_COL = { maxWidth: CELL_EXPAND_CAP_PX, opacity: 1 } as const;
+const STYLE_OVERFLOW_HIDDEN = { overflow: "hidden" } as const;
 
 function CaseFileHeader({ knowledge }: { knowledge: Knowledge }) {
     const t = useTranslations("deduce");

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -286,6 +286,7 @@ export function Checklist() {
         maxCol: totalCols - 1,
     };
 
+
     // Handle ⌘J / ⌘H focus requests: locate a cell by (row,col) and
     // focus it. "first" falls back to the first interactive cell.
     //
@@ -699,7 +700,9 @@ export function Checklist() {
                         const canRemoveCategory = setup.categories.length > 1;
                         const canRemoveCard = category.cards.length > 1;
                         return [
-                            <tr key={`h-${String(category.id)}`}>
+                            <tr
+                                key={`h-${String(category.id)}`}
+                                                            >
                                 <th
                                     colSpan={cardSpan}
                                     className="border-r border-b border-border bg-category-header px-2 py-1.5 text-left text-[11px] uppercase tracking-[0.05em] text-white"
@@ -777,7 +780,9 @@ export function Checklist() {
                                 const cardRowIdx =
                                     rowIdxByCard.get(entry.id) ?? -1;
                                 return (
-                                <tr key={String(entry.id)}>
+                                <tr
+                                    key={String(entry.id)}
+                                                                    >
                                     <th className="w-px whitespace-nowrap border-r border-b border-border px-2 py-1 text-left font-normal">
                                         {inSetup ? (
                                             <div className="flex items-center justify-between gap-2">
@@ -1234,7 +1239,9 @@ export function Checklist() {
                             }),
                             ...(inSetup
                                 ? [
-                                      <tr key={`add-card-${String(category.id)}`}>
+                                      <tr
+                                          key={`add-card-${String(category.id)}`}
+                                                                                >
                                           <th
                                               colSpan={cardSpan}
                                               className="border-r border-b border-border bg-row-alt px-1.5 py-1 text-left"

--- a/src/ui/components/InstallPromptModal.test.tsx
+++ b/src/ui/components/InstallPromptModal.test.tsx
@@ -2,10 +2,12 @@
  * Pins the install-prompt modal's analytics emission, including the
  * reengagement context (`reengaged`, `daysSinceLastDismissal`,
  * `visitCount`) read from `InstallPromptState` localStorage at the
- * moment the user clicks Install / Snooze / X.
+ * moment the user clicks Install / Snooze / X. Also pins the focus
+ * bias toward "Not now" so users who tap Enter don't get launched
+ * into the OS install dialog they didn't ask for.
  */
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { DateTime } from "effect";
 
 const captureCalls: Array<{
@@ -60,6 +62,68 @@ const seedState = (state: {
         JSON.stringify(payload),
     );
 };
+
+describe("InstallPromptModal — render", () => {
+    test("renders title, value-prop bullets, and both buttons when open", async () => {
+        const InstallPromptModal = await importModal();
+        render(
+            <InstallPromptModal
+                open
+                trigger="auto"
+                onInstall={async () => true}
+                onSnooze={() => {}}
+                onClose={() => {}}
+            />,
+        );
+        expect(
+            screen.getByText("installPrompt.title"),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText("installPrompt.benefitOffline"),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "installPrompt.notNow" }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "installPrompt.install" }),
+        ).toBeInTheDocument();
+    });
+
+    test("renders nothing when closed", async () => {
+        const InstallPromptModal = await importModal();
+        render(
+            <InstallPromptModal
+                open={false}
+                trigger="auto"
+                onInstall={async () => true}
+                onSnooze={() => {}}
+                onClose={() => {}}
+            />,
+        );
+        expect(
+            screen.queryByText("installPrompt.title"),
+        ).not.toBeInTheDocument();
+    });
+
+    test("auto-focuses Not now, not the X or Install", async () => {
+        const InstallPromptModal = await importModal();
+        render(
+            <InstallPromptModal
+                open
+                trigger="auto"
+                onInstall={async () => true}
+                onSnooze={() => {}}
+                onClose={() => {}}
+            />,
+        );
+        const notNow = screen.getByRole("button", {
+            name: "installPrompt.notNow",
+        });
+        await waitFor(() => {
+            expect(notNow).toHaveFocus();
+        });
+    });
+});
 
 describe("InstallPromptModal — analytics", () => {
     test("Install with no prior dismissal sends reengaged: false, visitCount from state", async () => {

--- a/src/ui/components/InstallPromptModal.tsx
+++ b/src/ui/components/InstallPromptModal.tsx
@@ -18,8 +18,9 @@
 "use client";
 
 import * as Dialog from "@radix-ui/react-dialog";
-import { useTranslations } from "next-intl";
 import { DateTime } from "effect";
+import { useTranslations } from "next-intl";
+import { useRef } from "react";
 import {
     installAccepted,
     installDismissed,
@@ -59,6 +60,7 @@ export function InstallPromptModal({
 }) {
     const t = useTranslations("installPrompt");
     const tCommon = useTranslations("common");
+    const notNowRef = useRef<HTMLButtonElement | null>(null);
 
     const handleInstall = async (): Promise<void> => {
         const ctx = computeInstallPromptAnalyticsContext(
@@ -107,6 +109,20 @@ export function InstallPromptModal({
                         "-translate-x-1/2 -translate-y-1/2 rounded-[var(--radius)] border border-border " +
                         "bg-panel shadow-[0_10px_28px_rgba(0,0,0,0.28)] focus:outline-none"
                     }
+                    onOpenAutoFocus={(e) => {
+                        // Radix focuses the X by default. We bias toward
+                        // "Not now" instead — the user wasn't seeking
+                        // out an install, so a stray Enter on the
+                        // primary "Install" button would feel hostile.
+                        // The setTimeout (vs rAF) lets Radix's
+                        // FocusScope settle before we override — rAF
+                        // can lose the race when the modal opens
+                        // during a busy render path.
+                        e.preventDefault();
+                        window.setTimeout(() => {
+                            notNowRef.current?.focus();
+                        }, 50);
+                    }}
                 >
                     <div className="flex shrink-0 items-start justify-between gap-3 px-5 pt-5">
                         <Dialog.Title className="m-0 font-display text-[20px] text-accent">
@@ -129,6 +145,7 @@ export function InstallPromptModal({
                     </ul>
                     <div className="mt-4 flex items-center justify-end gap-2 border-t border-border bg-panel px-5 pt-4 pb-5">
                         <button
+                            ref={notNowRef}
                             type="button"
                             onClick={handleSnooze}
                             className="cursor-pointer rounded-[var(--radius)] border border-border bg-white px-4 py-2 text-[14px] hover:bg-hover"

--- a/src/ui/components/SplashModal.test.tsx
+++ b/src/ui/components/SplashModal.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const captureCalls: Array<{
@@ -49,6 +49,17 @@ describe("SplashModal", () => {
         const SplashModal = await importModal();
         render(<SplashModal open={false} onDismiss={() => {}} />);
         expect(screen.queryByText("splash.title")).not.toBeInTheDocument();
+    });
+
+    test("auto-focuses the CTA, not the X", async () => {
+        const SplashModal = await importModal();
+        render(<SplashModal open onDismiss={() => {}} />);
+        const cta = screen.getByRole("button", {
+            name: "splash.startPlaying",
+        });
+        await waitFor(() => {
+            expect(cta).toHaveFocus();
+        });
     });
 
     test("'Start playing' fires dismiss with method=start_playing and the checkbox state", async () => {

--- a/src/ui/components/SplashModal.tsx
+++ b/src/ui/components/SplashModal.tsx
@@ -18,7 +18,7 @@
 
 import * as Dialog from "@radix-ui/react-dialog";
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { splashScreenDismissed } from "../../analytics/events";
 import { AboutContent } from "./AboutContent";
 import { ArrowRightIcon, XIcon } from "./Icons";
@@ -33,6 +33,7 @@ export function SplashModal({
 }) {
     const t = useTranslations("splash");
     const [dontShowAgain, setDontShowAgain] = useState(false);
+    const ctaRef = useRef<HTMLButtonElement | null>(null);
 
     const handleDismiss = (method: "start_playing" | "x_button") => {
         splashScreenDismissed({
@@ -58,6 +59,21 @@ export function SplashModal({
                         "-translate-x-1/2 -translate-y-1/2 rounded-[var(--radius)] border border-border " +
                         "bg-panel shadow-[0_10px_28px_rgba(0,0,0,0.28)] focus:outline-none"
                     }
+                    onOpenAutoFocus={(e) => {
+                        // Radix's default focuses the first focusable
+                        // descendant — that's the X. Bias instead toward
+                        // the CTA so a user who hits Enter on muscle
+                        // memory accepts rather than dismisses. The
+                        // setTimeout (vs rAF) lets Radix's FocusScope
+                        // settle before we override — rAF can lose the
+                        // race when the modal opens during a busy
+                        // render path (e.g. coming out of the startup
+                        // coordinator).
+                        e.preventDefault();
+                        window.setTimeout(() => {
+                            ctaRef.current?.focus();
+                        }, 50);
+                    }}
                 >
                     <div className="flex shrink-0 items-start justify-between gap-3 px-5 pt-5">
                         <Dialog.Title className="m-0 font-display text-[20px] text-accent">
@@ -78,6 +94,7 @@ export function SplashModal({
                     </div>
                     <div className="shrink-0 border-t border-border bg-panel px-5 pt-4 pb-5">
                         <button
+                            ref={ctaRef}
                             type="button"
                             onClick={() => handleDismiss("start_playing")}
                             className={

--- a/src/ui/components/StaleGameModal.test.tsx
+++ b/src/ui/components/StaleGameModal.test.tsx
@@ -1,0 +1,160 @@
+import { describe, expect, test, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { DateTime } from "effect";
+
+vi.mock("next-intl", () => ({
+    useTranslations: (ns?: string) => (
+        key: string,
+        values?: Record<string, string | number>,
+    ) => {
+        if (values === undefined) return ns ? `${ns}.${key}` : key;
+        const args = Object.entries(values)
+            .map(([k, v]) => `${k}=${String(v)}`)
+            .join(",");
+        return `${ns ?? ""}.${key}(${args})`;
+    },
+}));
+
+const importModal = async () => {
+    const mod = await import("./StaleGameModal");
+    return mod.StaleGameModal;
+};
+
+const baseProps = {
+    referenceTimestamp: DateTime.makeUnsafe("2026-04-22T12:00:00Z"),
+    now: DateTime.makeUnsafe("2026-04-25T12:00:00Z"),
+};
+
+describe("StaleGameModal", () => {
+    test("renders title, description (started variant), and both buttons", async () => {
+        const StaleGameModal = await importModal();
+        render(
+            <StaleGameModal
+                {...baseProps}
+                open
+                variant="started"
+                onSetupNewGame={() => {}}
+                onKeepWorking={() => {}}
+            />,
+        );
+        expect(screen.getByText("staleGame.title")).toBeInTheDocument();
+        expect(
+            screen.getByText(/staleGame\.descriptionStarted/),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "staleGame.keepWorking" }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: /staleGame\.setupNew/ }),
+        ).toBeInTheDocument();
+    });
+
+    test("renders the unstarted-variant description", async () => {
+        const StaleGameModal = await importModal();
+        render(
+            <StaleGameModal
+                {...baseProps}
+                open
+                variant="unstarted"
+                onSetupNewGame={() => {}}
+                onKeepWorking={() => {}}
+            />,
+        );
+        expect(
+            screen.getByText(/staleGame\.descriptionUnstarted/),
+        ).toBeInTheDocument();
+    });
+
+    test("renders nothing when closed", async () => {
+        const StaleGameModal = await importModal();
+        render(
+            <StaleGameModal
+                {...baseProps}
+                open={false}
+                variant="started"
+                onSetupNewGame={() => {}}
+                onKeepWorking={() => {}}
+            />,
+        );
+        expect(
+            screen.queryByText("staleGame.title"),
+        ).not.toBeInTheDocument();
+    });
+
+    test("auto-focuses 'Keep working', not 'Set up new game' or X", async () => {
+        const StaleGameModal = await importModal();
+        render(
+            <StaleGameModal
+                {...baseProps}
+                open
+                variant="started"
+                onSetupNewGame={() => {}}
+                onKeepWorking={() => {}}
+            />,
+        );
+        const keepWorking = screen.getByRole("button", {
+            name: "staleGame.keepWorking",
+        });
+        await waitFor(() => {
+            expect(keepWorking).toHaveFocus();
+        });
+    });
+
+    test("'Set up new game' fires onSetupNewGame", async () => {
+        const onSetupNewGame = vi.fn();
+        const onKeepWorking = vi.fn();
+        const StaleGameModal = await importModal();
+        render(
+            <StaleGameModal
+                {...baseProps}
+                open
+                variant="started"
+                onSetupNewGame={onSetupNewGame}
+                onKeepWorking={onKeepWorking}
+            />,
+        );
+        fireEvent.click(
+            screen.getByRole("button", { name: /staleGame\.setupNew/ }),
+        );
+        expect(onSetupNewGame).toHaveBeenCalledTimes(1);
+        expect(onKeepWorking).not.toHaveBeenCalled();
+    });
+
+    test("'Keep working' fires onKeepWorking", async () => {
+        const onSetupNewGame = vi.fn();
+        const onKeepWorking = vi.fn();
+        const StaleGameModal = await importModal();
+        render(
+            <StaleGameModal
+                {...baseProps}
+                open
+                variant="started"
+                onSetupNewGame={onSetupNewGame}
+                onKeepWorking={onKeepWorking}
+            />,
+        );
+        fireEvent.click(
+            screen.getByRole("button", { name: "staleGame.keepWorking" }),
+        );
+        expect(onKeepWorking).toHaveBeenCalledTimes(1);
+        expect(onSetupNewGame).not.toHaveBeenCalled();
+    });
+
+    test("X close fires onKeepWorking (snooze, not wipe)", async () => {
+        const onSetupNewGame = vi.fn();
+        const onKeepWorking = vi.fn();
+        const StaleGameModal = await importModal();
+        render(
+            <StaleGameModal
+                {...baseProps}
+                open
+                variant="started"
+                onSetupNewGame={onSetupNewGame}
+                onKeepWorking={onKeepWorking}
+            />,
+        );
+        fireEvent.click(screen.getByRole("button", { name: "common.close" }));
+        expect(onKeepWorking).toHaveBeenCalledTimes(1);
+        expect(onSetupNewGame).not.toHaveBeenCalled();
+    });
+});

--- a/src/ui/components/StaleGameModal.tsx
+++ b/src/ui/components/StaleGameModal.tsx
@@ -1,0 +1,194 @@
+/**
+ * Modal that asks the user whether they want to start fresh when
+ * they land on Checklist or Suggest with a game that's been sitting
+ * idle (or never started in the first place).
+ *
+ * Two flavors:
+ *   - "started" — the game has progress (known cards, suggestions,
+ *     accusations) but the user hasn't touched it in a while.
+ *   - "unstarted" — the game was created but never had progress
+ *     logged on it.
+ *
+ * Three exit paths:
+ *   - "Set up new game" → primary CTA, calls `onSetupNewGame()`.
+ *     The caller is responsible for dispatching `newGame` and
+ *     redirecting to the setup pane.
+ *   - "Keep working" / X / Esc / overlay click → calls `onKeepWorking()`.
+ *     The caller persists a snooze so we don't re-prompt every page
+ *     load.
+ *
+ * Auto-focus lands on "Keep working" — wiping the game is the
+ * destructive action, so an Enter on muscle memory should NOT be the
+ * thing that wipes it. Mirrors the install-prompt focus bias.
+ */
+"use client";
+
+import * as Dialog from "@radix-ui/react-dialog";
+import { DateTime, Duration } from "effect";
+import { useTranslations } from "next-intl";
+import { useEffect, useMemo, useRef } from "react";
+import { ArrowRightIcon, XIcon } from "./Icons";
+
+export type StaleGameVariant = "started" | "unstarted";
+
+// Wire-format discriminators for the variant union — pulled out so
+// the i18next/no-literal-string rule treats them as identifiers.
+export const STALE_GAME_VARIANT_STARTED: StaleGameVariant = "started";
+export const STALE_GAME_VARIANT_UNSTARTED: StaleGameVariant = "unstarted";
+
+// next-intl key names for the per-variant body copy. Same rationale.
+const STALE_GAME_DESCRIPTION_KEY_STARTED = "descriptionStarted" as const;
+const STALE_GAME_DESCRIPTION_KEY_UNSTARTED = "descriptionUnstarted" as const;
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+
+type TranslateFn = (
+    key: string,
+    values?: Record<string, string | number>,
+) => string;
+
+/**
+ * Render a coarse "N day(s)" / "N hour(s)" string for the modal body.
+ * We deliberately keep it imprecise — the user only needs to know
+ * whether this game is "the one I worked on yesterday" or "the one
+ * from last month".
+ */
+const humanizeIdleDuration = (
+    duration: Duration.Duration,
+    t: TranslateFn,
+): string => {
+    const ms = Duration.toMillis(duration);
+    if (ms >= DAY_MS) {
+        const days = Math.max(1, Math.round(ms / DAY_MS));
+        return t("durationDays", { count: days });
+    }
+    if (ms >= HOUR_MS) {
+        const hours = Math.max(1, Math.round(ms / HOUR_MS));
+        return t("durationHours", { count: hours });
+    }
+    return t("durationMinutes", {
+        count: Math.max(1, Math.round(ms / 60000)),
+    });
+};
+
+export function StaleGameModal({
+    open,
+    variant,
+    referenceTimestamp,
+    now,
+    onSetupNewGame,
+    onKeepWorking,
+}: {
+    readonly open: boolean;
+    readonly variant: StaleGameVariant;
+    /**
+     * For "started": the most recent `lastModifiedAt`.
+     * For "unstarted": the `createdAt`.
+     * Used for the human-readable "you haven't touched this in
+     * {duration}" copy. Caller is responsible for picking the right
+     * one — the modal only stringifies it.
+     */
+    readonly referenceTimestamp: DateTime.Utc;
+    /** Snapshot of "now" at modal open. Pure render function input. */
+    readonly now: DateTime.Utc;
+    readonly onSetupNewGame: () => void;
+    readonly onKeepWorking: () => void;
+}) {
+    const t = useTranslations("staleGame");
+    const tCommon = useTranslations("common");
+    const keepWorkingRef = useRef<HTMLButtonElement | null>(null);
+
+    const idleDuration = useMemo(
+        () => DateTime.distance(referenceTimestamp, now),
+        [referenceTimestamp, now],
+    );
+    const humanDuration = humanizeIdleDuration(idleDuration, t);
+
+    // Fallback focus pull when the modal goes from closed to open.
+    // `onOpenAutoFocus` covers the "mount with open=true" case; this
+    // handles "mount with open=false → re-render with open=true",
+    // which is the boot path coming out of the StartupCoordinator.
+    // The setTimeout (vs rAF) is a deliberate choice — Radix Dialog's
+    // FocusScope sets focus from a useEffect that runs after the
+    // first paint, so an rAF-deferred focus can lose the race. A
+    // small macrotask delay lets FocusScope settle before we
+    // override with the cancel-biased target.
+    useEffect(() => {
+        if (!open) return;
+        const id = window.setTimeout(() => {
+            keepWorkingRef.current?.focus();
+        }, 50);
+        return () => window.clearTimeout(id);
+    }, [open]);
+
+    const descriptionKey =
+        variant === STALE_GAME_VARIANT_STARTED
+            ? STALE_GAME_DESCRIPTION_KEY_STARTED
+            : STALE_GAME_DESCRIPTION_KEY_UNSTARTED;
+
+    return (
+        <Dialog.Root
+            open={open}
+            onOpenChange={(next) => {
+                if (!next) onKeepWorking();
+            }}
+        >
+            <Dialog.Portal>
+                <Dialog.Overlay className="fixed inset-0 z-40 bg-black/40" />
+                <Dialog.Content
+                    className={
+                        "fixed left-1/2 top-1/2 z-50 flex w-[min(92vw,480px)] flex-col "
+                        + "-translate-x-1/2 -translate-y-1/2 rounded-[var(--radius)] border border-border "
+                        + "bg-panel shadow-[0_10px_28px_rgba(0,0,0,0.28)] focus:outline-none"
+                    }
+                    onOpenAutoFocus={(e) => {
+                        e.preventDefault();
+                        // `setTimeout` rather than rAF so we settle
+                        // after Radix's FocusScope, which can win
+                        // races with a single rAF-deferred focus call.
+                        window.setTimeout(() => {
+                            keepWorkingRef.current?.focus();
+                        }, 50);
+                    }}
+                >
+                    <div className="flex shrink-0 items-start justify-between gap-3 px-5 pt-5">
+                        <Dialog.Title className="m-0 font-display text-[20px] text-accent">
+                            {t("title")}
+                        </Dialog.Title>
+                        <Dialog.Close
+                            aria-label={tCommon("close")}
+                            className="-mt-1 -mr-1 cursor-pointer rounded-[var(--radius)] border-none bg-transparent p-1 text-[#2a1f12] hover:bg-hover"
+                        >
+                            <XIcon size={18} />
+                        </Dialog.Close>
+                    </div>
+                    <Dialog.Description className="px-5 pt-3 pb-1 text-[14px] leading-relaxed">
+                        {t(descriptionKey, { humanDuration })}
+                    </Dialog.Description>
+                    <div className="mt-4 flex items-center justify-end gap-2 border-t border-border bg-panel px-5 pt-4 pb-5">
+                        <button
+                            ref={keepWorkingRef}
+                            type="button"
+                            onClick={onKeepWorking}
+                            className="cursor-pointer rounded-[var(--radius)] border border-border bg-white px-4 py-2 text-[14px] hover:bg-hover"
+                        >
+                            {t("keepWorking")}
+                        </button>
+                        <button
+                            type="button"
+                            onClick={onSetupNewGame}
+                            className={
+                                "inline-flex cursor-pointer items-center gap-2 rounded-[var(--radius)] border-2 border-accent bg-accent "
+                                + "px-4 py-2 text-[14px] font-semibold text-white hover:bg-accent-hover"
+                            }
+                        >
+                            <span>{t("setupNew")}</span>
+                            <ArrowRightIcon size={16} />
+                        </button>
+                    </div>
+                </Dialog.Content>
+            </Dialog.Portal>
+        </Dialog.Root>
+    );
+}

--- a/src/ui/hooks/useStaleGameGate.tsx
+++ b/src/ui/hooks/useStaleGameGate.tsx
@@ -1,0 +1,113 @@
+/**
+ * Owns the stale-game prompt's open/close logic. The
+ * `<StartupCoordinatorProvider>` decides whether the slot is active
+ * (eligibility + ordering); this hook just translates that into the
+ * data the modal needs (variant, reference timestamp, "now") and
+ * wires the two exit paths back to the coordinator.
+ *
+ * Two exit paths:
+ *  - `setupNewGame()` — wipes the current game and switches to the
+ *    setup pane. Calls `markGameCreated` via the dispatch wrapper so
+ *    a fresh `createdAt` is stamped immediately.
+ *  - `keepWorking()` — snoozes the gate for `STALE_GAME_SNOOZE` so
+ *    we don't re-prompt on every page load.
+ *
+ * Both call `reportClosed("staleGame")` to advance the coordinator's
+ * phase (which in turn re-evaluates tour and install).
+ */
+"use client";
+
+import { DateTime } from "effect";
+import { useCallback, useMemo } from "react";
+import {
+    loadGameLifecycleState,
+    markStaleGameSnoozed,
+} from "../../logic/GameLifecycleState";
+import { useStartupCoordinator } from "../onboarding/StartupCoordinator";
+import { useClue } from "../state";
+import {
+    STALE_GAME_VARIANT_STARTED,
+    STALE_GAME_VARIANT_UNSTARTED,
+    type StaleGameVariant,
+} from "../components/StaleGameModal";
+
+const SLOT_STALE_GAME = "staleGame" as const;
+
+interface UseStaleGameGateValue {
+    readonly open: boolean;
+    readonly variant: StaleGameVariant;
+    readonly referenceTimestamp: DateTime.Utc;
+    readonly now: DateTime.Utc;
+    readonly setupNewGame: () => void;
+    readonly keepWorking: () => void;
+}
+
+export function useStaleGameGate(): UseStaleGameGateValue {
+    const { phase, reportClosed } = useStartupCoordinator();
+    const { state, dispatch } = useClue();
+
+    const open = phase === SLOT_STALE_GAME;
+
+    const gameStarted =
+        state.knownCards.length > 0
+        || state.suggestions.length > 0
+        || state.accusations.length > 0;
+
+    // Snapshot the lifecycle timestamps + "now" once per open. Memoize
+    // on `open` so the modal's body copy doesn't re-stringify each
+    // render while the prompt is up — that's load-bearing for the
+    // `useMemo` inside `<StaleGameModal>` that consumes
+    // `referenceTimestamp` + `now`.
+    const snapshot = useMemo(() => {
+        if (!open) return null;
+        const now = DateTime.nowUnsafe();
+        const lifecycle = loadGameLifecycleState();
+        const variant: StaleGameVariant = gameStarted
+            ? STALE_GAME_VARIANT_STARTED
+            : STALE_GAME_VARIANT_UNSTARTED;
+        const reference = gameStarted
+            ? lifecycle.lastModifiedAt
+            : lifecycle.createdAt;
+        // Defensive — coordinator already checked these are defined,
+        // but if lifecycle was wiped between the eligibility check
+        // and this render, fall back to `now` so the modal still
+        // renders coherent copy.
+        return {
+            variant,
+            referenceTimestamp: reference ?? now,
+            now,
+        };
+        // Snapshot is intentionally captured at the open-edge only;
+        // re-running the memo when `gameStarted` flips mid-prompt
+        // would change the body copy from under the user. The lint
+        // for stale captures isn't enabled in this project — see
+        // `eslint.config.mjs`.
+    }, [open]);
+
+    const keepWorking = useCallback(() => {
+        markStaleGameSnoozed(DateTime.nowUnsafe());
+        reportClosed(SLOT_STALE_GAME);
+    }, [reportClosed]);
+
+    const setupNewGame = useCallback(() => {
+        // newGame's reducer resets state AND flips uiMode to setup
+        // (setup is the default in the new state). The dispatch
+        // wrapper in `state.tsx` calls `markGameCreated` so the
+        // fresh createdAt is stamped immediately.
+        dispatch({ type: "newGame" });
+        dispatch({ type: "setUiMode", mode: "setup" });
+        reportClosed(SLOT_STALE_GAME);
+    }, [dispatch, reportClosed]);
+
+    // Sentinel timestamps used only when `open === false` — the modal
+    // renders nothing in that case, so the values never reach the DOM.
+    const placeholder = DateTime.makeUnsafe(new Date(0));
+    return {
+        open,
+        variant: snapshot?.variant ?? STALE_GAME_VARIANT_UNSTARTED,
+        referenceTimestamp: snapshot?.referenceTimestamp ?? placeholder,
+        now: snapshot?.now ?? placeholder,
+        setupNewGame,
+        keepWorking,
+    };
+}

--- a/src/ui/onboarding/StartupCoordinator.test.tsx
+++ b/src/ui/onboarding/StartupCoordinator.test.tsx
@@ -28,6 +28,7 @@ const STORAGE_TOUR_SETUP = "effect-clue.tour.setup.v1";
 const STORAGE_TOUR_CHECKLIST_SUGGEST = "effect-clue.tour.checklistSuggest.v1";
 const STORAGE_TOUR_SHARING = "effect-clue.tour.sharing.v1";
 const STORAGE_INSTALL = "effect-clue.install-prompt.v1";
+const STORAGE_GAME_LIFECYCLE = "effect-clue.gameLifecycle.v1";
 
 const seed = (key: string, value: object): void => {
     window.localStorage.setItem(key, JSON.stringify(value));
@@ -79,7 +80,9 @@ const dismissedAtAllGates = (): void => {
 
 interface ProbeState {
     phase: string;
-    reportClosed: (slot: "splash" | "tour" | "install") => void;
+    reportClosed: (
+        slot: "splash" | "staleGame" | "tour" | "install",
+    ) => void;
 }
 
 const probe: { current: ProbeState | null } = { current: null };
@@ -93,6 +96,7 @@ function Probe() {
 const mount = (
     activeScreen: "setup" | "checklistSuggest" = "setup",
     onRedirectToScreen?: (screen: ScreenKey) => void,
+    gameStarted: boolean = false,
 ): { rerender: (nextScreen: ScreenKey) => void } => {
     // Conditional-spread the redirect callback so TypeScript's
     // `exactOptionalPropertyTypes` doesn't reject `undefined`. Tests
@@ -104,6 +108,7 @@ const mount = (
         <StartupCoordinatorProvider
             hydrated
             activeScreen={screen}
+            gameStarted={gameStarted}
             {...redirectProp}
         >
             <Probe />
@@ -643,5 +648,121 @@ describe("StartupCoordinator — sharing follow-up tour", () => {
 
         mount("setup");
         expect(probe.current?.phase).toBe("done");
+    });
+});
+
+describe("StartupCoordinator — staleGame slot", () => {
+    const longAgoIso = new Date(
+        Date.now() - 30 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+
+    test("started, idle past threshold, on Checklist → phase becomes staleGame", () => {
+        dismissedAtAllGates();
+        seed(STORAGE_GAME_LIFECYCLE, {
+            version: 1,
+            createdAt: longAgoIso,
+            lastModifiedAt: longAgoIso,
+        });
+        mount("checklistSuggest", undefined, true);
+        expect(probe.current?.phase).toBe("staleGame");
+    });
+
+    test("unstarted, older than threshold, on Checklist → phase becomes staleGame", () => {
+        dismissedAtAllGates();
+        seed(STORAGE_GAME_LIFECYCLE, {
+            version: 1,
+            createdAt: longAgoIso,
+        });
+        mount("checklistSuggest", undefined, false);
+        expect(probe.current?.phase).toBe("staleGame");
+    });
+
+    test("on Setup screen → never fires staleGame even if idle", () => {
+        dismissedAtAllGates();
+        seed(STORAGE_GAME_LIFECYCLE, {
+            version: 1,
+            createdAt: longAgoIso,
+            lastModifiedAt: longAgoIso,
+        });
+        mount("setup", undefined, true);
+        expect(probe.current?.phase).toBe("done");
+    });
+
+    test("freshly snoozed → suppressed", () => {
+        dismissedAtAllGates();
+        const recentSnooze = new Date(Date.now() - 60 * 1000).toISOString();
+        seed(STORAGE_GAME_LIFECYCLE, {
+            version: 1,
+            createdAt: longAgoIso,
+            lastModifiedAt: longAgoIso,
+            lastSnoozedAt: recentSnooze,
+        });
+        mount("checklistSuggest", undefined, true);
+        expect(probe.current?.phase).toBe("done");
+    });
+
+    test("staleGame closes → phase advances to checklistSuggest tour when eligible", () => {
+        // Splash + setup tour dismissed; checklistSuggest left
+        // unseeded so it remains eligible.
+        const recent = new Date().toISOString();
+        seed(STORAGE_SPLASH, {
+            version: 1,
+            lastVisitedAt: recent,
+            lastDismissedAt: recent,
+        });
+        seed(STORAGE_TOUR_SETUP, {
+            version: 1,
+            lastVisitedAt: recent,
+            lastDismissedAt: recent,
+        });
+        seed(STORAGE_TOUR_SHARING, {
+            version: 1,
+            lastVisitedAt: recent,
+            lastDismissedAt: recent,
+        });
+        seed(STORAGE_GAME_LIFECYCLE, {
+            version: 1,
+            createdAt: longAgoIso,
+            lastModifiedAt: longAgoIso,
+        });
+        seed(STORAGE_INSTALL, { version: 1, visits: 0 });
+
+        mount("checklistSuggest", undefined, true);
+        expect(probe.current?.phase).toBe("staleGame");
+        act(() => probe.current?.reportClosed("staleGame"));
+        expect(probe.current?.phase).toBe("tour");
+    });
+
+    test("staleGame closes with no tour eligible → advances to install or done", () => {
+        dismissedAtAllGates();
+        seed(STORAGE_GAME_LIFECYCLE, {
+            version: 1,
+            createdAt: longAgoIso,
+            lastModifiedAt: longAgoIso,
+        });
+        mount("checklistSuggest", undefined, true);
+        expect(probe.current?.phase).toBe("staleGame");
+        act(() => probe.current?.reportClosed("staleGame"));
+        expect(probe.current?.phase).toBe("done");
+    });
+
+    test("splash closes with stale-game eligible → advances to staleGame, not tour", () => {
+        // Splash eligible (no dismiss). Setup tour also unseeded so it
+        // would otherwise win, but staleGame should suppress it.
+        seed(STORAGE_SPLASH, { version: 1 });
+        seed(STORAGE_TOUR_SETUP, { version: 1 });
+        seed(STORAGE_TOUR_CHECKLIST_SUGGEST, { version: 1 });
+        seed(STORAGE_TOUR_SHARING, { version: 1 });
+        seed(STORAGE_GAME_LIFECYCLE, {
+            version: 1,
+            createdAt: longAgoIso,
+            lastModifiedAt: longAgoIso,
+        });
+        seed(STORAGE_INSTALL, { version: 1, visits: 0 });
+
+        mount("checklistSuggest", undefined, true);
+        expect(probe.current?.phase).toBe("splash");
+        act(() => probe.current?.reportClosed("splash"));
+        expect(probe.current?.phase).toBe("staleGame");
     });
 });

--- a/src/ui/onboarding/StartupCoordinator.tsx
+++ b/src/ui/onboarding/StartupCoordinator.tsx
@@ -49,6 +49,10 @@ import {
     type ReactNode,
 } from "react";
 import { DateTime, Duration } from "effect";
+import {
+    isStaleGameEligible,
+    loadGameLifecycleState,
+} from "../../logic/GameLifecycleState";
 import { loadInstallPromptState } from "../../logic/InstallPromptState";
 import { loadSplashState } from "../../logic/SplashState";
 import { ABOUT_APP_SPLASH_SCREEN_DISMISSAL_DURATION } from "../hooks/useSplashGate";
@@ -154,7 +158,7 @@ const decideTourDispatch = (
  * The slots the coordinator manages. Each maps to one auto-firable
  * surface on /play.
  */
-type StartupSlot = "splash" | "tour" | "install";
+type StartupSlot = "splash" | "staleGame" | "tour" | "install";
 
 // Module-scoped phase/slot constants. Pulled out so the
 // `i18next/no-literal-string` lint rule treats them as wire-format
@@ -162,8 +166,11 @@ type StartupSlot = "splash" | "tour" | "install";
 const PHASE_BOOT = "boot" as const;
 const PHASE_DONE = "done" as const;
 const SLOT_SPLASH: StartupSlot = "splash";
+const SLOT_STALE_GAME: StartupSlot = "staleGame";
 const SLOT_TOUR: StartupSlot = "tour";
 const SLOT_INSTALL: StartupSlot = "install";
+
+const SCREEN_CHECKLIST: ScreenKey = "checklistSuggest";
 
 /**
  * Phases the coordinator walks through. `boot` is the initial state
@@ -260,9 +267,34 @@ const isInstallEligibleByCounter = (now: DateTime.Utc): boolean => {
 
 interface Eligibility {
     readonly splash: boolean;
+    readonly staleGame: boolean;
     readonly tour: boolean;
     readonly install: boolean;
 }
+
+/**
+ * Stale-game prompt eligibility. Gates the prompt to:
+ *  - The Checklist / Suggest pane only — never on Setup, since the
+ *    user is already free to start fresh from there.
+ *  - Idle-or-empty games per the threshold pair in
+ *    `GameLifecycleState`. See `isStaleGameEligible` for the rules.
+ */
+const isStaleGameEligibleForCoordinator = ({
+    activeScreen,
+    gameStarted,
+    now,
+}: {
+    readonly activeScreen: ScreenKey;
+    readonly gameStarted: boolean;
+    readonly now: DateTime.Utc;
+}): boolean => {
+    if (activeScreen !== SCREEN_CHECKLIST) return false;
+    return isStaleGameEligible({
+        state: loadGameLifecycleState(),
+        gameStarted,
+        now,
+    });
+};
 
 /**
  * Pure decision helper. Picks the first slot from the priority list
@@ -274,6 +306,7 @@ interface Eligibility {
  */
 const pickNextPhase = (eligibility: Eligibility): StartupPhase => {
     if (eligibility.splash) return SLOT_SPLASH;
+    if (eligibility.staleGame) return SLOT_STALE_GAME;
     if (eligibility.tour) return SLOT_TOUR;
     if (eligibility.install) return SLOT_INSTALL;
     return PHASE_DONE;
@@ -283,6 +316,7 @@ export function StartupCoordinatorProvider({
     children,
     hydrated,
     activeScreen,
+    gameStarted,
     onRedirectToScreen,
 }: {
     readonly children: ReactNode;
@@ -300,6 +334,13 @@ export function StartupCoordinatorProvider({
      * re-fire a tour automatically (the user can use ⋯ → Take tour).
      */
     readonly activeScreen: ScreenKey;
+    /**
+     * Whether the hydrated game has any progress on it (known cards,
+     * suggestions, accusations). Drives the stale-game prompt's
+     * choice between the "started" and "unstarted" eligibility
+     * thresholds.
+     */
+    readonly gameStarted: boolean;
     /**
      * Optional precedence-redirect callback. When the highest-priority
      * eligible tour (per `TOUR_PRECEDENCE`) does NOT match
@@ -353,14 +394,35 @@ export function StartupCoordinatorProvider({
         if (isSplashEligible(now)) {
             const eligibility: Eligibility = {
                 splash: true,
-                // Tour eligibility is recomputed when splash closes;
-                // hold it as `false` here so a stale snapshot can't
-                // accidentally fire the tour for the wrong screen.
+                // Stale-game and tour eligibility are recomputed when
+                // splash closes; hold both as `false` here so a stale
+                // snapshot can't fire the wrong slot for the wrong
+                // screen.
+                staleGame: false,
                 tour: false,
                 install: isInstallEligibleByCounter(now),
             };
             eligibilityRef.current = eligibility;
             setPhase(SLOT_SPLASH);
+            return;
+        }
+
+        const staleGame = isStaleGameEligibleForCoordinator({
+            activeScreen,
+            gameStarted,
+            now,
+        });
+        if (staleGame) {
+            const eligibility: Eligibility = {
+                splash: false,
+                staleGame: true,
+                // Tour eligibility is recomputed when staleGame
+                // closes; hold as `false` here.
+                tour: false,
+                install: isInstallEligibleByCounter(now),
+            };
+            eligibilityRef.current = eligibility;
+            setPhase(SLOT_STALE_GAME);
             return;
         }
 
@@ -381,12 +443,13 @@ export function StartupCoordinatorProvider({
 
         const eligibility: Eligibility = {
             splash: false,
+            staleGame: false,
             tour: decision === TOUR_DECISION_FIRE,
             install: isInstallEligibleByCounter(now),
         };
         eligibilityRef.current = eligibility;
         setPhase(pickNextPhase(eligibility));
-    }, [hydrated, phase, activeScreen]);
+    }, [hydrated, phase, activeScreen, gameStarted]);
 
     const reportClosed = useCallback((slot: StartupSlot) => {
         const snapshot = eligibilityRef.current;
@@ -396,10 +459,29 @@ export function StartupCoordinatorProvider({
         // already advanced, e.g. install snooze + close fired twice.
         if (slot === SLOT_SPLASH) {
             // Re-run the precedence decision now that splash is gone.
-            // Same `decideTourDispatch` rule as boot — we only redirect
-            // off the user's current screen for the setup tour; other
-            // tours fire in place or wait for next navigation.
+            // Stale-game runs first if the user is on Checklist /
+            // Suggest with an idle game; otherwise fall through to the
+            // tour decision. Same `decideTourDispatch` rule as boot —
+            // we only redirect off the user's current screen for the
+            // setup tour; other tours fire in place or wait for next
+            // navigation.
             const now = DateTime.nowUnsafe();
+            if (
+                isStaleGameEligibleForCoordinator({
+                    activeScreen,
+                    gameStarted,
+                    now,
+                })
+            ) {
+                eligibilityRef.current = {
+                    splash: false,
+                    staleGame: true,
+                    tour: false,
+                    install: snapshot.install,
+                };
+                setPhase(prev => (prev === SLOT_SPLASH ? SLOT_STALE_GAME : prev));
+                return;
+            }
             const target = findHighestPriorityEligibleTour(now);
             const decision = decideTourDispatch(
                 target,
@@ -417,6 +499,7 @@ export function StartupCoordinatorProvider({
                     // fire on the new screen.
                     eligibilityRef.current = {
                         splash: false,
+                        staleGame: false,
                         tour: true,
                         install: snapshot.install,
                     };
@@ -426,11 +509,58 @@ export function StartupCoordinatorProvider({
                 const willFireTour = decision === TOUR_DECISION_FIRE;
                 eligibilityRef.current = {
                     splash: false,
+                    staleGame: false,
                     tour: willFireTour,
                     install: snapshot.install,
                 };
                 return pickNextPhase({
                     splash: false,
+                    staleGame: false,
+                    tour: willFireTour,
+                    install: snapshot.install,
+                });
+            });
+            return;
+        }
+        if (slot === SLOT_STALE_GAME) {
+            // After the stale-game prompt closes (accept OR keep
+            // working), recompute the tour decision. On accept the
+            // parent has already redirected to setup — the closure's
+            // `activeScreen` is still the old one for one render, but
+            // `decideTourDispatch` will return `redirect-then-fire`
+            // for the setup tour and the redirect call is idempotent
+            // with the parent's own `setUiMode`. On keep-working the
+            // user stayed on Checklist / Suggest and the
+            // `checklistSuggest` tour can fire if eligible.
+            const now = DateTime.nowUnsafe();
+            const target = findHighestPriorityEligibleTour(now);
+            const decision = decideTourDispatch(
+                target,
+                activeScreen,
+                redirectRef.current !== undefined,
+            );
+            setPhase(prev => {
+                if (prev !== SLOT_STALE_GAME) return prev;
+                if (decision === TOUR_DECISION_REDIRECT_THEN_FIRE) {
+                    eligibilityRef.current = {
+                        splash: false,
+                        staleGame: false,
+                        tour: true,
+                        install: snapshot.install,
+                    };
+                    redirectRef.current?.(target as ScreenKey);
+                    return SLOT_TOUR;
+                }
+                const willFireTour = decision === TOUR_DECISION_FIRE;
+                eligibilityRef.current = {
+                    splash: false,
+                    staleGame: false,
+                    tour: willFireTour,
+                    install: snapshot.install,
+                };
+                return pickNextPhase({
+                    splash: false,
+                    staleGame: false,
                     tour: willFireTour,
                     install: snapshot.install,
                 });
@@ -450,7 +580,7 @@ export function StartupCoordinatorProvider({
             // install
             return PHASE_DONE;
         });
-    }, [activeScreen]);
+    }, [activeScreen, gameStarted]);
 
     const value = useMemo<CoordinatorValue>(
         () => ({ phase, reportClosed }),

--- a/src/ui/state.tsx
+++ b/src/ui/state.tsx
@@ -70,6 +70,11 @@ import {
     loadFromLocalStorage,
     saveToLocalStorage,
 } from "../logic/Persistence";
+import {
+    loadGameLifecycleState,
+    markGameCreated,
+    markGameTouched,
+} from "../logic/GameLifecycleState";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
     deduceWithExplanations,
@@ -89,7 +94,7 @@ import {
     makeSetupLayer,
     makeSuggestionsLayer,
 } from "../logic/services";
-import { Duration, Layer } from "effect";
+import { DateTime, Duration, Layer } from "effect";
 import { requestFocusAddForm } from "./addFormFocus";
 import { requestFocusChecklistCell } from "./checklistFocus";
 import { useGlobalShortcut } from "./keyMap";
@@ -709,6 +714,18 @@ export function ClueProvider({ children }: { children: ReactNode }) {
                     dispatchRaw(action);
                 })(),
             );
+            // Sync game-lifecycle storage so the stale-game prompt
+            // sees genuine staleness. `setUiMode` and `replaceSession`
+            // are excluded — flipping panes or rehydrating from
+            // localStorage isn't "the user touched the game".
+            if (action.type === "newGame") {
+                markGameCreated(DateTime.nowUnsafe());
+            } else if (
+                action.type !== "setUiMode"
+                && action.type !== "replaceSession"
+            ) {
+                markGameTouched(DateTime.nowUnsafe());
+            }
         },
         [],
     );
@@ -726,8 +743,14 @@ export function ClueProvider({ children }: { children: ReactNode }) {
               previousState: history.current,
           }
         : undefined;
-    const undo = useCallback(() => dispatchRaw({ type: "__undo" }), []);
-    const redo = useCallback(() => dispatchRaw({ type: "__redo" }), []);
+    const undo = useCallback(() => {
+        dispatchRaw({ type: "__undo" });
+        markGameTouched(DateTime.nowUnsafe());
+    }, []);
+    const redo = useCallback(() => {
+        dispatchRaw({ type: "__redo" });
+        markGameTouched(DateTime.nowUnsafe());
+    }, []);
 
     // Refs shared by several shortcut handlers so their handler
     // references stay stable (no listener churn when state changes).
@@ -989,6 +1012,34 @@ export function ClueProvider({ children }: { children: ReactNode }) {
         const viewParam = params.get("view");
         const session = loadFromLocalStorage();
         if (session) dispatch({ type: "replaceSession", session });
+
+        // Backfill lifecycle timestamps for users upgrading from a
+        // build before this feature shipped. New users get fresh
+        // `createdAt`/`lastModifiedAt` from the `newGame` / mutation
+        // path; existing sessions need a one-time stamp so the
+        // stale-game gate has something to reason about. Use the
+        // most recent suggestion/accusation `loggedAt` when present
+        // (best-effort proxy for "last touched"), else stamp now.
+        const lifecycle = loadGameLifecycleState();
+        if (
+            lifecycle.createdAt === undefined
+            && lifecycle.lastModifiedAt === undefined
+        ) {
+            const loggedAtSamples: number[] = [];
+            for (const s of session?.suggestions ?? []) {
+                if (s.loggedAt > 0) loggedAtSamples.push(s.loggedAt);
+            }
+            for (const a of session?.accusations ?? []) {
+                if (a.loggedAt > 0) loggedAtSamples.push(a.loggedAt);
+            }
+            if (loggedAtSamples.length > 0) {
+                const maxLoggedAt = Math.max(...loggedAtSamples);
+                const stamp = DateTime.makeUnsafe(new Date(maxLoggedAt));
+                markGameCreated(stamp);
+            } else {
+                markGameCreated(DateTime.nowUnsafe());
+            }
+        }
 
         // View precedence: explicit `?view=` wins; otherwise pick based
         // on hydrated suggestions. The default state.uiMode is "setup",


### PR DESCRIPTION
## Summary

- **Splash CTA** ("Let's solve a murder!") auto-focuses instead of the X. Pressing Enter on muscle memory now accepts the modal rather than dismissing via the close button.
- **Install pop-up** auto-focuses "Not now" instead of the X. The user wasn't seeking out an install — biasing toward "Install" with focus would be hostile.
- **Stale-game prompt**: when a user lands on Checklist or Suggest with a game that's been idle, surface a Radix dialog asking "Pick up where you left off?" with **"Keep working"** auto-focused (cancel-biased — the destructive action is wiping the game). Accept dispatches \`newGame\` + redirects to Setup; dismiss snoozes 24h. Two thresholds: **3 days** for a started game (any known cards / suggestions / accusations), **1 day** for an unstarted one.
- **Tour popover** focusing Next was already wired correctly at \`TourPopover.tsx:486\`; verified, no change.

## Test plan

- [x] All five pre-commit checks green (typecheck, lint, test 958/958, knip, i18n:check).
- [x] Splash modal auto-focuses CTA — pressing Enter accepts; X still dismisses.
- [x] Install pop-up auto-focuses "Not now" (covered by new \`InstallPromptModal.test.tsx\`).
- [x] Stale-game modal fires only on Checklist/Suggest with the right thresholds; suppressed for 24h after dismiss; respects splash → staleGame → tour → install precedence.
- [x] Manual verification in \`next-dev\` preview at desktop (1280×800) and mobile (375×812).
- [ ] Animations for adding/removing players, cards, and categories — **deferred to a follow-up commit on this branch.** Both Framer Motion (\`<motion.tr>\` inside \`<AnimatePresence>\`) and CSS-keyframe approaches regressed in this codebase: Framer's \`<PopChild>\`/\`<PopChildMeasure>\` wrappers swallowed click events on row buttons; CSS animations got restarted on every parent re-render and stuck at \`opacity: 0\`. Will iterate with a wrapper-div-around-cell-content approach.

## Commits

- **Bias modal focus toward cancel actions; prompt to abandon stale games** — splash + install focus fixes; new \`GameLifecycleState\` module (\`createdAt\` / \`lastModifiedAt\` / \`lastSnoozedAt\` in \`localStorage\`); new \`StaleGameModal\` + \`useStaleGameGate\` hook; new \`staleGame\` slot in \`StartupCoordinator\` between splash and tour; \`state.tsx\` dispatch wrapper bumps lifecycle stamps; hydration backfills lifecycle from suggestion/accusation \`loggedAt\` for upgraded sessions. Modal focus uses \`setTimeout(50ms)\` rather than rAF in \`onOpenAutoFocus\` because Radix Dialog's FocusScope wins races against a single-rAF deferred focus during a busy render path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)