### PR TITLE
Add Neon workflows and local Postgres setup

### DIFF
--- a/.github/workflows/neon-delete-preview-branches.yml
+++ b/.github/workflows/neon-delete-preview-branches.yml
@@ -1,0 +1,115 @@
+# NOTE(delete-neon-preview-branches)
+# ----------------------------
+#
+# On our Neon free plan, we can have a max of 10 preview DB branches.
+#
+# Neon will clean up old branches after Vercel deletes the preview builds,
+# but those are configured to last for 1 or 2 weeks (and can't go much lower than that).
+# Because of this, it is very important that we clean up branches quicker than that
+# to make space for more active development.
+#
+# If/when we pay for a Neon plan, we can:
+# - delete this logic, since the limit will be higher. It should be enough to wait for
+#   the automatic cleanup of preview branches after the 1-2 weeks takes to delete them.
+# - PROTECT THE PRODUCTION DATABASE!
+#
+# This workflow is triggered by:
+# - PRs that are merged (not just closed) and head branch is not main
+# - delete events for any branch (not just a tag) and branch is not main
+#
+# VERY IMPORTANT!
+# - This workflow skips the main git branch
+# - This workflow skips deleting any database other than "preview/*" branches
+#
+# BE CAREFUL! On our free Neon plan, the production database is not protected,
+# so it can be deleted. Which would be very very bad. That is why the checks
+# are extremely defensive here.
+
+name: Delete Neon Preview Branches
+
+on:
+  pull_request:
+    types: [closed]
+    branches-ignore:
+      - main
+  delete:
+    branches-ignore:
+      - main
+
+jobs:
+  delete-preview-branch:
+    # For PR events: only run if PR was merged (not just closed) and head branch is not main
+    # For delete events: only run if it's a branch (not a tag) and branch is not main
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.merged == true && github.event.pull_request.head.ref != 'main') ||
+      (github.event_name == 'delete' && github.event.ref_type == 'branch' && github.event.ref != 'refs/heads/main')
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get branch name from event
+        id: branch_name
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            # For PR events, use the head ref.
+            branch_name="${{ github.event.pull_request.head.ref }}"
+          else
+            # For delete events, extract branch name from ref.
+            # github.event.ref can be either "refs/heads/branch-name" or just "branch-name".
+            branch_name="${{ github.event.ref }}"
+            if [[ "$branch_name" =~ ^refs/heads/ ]]; then
+              branch_name="${branch_name#refs/heads/}"
+            fi
+          fi
+
+          if [ -z "$branch_name" ]; then
+            echo "::error::Branch name is empty"
+            exit 1
+          fi
+
+          echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
+          echo "Detected branch: $branch_name"
+
+      - name: Map Git branch to Neon branch
+        id: branches
+        run: |
+          branch_name="${{ steps.branch_name.outputs.branch_name }}"
+
+          # Maps Git branch names to Neon database branch names.
+          # Same logic as neon-schema-diff.yml, except main is rejected here.
+          map_branch() {
+            local branch_name=$1
+            if [ "$branch_name" == "main" ]; then
+              echo "::error::This workflow should not be triggered on main. It is not safe to delete the database associated with main" >&2
+              exit 1
+            else
+              # The preview DB branch, automatically created by the Vercel-Neon integration for each preview deployment.
+              echo "preview/$branch_name"
+            fi
+          }
+
+          neon_branch=$(map_branch "$branch_name")
+          echo "neon_branch=$neon_branch" >> $GITHUB_OUTPUT
+          echo "git_branch=$branch_name" >> $GITHUB_OUTPUT
+
+      - name: Only preview branches are safe to delete
+        id: check
+        run: |
+          neon_branch="${{ steps.branches.outputs.neon_branch }}"
+          if [[ "$neon_branch" =~ ^preview/ ]]; then
+            echo "is_preview=true" >> $GITHUB_OUTPUT
+            echo "Will delete preview branch: $neon_branch"
+          else
+            echo "::error::Only preview branches (preview/*) are safe to delete. Refusing to delete: $neon_branch"
+            echo "is_preview=false" >> $GITHUB_OUTPUT
+            echo "Skipping deletion of non-preview branch: $neon_branch"
+            exit 1
+          fi
+
+      - name: Delete Neon Preview Branch
+        if: steps.check.outputs.is_preview == 'true'
+        uses: neondatabase/delete-branch-action@v3
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          branch: ${{ steps.branches.outputs.neon_branch }}
+          api_key: ${{ secrets.NEON_API_KEY }}

