### PR TITLE
Fix Codex environment setup

### DIFF
--- a/.codex/environments/environment.toml
+++ b/.codex/environments/environment.toml
@@ -5,6 +5,10 @@ name = "effect-clue"
 [setup]
 script = '''
 cd "$CODEX_WORKTREE_PATH"
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  . "$NVM_DIR/nvm.sh"
+fi
 nvm install
 nvm use
 pnpm install

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,14 @@ You may notice that each Bash tool call appears to start a fresh subshell, so PA
 
 Once per shell session — and after any `package.json` / `pnpm-lock.yaml` change — run `pnpm install` from the repo root. Every script in this repo reads from `node_modules` and will error out if it hasn't been populated. Run it as a plain `pnpm install` call; do not prepend nvm setup (see the Node version section above).
 
+In Codex, a fresh worktree may need to fetch the npm registry while the default
+command sandbox has DNS/network access disabled. If `node_modules` is missing or
+the install will clearly need registry tarballs, run the same plain
+`pnpm install` with network approval/escalation up front. If you see
+`getaddrinfo ENOTFOUND registry.npmjs.org`, treat it as sandbox networking and
+retry `pnpm install` with network approval; do not change package managers,
+clear the lockfile, or add nvm setup.
+
 Scripts that require `pnpm install`:
 
 - `pnpm typecheck` — TypeScript (`tsc --noEmit`)


### PR DESCRIPTION
## Summary
- Load nvm inside the Codex environment setup script before running nvm install/use.
- Document Codex sandbox DNS behavior for fresh pnpm installs and when to request network approval.

## Verification
- pnpm install
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm knip
- pnpm i18n:check

## Observability
- Events: none.
- Funnels: unchanged.
- Spans/logs: none.
