### PR TITLE
Left-align "+ add category" button

### DIFF
--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -1351,7 +1351,7 @@ export function Checklist() {
                         <tr>
                             <th
                                 colSpan={cardSpan}
-                                className="border-r border-b border-border bg-row-alt px-1.5 py-2 text-center"
+                                className="border-r border-b border-border bg-row-alt px-1.5 py-2 text-left"
                             >
                                 <button
                                     type="button"


### PR DESCRIPTION
The "+ add category" button now sits at the left edge of the table footer row instead of being centred across the card / owner columns.

## Commits

- **Left-align "+ add category" button** — swap `text-center` → `text-left` on the `<th>` wrapping the button in `src/ui/components/Checklist.tsx`.

https://claude.ai/code/session_01JTCZ5QYVMrqcE4WjmcNxX8

---
_Generated by [Claude Code](https://claude.ai/code/session_01JTCZ5QYVMrqcE4WjmcNxX8)_