--- a/.github/workflows/neon-schema-diff.yml
+++ b/.github/workflows/neon-schema-diff.yml
@@ -1,0 +1,39 @@
+name: Neon Schema Diff
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  schema-diff:
+    permissions:
+      pull-requests: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Map Git branches to Neon branches
+        id: branches
+        run: |
+          # Maps Git branch names to Neon database branch names.
+          map_branch() {
+            local branch_name=$1
+            if [ "$branch_name" == "main" ]; then
+              # The production DB branch, automatically managed by the Vercel-Neon integration.
+              echo "main"
+            else
+              # The preview DB branch, automatically created by the Vercel-Neon integration for each preview deployment.
+              echo "preview/$branch_name"
+            fi
+          }
+
+          compare_branch=$(map_branch "${{ github.head_ref }}")
+          base_branch=$(map_branch "${{ github.base_ref }}")
+
+          echo "compare=$compare_branch" >> $GITHUB_OUTPUT
+          echo "base=$base_branch" >> $GITHUB_OUTPUT
+      - uses: neondatabase/schema-diff-action@v1
+        with:
+          project_id: ${{ vars.NEON_PROJECT_ID }}
+          api_key: ${{ secrets.NEON_API_KEY }}
+          compare_branch: ${{ steps.branches.outputs.compare }}
+          base_branch: ${{ steps.branches.outputs.base }}

--- a/README.md
+++ b/README.md
@@ -101,13 +101,15 @@ pnpm db:up         # Postgres in Docker; safe to skip if you don't need server f
 pnpm dev
 ```
 
-Then open <http://localhost:3000>.
+Then open the local URL printed by Next.js. It is usually
+<http://localhost:3000>, but Next will automatically pick another
+available port when 3000 is already in use.
 
-The third-party SDKs (Sentry, Honeycomb, PostHog) all no-op when their env vars are unset, so the app runs end-to-end with an empty `.env.local`.
+The third-party SDKs (Sentry, Honeycomb, PostHog) all no-op when their env vars are unset, and local development falls back to the committed Docker Postgres URL when `DATABASE_URL` is blank, so the app runs end-to-end with an empty `.env.local` after `pnpm db:up`.
 
 ### Local Postgres via Docker
 
-`docker-compose.yml` at the repo root spins up a single `postgres:16-alpine` service on `localhost:5432`. The default `DATABASE_URL` to drop into `.env.local` is committed in [env.example](env.example) — copy the local-Docker block.
+`docker-compose.yml` at the repo root spins up a single Neon-aligned `postgres:17` service on `localhost:5432`. The default `DATABASE_URL` to drop into `.env.local` is committed in [env.example](env.example) — copy the local-Docker block. Set `POSTGRES_HOST_PORT` if port 5432 is already in use.
 
 | Command | What it does |
 | --- | --- |
@@ -167,10 +169,12 @@ Copy [env.example](env.example) to `.env.local`. All third-party integrations ar
 | `DATABASE_URL` | Postgres connection string. Local Docker default committed in [env.example](env.example); Neon URL for previews/production. |
 | `DATABASE_URL_UNPOOLED` | Direct (non-pooler) Postgres URL. Reserved for migration runs that need a stable session. |
 | `BETTER_AUTH_SECRET` | Server-only secret for session JWT signing. Generate with `openssl rand -hex 32`. |
-| `BETTER_AUTH_URL` | Public URL of the deployed app — `http://localhost:3000` in dev. |
+| `BETTER_AUTH_URL` | Public URL of the deployed app. Leave blank in local dev so auth follows the actual auto-selected localhost port. |
 | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` | Google OAuth client. Optional in local dev (the dev-only username/password flow covers it); required for previews/production. |
 
 In CI/production, the build job needs `SENTRY_AUTH_TOKEN` / `SENTRY_ORG` / `SENTRY_PROJECT` to upload source maps. Production also needs the DB and auth vars wired in Vercel — see [docs/setup-vercel-neon-google.md](docs/setup-vercel-neon-google.md).
+
+Neon schema-diff and preview-branch cleanup workflows also need GitHub Actions access to Neon: set repository variable `NEON_PROJECT_ID` and repository secret `NEON_API_KEY`. See [docs/setup-vercel-neon-google.md](docs/setup-vercel-neon-google.md) for the API key setup.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,10 +8,20 @@
 # The matching DATABASE_URL is committed in env.example as a copy-paste
 # block. The same migrator code path runs against this Docker container
 # AND Neon — "works locally" => "works on Vercel".
+#
+# This setup is based on Neon's local-development guide:
+# https://neon.com/guides/local-development-with-neon
+#
+# Optional offline hostname: if you want to use db.localtest.me in a
+# connection string, add this to /etc/hosts:
+#     127.0.0.1 db.localtest.me
 
 services:
     postgres:
-        image: postgres:16-alpine
+        # Keep this in sync with the Postgres major version Neon uses.
+        # Renovate updates this through StoryCut's neon-local-postgres preset.
+        image: postgres:17
+        command: ["-d 1", "-c", "log_statement=all"]
         container_name: effect-clue-postgres
         restart: unless-stopped
         environment:
@@ -19,14 +29,14 @@ services:
             POSTGRES_PASSWORD: local_dev_only
             POSTGRES_DB: effect_clue
         ports:
-            - "5432:5432"
+            - "${POSTGRES_HOST_PORT:-5432}:5432"
         volumes:
             - effect-clue-pg-data:/var/lib/postgresql/data
         healthcheck:
             test: ["CMD-SHELL", "pg_isready -U effect_clue -d effect_clue"]
-            interval: 5s
+            interval: 10s
             timeout: 5s
-            retries: 10
+            retries: 5
 
 volumes:
     effect-clue-pg-data:

--- a/docs/setup-vercel-neon-google.md
+++ b/docs/setup-vercel-neon-google.md
@@ -42,6 +42,32 @@ Verify `DATABASE_URL` and `DATABASE_URL_UNPOOLED` are present.
 Vercel + Neon auto-creates a Neon **branch per Vercel preview**, which
 isolates each preview's migrations. Confirm in the Neon dashboard.
 
+### GitHub Actions for Neon branch workflows
+
+The schema-diff and preview-branch cleanup workflows authenticate to
+Neon's API directly. The Vercel integration populates database
+connection strings for the app, but it does not provide a GitHub
+Actions API token.
+
+Add these under GitHub repo **Settings → Secrets and variables →
+Actions**:
+
+| Kind | Name | Value |
+| --- | --- | --- |
+| Repository variable | `NEON_PROJECT_ID` | The Neon project ID. |
+| Repository secret | `NEON_API_KEY` | A Neon API key. |
+
+Prefer a Neon **project-scoped API key** if the project is
+organization-owned: Neon Console → Organization Settings → API keys →
+Create new → Project-scoped → choose the Clue project. Project-scoped
+keys are limited to one project and cannot delete the associated
+project.
+
+If project-scoped keys are unavailable, create a personal API key:
+Neon Console → Account settings → API keys → Create new. Neon only
+shows the token once; copy it immediately and store it as the
+`NEON_API_KEY` repository secret.
+
 ### Neon free-tier auto-suspend
 
 Free-tier compute idles after a short window, adding cold-start
@@ -67,16 +93,20 @@ Per environment:
 | --- | --- |
 | Production | `https://winclue.vercel.app` |
 | Preview | `https://$VERCEL_URL` (Vercel system var — set the value literally to `https://$VERCEL_URL` in the dashboard; Vercel substitutes at runtime) |
-| Development | `http://localhost:3000` |
+| Development | Leave blank unless you need to force a fixed local OAuth callback URL |
 
 better-auth uses this to build the OAuth callback URLs.
+In local development, leaving it blank lets Better Auth derive the
+actual `localhost` host and port from the incoming request, so Next's
+automatic port fallback keeps working when 3000 is already occupied.
 
 ## 5. Google OAuth client
 
 Required for previews and production. Local dev can use the dev-only
-username/password path inside the Account modal, but the Google
-client ID and secret still need to be present because the Better Auth
-server config fails fast when either is missing. That keeps OAuth
+username/password path inside the Account modal, so
+`GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` may be left blank when
+running against Docker offline. Production and Vercel previews still
+fail fast when either Google value is missing, which keeps OAuth
 misconfiguration from turning into a confusing missing-provider error.
 The dev credential path tree-shakes out of production bundles, see CI
 assertion below.
@@ -90,13 +120,18 @@ assertion below.
    - Add your email + any other testers as test users.
 3. **Authorized JavaScript origins** — add:
    - `https://winclue.vercel.app`
-   - `http://localhost:3000`
+   - Any localhost ports you use for local Google OAuth, e.g.
+     `http://localhost:3000`
    - Specific Vercel preview URLs as needed (Google may reject
      wildcards).
 4. **Authorized redirect URIs** — add the exact callback URL for each
    environment:
    - `https://winclue.vercel.app/api/auth/callback/google`
-   - `http://localhost:3000/api/auth/callback/google`
+   - The exact localhost callback URL for any local Google OAuth port
+     you use, e.g. `http://localhost:3000/api/auth/callback/google`.
+     Next may auto-select another port when 3000 is occupied; either
+     add that exact callback too, or free/pin port 3000 before testing
+     Google OAuth locally.
    - Specific preview-deploy URLs as they come up. Wildcards are not
      supported here.
 5. Capture `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`. Add both to

--- a/env.example
+++ b/env.example
@@ -41,15 +41,16 @@ BETTER_AUTH_SECRET=
 # callback URLs. Per environment:
 #   Production:   https://winclue.vercel.app
 #   Preview:      https://$VERCEL_URL  (Vercel system var)
-#   Development:  http://localhost:3000 (auth.ts defaults to this only in dev)
+#   Development:  leave blank so auth follows Next's actual localhost port
 BETTER_AUTH_URL=
 # Set to 1 to enable Better Auth debug-level server logs locally.
 AUTH_DEBUG=
 
 # Google OAuth client ID + secret. Create at
 # https://console.cloud.google.com → APIs & Services → Credentials.
-# Authorised redirect URIs must include each environment's
-# `${BETTER_AUTH_URL}/api/auth/callback/google`.
+# Authorised redirect URIs must include each environment's auth callback URL.
+# If testing Google OAuth locally, include the active localhost port printed by
+# `pnpm dev`, e.g. `http://localhost:3000/api/auth/callback/google`.
 #
 # Required in every environment. The app fails at startup when either
 # value is missing so OAuth misconfiguration is loud instead of

--- a/src/server/README.md
+++ b/src/server/README.md
@@ -73,10 +73,12 @@ against the migrator's metadata table.
 ## Local development
 
 The committed [`docker-compose.yml`](../../docker-compose.yml) at the
-repo root spins up a `postgres:16-alpine` service on
-`localhost:5432`. The same `MigratorLive` code path that runs against
-Neon in production runs against this Docker container locally, so
-"works on Docker" implies "works on Vercel" for migrations.
+repo root spins up a Neon-aligned `postgres:17` service on
+`localhost:5432` by default. Set `POSTGRES_HOST_PORT` if another local
+Postgres already owns 5432. The same `MigratorLive` code path that
+runs against Neon in production runs against this Docker container
+locally, so "works on Docker" implies "works on Vercel" for
+migrations.
 
 ```bash
 pnpm db:up         # start postgres
@@ -86,7 +88,9 @@ pnpm db:reset      # wipe the volume; migrations re-run on next request
 
 Drop the local `DATABASE_URL` from
 [`env.example`](../../env.example) into your `.env.local` —
-nothing else needs to change to switch between Docker and Neon.
+nothing else needs to change to switch between Docker and Neon. In
+development, a blank or missing `DATABASE_URL` falls back to that same
+local Docker URL.
 
 ## Env vars
 
@@ -94,7 +98,9 @@ nothing else needs to change to switch between Docker and Neon.
 never accidentally lands in a log. Pull the production-shaped vars
 locally with `vercel env pull .env.development.local`, or use the
 local Docker block in [`env.example`](../../env.example) and skip
-Vercel entirely for local work.
+Vercel entirely for local work. Leave `BETTER_AUTH_URL` blank in
+local development so Better Auth derives the actual localhost port
+from the request when Next auto-selects a fallback port.
 
 | Variable | Owner | Used for |
 | --- | --- | --- |

--- a/src/server/auth.test.ts
+++ b/src/server/auth.test.ts
@@ -30,17 +30,28 @@ const importAuthWithEnv = async (
             }
         },
     }));
-    process.env = { ...ORIGINAL_ENV, ...env };
+    process.env = {
+        ...ORIGINAL_ENV,
+        DATABASE_URL: "postgres://example.test/app",
+        ...env,
+    };
     await import("./auth");
     return capturedConfig as {
-        readonly baseURL: string;
-        readonly socialProviders: {
-            readonly google: {
-                readonly clientId: string;
-                readonly clientSecret: string;
-                readonly prompt: string;
-            };
-        };
+        readonly baseURL:
+            | string
+            | {
+                  readonly allowedHosts: ReadonlyArray<string>;
+                  readonly protocol: string;
+              };
+        readonly socialProviders:
+            | undefined
+            | {
+                  readonly google: {
+                      readonly clientId: string;
+                      readonly clientSecret: string;
+                      readonly prompt: string;
+                  };
+              };
         readonly logger: { readonly level: string };
         readonly plugins: ReadonlyArray<string>;
     };
@@ -55,7 +66,7 @@ describe("better-auth config", () => {
         });
 
         expect(config.baseURL).toBe("https://example.test");
-        expect(config.socialProviders.google).toEqual({
+        expect(config.socialProviders?.google).toEqual({
             clientId: "google-id",
             clientSecret: "google-secret",
             prompt: "select_account",
@@ -66,6 +77,7 @@ describe("better-auth config", () => {
     test("fails fast when Google client id is missing", async () => {
         await expect(
             importAuthWithEnv({
+                NODE_ENV: "production",
                 BETTER_AUTH_URL: "https://example.test",
                 GOOGLE_CLIENT_ID: undefined,
                 GOOGLE_CLIENT_SECRET: "google-secret",
@@ -76,11 +88,27 @@ describe("better-auth config", () => {
     test("fails fast when Google client secret is missing", async () => {
         await expect(
             importAuthWithEnv({
+                NODE_ENV: "production",
                 BETTER_AUTH_URL: "https://example.test",
                 GOOGLE_CLIENT_ID: "google-id",
                 GOOGLE_CLIENT_SECRET: undefined,
             }),
         ).rejects.toThrow("GOOGLE_CLIENT_SECRET is required");
+    });
+
+    test("uses request-derived local auth URL and disables Google OAuth when credentials are absent", async () => {
+        const config = await importAuthWithEnv({
+            NODE_ENV: "development",
+            BETTER_AUTH_URL: undefined,
+            GOOGLE_CLIENT_ID: undefined,
+            GOOGLE_CLIENT_SECRET: undefined,
+        });
+
+        expect(config.baseURL).toEqual({
+            allowedHosts: ["localhost:*", "127.*:*", "[::1]:*"],
+            protocol: "http",
+        });
+        expect(config.socialProviders).toBeUndefined();
     });
 
     test("enables Better Auth debug logs with AUTH_DEBUG=1", async () => {

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -39,12 +39,16 @@
 import "server-only";
 
 import { betterAuth } from "better-auth";
+import type { BaseURLConfig } from "better-auth";
 import { anonymous } from "better-auth/plugins";
 import { Pool } from "pg";
+import { LOCAL_DATABASE_URL } from "./localDatabase";
 
 const isDev = process.env["NODE_ENV"] === "development";
+const isLocalRuntime = process.env["NODE_ENV"] !== "production";
 const AUTH_DEBUG_ON = "1";
 const GOOGLE_PROMPT_SELECT_ACCOUNT = "select_account" as const;
+const LOCAL_AUTH_PROTOCOL = "http" as const;
 const LOGGER_LEVEL_DEBUG = "debug" as const;
 const LOGGER_LEVEL_WARN = "warn" as const;
 const FIELD_ACCOUNT_ID = "account_id" as const;
@@ -90,21 +94,76 @@ const requiredEnv = (name: string): string => {
     return value;
 };
 
-const requiredBaseURL = (): string => {
-    const value = process.env["BETTER_AUTH_URL"];
-    if (value !== undefined && value.trim() !== "") return value;
-    if (isDev) return "http://localhost:3000";
+const optionalEnv = (name: string): string | undefined => {
+    const value = process.env[name];
+    if (value === undefined || value.trim() === "") return undefined;
+    return value;
+};
+
+const requiredBaseURL = (): BaseURLConfig => {
+    const value = optionalEnv("BETTER_AUTH_URL");
+    if (value !== undefined) return value;
+    if (isLocalRuntime) {
+        return {
+            allowedHosts: ["localhost:*", "127.*:*", "[::1]:*"],
+            protocol: LOCAL_AUTH_PROTOCOL,
+        };
+    }
     throw new Error(
         // eslint-disable-next-line i18next/no-literal-string -- developer-facing configuration error.
         "BETTER_AUTH_URL is required outside local development.",
     );
 };
 
-const databaseUrl = process.env["DATABASE_URL"] ?? "";
+const requiredDatabaseUrl = (): string => {
+    const value = optionalEnv("DATABASE_URL");
+    if (value !== undefined) return value;
+    if (isLocalRuntime) return LOCAL_DATABASE_URL;
+    throw new Error(
+        // eslint-disable-next-line i18next/no-literal-string -- developer-facing configuration error.
+        "DATABASE_URL is required outside local development.",
+    );
+};
+
+const googleProviderConfig = ():
+    | {
+          readonly google: {
+              readonly clientId: string;
+              readonly clientSecret: string;
+              readonly prompt: typeof GOOGLE_PROMPT_SELECT_ACCOUNT;
+          };
+      }
+    | undefined => {
+    const clientId = optionalEnv("GOOGLE_CLIENT_ID");
+    const clientSecret = optionalEnv("GOOGLE_CLIENT_SECRET");
+    if (clientId !== undefined && clientSecret !== undefined) {
+        return {
+            google: {
+                clientId,
+                clientSecret,
+                prompt: GOOGLE_PROMPT_SELECT_ACCOUNT,
+            },
+        };
+    }
+    if (
+        isLocalRuntime &&
+        clientId === undefined &&
+        clientSecret === undefined
+    ) {
+        return undefined;
+    }
+    if (clientId === undefined) {
+        requiredEnv("GOOGLE_CLIENT_ID");
+    } else {
+        requiredEnv("GOOGLE_CLIENT_SECRET");
+    }
+    return undefined;
+};
+
+const databaseUrl = requiredDatabaseUrl();
 const baseURL = requiredBaseURL();
 const secret = process.env["BETTER_AUTH_SECRET"] ?? "";
-const googleClientId = requiredEnv("GOOGLE_CLIENT_ID");
-const googleClientSecret = requiredEnv("GOOGLE_CLIENT_SECRET");
+const socialProviders = googleProviderConfig();
 
 /**
  * The better-auth pool is a *separate* pg pool from the one
@@ -162,13 +221,7 @@ export const auth = betterAuth({
             updatedAt: FIELD_UPDATED_AT,
         },
     },
-    socialProviders: {
-        google: {
-            clientId: googleClientId,
-            clientSecret: googleClientSecret,
-            prompt: GOOGLE_PROMPT_SELECT_ACCOUNT,
-        },
-    },
+    socialProviders,
     logger: {
         level:
             process.env["AUTH_DEBUG"] === AUTH_DEBUG_ON

--- a/src/server/localDatabase.ts
+++ b/src/server/localDatabase.ts
@@ -1,0 +1,2 @@
+export const LOCAL_DATABASE_URL =
+    "postgres://effect_clue:local_dev_only@localhost:5432/effect_clue";

--- a/src/server/runtime.ts
+++ b/src/server/runtime.ts
@@ -27,12 +27,26 @@ import {
     NodePath,
 } from "@effect/platform-node";
 import { PgClient, PgMigrator } from "@effect/sql-pg";
-import { Config, Layer, ManagedRuntime } from "effect";
+import { Config, Layer, ManagedRuntime, Redacted } from "effect";
 import { Migrator } from "effect/unstable/sql";
+import { LOCAL_DATABASE_URL } from "./localDatabase";
 import { migrations } from "./migrations";
 
+const isLocalRuntime = process.env["NODE_ENV"] !== "production";
+
+const databaseUrlConfig = isLocalRuntime
+    ? Config.string("DATABASE_URL").pipe(
+          Config.withDefault(LOCAL_DATABASE_URL),
+          Config.map((value) =>
+              Redacted.make(
+                  value.trim() === "" ? LOCAL_DATABASE_URL : value,
+              ),
+          ),
+      )
+    : Config.nonEmptyString("DATABASE_URL").pipe(Config.map(Redacted.make));
+
 const PgLive = PgClient.layerConfig({
-    url: Config.redacted("DATABASE_URL"),
+    url: databaseUrlConfig,
 });
 
 /**


### PR DESCRIPTION
## Summary
- add Neon schema diff and preview branch cleanup workflows
- map Clue's main branch to the Neon main database branch, with non-main branches mapped to preview/<branch>
- update local Docker Postgres to the Neon-aligned postgres:17 setup while preserving the existing effect_clue local DATABASE_URL
- let local/test runtimes fall back to the Docker DATABASE_URL and omit Google OAuth when Google credentials are blank, while production/previews still fail fast
- let local Better Auth derive the active localhost host/port from the request so Next's auto-port fallback works without changing BETTER_AUTH_URL
- document the NEON_API_KEY repository secret setup and local auto-port behavior

## Verification
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm knip
- pnpm i18n:check
- docker compose config
- pnpm db:up confirmed effect-clue-postgres started healthy
- with port 3000 already occupied, pnpm dev auto-selected http://localhost:3001
- local preview at http://localhost:3001/play?view=setup loaded the setup UI with no browser console warnings/errors
- dev server logs showed GET /play?view=setup 200 and GET /api/auth/get-session 200 on the auto-selected port
- pnpm db:down stopped the local container

## Notes
- New GitHub Actions requirement: repository variable NEON_PROJECT_ID and repository secret NEON_API_KEY.
- Observability: no new app events, funnels, or spans; this is CI/local infrastructure plus local-only config fallback.