### PR TITLE
Tour, share, checklist, and sync updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,10 +62,37 @@ Scripts that require `pnpm install`:
 - `pnpm knip` — unused-exports audit
 - `pnpm i18n:check` — orphan-key audit (`scripts/check-i18n-keys.mjs`)
 - `pnpm dev` — Next.js dev server (used by Claude's `next-dev` preview and by Codex browser verification)
+- `pnpm db:up` / `pnpm db:down` — local Docker Postgres for server actions, auth, sharing, and card-pack sync
 - `pnpm build` — static export
 - `pnpm start` — serve the static export
 
-Claude's `next-dev` preview configured in `.claude/launch.json` runs `pnpm install && exec pnpm dev` itself, so those previews are self-healing and the dev server receives shutdown signals directly. In Codex, run `pnpm install` and then `pnpm dev` directly, then open `http://localhost:3000` in the in-app browser. When you start a dev server from a shell session, stop that same session before finishing the turn so the Next.js process does not remain orphaned on port 3000. The pre-commit checks above are not self-healing; if any of them fails with a module-not-found error, run `pnpm install` first and retry.
+Claude's `next-dev` preview configured in `.claude/launch.json` runs `pnpm install && exec pnpm dev` itself, so those previews are self-healing and the dev server receives shutdown signals directly. In Codex, use the local preview workflow below. The pre-commit checks above are not self-healing; if any of them fails with a module-not-found error, run `pnpm install` first and retry.
+
+## Local database and dev server lifecycle
+
+The local app uses Docker Postgres for server actions, Better Auth,
+sharing, and synced card packs. Do not paper over PgClient connection
+errors in application code; fix the local database/env setup instead.
+
+Before starting the preview in Codex:
+
+1. Make sure `.env.local` points `DATABASE_URL` at the Docker database:
+   `postgres://effect_clue:local_dev_only@localhost:5432/effect_clue`.
+2. Make sure `.env.local` has non-empty `GOOGLE_CLIENT_ID` and
+   `GOOGLE_CLIENT_SECRET`. Missing or blank Google OAuth env vars are
+   startup-time errors by design.
+3. Do not print secret values. If you need to inspect env health, print
+   only `<set>` / `<empty>` status.
+4. Start the local database with `pnpm db:up`.
+5. Start the app with `pnpm dev`, then open `http://localhost:3000` in
+   the in-app browser.
+
+Shutdown is part of the workflow. When you start `pnpm dev` from a
+shell session, stop that same session with Ctrl-C before finishing.
+Then run `pnpm db:down` so the Docker Postgres container is not left
+running after the agent/session is done. The only exception is an
+explicit user request to leave the preview running for handoff; in that
+case, say which server/database processes were intentionally left up.
 
 ## Verification checks
 
@@ -81,7 +108,7 @@ If you amend or update a commit, re-run the full set — a previously-green comm
 
 ## Manual verification in the preview
 
-For any change that's observable in the browser, exercise the change yourself before reporting the task done. In Claude, use the `next-dev` preview configured in `.claude/launch.json`; in Codex, run `pnpm dev` and use the in-app browser at `http://localhost:3000`. Follow the active agent's browser verification workflow: start/reload the preview, check console/network/logs, take a screenshot or snapshot as proof. Don't ask the user to verify manually.
+For any change that's observable in the browser, exercise the change yourself before reporting the task done. In Claude, use the `next-dev` preview configured in `.claude/launch.json`; in Codex, follow the local database and dev server lifecycle above, then use the in-app browser at `http://localhost:3000`. Follow the active agent's browser verification workflow: start/reload the preview, check console/network/logs, take a screenshot or snapshot as proof. Don't ask the user to verify manually.
 
 ### Layout, scroll, and animation behaviors
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Scripts that require `pnpm install`:
 - `pnpm test` — Vitest (run mode) / `pnpm test:watch` — Vitest watch / `pnpm test:ui` — Vitest UI
 - `pnpm knip` — unused-exports audit
 - `pnpm i18n:check` — orphan-key audit (`scripts/check-i18n-keys.mjs`)
-- `pnpm dev` — Next.js dev server (used by Claude's `next-dev` preview and by Codex browser verification)
+- `pnpm dev` — Next.js dev server (used by Claude's `next-dev` preview and by Codex browser verification). It starts at `PORT` or `3000`, then automatically uses the next available port if that one is busy.
 - `pnpm db:up` / `pnpm db:down` — local Docker Postgres for server actions, auth, sharing, and card-pack sync
 - `pnpm build` — static export
 - `pnpm start` — serve the static export
@@ -84,8 +84,10 @@ Before starting the preview in Codex:
 3. Do not print secret values. If you need to inspect env health, print
    only `<set>` / `<empty>` status.
 4. Start the local database with `pnpm db:up`.
-5. Start the app with `pnpm dev`, then open `http://localhost:3000` in
-   the in-app browser.
+5. Start the app with `pnpm dev`, then open the `Local:` URL printed
+   by Next.js in the in-app browser. It is usually
+   `http://localhost:3000`, but the dev script auto-selects the next
+   available port when 3000 is already in use.
 
 Shutdown is part of the workflow. When you start `pnpm dev` from a
 shell session, stop that same session with Ctrl-C before finishing.
@@ -108,7 +110,7 @@ If you amend or update a commit, re-run the full set — a previously-green comm
 
 ## Manual verification in the preview
 
-For any change that's observable in the browser, exercise the change yourself before reporting the task done. In Claude, use the `next-dev` preview configured in `.claude/launch.json`; in Codex, follow the local database and dev server lifecycle above, then use the in-app browser at `http://localhost:3000`. Follow the active agent's browser verification workflow: start/reload the preview, check console/network/logs, take a screenshot or snapshot as proof. Don't ask the user to verify manually.
+For any change that's observable in the browser, exercise the change yourself before reporting the task done. In Claude, use the `next-dev` preview configured in `.claude/launch.json`; in Codex, follow the local database and dev server lifecycle above, then use the printed `Local:` URL in the in-app browser. Follow the active agent's browser verification workflow: start/reload the preview, check console/network/logs, take a screenshot or snapshot as proof. Don't ask the user to verify manually.
 
 ### Layout, scroll, and animation behaviors
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -112,6 +112,41 @@
     --color-tour-bg-hover: #dbeafe;
     --color-tour-text: #1e3a8a;
     --tour-radius: 8px;
+
+    /*
+     * Z-index ladder.
+     *
+     * Keep every cross-component stacking value here so table
+     * stickies, app chrome, dialogs, and tours don't silently race
+     * each other through unrelated Tailwind literals.
+     *
+     * Ordering constraints:
+     * - Checklist hover/focus rings sit above neighboring body cells,
+     *   but below sticky first-column cells and sticky headers.
+     * - Sticky first-column cells sit above scrolled body cells, while
+     *   sticky table headers sit above both so column labels remain
+     *   readable during vertical scroll.
+     * - App chrome (page header / bottom nav) sits above the checklist
+     *   table, and dropdowns/tooltips sit above app chrome.
+     * - The contradiction banner sits above app chrome because headers
+     *   deliberately tuck under it.
+     * - Dialogs sit above page chrome and banners.
+     * - Tour UI sits above normal portaled menus/popovers so the tour
+     *   copy is never hidden by the thing it forced open.
+     */
+    --z-local-raised: 10;
+    --z-checklist-cell-hover: 20;
+    --z-checklist-cell-focus: 25;
+    --z-checklist-sticky-column: 30;
+    --z-checklist-sticky-header: 35;
+    --z-app-chrome: 40;
+    --z-popover: 50;
+    --z-contradiction-banner: 55;
+    --z-dialog-overlay: 60;
+    --z-dialog-content: 70;
+    --z-tour-backdrop: 80;
+    --z-tour-spotlight: 81;
+    --z-tour-popover: 90;
 }
 
 html,
@@ -211,4 +246,3 @@ h3 {
         border-radius: 3px;
     }
 }
-

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,8 +2,11 @@ import type { Metadata } from "next";
 import { Alfa_Slab_One, Crimson_Text } from "next/font/google";
 import { I18nProvider } from "../src/i18n/I18nProvider";
 import { messages } from "../src/i18n/messages";
+import { assertGoogleOAuthEnvConfigured } from "../src/server/authEnv";
 import { Providers } from "./Providers";
 import "./globals.css";
+
+assertGoogleOAuthEnvConfigured();
 
 /**
  * Display font for titles / section headings.

--- a/app/share/[id]/page.tsx
+++ b/app/share/[id]/page.tsx
@@ -1,21 +1,23 @@
 /**
  * Server-stored share landing page.
  *
- * Server-side: looks up the share by id; on miss, returns 404
- * (`notFound()`). On hit, renders the client-side
+ * Server-side: looks up the share by id; on not-found / expired,
+ * renders a client-side missing-share modal. On hit, renders the
  * `<ShareImportPage>` with the snapshot. The actual import logic
  * (decode → toggle UI → apply to local game state) lives on the
  * client because it needs access to the receiver's
  * `<ClueProvider>`.
  */
-import { notFound } from "next/navigation";
 import { ConfirmProvider } from "../../../src/ui/hooks/useConfirm";
 import { getShare } from "../../../src/server/actions/shares";
 import { ShareImportPage } from "../../../src/ui/share/ShareImportPage";
+import { ShareMissingPage } from "../../../src/ui/share/ShareMissingPage";
 
 interface Params {
     readonly id: string;
 }
+
+const ERR_SHARE_NOT_FOUND = "share_not_found";
 
 export default async function SharePageRoute({
     params,
@@ -26,8 +28,11 @@ export default async function SharePageRoute({
     let snapshot;
     try {
         snapshot = await getShare({ id });
-    } catch {
-        notFound();
+    } catch (e) {
+        if (String(e).includes(ERR_SHARE_NOT_FOUND)) {
+            return <ShareMissingPage shareId={id} />;
+        }
+        throw e;
     }
     return (
         <ConfirmProvider>

--- a/app/share/[id]/page.tsx
+++ b/app/share/[id]/page.tsx
@@ -10,14 +10,13 @@
  */
 import { ConfirmProvider } from "../../../src/ui/hooks/useConfirm";
 import { getShare } from "../../../src/server/actions/shares";
+import { ERR_SHARE_NOT_FOUND } from "../../../src/server/shares/errors";
 import { ShareImportPage } from "../../../src/ui/share/ShareImportPage";
 import { ShareMissingPage } from "../../../src/ui/share/ShareMissingPage";
 
 interface Params {
     readonly id: string;
 }
-
-const ERR_SHARE_NOT_FOUND = "share_not_found";
 
 export default async function SharePageRoute({
     params,

--- a/env.example
+++ b/env.example
@@ -26,9 +26,9 @@ NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 #
 # `vercel env pull .env.development.local` writes both for local dev.
 #
-# LOCAL DOCKER OVERRIDE: if you'd rather run Postgres locally via the
-# committed `docker-compose.yml` (run `pnpm db:up`), use this URL
-# instead — no Vercel/Neon login needed:
+# LOCAL DOCKER DEFAULT FOR AGENTS: run `pnpm db:up` and use this URL in
+# `.env.local` for Codex/Claude preview work — no Vercel/Neon login
+# needed. Stop it with `pnpm db:down` when the session is done:
 #   DATABASE_URL=postgres://effect_clue:local_dev_only@localhost:5432/effect_clue
 DATABASE_URL=
 DATABASE_URL_UNPOOLED=

--- a/messages/en.json
+++ b/messages/en.json
@@ -317,6 +317,7 @@
         "creating": "Creating…",
         "copied": "Link copied!",
         "copyFallback": "Copy this URL:",
+        "shareUrlAria": "Share link",
         "errorGeneric": "Couldn't create the share. Try again in a moment.",
         "importTitle": "A friend shared something for Clue Solver",
         "importModalTitlePack": "Import a card pack",
@@ -337,6 +338,10 @@
         "importIncludesSuggestions": "Suggestions ({count})",
         "importIncludesAccusations": "Accusations ({count})",
         "importEmpty": "This share is empty — nothing to import.",
+        "missingTitle": "Oops, we couldn't solve this one",
+        "missingBody": "This share link doesn't exist, or it expired. Ask your friend to send a new one.",
+        "missingActionContinue": "Continue your current game",
+        "missingActionStart": "Start a new game",
         "importActionPack": "Import this pack",
         "importActionInvite": "Start this game",
         "importActionTransfer": "Continue this game",
@@ -402,8 +407,8 @@
                 "body": "How many cards each player was dealt. The solver uses this to deduce who can't be holding which card."
             },
             "knownCard": {
-                "title": "Mark cards you've seen",
-                "body": "Click a cell to record what you know about each (player, card) pair: Y if they hold it, N if you know they don't, blank if unknown."
+                "title": "Mark the cards you were dealt",
+                "body": "Click a cell to mark the cards you were dealt, plus any other cards you happen to know. Maybe you snuck a peek. We won't judge."
             },
             "overflow": {
                 "title": "Everything else lives here",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"i18n:check": "node scripts/check-i18n-keys.mjs",
 		"assert:no-dev-auth": "node scripts/assert-no-dev-auth.mjs",
 		"assert:sw-emitted": "node scripts/assert-sw-emitted.mjs",
-		"dev": "next dev",
+		"dev": "node scripts/dev.mjs",
 		"build": "next build && serwist build",
 		"build:offline-test": "pnpm build && pnpm start",
 		"start": "next start",

--- a/scripts/dev-port.mjs
+++ b/scripts/dev-port.mjs
@@ -1,0 +1,46 @@
+import { createServer } from "node:net";
+
+export const DEFAULT_DEV_PORT = 3000;
+export const MAX_PORT = 65535;
+
+export const parsePort = (
+    rawPort,
+    fallback = DEFAULT_DEV_PORT,
+) => {
+    if (rawPort === undefined || rawPort.trim() === "") {
+        return fallback;
+    }
+    const port = Number(rawPort);
+    if (!Number.isInteger(port) || port < 1 || port > MAX_PORT) {
+        throw new Error(`Invalid PORT value: ${rawPort}`);
+    }
+    return port;
+};
+
+const canListenOnPort = (port) =>
+    new Promise((resolve, reject) => {
+        const server = createServer();
+        server.unref();
+        server.once("error", (error) => {
+            if (error.code === "EADDRINUSE") {
+                resolve(false);
+                return;
+            }
+            reject(error);
+        });
+        server.listen({ port }, () => {
+            server.close(() => resolve(true));
+        });
+    });
+
+export const findAvailablePort = async ({
+    startPort = DEFAULT_DEV_PORT,
+    maxPort = MAX_PORT,
+} = {}) => {
+    for (let port = startPort; port <= maxPort; port += 1) {
+        if (await canListenOnPort(port)) {
+            return port;
+        }
+    }
+    throw new Error(`No available port found from ${startPort} to ${maxPort}`);
+};

--- a/scripts/dev-port.test.mjs
+++ b/scripts/dev-port.test.mjs
@@ -1,0 +1,64 @@
+import { createServer } from "node:net";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+    DEFAULT_DEV_PORT,
+    findAvailablePort,
+    parsePort,
+} from "./dev-port.mjs";
+
+const openServers = [];
+
+afterEach(async () => {
+    await Promise.all(
+        openServers.splice(0).map(
+            (server) =>
+                new Promise((resolve, reject) => {
+                    server.close((error) =>
+                        error === undefined ? resolve() : reject(error),
+                    );
+                }),
+        ),
+    );
+});
+
+const occupyPort = async () =>
+    new Promise((resolve, reject) => {
+        const server = createServer();
+        server.once("error", reject);
+        server.listen({ port: 0 }, () => {
+            openServers.push(server);
+            const address = server.address();
+            if (address === null || typeof address === "string") {
+                reject(new Error("Expected TCP server address"));
+                return;
+            }
+            resolve(address.port);
+        });
+    });
+
+describe("dev port selection", () => {
+    test("defaults to the standard Next.js dev port", () => {
+        expect(parsePort(undefined)).toBe(DEFAULT_DEV_PORT);
+        expect(parsePort("")).toBe(DEFAULT_DEV_PORT);
+    });
+
+    test("uses the supplied PORT as the starting port", () => {
+        expect(parsePort("4000")).toBe(4000);
+    });
+
+    test("rejects invalid PORT values", () => {
+        expect(() => parsePort("abc")).toThrow("Invalid PORT value");
+        expect(() => parsePort("70000")).toThrow("Invalid PORT value");
+    });
+
+    test("skips an occupied starting port", async () => {
+        const occupiedPort = await occupyPort();
+
+        await expect(
+            findAvailablePort({
+                startPort: occupiedPort,
+                maxPort: occupiedPort + 10,
+            }),
+        ).resolves.toBeGreaterThan(occupiedPort);
+    });
+});

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import {
+    DEFAULT_DEV_PORT,
+    findAvailablePort,
+    parsePort,
+} from "./dev-port.mjs";
+
+const startPort = parsePort(process.env.PORT, DEFAULT_DEV_PORT);
+const port = await findAvailablePort({ startPort });
+
+if (port !== startPort) {
+    console.log(
+        `Port ${startPort} is busy; starting Next.js on port ${port}.`,
+    );
+}
+
+const child = spawn("next", ["dev", "--port", String(port)], {
+    env: {
+        ...process.env,
+        PORT: String(port),
+    },
+    stdio: "inherit",
+});
+
+child.on("exit", (code, signal) => {
+    if (signal !== null) {
+        process.kill(process.pid, signal);
+        return;
+    }
+    process.exit(code ?? 0);
+});

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -26,6 +26,10 @@
  *   PWA install         : installPrompted, installAccepted,
  *                         installDismissed, installCompleted,
  *                         appLaunchedStandalone
+ *   Sharing              : shareCreateStarted, shareCreated,
+ *                         shareLinkCopied, shareOpened,
+ *                         shareOpenFailed, shareImportStarted,
+ *                         shareImported, shareImportDismissed
  *   Performance signals : webVital, deducerRun
  *
  * Several of the splash / install / tour emitters layer PostHog
@@ -609,6 +613,8 @@ export const localPacksPushedOnSignIn = (props: {
     countPushed: number;
     countAlreadySynced: number;
     countRenamed: number;
+    countDeduped: number;
+    countPulled: number;
     countFailed: number;
 }): void => capture("local_packs_pushed_on_sign_in", props);
 
@@ -662,6 +668,11 @@ export const shareLinkCopied = (): void => capture("share_link_copied");
 export const shareOpened = (props: {
     shareIdHash: string;
 }): void => capture("share_opened", props);
+
+export const shareOpenFailed = (props: {
+    shareIdHash: string;
+    reason: "not_found_or_expired";
+}): void => capture("share_open_failed", props);
 
 export const shareImportStarted = (props: {
     shareIdHash: string;

--- a/src/data/cardPacksSync.test.tsx
+++ b/src/data/cardPacksSync.test.tsx
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "vitest";
+import { CardSet } from "../logic/CardSet";
+import { Card, CardCategory } from "../logic/GameObjects";
+import { CardEntry, Category } from "../logic/GameSetup";
+import type { CustomCardSet } from "../logic/CustomCardSets";
+import type { PersistedCardPack } from "../server/actions/packs";
+import { reconcileCardPacks } from "./cardPacksSync";
+
+const makeCardSet = (cardName: string): CardSet =>
+    CardSet({
+        categories: [
+            Category({
+                id: CardCategory(`category-${cardName}`),
+                name: "Suspect",
+                cards: [
+                    CardEntry({
+                        id: Card(`card-${cardName}`),
+                        name: cardName,
+                    }),
+                ],
+            }),
+        ],
+    });
+
+const localPack = (
+    id: string,
+    label: string,
+    cardName: string,
+): CustomCardSet => ({
+    id,
+    label,
+    cardSet: makeCardSet(cardName),
+});
+
+const serverPack = (
+    id: string,
+    clientGeneratedId: string,
+    label: string,
+    cardName: string,
+): PersistedCardPack => ({
+    id,
+    clientGeneratedId,
+    label,
+    cardSetData: JSON.stringify(makeCardSet(cardName)),
+});
+
+describe("reconcileCardPacks", () => {
+    test("exact duplicate keeps the server canonical pack", () => {
+        const result = reconcileCardPacks(
+            [localPack("local-1", "Office", "Rope")],
+            [serverPack("server-1", "other-client", "Office", "Rope")],
+        );
+
+        expect(result.packs.map((pack) => pack.id)).toEqual(["server-1"]);
+        expect(result.idMap.get("local-1")).toBe("server-1");
+        expect(result.countPulled).toBe(0);
+    });
+
+    test("same label with different contents keeps both packs", () => {
+        const result = reconcileCardPacks(
+            [localPack("local-1", "Office", "Rope")],
+            [serverPack("server-1", "other-client", "Office", "Pipe")],
+        );
+
+        expect(result.packs.map((pack) => pack.id)).toEqual([
+            "server-1",
+            "local-1",
+        ]);
+        expect(result.idMap.size).toBe(0);
+    });
+
+    test("same contents with a different label keeps both packs", () => {
+        const result = reconcileCardPacks(
+            [localPack("local-1", "Office", "Rope")],
+            [serverPack("server-1", "other-client", "Mansion", "Rope")],
+        );
+
+        expect(result.packs.map((pack) => pack.id)).toEqual([
+            "server-1",
+            "local-1",
+        ]);
+        expect(result.idMap.size).toBe(0);
+    });
+
+    test("server-only packs are pulled into the local library", () => {
+        const result = reconcileCardPacks(
+            [],
+            [serverPack("server-1", "other-client", "Office", "Rope")],
+        );
+
+        expect(result.packs.map((pack) => pack.id)).toEqual(["server-1"]);
+        expect(result.countPulled).toBe(1);
+    });
+
+    test("same client id keeps the server label after rename-on-push", () => {
+        const result = reconcileCardPacks(
+            [localPack("local-1", "Office", "Rope")],
+            [serverPack("server-1", "local-1", "Office (2)", "Rope")],
+        );
+
+        expect(result.packs).toMatchObject([
+            { id: "server-1", label: "Office (2)" },
+        ]);
+        expect(result.idMap.get("local-1")).toBe("server-1");
+    });
+});

--- a/src/data/cardPacksSync.tsx
+++ b/src/data/cardPacksSync.tsx
@@ -21,10 +21,169 @@ import { useQueryClient } from "@tanstack/react-query";
 import {
     localPacksPushedOnSignIn,
 } from "../analytics/events";
-import { loadCustomCardSets } from "../logic/CustomCardSets";
-import { pushLocalPacksOnSignIn } from "../server/actions/packs";
+import { cardSetEquals, CardSet } from "../logic/CardSet";
+import { CardEntry, Category } from "../logic/GameSetup";
+import { Card, CardCategory } from "../logic/GameObjects";
+import {
+    loadCustomCardSets,
+    replaceCustomCardSets,
+    type CustomCardSet,
+} from "../logic/CustomCardSets";
+import {
+    remapCardPackUsageIds,
+} from "../logic/CardPackUsage";
+import {
+    cardPackUsageQueryKey,
+} from "./cardPackUsage";
+import {
+    customCardPacksQueryKey,
+} from "./customCardPacks";
+import {
+    getMyCardPacks,
+    pushLocalPacksOnSignIn,
+    type PersistedCardPack,
+    type PushResult,
+} from "../server/actions/packs";
 import { useSession } from "../ui/hooks/useSession";
 import { myCardPacksQueryKey } from "../ui/account/AccountModal";
+
+interface ReconcileResult {
+    readonly packs: ReadonlyArray<CustomCardSet>;
+    readonly idMap: ReadonlyMap<string, string>;
+    readonly countPulled: number;
+}
+
+const emptyPushResult: PushResult = {
+    countPushed: 0,
+    countAlreadySynced: 0,
+    countRenamed: 0,
+    countDeduped: 0,
+    countFailed: 0,
+};
+
+const decodeServerPack = (
+    pack: PersistedCardPack,
+): CustomCardSet | null => {
+    try {
+        const parsed: unknown = JSON.parse(pack.cardSetData);
+        if (
+            typeof parsed !== "object" ||
+            parsed === null ||
+            !("categories" in parsed) ||
+            !Array.isArray(parsed.categories)
+        ) {
+            return null;
+        }
+        const categories = [];
+        for (const category of parsed.categories) {
+            if (
+                typeof category !== "object" ||
+                category === null ||
+                !("id" in category) ||
+                typeof category.id !== "string" ||
+                !("name" in category) ||
+                typeof category.name !== "string" ||
+                !("cards" in category) ||
+                !Array.isArray(category.cards)
+            ) {
+                return null;
+            }
+            const cards = [];
+            for (const card of category.cards) {
+                if (
+                    typeof card !== "object" ||
+                    card === null ||
+                    !("id" in card) ||
+                    typeof card.id !== "string" ||
+                    !("name" in card) ||
+                    typeof card.name !== "string"
+                ) {
+                    return null;
+                }
+                cards.push(
+                    CardEntry({
+                        id: Card(card.id),
+                        name: card.name,
+                    }),
+                );
+            }
+            categories.push(
+                Category({
+                    id: CardCategory(category.id),
+                    name: category.name,
+                    cards,
+                }),
+            );
+        }
+        return {
+            id: pack.id,
+            label: pack.label,
+            cardSet: CardSet({ categories }),
+        };
+    } catch {
+        return null;
+    }
+};
+
+const isExactDuplicate = (
+    a: CustomCardSet,
+    b: CustomCardSet,
+): boolean => a.label === b.label && cardSetEquals(a.cardSet, b.cardSet);
+
+export const reconcileCardPacks = (
+    localPacks: ReadonlyArray<CustomCardSet>,
+    serverPacks: ReadonlyArray<PersistedCardPack>,
+): ReconcileResult => {
+    const decodedServer = serverPacks.flatMap((pack) => {
+        const decoded = decodeServerPack(pack);
+        return decoded === null ? [] : [decoded];
+    });
+    const merged: Array<CustomCardSet> = [];
+    const idMap = new Map<string, string>();
+    let countPulled = 0;
+
+    for (const serverPack of decodedServer) {
+        const existing = merged.find((pack) =>
+            isExactDuplicate(pack, serverPack),
+        );
+        if (existing) {
+            idMap.set(serverPack.id, existing.id);
+            continue;
+        }
+        const hadLocalEquivalent = localPacks.some((pack) =>
+            isExactDuplicate(pack, serverPack),
+        );
+        const hadLocalClientId = serverPacks.some(
+            (pack) =>
+                pack.id === serverPack.id &&
+                localPacks.some((local) => local.id === pack.clientGeneratedId),
+        );
+        if (!hadLocalEquivalent && !hadLocalClientId) {
+            countPulled += 1;
+        }
+        merged.push(serverPack);
+    }
+
+    for (const localPack of localPacks) {
+        const sameClientServer = serverPacks.find(
+            (pack) => pack.clientGeneratedId === localPack.id,
+        );
+        if (sameClientServer !== undefined) {
+            idMap.set(localPack.id, sameClientServer.id);
+            continue;
+        }
+        const exactDuplicate = merged.find((pack) =>
+            isExactDuplicate(pack, localPack),
+        );
+        if (exactDuplicate) {
+            idMap.set(localPack.id, exactDuplicate.id);
+            continue;
+        }
+        merged.push(localPack);
+    }
+
+    return { packs: merged, idMap, countPulled };
+};
 
 export function CardPacksSyncOnSignIn() {
     const session = useSession();
@@ -38,25 +197,38 @@ export function CardPacksSyncOnSignIn() {
         lastSyncedUserIdRef.current = user.id;
 
         const packs = loadCustomCardSets();
-        if (packs.length === 0) return;
 
         void (async () => {
             try {
-                const result = await pushLocalPacksOnSignIn({
-                    packs: packs.map((p) => ({
-                        clientGeneratedId: p.id,
-                        label: p.label,
-                        cardSet: p.cardSet,
-                    })),
-                });
+                const result = packs.length > 0
+                    ? await pushLocalPacksOnSignIn({
+                          packs: packs.map((p) => ({
+                              clientGeneratedId: p.id,
+                              label: p.label,
+                              cardSet: p.cardSet,
+                          })),
+                      })
+                    : emptyPushResult;
+                const serverPacks = await getMyCardPacks();
+                const reconciled = reconcileCardPacks(packs, serverPacks);
+                replaceCustomCardSets(reconciled.packs);
+                const usage = remapCardPackUsageIds(reconciled.idMap);
+                queryClient.setQueryData(
+                    customCardPacksQueryKey,
+                    reconciled.packs,
+                );
+                queryClient.setQueryData(cardPackUsageQueryKey, usage);
+                queryClient.setQueryData(
+                    myCardPacksQueryKey(user.id),
+                    serverPacks,
+                );
                 localPacksPushedOnSignIn({
                     countPushed: result.countPushed,
                     countAlreadySynced: result.countAlreadySynced,
                     countRenamed: result.countRenamed,
+                    countDeduped: result.countDeduped,
+                    countPulled: reconciled.countPulled,
                     countFailed: result.countFailed,
-                });
-                await queryClient.invalidateQueries({
-                    queryKey: myCardPacksQueryKey(user.id),
                 });
             } catch {
                 // Sign-in itself succeeded — the push is best-effort

--- a/src/logic/CardPackUsage.test.ts
+++ b/src/logic/CardPackUsage.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
     forgetCardPackUse,
     loadCardPackUsage,
+    remapCardPackUsageIds,
     recordCardPackUse,
     topRecentPacks,
 } from "./CardPackUsage";
@@ -117,6 +118,32 @@ describe("recordCardPackUse + loadCardPackUsage", () => {
             });
         expect(() => recordCardPackUse("classic")).not.toThrow();
         spy.mockRestore();
+    });
+});
+
+describe("remapCardPackUsageIds", () => {
+    test("moves recency from duplicate local ids to the canonical server id", () => {
+        window.localStorage.setItem(
+            STORAGE_KEY,
+            JSON.stringify({
+                version: 1,
+                entries: [
+                    { id: "local-pack", usedAt: 1700000000000 },
+                    { id: "server-pack", usedAt: 1600000000000 },
+                ],
+            }),
+        );
+
+        const usage = remapCardPackUsageIds(
+            new Map([["local-pack", "server-pack"]]),
+        );
+
+        expect(usage.has("local-pack")).toBe(false);
+        const serverUsage = usage.get("server-pack");
+        expect(serverUsage).toBeDefined();
+        expect(serverUsage && DateTime.toEpochMillis(serverUsage)).toBe(
+            1700000000000,
+        );
     });
 });
 

--- a/src/logic/CardPackUsage.ts
+++ b/src/logic/CardPackUsage.ts
@@ -99,6 +99,31 @@ export const forgetCardPackUse = (packId: string): void => {
 };
 
 /**
+ * Rewrite usage entries from old pack ids to canonical pack ids after
+ * de-duplication. If both ids have recency, keep the newer timestamp.
+ */
+export const remapCardPackUsageIds = (
+    idMap: ReadonlyMap<string, string>,
+): CardPackUsage => {
+    if (idMap.size === 0) return loadCardPackUsage();
+    const current = loadCardPackUsage();
+    const next = new Map<string, DateTime.Utc>();
+    for (const [id, usedAt] of current.entries()) {
+        const target = idMap.get(id) ?? id;
+        const existing = next.get(target);
+        if (
+            existing === undefined ||
+            DateTime.toEpochMillis(usedAt) >
+                DateTime.toEpochMillis(existing)
+        ) {
+            next.set(target, usedAt);
+        }
+    }
+    writeAll(next);
+    return next;
+};
+
+/**
  * Pack-shaped record consumed by `topRecentPacks`. Anything with an
  * `id` and a `label` qualifies — the helper is generic so callers can
  * pass the union of built-in `CardSetChoice` and user `CustomCardSet`

--- a/src/logic/CustomCardSets.ts
+++ b/src/logic/CustomCardSets.ts
@@ -163,3 +163,14 @@ export const deleteCustomCardSet = (id: string): void => {
     const packs = loadCustomCardSets();
     writeAll(packs.filter(p => p.id !== id));
 };
+
+/**
+ * Replace the whole saved-pack library. Used by sign-in
+ * reconciliation after the server and local libraries have been
+ * de-duplicated into one canonical list.
+ */
+export const replaceCustomCardSets = (
+    packs: ReadonlyArray<CustomCardSet>,
+): void => {
+    writeAll(packs);
+};

--- a/src/server/actions/packs.ts
+++ b/src/server/actions/packs.ts
@@ -42,7 +42,7 @@ import type { CardSet } from "../../logic/CardSet";
 import { auth } from "../auth";
 import { withServerAction } from "../withServerAction";
 
-interface PersistedCardPack {
+export interface PersistedCardPack {
     readonly id: string;
     readonly clientGeneratedId: string;
     readonly label: string;
@@ -68,10 +68,11 @@ interface PushLocalPacksInput {
     }>;
 }
 
-interface PushResult {
+export interface PushResult {
     readonly countPushed: number;
     readonly countAlreadySynced: number;
     readonly countRenamed: number;
+    readonly countDeduped: number;
     readonly countFailed: number;
 }
 
@@ -79,6 +80,61 @@ interface PushResult {
 // i18next/no-literal-string rule.
 const ERR_NOT_SIGNED_IN = "not_signed_in";
 const ERR_UPSERT_NO_ROWS = "upsert_returned_no_rows";
+const PUSH_OUTCOME_ALREADY_SYNCED = "already_synced" as const;
+const PUSH_OUTCOME_DEDUPED = "deduped" as const;
+const PUSH_OUTCOME_RENAMED = "renamed" as const;
+const PUSH_OUTCOME_PUSHED = "pushed" as const;
+
+const visibleCardSetSignature = (cardSet: CardSet): string =>
+    JSON.stringify(
+        cardSet.categories.map((category) => ({
+            name: category.name,
+            cards: category.cards.map((card) => card.name),
+        })),
+    );
+
+const visibleCardSetSignatureFromData = (raw: string): string | null => {
+    try {
+        const parsed: unknown = JSON.parse(raw);
+        if (
+            typeof parsed !== "object" ||
+            parsed === null ||
+            !("categories" in parsed) ||
+            !Array.isArray(parsed.categories)
+        ) {
+            return null;
+        }
+        const categories = [];
+        for (const category of parsed.categories) {
+            if (
+                typeof category !== "object" ||
+                category === null ||
+                !("name" in category) ||
+                typeof category.name !== "string" ||
+                !("cards" in category) ||
+                !Array.isArray(category.cards)
+            ) {
+                return null;
+            }
+            const cards = [];
+            for (const card of category.cards) {
+                if (
+                    typeof card !== "object" ||
+                    card === null ||
+                    !("name" in card) ||
+                    typeof card.name !== "string"
+                ) {
+                    return null;
+                }
+                cards.push(card.name);
+            }
+            categories.push({ name: category.name, cards });
+        }
+        return JSON.stringify(categories);
+    } catch {
+        return null;
+    }
+};
 
 const requireSignedInUser = async (): Promise<{
     readonly userId: string;
@@ -223,11 +279,13 @@ export async function pushLocalPacksOnSignIn(
     let countPushed = 0;
     let countAlreadySynced = 0;
     let countRenamed = 0;
+    let countDeduped = 0;
     let countFailed = 0;
     for (const pack of input.packs) {
         const cardSetData = encodeCardSet(pack.cardSet);
+        const incomingSignature = visibleCardSetSignature(pack.cardSet);
         try {
-            const wasRenamed = await withServerAction(
+            const outcome = await withServerAction(
                 Effect.gen(function* () {
                     const sql = yield* PgClient.PgClient;
 
@@ -235,8 +293,9 @@ export async function pushLocalPacksOnSignIn(
                     const existingLabels = yield* sql<{
                         label: string;
                         client_generated_id: string;
+                        card_set_data: string;
                     }>`
-                        SELECT label, client_generated_id
+                        SELECT label, client_generated_id, card_set_data
                         FROM card_packs
                         WHERE owner_id = ${userId}
                     `;
@@ -260,7 +319,18 @@ export async function pushLocalPacksOnSignIn(
                                 card_set_data = EXCLUDED.card_set_data,
                                 updated_at = NOW()
                         `;
-                        return false; // not renamed; treated as already-synced
+                        return PUSH_OUTCOME_ALREADY_SYNCED;
+                    }
+
+                    const exactDuplicate = existingLabels.find((r) => {
+                        if (r.label !== pack.label) return false;
+                        return (
+                            visibleCardSetSignatureFromData(r.card_set_data) ===
+                            incomingSignature
+                        );
+                    });
+                    if (exactDuplicate) {
+                        return PUSH_OUTCOME_DEDUPED;
                     }
 
                     const labels = new Set(
@@ -285,23 +355,17 @@ export async function pushLocalPacksOnSignIn(
                             ${userId}, ${chosen}, ${cardSetData}
                         )
                     `;
-                    return renamed;
+                    return renamed
+                        ? PUSH_OUTCOME_RENAMED
+                        : PUSH_OUTCOME_PUSHED;
                 }),
             );
-            const same = wasRenamed === false;
-            // We can't (cleanly) tell here whether `same===false`
-            // means "renamed-on-insert" vs "fresh-insert" without
-            // returning the flag from inside the closure; the
-            // helper does, so re-classify here.
-            // (The closure returns `false` for the already-synced
-            // path AND the no-rename fresh path — but the
-            // `same` boolean is overloaded. Cheap fix: track via a
-            // separate query. Skipped for code-density reasons;
-            // the analytics breakdown is approximate.)
-            if (wasRenamed) {
+            if (outcome === PUSH_OUTCOME_RENAMED) {
                 countRenamed += 1;
-            } else if (same) {
+            } else if (outcome === PUSH_OUTCOME_ALREADY_SYNCED) {
                 countAlreadySynced += 1;
+            } else if (outcome === PUSH_OUTCOME_DEDUPED) {
+                countDeduped += 1;
             } else {
                 countPushed += 1;
             }
@@ -309,5 +373,11 @@ export async function pushLocalPacksOnSignIn(
             countFailed += 1;
         }
     }
-    return { countPushed, countAlreadySynced, countRenamed, countFailed };
+    return {
+        countPushed,
+        countAlreadySynced,
+        countRenamed,
+        countDeduped,
+        countFailed,
+    };
 }

--- a/src/server/actions/shares.ts
+++ b/src/server/actions/shares.ts
@@ -37,6 +37,7 @@ import {
     suggestionsCodec,
 } from "../../logic/ShareCodec";
 import { SHARE_TTL } from "../shares/constants";
+import { ERR_SHARE_NOT_FOUND } from "../shares/errors";
 import { withServerAction } from "../withServerAction";
 
 /**
@@ -96,7 +97,6 @@ interface ShareSnapshot {
 }
 
 const ERR_SIGN_IN_REQUIRED = "sign_in_required_to_share";
-const ERR_SHARE_NOT_FOUND = "share_not_found";
 const ERR_MALFORMED_INPUT = "share_malformed_input";
 
 // Wire-format field names. Module-scope so they don't trip the

--- a/src/server/actions/shares.ts
+++ b/src/server/actions/shares.ts
@@ -36,7 +36,6 @@ import {
     playersCodec,
     suggestionsCodec,
 } from "../../logic/ShareCodec";
-import { auth } from "../auth";
 import { SHARE_TTL } from "../shares/constants";
 import { withServerAction } from "../withServerAction";
 
@@ -266,6 +265,7 @@ const validateInputShape = (input: unknown): CreateShareInput => {
  * navigate to / contact, not to a throwaway local identity.
  */
 const realUserId = async (): Promise<string | null> => {
+    const { auth } = await import("../auth");
     const session = await auth.api.getSession({
         headers: await headers(),
     });

--- a/src/server/auth.test.ts
+++ b/src/server/auth.test.ts
@@ -43,15 +43,13 @@ const importAuthWithEnv = async (
                   readonly allowedHosts: ReadonlyArray<string>;
                   readonly protocol: string;
               };
-        readonly socialProviders:
-            | undefined
-            | {
-                  readonly google: {
-                      readonly clientId: string;
-                      readonly clientSecret: string;
-                      readonly prompt: string;
-                  };
-              };
+        readonly socialProviders: {
+            readonly google: {
+                readonly clientId: string;
+                readonly clientSecret: string;
+                readonly prompt: string;
+            };
+        };
         readonly logger: { readonly level: string };
         readonly plugins: ReadonlyArray<string>;
     };
@@ -96,19 +94,23 @@ describe("better-auth config", () => {
         ).rejects.toThrow("GOOGLE_CLIENT_SECRET is required");
     });
 
-    test("uses request-derived local auth URL and disables Google OAuth when credentials are absent", async () => {
+    test("uses request-derived local auth URL when Google credentials are configured", async () => {
         const config = await importAuthWithEnv({
             NODE_ENV: "development",
             BETTER_AUTH_URL: undefined,
-            GOOGLE_CLIENT_ID: undefined,
-            GOOGLE_CLIENT_SECRET: undefined,
+            GOOGLE_CLIENT_ID: "google-id",
+            GOOGLE_CLIENT_SECRET: "google-secret",
         });
 
         expect(config.baseURL).toEqual({
             allowedHosts: ["localhost:*", "127.*:*", "[::1]:*"],
             protocol: "http",
         });
-        expect(config.socialProviders).toBeUndefined();
+        expect(config.socialProviders.google).toEqual({
+            clientId: "google-id",
+            clientSecret: "google-secret",
+            prompt: "select_account",
+        });
     });
 
     test("enables Better Auth debug logs with AUTH_DEBUG=1", async () => {

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -42,12 +42,12 @@ import { betterAuth } from "better-auth";
 import type { BaseURLConfig } from "better-auth";
 import { anonymous } from "better-auth/plugins";
 import { Pool } from "pg";
+import { googleProviderConfig } from "./authEnv";
 import { LOCAL_DATABASE_URL } from "./localDatabase";
 
 const isDev = process.env["NODE_ENV"] === "development";
 const isLocalRuntime = process.env["NODE_ENV"] !== "production";
 const AUTH_DEBUG_ON = "1";
-const GOOGLE_PROMPT_SELECT_ACCOUNT = "select_account" as const;
 const LOCAL_AUTH_PROTOCOL = "http" as const;
 const LOGGER_LEVEL_DEBUG = "debug" as const;
 const LOGGER_LEVEL_WARN = "warn" as const;
@@ -84,16 +84,6 @@ if (
     );
 }
 
-const requiredEnv = (name: string): string => {
-    const value = process.env[name];
-    if (value === undefined || value.trim() === "") {
-        throw new Error(
-            `${name} is required for Better Auth configuration.`,
-        );
-    }
-    return value;
-};
-
 const optionalEnv = (name: string): string | undefined => {
     const value = process.env[name];
     if (value === undefined || value.trim() === "") return undefined;
@@ -123,41 +113,6 @@ const requiredDatabaseUrl = (): string => {
         // eslint-disable-next-line i18next/no-literal-string -- developer-facing configuration error.
         "DATABASE_URL is required outside local development.",
     );
-};
-
-const googleProviderConfig = ():
-    | {
-          readonly google: {
-              readonly clientId: string;
-              readonly clientSecret: string;
-              readonly prompt: typeof GOOGLE_PROMPT_SELECT_ACCOUNT;
-          };
-      }
-    | undefined => {
-    const clientId = optionalEnv("GOOGLE_CLIENT_ID");
-    const clientSecret = optionalEnv("GOOGLE_CLIENT_SECRET");
-    if (clientId !== undefined && clientSecret !== undefined) {
-        return {
-            google: {
-                clientId,
-                clientSecret,
-                prompt: GOOGLE_PROMPT_SELECT_ACCOUNT,
-            },
-        };
-    }
-    if (
-        isLocalRuntime &&
-        clientId === undefined &&
-        clientSecret === undefined
-    ) {
-        return undefined;
-    }
-    if (clientId === undefined) {
-        requiredEnv("GOOGLE_CLIENT_ID");
-    } else {
-        requiredEnv("GOOGLE_CLIENT_SECRET");
-    }
-    return undefined;
 };
 
 const databaseUrl = requiredDatabaseUrl();

--- a/src/server/authEnv.test.ts
+++ b/src/server/authEnv.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, test } from "vitest";
+import {
+    assertGoogleOAuthEnvConfigured,
+    googleProviderConfig,
+} from "./authEnv";
+
+const ORIGINAL_ENV = { ...process.env };
+
+afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+});
+
+describe("Google OAuth environment", () => {
+    test("builds the Better Auth Google provider when both credentials are set", () => {
+        process.env["GOOGLE_CLIENT_ID"] = "google-client-id";
+        process.env["GOOGLE_CLIENT_SECRET"] = "google-client-secret";
+
+        expect(googleProviderConfig()).toEqual({
+            google: {
+                clientId: "google-client-id",
+                clientSecret: "google-client-secret",
+                prompt: "select_account",
+            },
+        });
+    });
+
+    test("fails when Google client id is blank", () => {
+        process.env["GOOGLE_CLIENT_ID"] = "";
+        process.env["GOOGLE_CLIENT_SECRET"] = "google-client-secret";
+
+        expect(assertGoogleOAuthEnvConfigured).toThrow(
+            "GOOGLE_CLIENT_ID is required",
+        );
+    });
+
+    test("fails when Google client secret is missing", () => {
+        process.env["GOOGLE_CLIENT_ID"] = "google-client-id";
+        delete process.env["GOOGLE_CLIENT_SECRET"];
+
+        expect(assertGoogleOAuthEnvConfigured).toThrow(
+            "GOOGLE_CLIENT_SECRET is required",
+        );
+    });
+});

--- a/src/server/authEnv.ts
+++ b/src/server/authEnv.ts
@@ -1,0 +1,32 @@
+const GOOGLE_CLIENT_ID_ENV = "GOOGLE_CLIENT_ID";
+const GOOGLE_CLIENT_SECRET_ENV = "GOOGLE_CLIENT_SECRET";
+const GOOGLE_PROMPT_SELECT_ACCOUNT = "select_account" as const;
+
+const requiredEnv = (name: string): string => {
+    const value = process.env[name];
+    if (value === undefined || value.trim() === "") {
+        throw new Error(
+            `${name} is required for Better Auth configuration.`,
+        );
+    }
+    return value;
+};
+
+export const assertGoogleOAuthEnvConfigured = (): void => {
+    requiredEnv(GOOGLE_CLIENT_ID_ENV);
+    requiredEnv(GOOGLE_CLIENT_SECRET_ENV);
+};
+
+export const googleProviderConfig = (): {
+    readonly google: {
+        readonly clientId: string;
+        readonly clientSecret: string;
+        readonly prompt: typeof GOOGLE_PROMPT_SELECT_ACCOUNT;
+    };
+} => ({
+    google: {
+        clientId: requiredEnv(GOOGLE_CLIENT_ID_ENV),
+        clientSecret: requiredEnv(GOOGLE_CLIENT_SECRET_ENV),
+        prompt: GOOGLE_PROMPT_SELECT_ACCOUNT,
+    },
+});

--- a/src/server/shares/errors.ts
+++ b/src/server/shares/errors.ts
@@ -1,0 +1,1 @@
+export const ERR_SHARE_NOT_FOUND = "share_not_found";

--- a/src/server/shares/sharePageRoute.test.tsx
+++ b/src/server/shares/sharePageRoute.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { ERR_SHARE_NOT_FOUND } from "./errors";
+
+const mocks = vi.hoisted(() => ({
+    getShare: vi.fn(),
+}));
+
+vi.mock("../../../src/server/actions/shares", () => ({
+    getShare: mocks.getShare,
+}));
+
+vi.mock("../../../src/ui/hooks/useConfirm", () => ({
+    ConfirmProvider: ({ children }: { readonly children: React.ReactNode }) => (
+        <>{children}</>
+    ),
+}));
+
+vi.mock("../../../src/ui/share/ShareImportPage", () => ({
+    ShareImportPage: () => <div data-testid="share-import-page" />,
+}));
+
+vi.mock("../../../src/ui/share/ShareMissingPage", () => ({
+    ShareMissingPage: ({ shareId }: { readonly shareId: string }) => (
+        <div data-share-id={shareId} data-testid="share-missing-page" />
+    ),
+}));
+
+import SharePageRoute from "../../../app/share/[id]/page";
+
+const routeParams = (id: string): Parameters<typeof SharePageRoute>[0] => ({
+    params: Promise.resolve({ id }),
+});
+
+describe("SharePageRoute", () => {
+    test("renders the missing-share page for a missing or expired share", async () => {
+        mocks.getShare.mockRejectedValueOnce(new Error(ERR_SHARE_NOT_FOUND));
+
+        render(await SharePageRoute(routeParams("missing-share-id")));
+
+        expect(mocks.getShare).toHaveBeenCalledWith({
+            id: "missing-share-id",
+        });
+        expect(screen.getByTestId("share-missing-page")).toHaveAttribute(
+            "data-share-id",
+            "missing-share-id",
+        );
+    });
+
+    test("surfaces Postgres connection failures instead of hiding them as missing shares", async () => {
+        mocks.getShare.mockRejectedValueOnce(
+            Object.assign(new Error("PgClient: Failed to connect"), {
+                name: "effect/sql/SqlError",
+            }),
+        );
+
+        await expect(
+            SharePageRoute(routeParams("made-up-preview-id")),
+        ).rejects.toThrow("PgClient: Failed to connect");
+    });
+
+    test("still rethrows unrelated share lookup errors", async () => {
+        mocks.getShare.mockRejectedValueOnce(new Error("malformed share"));
+
+        await expect(
+            SharePageRoute(routeParams("broken-share-id")),
+        ).rejects.toThrow("malformed share");
+    });
+});

--- a/src/ui/Clue.test.tsx
+++ b/src/ui/Clue.test.tsx
@@ -66,6 +66,32 @@ import { Clue } from "./Clue";
 import { TestQueryClientProvider } from "../test-utils/queryClient";
 import { seedOnboardingDismissed } from "../test-utils/onboardingSeed";
 
+const seedStartupDismissedWithSharingEligible = (): void => {
+    const recent = new Date().toISOString();
+    window.localStorage.setItem(
+        "effect-clue.splash.v1",
+        JSON.stringify({
+            version: 1,
+            lastVisitedAt: recent,
+            lastDismissedAt: recent,
+        }),
+    );
+    window.localStorage.setItem(
+        "effect-clue.install-prompt.v1",
+        JSON.stringify({ version: 1, visits: 0 }),
+    );
+    const primaryTourSeed = JSON.stringify({
+        version: 1,
+        lastVisitedAt: recent,
+        lastDismissedAt: recent,
+    });
+    window.localStorage.setItem("effect-clue.tour.setup.v1", primaryTourSeed);
+    window.localStorage.setItem(
+        "effect-clue.tour.checklistSuggest.v1",
+        primaryTourSeed,
+    );
+};
+
 beforeEach(() => {
     window.localStorage.clear();
     // Reset URL between tests — the URL-sync `useEffect` in
@@ -177,6 +203,35 @@ describe("Clue — URL-based view hydration", () => {
         await waitFor(() => {
             expect(window.location.search).toContain("view=setup");
         });
+    });
+
+    test("returning to setup after primary tours does not auto-fire the sharing follow-up mid-session", async () => {
+        const { default: userEvent } = await import("@testing-library/user-event");
+        window.localStorage.clear();
+        seedStartupDismissedWithSharingEligible();
+        window.history.replaceState(null, "", "/?view=checklist");
+
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        await waitFor(() => {
+            expect(window.location.search).toContain("view=checklist");
+        });
+        expect(screen.queryByText("sharing.pack.title")).toBeNull();
+
+        const user = userEvent.setup();
+        const triggers = document.querySelectorAll<HTMLElement>(
+            "[data-tour-anchor='overflow-menu']",
+        );
+        expect(triggers.length).toBeGreaterThan(0);
+        await user.click(triggers[0]!);
+        const item = await screen.findByRole("button", {
+            name: /^gameSetup/,
+        });
+        await user.click(item);
+
+        await waitFor(() => {
+            expect(window.location.search).toContain("view=setup");
+        });
+        expect(screen.queryByText("sharing.pack.title")).toBeNull();
     });
 
     test("a hydrated session with saved suggestions lands on checklist when no view is specified", async () => {

--- a/src/ui/Clue.tsx
+++ b/src/ui/Clue.tsx
@@ -224,7 +224,7 @@ function ClueShell({
             <main className="mx-auto flex min-w-max max-w-[1400px] flex-col gap-5 px-5 pb-24 [@media(min-width:800px)]:pb-5 [padding-top:calc(var(--contradiction-banner-offset,0px)+1.5rem)]">
                 <header
                     ref={headerRef}
-                    className="sticky top-[var(--contradiction-banner-offset,0px)] z-30 flex flex-wrap items-center justify-between gap-4 bg-bg py-2 [@media(min-width:800px)]:left-5 [@media(min-width:800px)]:max-w-[calc(100vw-2.5rem)]"
+                    className="sticky top-[var(--contradiction-banner-offset,0px)] z-[var(--z-app-chrome)] flex flex-wrap items-center justify-between gap-4 bg-bg py-2 [@media(min-width:800px)]:left-5 [@media(min-width:800px)]:max-w-[calc(100vw-2.5rem)]"
                 >
                     <h1 className="m-0 text-[36px] uppercase tracking-[0.08em] text-accent drop-shadow-sm">
                         {t("title")}
@@ -573,4 +573,3 @@ function ViewSkeleton() {
         </div>
     );
 }
-

--- a/src/ui/Clue.tsx
+++ b/src/ui/Clue.tsx
@@ -424,10 +424,10 @@ function FirstSuggestionTourGate() {
         firedRef.current = true;
         startTour(FIRST_SUGGESTION_SCREEN_KEY);
         // Persist BOTH timestamps so the gate returns false until
-        // the next 4-week re-engage window opens. Saving only
-        // `lastDismissedAt` would keep the gate eligible because
-        // the gate's "dismissed but never visited" branch returns
-        // true (a defensive "if state is incoherent, show again").
+        // the next 4-week re-engage window opens. `saveTourDismissed`
+        // also writes the visit timestamp, but the explicit visit
+        // write documents that this event-triggered tour was shown
+        // outside the usual screen-mount gate.
         saveTourVisited(FIRST_SUGGESTION_SCREEN_KEY, now);
         saveTourDismissed(FIRST_SUGGESTION_SCREEN_KEY, now);
     }, [state.suggestions.length, hydrated, activeScreen, phase, startTour]);

--- a/src/ui/Clue.tsx
+++ b/src/ui/Clue.tsx
@@ -58,6 +58,7 @@ const TOP_LEVEL_PLAY = "play";
 // pulled out as constants so the i18next/no-literal-string lint rule
 // treats them as wire-format identifiers, not user copy.
 const COORDINATOR_PHASE_TOUR = "tour" as const;
+const COORDINATOR_PHASE_DONE = "done" as const;
 // ScreenKey discriminator for the M22 first-suggestion tour. Pulled
 // to module scope for the same i18next-lint reason.
 const FIRST_SUGGESTION_SCREEN_KEY = "firstSuggestion" as const;
@@ -286,11 +287,21 @@ function TourScreenGate() {
     // useTourGate signature stays stable.
     const screenKey = useMemo(() => {
         if (!hydrated) return screenKeyForUiMode(state.uiMode);
+        // Setup has two possible tours: the foundational setup tour
+        // and the later sharing follow-up. Let the coordinator pick
+        // either during boot, but after boot only fire the primary
+        // screen tour on navigation. Otherwise a user who completes
+        // setup, completes Checklist & Suggest, and immediately
+        // returns to Game setup sees another tour in the same flow.
+        const candidates =
+            phase === COORDINATOR_PHASE_DONE && state.uiMode === UI_SETUP
+                ? [screenKeyForUiMode(state.uiMode)]
+                : screensForUiMode(state.uiMode);
         return pickFirstEligibleScreenKey(
-            screensForUiMode(state.uiMode),
+            candidates,
             DateTime.nowUnsafe(),
         );
-    }, [hydrated, state.uiMode]);
+    }, [hydrated, phase, state.uiMode]);
     const { shouldShow, dismiss } = useTourGate(screenKey, {
         enabled: hydrated,
     });

--- a/src/ui/account/AccountModal.tsx
+++ b/src/ui/account/AccountModal.tsx
@@ -114,10 +114,10 @@ export function AccountModal({
     return (
         <Dialog.Root open={open} onOpenChange={(next) => !next && onClose()}>
             <Dialog.Portal>
-                <Dialog.Overlay className="fixed inset-0 z-40 bg-black/40" />
+                <Dialog.Overlay className="fixed inset-0 z-[var(--z-dialog-overlay)] bg-black/40" />
                 <Dialog.Content
                     className={
-                        "fixed left-1/2 top-1/2 z-50 flex w-[min(92vw,440px)] flex-col " +
+                        "fixed left-1/2 top-1/2 z-[var(--z-dialog-content)] flex w-[min(92vw,440px)] flex-col " +
                         "-translate-x-1/2 -translate-y-1/2 rounded-[var(--radius)] border border-border " +
                         "bg-panel shadow-[0_10px_28px_rgba(0,0,0,0.28)] focus:outline-none"
                     }

--- a/src/ui/components/BottomNav.tsx
+++ b/src/ui/components/BottomNav.tsx
@@ -74,7 +74,7 @@ export function BottomNav() {
         <nav
             aria-label={t("ariaLabel")}
             className={
-                "fixed inset-x-0 bottom-0 z-40 border-t border-border bg-panel " +
+                "fixed inset-x-0 bottom-0 z-[var(--z-app-chrome)] border-t border-border bg-panel " +
                 "[padding-bottom:env(safe-area-inset-bottom,0px)] " +
                 "[@media(min-width:800px)]:hidden"
             }
@@ -231,7 +231,7 @@ function NavIconItem({
                         sideOffset={6}
                         collisionPadding={8}
                         onOpenAutoFocus={e => e.preventDefault()}
-                        className="z-50 max-w-[280px] rounded-[var(--radius)] border border-border bg-panel px-3 py-2 text-[12px] leading-snug shadow-[0_6px_16px_rgba(0,0,0,0.18)]"
+                        className="z-[var(--z-popover)] max-w-[280px] rounded-[var(--radius)] border border-border bg-panel px-3 py-2 text-[12px] leading-snug shadow-[0_6px_16px_rgba(0,0,0,0.18)]"
                     >
                         {preview ?? label}
                         <RadixPopover.Arrow

--- a/src/ui/components/CardPackPicker.tsx
+++ b/src/ui/components/CardPackPicker.tsx
@@ -175,7 +175,7 @@ export function CardPackPicker({
                         inputRef.current?.focus();
                     }}
                     className={
-                        "z-50 w-[min(90vw,320px)] rounded-[var(--radius)] border border-border bg-panel " +
+                        "z-[var(--z-popover)] w-[min(90vw,320px)] rounded-[var(--radius)] border border-border bg-panel " +
                         "shadow-[0_6px_16px_rgba(0,0,0,0.18)] focus:outline-none"
                     }
                 >
@@ -253,7 +253,7 @@ export function CardPackPicker({
                                             {onSharePack ? (
                                                 <button
                                                     type="button"
-                                                    className="ml-1 cursor-pointer rounded px-2 py-0.5 text-muted hover:bg-white hover:text-accent"
+                                                    className="ml-1 inline-flex cursor-pointer items-center self-stretch rounded px-2 text-muted hover:bg-white hover:text-accent"
                                                     onClick={() =>
                                                         onSharePack(pack)
                                                     }

--- a/src/ui/components/CardPackRow.tsx
+++ b/src/ui/components/CardPackRow.tsx
@@ -393,12 +393,12 @@ export function CardPackRow() {
                     // `layout` prop drives the FLIP-style reposition when
                     // pack ordering changes.
                     const wrapperBase =
-                        "inline-flex items-center overflow-hidden rounded border text-[13px] transition-colors duration-200 ease-out";
+                        "inline-flex items-stretch overflow-hidden rounded border text-[13px] transition-colors duration-200 ease-out";
                     const wrapperTone = isActive
                         ? "border-accent bg-accent text-white"
                         : "border-border bg-white";
                     const loadBase =
-                        "cursor-pointer px-3 py-1 transition-colors duration-200 ease-out";
+                        "inline-flex cursor-pointer items-center px-3 py-1 transition-colors duration-200 ease-out";
                     const loadTone = isActive
                         ? "font-semibold"
                         : "hover:bg-hover";
@@ -410,7 +410,7 @@ export function CardPackRow() {
                     // Custom pills additionally append a trash-icon
                     // delete (destructive — paired with a confirm dialog).
                     const sharePillBase =
-                        "cursor-pointer border-l px-2 py-1 transition-colors duration-200 ease-out";
+                        "inline-flex cursor-pointer items-center border-l px-2 py-1 transition-colors duration-200 ease-out";
                     const sharePillTone = isActive
                         ? "border-white/40 text-white/80 hover:bg-white/15"
                         : "border-border text-muted hover:bg-hover hover:text-accent";

--- a/src/ui/components/Checklist.setup.test.tsx
+++ b/src/ui/components/Checklist.setup.test.tsx
@@ -297,6 +297,24 @@ describe("Checklist — setup mode — player cell interactions", () => {
             expect(checkboxes.length).toBeGreaterThan(50);
         });
     });
+
+    test("centers checkbox content within the player cells", async () => {
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        await waitFor(() => {
+            expect(
+                document.querySelector<HTMLInputElement>("input[type='checkbox']"),
+            ).toBeInTheDocument();
+        });
+
+        const checkbox = document.querySelector<HTMLInputElement>(
+            "input[type='checkbox']",
+        );
+        expect(checkbox).toBeDefined();
+        if (!checkbox) return;
+        expect(checkbox.parentElement?.className).toContain("mx-auto");
+        expect(checkbox.parentElement?.parentElement?.parentElement?.className)
+            .toContain("mx-auto");
+    });
 });
 
 describe("Checklist — setup mode — add-player column", () => {

--- a/src/ui/components/Checklist.setup.test.tsx
+++ b/src/ui/components/Checklist.setup.test.tsx
@@ -109,6 +109,26 @@ describe("Checklist — setup mode — top-level structure", () => {
         // is hidden when `inSetup` is true.
         expect(screen.queryByText(/caseFileLabel/)).toBeNull();
     });
+
+    test("uses tokenized sticky z-index classes for the header and first column", async () => {
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        await waitForSetupChecklist();
+
+        const thead = document.querySelector("thead");
+        expect(thead?.className).toContain(
+            "z-[var(--z-checklist-sticky-header)]",
+        );
+        const firstHeader = thead?.querySelector("th");
+        expect(firstHeader?.className).toContain("sticky left-0");
+        expect(firstHeader?.className).toContain(
+            "z-[var(--z-checklist-sticky-header)]",
+        );
+        const firstBodyHeader = document.querySelector("tbody th");
+        expect(firstBodyHeader?.className).toContain("sticky left-0");
+        expect(firstBodyHeader?.className).toContain(
+            "z-[var(--z-checklist-sticky-column)]",
+        );
+    });
 });
 
 describe("Checklist — setup mode — hand-size inputs", () => {

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -700,9 +700,9 @@ export function Checklist() {
             )}
             <div className="-mx-4 px-4">
             <table className="w-full border-separate border-spacing-0 border-t border-l border-border text-[13px]">
-                <thead className="sticky top-[calc(var(--contradiction-banner-offset,0px)+var(--header-offset,0px))] z-20 bg-row-header">
+                <thead className="sticky top-[calc(var(--contradiction-banner-offset,0px)+var(--header-offset,0px))] z-[var(--z-checklist-sticky-header)] bg-row-header">
                     <tr>
-                        <th className="border-r border-b border-border bg-row-header px-2 py-1 text-center text-[10px] font-semibold uppercase tracking-[0.05em] text-muted">
+                        <th className={`${STICKY_FIRST_COL_HEADER} border-r border-b border-border bg-row-header px-2 py-1 text-center text-[10px] font-semibold uppercase tracking-[0.05em] text-muted`}>
                             {inSetup || !hasKeyboard ? null : label("global.gotoChecklist")}
                         </th>
                         <AnimatePresence initial={false} mode={MOTION_SYNC}>
@@ -764,7 +764,7 @@ export function Checklist() {
                     {inSetup && (
                         <tr>
                             <th
-                                className="whitespace-nowrap border-r border-b border-border bg-row-header px-1.5 py-1 text-left font-semibold"
+                                className={`${STICKY_FIRST_COL_HEADER} whitespace-nowrap border-r border-b border-border bg-row-header px-1.5 py-1 text-left font-semibold`}
                                 // The setup tour's "Set hand sizes"
                                 // step highlights the row label cell
                                 // alongside every player's input so
@@ -872,8 +872,7 @@ export function Checklist() {
                                 {...tableRowMotionProps}
                             >
                                 <motion.th
-                                    colSpan={cardSpan}
-                                    className="overflow-hidden border-r border-b border-border bg-category-header p-0 text-left text-[11px] uppercase tracking-[0.05em] text-white"
+                                    className={`${STICKY_FIRST_COL} overflow-hidden border-r border-b border-border bg-category-header p-0 text-left text-[11px] uppercase tracking-[0.05em] text-white`}
                                     exit={cellExitTone}
                                 >
                                     {renderRowReveal(
@@ -948,6 +947,10 @@ export function Checklist() {
                                         ),
                                     )}
                                 </motion.th>
+                                <td
+                                    colSpan={cardSpan - 1}
+                                    className="border-r border-b border-border bg-category-header"
+                                />
                             </motion.tr>,
                             ...category.cards.map(entry => {
                                 const cardRowIdx =
@@ -958,7 +961,7 @@ export function Checklist() {
                                     {...tableRowMotionProps}
                                 >
                                     <motion.th
-                                        className="w-px overflow-hidden whitespace-nowrap border-r border-b border-border p-0 text-left font-normal"
+                                        className={`${STICKY_FIRST_COL} w-px overflow-hidden whitespace-nowrap border-r border-b border-border bg-panel p-0 text-left font-normal`}
                                         exit={cellExitTone}
                                     >
                                         {renderRowReveal(
@@ -1444,8 +1447,7 @@ export function Checklist() {
                                           {...tableRowMotionProps}
                                       >
                                           <motion.th
-                                              colSpan={cardSpan}
-                                              className="overflow-hidden border-r border-b border-border bg-row-alt p-0 text-left"
+                                              className={`${STICKY_FIRST_COL} overflow-hidden border-r border-b border-border bg-row-alt p-0 text-left`}
                                               exit={cellExitTone}
                                           >
                                               {renderRowReveal(
@@ -1465,6 +1467,10 @@ export function Checklist() {
                                                   </div>,
                                               )}
                                           </motion.th>
+                                          <td
+                                              colSpan={cardSpan - 1}
+                                              className="border-r border-b border-border bg-row-alt"
+                                          />
                                       </motion.tr>,
                                   ]
                                 : []),
@@ -1473,8 +1479,7 @@ export function Checklist() {
                     {inSetup && (
                         <motion.tr key="add-category" {...tableRowMotionProps}>
                             <motion.th
-                                colSpan={cardSpan}
-                                className="overflow-hidden border-r border-b border-border bg-row-alt p-0 text-left"
+                                className={`${STICKY_FIRST_COL} overflow-hidden border-r border-b border-border bg-row-alt p-0 text-left`}
                                 exit={cellExitTone}
                             >
                                 {renderRowReveal(
@@ -1491,6 +1496,10 @@ export function Checklist() {
                                     </div>,
                                 )}
                             </motion.th>
+                            <td
+                                colSpan={cardSpan - 1}
+                                className="border-r border-b border-border bg-row-alt"
+                            />
                         </motion.tr>
                     )}
                     </AnimatePresence>
@@ -2269,21 +2278,22 @@ const CELL_BASE =
 const CELL_CONTENT =
     "flex h-full w-9 min-w-9 items-center justify-center px-2 py-1";
 
+const STICKY_FIRST_COL =
+    "sticky left-0 z-[var(--z-checklist-sticky-column)]";
+
+const STICKY_FIRST_COL_HEADER =
+    "sticky left-0 z-[var(--z-checklist-sticky-header)]";
+
 // Z-index ladder for the checklist:
-//   - sticky <thead>            : z-20 (anchored at top during scroll)
-//   - body cell hover ring      : z-30 (above thead so the hover ring
-//                                 doesn't get clipped when the cell is
-//                                 near the top of the viewport)
-//   - cross-pane highlight ring : z-30 (same reason)
-//   - body cell focus-visible   : z-40 (above hover so a hovered ring
-//                                 doesn't obscure the focused outline,
-//                                 and well above any neighboring cell
-//                                 painted in document order)
-// Without these bumps, a hovered cell sitting under the sticky thead
-// got its top ring sheared off, and a focused cell's right/bottom
-// outline was painted over by its neighbors (each cell has
-// position:relative, so without z-index escape they stack in DOM
-// order and the right neighbour wins).
+//   - body cell hover ring      : --z-checklist-cell-hover
+//   - body cell focus-visible   : --z-checklist-cell-focus
+//   - sticky first column       : --z-checklist-sticky-column
+//   - sticky <thead>            : --z-checklist-sticky-header
+// The body-cell z-index escape keeps rings from being painted under
+// neighboring cells in document order. The sticky first column and
+// sticky header deliberately sit higher so horizontal / vertical
+// scroll never hides the card/category labels or column labels under
+// an active body cell.
 //
 // Focus indicator: `ring-[3px] ring-offset-2` (box-shadow) instead of
 // `outline-3 outline-offset-2`. Outlines on `<td>` cells in
@@ -2305,10 +2315,10 @@ const CELL_CONTENT =
 // Without that match the offset would render as a solid panel band
 // and the focus indicator would look like a thick double-ring.
 const CELL_INTERACTIVE =
-    " cursor-pointer hover:z-30 hover:rounded-[2px] hover:ring-2 hover:ring-accent/30 focus-visible:z-40 focus-visible:ring-[3px] focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:rounded-[2px] focus-visible:outline-none";
+    " cursor-pointer hover:z-[var(--z-checklist-cell-hover)] hover:rounded-[2px] hover:ring-2 hover:ring-accent/30 focus-visible:z-[var(--z-checklist-cell-focus)] focus-visible:ring-[3px] focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:rounded-[2px] focus-visible:outline-none";
 
 const CELL_HIGHLIGHTED =
-    " z-30 ring-2 ring-accent ring-offset-1 ring-offset-panel";
+    " z-[var(--z-checklist-cell-hover)] ring-2 ring-accent ring-offset-1 ring-offset-panel";
 
 const cellClass = (
     value: CellValue | undefined,

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -408,6 +408,7 @@ export function Checklist() {
                 undefined,
                 tableEntryTransition,
             ),
+            "mx-auto",
         );
 
     // Handle ⌘J / ⌘H focus requests: locate a cell by (row,col) and
@@ -2276,7 +2277,7 @@ const ADD_PLAYER_COLUMN_KEY = "add-player-col";
 const CELL_BASE =
     "border-r border-b border-border text-center font-semibold relative overflow-hidden";
 const CELL_CONTENT =
-    "flex h-full w-9 min-w-9 items-center justify-center px-2 py-1";
+    "mx-auto flex h-full w-9 min-w-9 items-center justify-center px-2 py-1";
 
 const STICKY_FIRST_COL =
     "sticky left-0 z-[var(--z-checklist-sticky-column)]";

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -703,7 +703,10 @@ export function Checklist() {
             <table className="w-full border-separate border-spacing-0 border-t border-l border-border text-[13px]">
                 <thead className="sticky top-[calc(var(--contradiction-banner-offset,0px)+var(--header-offset,0px))] z-[var(--z-checklist-sticky-header)] bg-row-header">
                     <tr>
-                        <th className={`${STICKY_FIRST_COL_HEADER} border-r border-b border-border bg-row-header px-2 py-1 text-center text-[10px] font-semibold uppercase tracking-[0.05em] text-muted`}>
+                        <th
+                            className={`${STICKY_FIRST_COL_HEADER} border-r border-b border-border bg-row-header px-2 py-1 text-center text-[10px] font-semibold uppercase tracking-[0.05em] text-muted`}
+                            data-tour-sticky-left=""
+                        >
                             {inSetup || !hasKeyboard ? null : label("global.gotoChecklist")}
                         </th>
                         <AnimatePresence initial={false} mode={MOTION_SYNC}>
@@ -766,6 +769,7 @@ export function Checklist() {
                         <tr>
                             <th
                                 className={`${STICKY_FIRST_COL_HEADER} whitespace-nowrap border-r border-b border-border bg-row-header px-1.5 py-1 text-left font-semibold`}
+                                data-tour-sticky-left=""
                                 // The setup tour's "Set hand sizes"
                                 // step highlights the row label cell
                                 // alongside every player's input so
@@ -874,6 +878,7 @@ export function Checklist() {
                             >
                                 <motion.th
                                     className={`${STICKY_FIRST_COL} overflow-hidden border-r border-b border-border bg-category-header p-0 text-left text-[11px] uppercase tracking-[0.05em] text-white`}
+                                    data-tour-sticky-left=""
                                     exit={cellExitTone}
                                 >
                                     {renderRowReveal(
@@ -963,6 +968,7 @@ export function Checklist() {
                                 >
                                     <motion.th
                                         className={`${STICKY_FIRST_COL} w-px overflow-hidden whitespace-nowrap border-r border-b border-border bg-panel p-0 text-left font-normal`}
+                                        data-tour-sticky-left=""
                                         exit={cellExitTone}
                                     >
                                         {renderRowReveal(
@@ -1449,6 +1455,7 @@ export function Checklist() {
                                       >
                                           <motion.th
                                               className={`${STICKY_FIRST_COL} overflow-hidden border-r border-b border-border bg-row-alt p-0 text-left`}
+                                              data-tour-sticky-left=""
                                               exit={cellExitTone}
                                           >
                                               {renderRowReveal(
@@ -1481,6 +1488,7 @@ export function Checklist() {
                         <motion.tr key="add-category" {...tableRowMotionProps}>
                             <motion.th
                                 className={`${STICKY_FIRST_COL} overflow-hidden border-r border-b border-border bg-row-alt p-0 text-left`}
+                                data-tour-sticky-left=""
                                 exit={cellExitTone}
                             >
                                 {renderRowReveal(

--- a/src/ui/components/GlobalContradictionBanner.tsx
+++ b/src/ui/components/GlobalContradictionBanner.tsx
@@ -73,7 +73,7 @@ function ContradictionBody({
             animate={{ y: 0, opacity: 1 }}
             exit={{ y: -16, opacity: 0 }}
             transition={transition}
-            className="fixed inset-x-0 top-0 z-50 border-b border-danger-border bg-panel/95 shadow-lg backdrop-blur-sm"
+            className="fixed inset-x-0 top-0 z-[var(--z-contradiction-banner)] border-b border-danger-border bg-panel/95 shadow-lg backdrop-blur-sm"
         >
             <div className="mx-auto max-w-[1400px] px-5 pt-3">
                 <ContradictionBanner trace={trace} />

--- a/src/ui/components/Icons.tsx
+++ b/src/ui/components/Icons.tsx
@@ -88,6 +88,28 @@ export function XIcon({ className, size = 18 }: IconProps) {
     );
 }
 
+/** Check mark — paired with successful inline confirmations. */
+export function CheckIcon({ className, size = 18 }: IconProps) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+            focusable="false"
+            className={className}
+        >
+            <polyline points="20 6 9 17 4 12" />
+        </svg>
+    );
+}
+
 /** Right-pointing arrow — paired with primary "get started" CTAs. */
 export function ArrowRightIcon({ className, size = 18 }: IconProps) {
     return (

--- a/src/ui/components/InfoPopover.tsx
+++ b/src/ui/components/InfoPopover.tsx
@@ -102,7 +102,7 @@ export function InfoPopover({
                     collisionPadding={8}
                     onOpenAutoFocus={e => e.preventDefault()}
                     className={
-                        "z-50 rounded-[var(--radius)] border px-3 py-2 text-[12px] leading-snug shadow-[0_6px_16px_rgba(0,0,0,0.18)] " +
+                        "z-[var(--z-popover)] rounded-[var(--radius)] border px-3 py-2 text-[12px] leading-snug shadow-[0_6px_16px_rgba(0,0,0,0.18)] " +
                         "focus:outline-none " +
                         toneClasses
                     }

--- a/src/ui/components/InstallPromptModal.tsx
+++ b/src/ui/components/InstallPromptModal.tsx
@@ -102,10 +102,10 @@ export function InstallPromptModal({
             }}
         >
             <Dialog.Portal>
-                <Dialog.Overlay className="fixed inset-0 z-40 bg-black/40" />
+                <Dialog.Overlay className="fixed inset-0 z-[var(--z-dialog-overlay)] bg-black/40" />
                 <Dialog.Content
                     className={
-                        "fixed left-1/2 top-1/2 z-50 flex w-[min(92vw,480px)] flex-col " +
+                        "fixed left-1/2 top-1/2 z-[var(--z-dialog-content)] flex w-[min(92vw,480px)] flex-col " +
                         "-translate-x-1/2 -translate-y-1/2 rounded-[var(--radius)] border border-border " +
                         "bg-panel shadow-[0_10px_28px_rgba(0,0,0,0.28)] focus:outline-none"
                     }

--- a/src/ui/components/OverflowMenu.tsx
+++ b/src/ui/components/OverflowMenu.tsx
@@ -99,7 +99,7 @@ export function OverflowMenu({
                     // unions every match.
                     data-tour-anchor="overflow-menu"
                     className={
-                        "z-50 min-w-[200px] rounded-[var(--radius)] border border-border bg-panel p-1 text-[13px] shadow-[0_6px_16px_rgba(0,0,0,0.18)]" +
+                        "z-[var(--z-popover)] min-w-[200px] rounded-[var(--radius)] border border-border bg-panel p-1 text-[13px] shadow-[0_6px_16px_rgba(0,0,0,0.18)]" +
                         (contentClassName ? ` ${contentClassName}` : "")
                     }
                 >

--- a/src/ui/components/SplashModal.tsx
+++ b/src/ui/components/SplashModal.tsx
@@ -52,10 +52,10 @@ export function SplashModal({
             }}
         >
             <Dialog.Portal>
-                <Dialog.Overlay className="fixed inset-0 z-40 bg-black/40" />
+                <Dialog.Overlay className="fixed inset-0 z-[var(--z-dialog-overlay)] bg-black/40" />
                 <Dialog.Content
                     className={
-                        "fixed left-1/2 top-1/2 z-50 flex w-[min(92vw,640px)] max-h-[90vh] flex-col " +
+                        "fixed left-1/2 top-1/2 z-[var(--z-dialog-content)] flex w-[min(92vw,640px)] max-h-[90vh] flex-col " +
                         "-translate-x-1/2 -translate-y-1/2 rounded-[var(--radius)] border border-border " +
                         "bg-panel shadow-[0_10px_28px_rgba(0,0,0,0.28)] focus:outline-none"
                     }

--- a/src/ui/components/StaleGameModal.tsx
+++ b/src/ui/components/StaleGameModal.tsx
@@ -135,10 +135,10 @@ export function StaleGameModal({
             }}
         >
             <Dialog.Portal>
-                <Dialog.Overlay className="fixed inset-0 z-40 bg-black/40" />
+                <Dialog.Overlay className="fixed inset-0 z-[var(--z-dialog-overlay)] bg-black/40" />
                 <Dialog.Content
                     className={
-                        "fixed left-1/2 top-1/2 z-50 flex w-[min(92vw,480px)] flex-col "
+                        "fixed left-1/2 top-1/2 z-[var(--z-dialog-content)] flex w-[min(92vw,480px)] flex-col "
                         + "-translate-x-1/2 -translate-y-1/2 rounded-[var(--radius)] border border-border "
                         + "bg-panel shadow-[0_10px_28px_rgba(0,0,0,0.28)] focus:outline-none"
                     }

--- a/src/ui/components/SuggestionLogPanel.tsx
+++ b/src/ui/components/SuggestionLogPanel.tsx
@@ -455,7 +455,7 @@ function TabButton({
                     transition={indicatorTransition}
                 />
             )}
-            <span className="relative z-10">{children}</span>
+            <span className="relative z-[var(--z-local-raised)]">{children}</span>
         </button>
     );
 }

--- a/src/ui/components/SuggestionPills.tsx
+++ b/src/ui/components/SuggestionPills.tsx
@@ -360,7 +360,7 @@ export function PillPopover({
                             e.preventDefault();
                         }
                     }}
-                    className="z-50 min-w-[200px] rounded-[var(--radius)] border border-border bg-panel p-1 text-[13px] shadow-[0_6px_16px_rgba(0,0,0,0.18)]"
+                    className="z-[var(--z-popover)] min-w-[200px] rounded-[var(--radius)] border border-border bg-panel p-1 text-[13px] shadow-[0_6px_16px_rgba(0,0,0,0.18)]"
                 >
                     {disabled ? (
                         <div

--- a/src/ui/components/Tooltip.tsx
+++ b/src/ui/components/Tooltip.tsx
@@ -60,7 +60,7 @@ export function Tooltip({
                         sideOffset={6}
                         collisionPadding={8}
                         className={
-                            "z-50 max-w-[320px] rounded-[var(--radius)] border px-3 py-2 text-[12px] leading-snug shadow-[0_6px_16px_rgba(0,0,0,0.18)] " +
+                            "z-[var(--z-popover)] max-w-[320px] rounded-[var(--radius)] border px-3 py-2 text-[12px] leading-snug shadow-[0_6px_16px_rgba(0,0,0,0.18)] " +
                             toneClasses
                         }
                     >

--- a/src/ui/hooks/useConfirm.tsx
+++ b/src/ui/hooks/useConfirm.tsx
@@ -70,11 +70,11 @@ export function ConfirmProvider({ children }: { readonly children: ReactNode }) 
             >
                 <AlertDialog.Portal>
                     <AlertDialog.Overlay
-                        className="fixed inset-0 z-50 bg-black/30"
+                        className="fixed inset-0 z-[var(--z-dialog-overlay)] bg-black/30"
                     />
                     <AlertDialog.Content
                         className={
-                            "fixed left-1/2 top-1/2 z-50 w-[min(90vw,420px)] -translate-x-1/2 -translate-y-1/2 " +
+                            "fixed left-1/2 top-1/2 z-[var(--z-dialog-content)] w-[min(90vw,420px)] -translate-x-1/2 -translate-y-1/2 " +
                             "rounded-[var(--radius)] border border-border bg-panel p-5 shadow-[0_10px_28px_rgba(0,0,0,0.28)] " +
                             "focus:outline-none"
                         }

--- a/src/ui/onboarding/StartupCoordinator.test.tsx
+++ b/src/ui/onboarding/StartupCoordinator.test.tsx
@@ -377,6 +377,30 @@ describe("StartupCoordinator — tour precedence", () => {
         expect(probe.current?.phase).toBe("tour");
     });
 
+    test("dismissed-only setup state does not redirect back to setup", () => {
+        // A completion/dismissal timestamp by itself is enough to
+        // keep setup suppressed. This protects the real flow where a
+        // setup dismissal can be present before a visit timestamp has
+        // been persisted for that same key.
+        const recent = new Date().toISOString();
+        seed(STORAGE_SPLASH, {
+            version: 1,
+            lastVisitedAt: recent,
+            lastDismissedAt: recent,
+        });
+        seed(STORAGE_TOUR_SETUP, {
+            version: 1,
+            lastDismissedAt: recent,
+        });
+        // checklistSuggest left unseeded → eligible.
+        seed(STORAGE_INSTALL, { version: 1, visits: 0 });
+
+        const onRedirect = vi.fn();
+        mount("checklistSuggest", onRedirect);
+        expect(onRedirect).not.toHaveBeenCalled();
+        expect(probe.current?.phase).toBe("tour");
+    });
+
     test("no tours eligible → no redirect; phase advances past tour", () => {
         // All tours dismissed. Coordinator finds no eligible target;
         // no redirect. Tour eligibility = false; phase falls through

--- a/src/ui/onboarding/StartupCoordinator.tsx
+++ b/src/ui/onboarding/StartupCoordinator.tsx
@@ -229,9 +229,9 @@ const isTourEligible = (screen: ScreenKey, now: DateTime.Utc): boolean => {
     }
     const state = loadTourState(screen);
     if (state.lastDismissedAt === undefined) return true;
-    if (state.lastVisitedAt === undefined) return true;
+    const referenceAt = state.lastVisitedAt ?? state.lastDismissedAt;
     return Duration.isGreaterThan(
-        DateTime.distance(state.lastVisitedAt, now),
+        DateTime.distance(referenceAt, now),
         TOUR_RE_ENGAGE_DURATION,
     );
 };

--- a/src/ui/share/ShareCreateModal.test.tsx
+++ b/src/ui/share/ShareCreateModal.test.tsx
@@ -367,13 +367,18 @@ describe("ShareCreateModal — sign-in slide", () => {
         await act(async () => {
             fireEvent.click(findCta());
         });
+        const googleButton = await screen.findByRole("button", {
+            name: "signInWithGoogle",
+        });
         await act(async () => {
-            fireEvent.click(screen.getByText("signInWithGoogle"));
+            fireEvent.click(googleButton);
         });
 
-        expect(signInSocialMock).toHaveBeenCalledWith({
-            provider: "google",
-            callbackURL: "/play?view=setup",
+        await waitFor(() => {
+            expect(signInSocialMock).toHaveBeenCalledWith({
+                provider: "google",
+                callbackURL: "/play?view=setup",
+            });
         });
         expect(
             window.sessionStorage.getItem("effect-clue.pending-share.v1"),

--- a/src/ui/share/ShareCreateModal.test.tsx
+++ b/src/ui/share/ShareCreateModal.test.tsx
@@ -129,6 +129,11 @@ const findCta = (): HTMLButtonElement => {
 beforeEach(() => {
     window.localStorage.clear();
     window.sessionStorage.clear();
+    Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: undefined,
+    });
+    window.prompt = vi.fn();
     createShareMock.mockReset();
     createShareMock.mockResolvedValue({ id: "stub-share-id" });
     signInSocialMock.mockReset();
@@ -168,6 +173,13 @@ describe("ShareCreateModal — variant chrome", () => {
         );
         expect(warning).not.toBeNull();
         expect(warning?.textContent).toContain("transferWarning");
+    });
+
+    test("shows the share expiry copy", () => {
+        mountModal("pack");
+        expect(
+            screen.getByText('linkExpiresIn:{"duration":"ttl"}'),
+        ).toBeTruthy();
     });
 
     test("invite variant with no logged progress hides the optional checkbox", () => {
@@ -296,6 +308,45 @@ describe("ShareCreateModal — wire payload by variant", () => {
         expect(payload.knownCardsData).toBeTypeOf("string");
         expect(payload.suggestionsData).toBeTypeOf("string");
         expect(payload.accusationsData).toBeTypeOf("string");
+    });
+});
+
+describe("ShareCreateModal — copy existing share URL", () => {
+    test("successful create stores the URL and recopy does not create another share", async () => {
+        const writeText = vi.fn().mockResolvedValue(undefined);
+        Object.defineProperty(navigator, "clipboard", {
+            configurable: true,
+            value: { writeText },
+        });
+        mockSession = {
+            data: { user: { id: "u1", isAnonymous: false } },
+        };
+        mountModal("pack");
+
+        await act(async () => {
+            fireEvent.click(findCta());
+        });
+        await waitFor(() => {
+            expect(createShareMock).toHaveBeenCalledTimes(1);
+        });
+        expect(
+            document.querySelector("[data-share-created-url]"),
+        ).not.toBeNull();
+        expect(writeText).toHaveBeenCalledTimes(1);
+
+        const copyButton = document.querySelector(
+            "[data-share-copy-existing]",
+        ) as HTMLButtonElement | null;
+        expect(copyButton).not.toBeNull();
+        await act(async () => {
+            fireEvent.click(copyButton!);
+        });
+
+        expect(createShareMock).toHaveBeenCalledTimes(1);
+        expect(writeText).toHaveBeenCalledTimes(2);
+        expect(
+            document.querySelector("[data-share-copy-check]"),
+        ).not.toBeNull();
     });
 });
 

--- a/src/ui/share/ShareCreateModal.tsx
+++ b/src/ui/share/ShareCreateModal.tsx
@@ -72,7 +72,7 @@ import { useSession } from "../hooks/useSession";
 import { authClient } from "../account/authClient";
 import { DevSignInForm } from "../account/DevSignInForm";
 import { T_STANDARD, useReducedTransition } from "../motion";
-import { XIcon } from "../components/Icons";
+import { CheckIcon, XIcon } from "../components/Icons";
 import {
     savePendingShareIntent,
     type PendingShareIntent,
@@ -171,6 +171,7 @@ const COPY_FALLBACK_KEY = "copyFallback";
 const ERROR_GENERIC_KEY = "errorGeneric";
 const LINK_EXPIRES_IN_KEY = "linkExpiresIn";
 const TTL_KEY = "ttl";
+const SHARE_URL_ARIA_KEY = "shareUrlAria";
 
 const ERR_SIGN_IN_REQUIRED_MSG = "sign_in_required_to_share";
 
@@ -351,11 +352,14 @@ export function ShareCreateModal({
     useEffect(() => {
         if (open && !prevOpenRef.current) {
             setIncludeProgress(false);
+            setCopied(false);
+            setShareUrl(null);
         }
         prevOpenRef.current = open;
     }, [open]);
     const [submitting, setSubmitting] = useState(false);
     const [copied, setCopied] = useState(false);
+    const [shareUrl, setShareUrl] = useState<string | null>(null);
     const [error, setError] = useState<string | null>(null);
 
     // The pack the share will contain. Picker entry overrides; setup
@@ -440,6 +444,22 @@ export function ShareCreateModal({
         variant,
     ]);
 
+    const copyShareUrl = useCallback(async (url: string): Promise<void> => {
+        try {
+            if (typeof navigator !== "undefined" && navigator.clipboard) {
+                await navigator.clipboard.writeText(url);
+                shareLinkCopied();
+                setCopied(true);
+                return;
+            }
+        } catch {
+            // Fall through to the prompt fallback below.
+        }
+        if (typeof window !== "undefined") {
+            window.prompt(t(COPY_FALLBACK_KEY), url);
+        }
+    }, [t]);
+
     const createFromPayload = useCallback(async (
         payload: CreateShareInput,
         meta: {
@@ -458,17 +478,8 @@ export function ShareCreateModal({
                 typeof globalThis.location !== "undefined"
                     ? `${globalThis.location.origin}${SHARE_BASE_PATH}${result.id}`
                     : `${SHARE_BASE_PATH}${result.id}`;
-            try {
-                if (typeof navigator !== "undefined" && navigator.clipboard) {
-                    await navigator.clipboard.writeText(url);
-                    shareLinkCopied();
-                    setCopied(true);
-                }
-            } catch {
-                if (typeof window !== "undefined") {
-                    window.prompt(t(COPY_FALLBACK_KEY), url);
-                }
-            }
+            setShareUrl(url);
+            await copyShareUrl(url);
         } catch (e) {
             const msg = String(e);
             if (msg.includes(ERR_SIGN_IN_REQUIRED_MSG)) {
@@ -482,9 +493,13 @@ export function ShareCreateModal({
         } finally {
             setSubmitting(false);
         }
-    }, [t]);
+    }, [copyShareUrl, t]);
 
     const onCreate = async (): Promise<void> => {
+        if (shareUrl !== null) {
+            await copyShareUrl(shareUrl);
+            return;
+        }
         if (needsSignIn) {
             setError(null);
             setDirection(1);
@@ -573,6 +588,7 @@ export function ShareCreateModal({
 
     const close = (): void => {
         setCopied(false);
+        setShareUrl(null);
         setError(null);
         setStep(STEP_TOGGLES);
         setDirection(1);
@@ -594,10 +610,10 @@ export function ShareCreateModal({
     return (
         <Dialog.Root open={open} onOpenChange={(next) => !next && close()}>
             <Dialog.Portal>
-                <Dialog.Overlay className="fixed inset-0 z-40 bg-black/40" />
+                <Dialog.Overlay className="fixed inset-0 z-[var(--z-dialog-overlay)] bg-black/40" />
                 <Dialog.Content
                     className={
-                        "fixed left-1/2 top-1/2 z-50 flex w-[min(92vw,480px)] flex-col " +
+                        "fixed left-1/2 top-1/2 z-[var(--z-dialog-content)] flex w-[min(92vw,480px)] flex-col " +
                         "-translate-x-1/2 -translate-y-1/2 rounded-[var(--radius)] border border-border " +
                         "bg-panel shadow-[0_10px_28px_rgba(0,0,0,0.28)] focus:outline-none"
                     }
@@ -701,6 +717,56 @@ export function ShareCreateModal({
                                             duration: t(TTL_KEY),
                                         })}
                                     </div>
+                                    {shareUrl !== null ? (
+                                        <div
+                                            className="mx-5 mt-3 flex min-w-0 items-center gap-2 rounded-[var(--radius)] border border-border bg-white p-2"
+                                            data-share-created-url
+                                        >
+                                            <input
+                                                readOnly
+                                                value={shareUrl}
+                                                aria-label={t(SHARE_URL_ARIA_KEY)}
+                                                className="min-w-0 flex-1 rounded border border-border bg-panel px-2 py-1 text-[12px] text-muted"
+                                                onFocus={(e) =>
+                                                    e.currentTarget.select()
+                                                }
+                                            />
+                                            <button
+                                                type="button"
+                                                onClick={() =>
+                                                    void copyShareUrl(shareUrl)
+                                                }
+                                                className="inline-flex min-h-8 cursor-pointer items-center gap-1 rounded-[var(--radius)] border border-border bg-white px-2 py-1 text-[12px] font-semibold text-accent hover:bg-hover"
+                                                data-share-copy-existing
+                                            >
+                                                <AnimatePresence initial={false}>
+                                                    {copied ? (
+                                                        <motion.span
+                                                            key="check"
+                                                            initial={{
+                                                                scale: 0.6,
+                                                                opacity: 0,
+                                                            }}
+                                                            animate={{
+                                                                scale: 1,
+                                                                opacity: 1,
+                                                            }}
+                                                            exit={{
+                                                                scale: 0.6,
+                                                                opacity: 0,
+                                                            }}
+                                                            transition={transition}
+                                                            className="inline-flex"
+                                                            data-share-copy-check
+                                                        >
+                                                            <CheckIcon size={14} />
+                                                        </motion.span>
+                                                    ) : null}
+                                                </AnimatePresence>
+                                                {t(COPY_LINK_KEY)}
+                                            </button>
+                                        </div>
+                                    ) : null}
                                 </motion.div>
                             ) : (
                                 <motion.div

--- a/src/ui/share/ShareImportPage.tsx
+++ b/src/ui/share/ShareImportPage.tsx
@@ -50,6 +50,7 @@ import {
     saveCardPackFromSnapshot,
     useApplyShareSnapshot,
 } from "./useApplyShareSnapshot";
+import { hashShareId } from "./shareAnalytics";
 
 interface ShareSnapshot {
     readonly id: string;
@@ -364,10 +365,10 @@ export function ShareImportPage({
                 onOpenChange={(next) => !next && close(VIA_BACKDROP)}
             >
                 <Dialog.Portal>
-                    <Dialog.Overlay className="fixed inset-0 z-40 bg-black/40" />
+                    <Dialog.Overlay className="fixed inset-0 z-[var(--z-dialog-overlay)] bg-black/40" />
                     <Dialog.Content
                         className={
-                            "fixed left-1/2 top-1/2 z-50 flex w-[min(92vw,480px)] flex-col " +
+                            "fixed left-1/2 top-1/2 z-[var(--z-dialog-content)] flex w-[min(92vw,480px)] flex-col " +
                             "-translate-x-1/2 -translate-y-1/2 rounded-[var(--radius)] border border-border " +
                             "bg-panel shadow-[0_10px_28px_rgba(0,0,0,0.28)] focus:outline-none"
                         }
@@ -494,19 +495,3 @@ export function ShareImportPage({
         </main>
     );
 }
-
-/**
- * Hash a share id for analytics so PostHog never sees the raw
- * cuid2. The hash function is intentionally simple (FNV-1a 32-bit
- * folded to 8 hex chars) — collisions are fine; we only need the
- * identifier to be stable across events for the same share so
- * funnels work.
- */
-const hashShareId = (id: string): string => {
-    let h = 0x811c9dc5;
-    for (let i = 0; i < id.length; i += 1) {
-        h ^= id.charCodeAt(i);
-        h = (h * 0x01000193) >>> 0;
-    }
-    return h.toString(16).padStart(8, "0");
-};

--- a/src/ui/share/ShareMissingPage.test.tsx
+++ b/src/ui/share/ShareMissingPage.test.tsx
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("next-intl", () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+const routerPushMock = vi.fn();
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ push: routerPushMock }),
+}));
+
+let mockHasPersistedGameData = false;
+vi.mock("./useApplyShareSnapshot", () => ({
+    hasPersistedGameData: () => mockHasPersistedGameData,
+}));
+
+const shareOpenFailedMock = vi.fn();
+vi.mock("../../analytics/events", () => ({
+    shareOpenFailed: (input: unknown) => shareOpenFailedMock(input),
+}));
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { ShareMissingPage } from "./ShareMissingPage";
+
+beforeEach(() => {
+    mockHasPersistedGameData = false;
+    routerPushMock.mockReset();
+    shareOpenFailedMock.mockReset();
+});
+
+describe("ShareMissingPage", () => {
+    test("empty local state offers to start a new game", async () => {
+        render(<ShareMissingPage shareId="missing-share" />);
+
+        expect(screen.getByText("missingTitle")).toBeInTheDocument();
+        expect(screen.getByText("missingBody")).toBeInTheDocument();
+        fireEvent.click(screen.getByText("missingActionStart"));
+
+        expect(routerPushMock).toHaveBeenCalledWith("/play?view=setup");
+        await waitFor(() => {
+            expect(shareOpenFailedMock).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    reason: "not_found_or_expired",
+                }),
+            );
+        });
+    });
+
+    test("existing local progress offers to continue the current game", async () => {
+        mockHasPersistedGameData = true;
+        render(<ShareMissingPage shareId="missing-share" />);
+
+        await waitFor(() => {
+            expect(
+                screen.getByText("missingActionContinue"),
+            ).toBeInTheDocument();
+        });
+        fireEvent.click(screen.getByText("missingActionContinue"));
+
+        expect(routerPushMock).toHaveBeenCalledWith("/play");
+    });
+});

--- a/src/ui/share/ShareMissingPage.tsx
+++ b/src/ui/share/ShareMissingPage.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import * as Dialog from "@radix-ui/react-dialog";
+import { useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import { shareOpenFailed } from "../../analytics/events";
+import { routes } from "../../routes";
+import { hasPersistedGameData } from "./useApplyShareSnapshot";
+import { hashShareId } from "./shareAnalytics";
+
+const SHARE_OPEN_FAILED_REASON = "not_found_or_expired" as const;
+const SETUP_VIEW_QUERY = "?view=setup" as const;
+
+export function ShareMissingPage({
+    shareId,
+}: {
+    readonly shareId: string;
+}) {
+    const t = useTranslations("share");
+    const router = useRouter();
+    const [hasCurrentGame, setHasCurrentGame] = useState(false);
+
+    useEffect(() => {
+        setHasCurrentGame(hasPersistedGameData());
+    }, []);
+
+    useEffect(() => {
+        shareOpenFailed({
+            shareIdHash: hashShareId(shareId),
+            reason: SHARE_OPEN_FAILED_REASON,
+        });
+    }, [shareId]);
+
+    const target = hasCurrentGame
+        ? routes.play
+        : `${routes.play}${SETUP_VIEW_QUERY}`;
+    const actionLabel = hasCurrentGame
+        ? t("missingActionContinue")
+        : t("missingActionStart");
+
+    return (
+        <main className="mx-auto flex max-w-[640px] flex-col gap-5 px-5 py-8">
+            <h1 className="m-0 font-display text-[28px] text-accent">
+                {t("importTitle")}
+            </h1>
+            <Dialog.Root open>
+                <Dialog.Portal>
+                    <Dialog.Overlay className="fixed inset-0 z-[var(--z-dialog-overlay)] bg-black/40" />
+                    <Dialog.Content
+                        className={
+                            "fixed left-1/2 top-1/2 z-[var(--z-dialog-content)] flex w-[min(92vw,480px)] flex-col " +
+                            "-translate-x-1/2 -translate-y-1/2 rounded-[var(--radius)] border border-border " +
+                            "bg-panel shadow-[0_10px_28px_rgba(0,0,0,0.28)] focus:outline-none"
+                        }
+                    >
+                        <div className="px-5 pt-5">
+                            <Dialog.Title className="m-0 font-display text-[20px] text-accent">
+                                {t("missingTitle")}
+                            </Dialog.Title>
+                            <Dialog.Description className="pt-3 text-[14px] leading-relaxed text-muted">
+                                {t("missingBody")}
+                            </Dialog.Description>
+                        </div>
+                        <div className="mt-4 flex items-center justify-end border-t border-border bg-panel px-5 pt-4 pb-5">
+                            <button
+                                type="button"
+                                onClick={() => router.push(target)}
+                                className="cursor-pointer rounded-[var(--radius)] border-2 border-accent bg-accent px-4 py-2 text-[14px] font-semibold text-white hover:bg-accent-hover"
+                                data-share-missing-cta
+                            >
+                                {actionLabel}
+                            </button>
+                        </div>
+                    </Dialog.Content>
+                </Dialog.Portal>
+            </Dialog.Root>
+        </main>
+    );
+}

--- a/src/ui/share/shareAnalytics.ts
+++ b/src/ui/share/shareAnalytics.ts
@@ -1,0 +1,12 @@
+/**
+ * Hash a share id for analytics so PostHog never sees the raw cuid2.
+ * Collisions are acceptable; we only need a stable per-link join key.
+ */
+export const hashShareId = (id: string): string => {
+    let h = 0x811c9dc5;
+    for (let i = 0; i < id.length; i += 1) {
+        h ^= id.charCodeAt(i);
+        h = (h * 0x01000193) >>> 0;
+    }
+    return h.toString(16).padStart(8, "0");
+};

--- a/src/ui/tour/TourPopover.test.tsx
+++ b/src/ui/tour/TourPopover.test.tsx
@@ -18,45 +18,12 @@
  * space-separated `data-tour-anchor` values.
  */
 import { beforeEach, describe, expect, test, vi } from "vitest";
-import { forwardRef, createElement, type ReactNode } from "react";
-
-const motionMock = vi.hoisted(() => ({ reducedMotion: false }));
+import { createElement, type ReactNode } from "react";
 
 vi.mock("next-intl", () => {
     const t = (key: string, values?: Record<string, unknown>): string =>
         values ? `${key}:${JSON.stringify(values)}` : key;
     return { useTranslations: () => t };
-});
-
-// Minimal `motion/react` mock so jsdom doesn't trip on Framer's rAF.
-vi.mock("motion/react", () => {
-    const motion = new Proxy(
-        {},
-        {
-            get: (_t, tag: string) =>
-                forwardRef(
-                    (
-                        props: Record<string, unknown>,
-                        ref: React.Ref<HTMLElement>,
-                    ) => {
-                        const {
-                            initial: _i,
-                            animate: _a,
-                            exit: _e,
-                            transition: _tr,
-                            variants: _v,
-                            ...rest
-                        } = props;
-                        return createElement(tag, { ...rest, ref });
-                    },
-                ),
-        },
-    );
-    return {
-        motion,
-        AnimatePresence: ({ children }: { children: ReactNode }) => children,
-        useReducedMotion: () => motionMock.reducedMotion,
-    };
 });
 
 import { act, fireEvent, render, screen } from "@testing-library/react";
@@ -66,7 +33,6 @@ import { TourProvider, useTour } from "./TourProvider";
 import { TourPopover } from "./TourPopover";
 
 beforeEach(() => {
-    motionMock.reducedMotion = false;
     Object.defineProperty(window, "scrollX", {
         configurable: true,
         value: 0,
@@ -538,7 +504,7 @@ describe("TourPopover — veil isolation", () => {
         expect(document.body.style.overflow).toBe(before);
     });
 
-    test("out-of-view anchors use native smooth body scroll", () => {
+    test("out-of-view anchors use instant body scroll", () => {
         let api!: ReturnType<typeof useTour>;
         Object.defineProperty(window, "innerHeight", {
             configurable: true,
@@ -579,7 +545,7 @@ describe("TourPopover — veil isolation", () => {
         act(() => api.startTour("setup"));
 
         expect(bodyScrollTo).toHaveBeenCalledWith(
-            expect.objectContaining({ behavior: "smooth" }),
+            expect.objectContaining({ behavior: "auto" }),
         );
     });
 
@@ -630,7 +596,7 @@ describe("TourPopover — veil isolation", () => {
 
         expect(bodyScrollTo).toHaveBeenCalledWith(
             expect.objectContaining({
-                behavior: "smooth",
+                behavior: "auto",
                 left: 0,
             }),
         );
@@ -741,51 +707,6 @@ describe("TourPopover — veil isolation", () => {
         );
     });
 
-    test("out-of-view anchors use instant scroll for reduced motion", () => {
-        motionMock.reducedMotion = true;
-        let api!: ReturnType<typeof useTour>;
-        Object.defineProperty(window, "innerHeight", {
-            configurable: true,
-            value: 500,
-        });
-        Object.defineProperty(window, "innerWidth", {
-            configurable: true,
-            value: 500,
-        });
-        Object.defineProperty(document.body, "scrollHeight", {
-            configurable: true,
-            value: 2000,
-        });
-        Object.defineProperty(document.body, "clientHeight", {
-            configurable: true,
-            value: 500,
-        });
-        const bodyScrollTo = vi.fn();
-        document.body.scrollTo = bodyScrollTo;
-
-        render(
-            <Harness
-                anchors={[
-                    { testId: "card-pack", anchorAttr: "setup-card-pack" },
-                ]}
-            >
-                {c => {
-                    api = c;
-                    return null;
-                }}
-            </Harness>,
-            { wrapper: TestQueryClientProvider },
-        );
-        const anchor = screen.getByTestId("card-pack");
-        anchor.getBoundingClientRect = () =>
-            new DOMRect(100, 1000, 100, 100);
-
-        act(() => api.startTour("setup"));
-
-        expect(bodyScrollTo).toHaveBeenCalledWith(
-            expect.objectContaining({ behavior: "auto" }),
-        );
-    });
 });
 
 // -----------------------------------------------------------------------

--- a/src/ui/tour/TourPopover.test.tsx
+++ b/src/ui/tour/TourPopover.test.tsx
@@ -17,8 +17,10 @@
  * support — is exercised by mounting elements with both single and
  * space-separated `data-tour-anchor` values.
  */
-import { describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { forwardRef, createElement, type ReactNode } from "react";
+
+const motionMock = vi.hoisted(() => ({ reducedMotion: false }));
 
 vi.mock("next-intl", () => {
     const t = (key: string, values?: Record<string, unknown>): string =>
@@ -53,7 +55,7 @@ vi.mock("motion/react", () => {
     return {
         motion,
         AnimatePresence: ({ children }: { children: ReactNode }) => children,
-        useReducedMotion: () => false,
+        useReducedMotion: () => motionMock.reducedMotion,
     };
 });
 
@@ -62,6 +64,10 @@ import { ClueProvider } from "../state";
 import { TestQueryClientProvider } from "../../test-utils/queryClient";
 import { TourProvider, useTour } from "./TourProvider";
 import { TourPopover } from "./TourPopover";
+
+beforeEach(() => {
+    motionMock.reducedMotion = false;
+});
 
 /**
  * Mounts the popover inside a `<TourProvider>` and exposes the
@@ -273,11 +279,14 @@ describe("TourPopover — M20 interaction rules", () => {
         );
         act(() => api.startTour("setup"));
         expect(api.activeScreen).toBe("setup");
-        // The backdrop is the fixed-inset div with z-40 that has no
+        // The backdrop is the fixed-inset div using the tour-backdrop
+        // z-index token and has no
         // `aria-hidden` siblings carrying the tour content. Find it
         // by its class signature.
-        const backdrop = document.querySelector<HTMLDivElement>(
-            "div.fixed.inset-0.z-40",
+        const backdrop = Array.from(
+            document.querySelectorAll<HTMLDivElement>("div.fixed.inset-0"),
+        ).find((el) =>
+            el.className.includes("z-[var(--z-tour-backdrop)]"),
         );
         expect(backdrop).not.toBeNull();
         fireEvent.click(backdrop!);
@@ -511,6 +520,97 @@ describe("TourPopover — veil isolation", () => {
         expect(document.body.style.overflow).toBe(before);
         act(() => api.dismissTour("close"));
         expect(document.body.style.overflow).toBe(before);
+    });
+
+    test("out-of-view anchors use native smooth body scroll", () => {
+        let api!: ReturnType<typeof useTour>;
+        Object.defineProperty(window, "innerHeight", {
+            configurable: true,
+            value: 500,
+        });
+        Object.defineProperty(window, "innerWidth", {
+            configurable: true,
+            value: 500,
+        });
+        Object.defineProperty(document.body, "scrollHeight", {
+            configurable: true,
+            value: 2000,
+        });
+        Object.defineProperty(document.body, "clientHeight", {
+            configurable: true,
+            value: 500,
+        });
+        const bodyScrollTo = vi.fn();
+        document.body.scrollTo = bodyScrollTo;
+
+        render(
+            <Harness
+                anchors={[
+                    { testId: "card-pack", anchorAttr: "setup-card-pack" },
+                ]}
+            >
+                {c => {
+                    api = c;
+                    return null;
+                }}
+            </Harness>,
+            { wrapper: TestQueryClientProvider },
+        );
+        const anchor = screen.getByTestId("card-pack");
+        anchor.getBoundingClientRect = () =>
+            new DOMRect(100, 1000, 100, 100);
+
+        act(() => api.startTour("setup"));
+
+        expect(bodyScrollTo).toHaveBeenCalledWith(
+            expect.objectContaining({ behavior: "smooth" }),
+        );
+    });
+
+    test("out-of-view anchors use instant scroll for reduced motion", () => {
+        motionMock.reducedMotion = true;
+        let api!: ReturnType<typeof useTour>;
+        Object.defineProperty(window, "innerHeight", {
+            configurable: true,
+            value: 500,
+        });
+        Object.defineProperty(window, "innerWidth", {
+            configurable: true,
+            value: 500,
+        });
+        Object.defineProperty(document.body, "scrollHeight", {
+            configurable: true,
+            value: 2000,
+        });
+        Object.defineProperty(document.body, "clientHeight", {
+            configurable: true,
+            value: 500,
+        });
+        const bodyScrollTo = vi.fn();
+        document.body.scrollTo = bodyScrollTo;
+
+        render(
+            <Harness
+                anchors={[
+                    { testId: "card-pack", anchorAttr: "setup-card-pack" },
+                ]}
+            >
+                {c => {
+                    api = c;
+                    return null;
+                }}
+            </Harness>,
+            { wrapper: TestQueryClientProvider },
+        );
+        const anchor = screen.getByTestId("card-pack");
+        anchor.getBoundingClientRect = () =>
+            new DOMRect(100, 1000, 100, 100);
+
+        act(() => api.startTour("setup"));
+
+        expect(bodyScrollTo).toHaveBeenCalledWith(
+            expect.objectContaining({ behavior: "auto" }),
+        );
     });
 });
 

--- a/src/ui/tour/TourPopover.test.tsx
+++ b/src/ui/tour/TourPopover.test.tsx
@@ -67,6 +67,18 @@ import { TourPopover } from "./TourPopover";
 
 beforeEach(() => {
     motionMock.reducedMotion = false;
+    Object.defineProperty(window, "scrollX", {
+        configurable: true,
+        value: 0,
+    });
+    Object.defineProperty(window, "scrollY", {
+        configurable: true,
+        value: 0,
+    });
+    Object.defineProperty(window, "scrollTo", {
+        configurable: true,
+        value: vi.fn(),
+    });
 });
 
 /**
@@ -83,6 +95,7 @@ function Harness({
     readonly anchors: ReadonlyArray<{
         readonly testId: string;
         readonly anchorAttr?: string;
+        readonly stickyLeft?: boolean;
     }>;
     /** Render-prop receives the tour controls so the test can call
      *  `startTour("setup")` etc. */
@@ -98,6 +111,9 @@ function Harness({
                     };
                     if (a.anchorAttr !== undefined) {
                         props["data-tour-anchor"] = a.anchorAttr;
+                    }
+                    if (a.stickyLeft) {
+                        props["data-tour-sticky-left"] = "";
                     }
                     return createElement("div", { key: a.testId, ...props });
                 })}
@@ -564,6 +580,164 @@ describe("TourPopover — veil isolation", () => {
 
         expect(bodyScrollTo).toHaveBeenCalledWith(
             expect.objectContaining({ behavior: "smooth" }),
+        );
+    });
+
+    test("anchors covered by the sticky first column scroll into the unobscured viewport", () => {
+        let api!: ReturnType<typeof useTour>;
+        Object.defineProperty(window, "innerHeight", {
+            configurable: true,
+            value: 500,
+        });
+        Object.defineProperty(window, "innerWidth", {
+            configurable: true,
+            value: 500,
+        });
+        Object.defineProperty(document.body, "scrollWidth", {
+            configurable: true,
+            value: 1000,
+        });
+        Object.defineProperty(document.body, "clientWidth", {
+            configurable: true,
+            value: 500,
+        });
+        document.body.scrollLeft = 120;
+        const bodyScrollTo = vi.fn();
+        document.body.scrollTo = bodyScrollTo;
+
+        render(
+            <Harness
+                anchors={[
+                    { testId: "card-pack", anchorAttr: "setup-card-pack" },
+                    { testId: "sticky", stickyLeft: true },
+                ]}
+            >
+                {c => {
+                    api = c;
+                    return null;
+                }}
+            </Harness>,
+            { wrapper: TestQueryClientProvider },
+        );
+        const anchor = screen.getByTestId("card-pack");
+        anchor.getBoundingClientRect = () =>
+            new DOMRect(120, 100, 80, 40);
+        const sticky = screen.getByTestId("sticky");
+        sticky.getBoundingClientRect = () =>
+            new DOMRect(0, 0, 170, 500);
+
+        act(() => api.startTour("setup"));
+
+        expect(bodyScrollTo).toHaveBeenCalledWith(
+            expect.objectContaining({
+                behavior: "smooth",
+                left: 0,
+            }),
+        );
+    });
+
+    test("sticky first-column clearance does not affect non-overlapping anchors", () => {
+        let api!: ReturnType<typeof useTour>;
+        Object.defineProperty(window, "innerHeight", {
+            configurable: true,
+            value: 500,
+        });
+        Object.defineProperty(window, "innerWidth", {
+            configurable: true,
+            value: 500,
+        });
+        Object.defineProperty(document.body, "scrollWidth", {
+            configurable: true,
+            value: 1000,
+        });
+        Object.defineProperty(document.body, "clientWidth", {
+            configurable: true,
+            value: 500,
+        });
+        document.body.scrollLeft = 120;
+        const bodyScrollTo = vi.fn();
+        document.body.scrollTo = bodyScrollTo;
+
+        render(
+            <Harness
+                anchors={[
+                    { testId: "card-pack", anchorAttr: "setup-card-pack" },
+                    { testId: "sticky", stickyLeft: true },
+                ]}
+            >
+                {c => {
+                    api = c;
+                    return null;
+                }}
+            </Harness>,
+            { wrapper: TestQueryClientProvider },
+        );
+        const anchor = screen.getByTestId("card-pack");
+        anchor.getBoundingClientRect = () =>
+            new DOMRect(120, 300, 80, 40);
+        const sticky = screen.getByTestId("sticky");
+        sticky.getBoundingClientRect = () =>
+            new DOMRect(0, 0, 170, 120);
+
+        act(() => api.startTour("setup"));
+
+        expect(bodyScrollTo).not.toHaveBeenCalled();
+    });
+
+    test("page-level horizontal scroll uses window.scrollX when body.scrollLeft is stale", () => {
+        let api!: ReturnType<typeof useTour>;
+        Object.defineProperty(window, "innerHeight", {
+            configurable: true,
+            value: 500,
+        });
+        Object.defineProperty(window, "innerWidth", {
+            configurable: true,
+            value: 500,
+        });
+        Object.defineProperty(window, "scrollX", {
+            configurable: true,
+            value: 120,
+        });
+        Object.defineProperty(document.body, "scrollWidth", {
+            configurable: true,
+            value: 1000,
+        });
+        Object.defineProperty(document.body, "clientWidth", {
+            configurable: true,
+            value: 500,
+        });
+        document.body.scrollLeft = 0;
+        const bodyScrollTo = vi.fn();
+        document.body.scrollTo = bodyScrollTo;
+
+        render(
+            <Harness
+                anchors={[
+                    { testId: "card-pack", anchorAttr: "setup-card-pack" },
+                    { testId: "sticky", stickyLeft: true },
+                ]}
+            >
+                {c => {
+                    api = c;
+                    return null;
+                }}
+            </Harness>,
+            { wrapper: TestQueryClientProvider },
+        );
+        const anchor = screen.getByTestId("card-pack");
+        anchor.getBoundingClientRect = () =>
+            new DOMRect(120, 100, 80, 40);
+        const sticky = screen.getByTestId("sticky");
+        sticky.getBoundingClientRect = () =>
+            new DOMRect(0, 0, 170, 500);
+
+        act(() => api.startTour("setup"));
+
+        expect(bodyScrollTo).toHaveBeenCalledWith(
+            expect.objectContaining({ left: 0 }),
+        );
+        expect(window.scrollTo).toHaveBeenCalledWith(
+            expect.objectContaining({ left: 0 }),
         );
     });
 

--- a/src/ui/tour/TourPopover.tsx
+++ b/src/ui/tour/TourPopover.tsx
@@ -42,7 +42,6 @@
 "use client";
 
 import * as Popover from "@radix-ui/react-popover";
-import { useReducedMotion } from "motion/react";
 import { useTranslations } from "next-intl";
 import { useEffect, useRef, useState } from "react";
 import { XIcon } from "../components/Icons";
@@ -73,7 +72,6 @@ const KEY_ESCAPE = "Escape" as const;
 // Analytics discriminator for tour dismissal via Esc keypress.
 const DISMISS_VIA_ESC = "esc" as const;
 const SCROLL_BEHAVIOR_AUTO: ScrollBehavior = "auto";
-const SCROLL_BEHAVIOR_SMOOTH: ScrollBehavior = "smooth";
 // Attribute we add to the Radix Popover.Content so the keyboard
 // isolator can do an O(1) `popoverContent.contains(eventTarget)` check
 // to allow keyboard events that target the popover's own buttons.
@@ -191,7 +189,6 @@ export function TourPopover() {
         dismissTour,
     } = useTour();
     const { state, dispatch } = useClue();
-    const prefersReducedMotion = useReducedMotion();
 
     // The virtualRef passed into Radix Popover. Each step recomputes
     // it via the effect below.
@@ -305,9 +302,7 @@ export function TourPopover() {
                         + rect.width / 2
                         - (minVisibleLeft + unobscuredWidth / 2)
                     : rect.left - minVisibleLeft;
-            const behavior: ScrollBehavior = prefersReducedMotion
-                ? SCROLL_BEHAVIOR_AUTO
-                : SCROLL_BEHAVIOR_SMOOTH;
+            const behavior: ScrollBehavior = SCROLL_BEHAVIOR_AUTO;
             const body = document.body;
             const html = document.documentElement;
             // Pick whichever element is actually scrollable for each
@@ -415,7 +410,26 @@ export function TourPopover() {
             virtualElementRef.current = {
                 getBoundingClientRect: popoverMeasure,
             };
-            const measured = spotlightMeasure();
+            let measured = spotlightMeasure();
+            // Auto-scroll at most once per step so anchors below the
+            // fold (or off to the side on a horizontally-scrolling
+            // page) come into view. This is deliberately instant:
+            // tour popover positioning depends on stable viewport
+            // geometry, and smooth scrolling leaves the spotlight and
+            // Radix popper measuring a moving target.
+            const scrollTracker = scrolledForStepRef.current;
+            if (
+                scrollTracker.screen !== activeScreen ||
+                scrollTracker.step !== stepIndex
+            ) {
+                scrolledForStepRef.current = {
+                    screen: activeScreen,
+                    step: stepIndex,
+                };
+                if (scrollSpotlightIntoView(measured)) {
+                    measured = spotlightMeasure();
+                }
+            }
             setSpotlight(measured);
             // Bump the Radix-remount key only when the union rect
             // changed enough to matter (sub-pixel jitter doesn't
@@ -427,23 +441,6 @@ export function TourPopover() {
             if (unionKey !== lastUnionKeyRef.current) {
                 lastUnionKeyRef.current = unionKey;
                 setAnchorTick(n => n + 1);
-            }
-            // Auto-scroll at most once per step so anchors below the
-            // fold (or off to the side on a horizontally-scrolling
-            // page) come into view. Native smooth scroll emits scroll
-            // events while it moves; avoiding repeated calls here
-            // keeps the browser's own animation from being cancelled
-            // and restarted by our tracking recomputes.
-            const scrollTracker = scrolledForStepRef.current;
-            if (
-                scrollTracker.screen !== activeScreen ||
-                scrollTracker.step !== stepIndex
-            ) {
-                scrolledForStepRef.current = {
-                    screen: activeScreen,
-                    step: stepIndex,
-                };
-                scrollSpotlightIntoView(measured);
             }
         };
 
@@ -535,7 +532,6 @@ export function TourPopover() {
         stepIndex,
         currentStep,
         state.uiMode,
-        prefersReducedMotion,
     ]);
 
     // While a tour is active, the page beneath the veil should be

--- a/src/ui/tour/TourPopover.tsx
+++ b/src/ui/tour/TourPopover.tsx
@@ -42,6 +42,7 @@
 "use client";
 
 import * as Popover from "@radix-ui/react-popover";
+import { useReducedMotion } from "motion/react";
 import { useTranslations } from "next-intl";
 import { useEffect, useRef, useState } from "react";
 import { XIcon } from "../components/Icons";
@@ -71,6 +72,8 @@ type VirtualElement = {
 const KEY_ESCAPE = "Escape" as const;
 // Analytics discriminator for tour dismissal via Esc keypress.
 const DISMISS_VIA_ESC = "esc" as const;
+const SCROLL_BEHAVIOR_AUTO: ScrollBehavior = "auto";
+const SCROLL_BEHAVIOR_SMOOTH: ScrollBehavior = "smooth";
 // Attribute we add to the Radix Popover.Content so the keyboard
 // isolator can do an O(1) `popoverContent.contains(eventTarget)` check
 // to allow keyboard events that target the popover's own buttons.
@@ -108,6 +111,7 @@ export function TourPopover() {
         dismissTour,
     } = useTour();
     const { state, dispatch } = useClue();
+    const prefersReducedMotion = useReducedMotion();
 
     // The virtualRef passed into Radix Popover. Each step recomputes
     // it via the effect below.
@@ -174,8 +178,8 @@ export function TourPopover() {
             return;
         }
 
-        const scrollSpotlightIntoView = (rect: DOMRect): void => {
-            if (typeof window === "undefined") return;
+        const scrollSpotlightIntoView = (rect: DOMRect): boolean => {
+            if (typeof window === "undefined") return false;
             const margin = 48;
             const vw = window.innerWidth;
             const vh = window.innerHeight;
@@ -183,7 +187,7 @@ export function TourPopover() {
                 rect.top >= margin && rect.bottom <= vh - margin;
             const inViewHorizontal =
                 rect.left >= margin && rect.right <= vw - margin;
-            if (inViewVertical && inViewHorizontal) return;
+            if (inViewVertical && inViewHorizontal) return false;
             // The page splits scroll: vertical scroll lives on the
             // body when content overflows (the `min-w-max` <main> +
             // tall checklist make body's scrollHeight > clientHeight);
@@ -211,17 +215,9 @@ export function TourPopover() {
                 : rect.width + margin * 2 < vw
                     ? rect.left + rect.width / 2 - vw / 2
                     : rect.left - margin;
-            // Use `auto` (instantaneous) rather than `smooth`. The
-            // recompute fires multiple times per step (mutation
-            // observer + step-change effect + React re-renders all
-            // re-trigger it), and back-to-back smooth-scroll calls
-            // cancel each other before the animation can commit any
-            // movement — leaving body.scrollTop stuck at 0. Instant
-            // scroll matches the user's mental model anyway: the
-            // tour jumped to a new step, the page should already be
-            // showing what the step is about.
-            // eslint-disable-next-line i18next/no-literal-string -- ScrollBehavior enum
-            const behavior: ScrollBehavior = "auto";
+            const behavior: ScrollBehavior = prefersReducedMotion
+                ? SCROLL_BEHAVIOR_AUTO
+                : SCROLL_BEHAVIOR_SMOOTH;
             const body = document.body;
             const html = document.documentElement;
             // Pick whichever element is actually scrollable for each
@@ -238,13 +234,26 @@ export function TourPopover() {
                     top: verticalEl.scrollTop + dy,
                     behavior,
                 });
+                if (verticalEl === html) {
+                    window.scrollTo({
+                        top: window.scrollY + dy,
+                        behavior,
+                    });
+                }
             }
             if (dx !== 0) {
                 horizontalEl.scrollTo({
                     left: horizontalEl.scrollLeft + dx,
                     behavior,
                 });
+                if (horizontalEl === html) {
+                    window.scrollTo({
+                        left: window.scrollX + dx,
+                        behavior,
+                    });
+                }
             }
+            return dx !== 0 || dy !== 0;
         };
 
         const recompute = (): void => {
@@ -328,10 +337,12 @@ export function TourPopover() {
                 lastUnionKeyRef.current = unionKey;
                 setAnchorTick(n => n + 1);
             }
-            // Auto-scroll once per step so anchors below the fold
-            // (or off to the side on a horizontally-scrolling page)
-            // come into view. Subsequent recomputes don't re-scroll;
-            // the user is in control once they start interacting.
+            // Auto-scroll at most once per step so anchors below the
+            // fold (or off to the side on a horizontally-scrolling
+            // page) come into view. Native smooth scroll emits scroll
+            // events while it moves; avoiding repeated calls here
+            // keeps the browser's own animation from being cancelled
+            // and restarted by our tracking recomputes.
             const scrollTracker = scrolledForStepRef.current;
             if (
                 scrollTracker.screen !== activeScreen ||
@@ -341,13 +352,8 @@ export function TourPopover() {
                     screen: activeScreen,
                     step: stepIndex,
                 };
+                scrollSpotlightIntoView(measured);
             }
-            // Always re-check whether the spotlight is in view: the
-            // page may have reflowed (e.g. menu opened, image
-            // loaded) since we last checked. The fn no-ops when the
-            // rect is comfortably inside the viewport, and `auto`
-            // scroll is idempotent at the same target.
-            scrollSpotlightIntoView(measured);
         };
 
         recompute();
@@ -433,7 +439,13 @@ export function TourPopover() {
                 if (t !== undefined) window.clearTimeout(t);
             }
         };
-    }, [activeScreen, stepIndex, currentStep, state.uiMode]);
+    }, [
+        activeScreen,
+        stepIndex,
+        currentStep,
+        state.uiMode,
+        prefersReducedMotion,
+    ]);
 
     // While a tour is active, the page beneath the veil should be
     // keyboard-inert. App-level shortcuts (`⌘K`, `⌘Z`, the per-tab
@@ -531,7 +543,7 @@ export function TourPopover() {
                 with content. */}
             <div
                 aria-hidden
-                className="fixed inset-0 z-40"
+                className="fixed inset-0 z-[var(--z-tour-backdrop)]"
             />
             {/* Spotlight: a transparent box sized to the anchor with
                 a giant `box-shadow` painting darkness OUTSIDE the box.
@@ -559,14 +571,14 @@ export function TourPopover() {
                             "0 0 0 9999px rgba(0,0,0,0.45), 0 0 0 2px var(--color-tour-accent)",
                         borderRadius: "var(--tour-radius)",
                         pointerEvents: "auto",
-                        zIndex: 41,
+                        zIndex: "var(--z-tour-spotlight)",
                     }}
                     className="tour-spotlight transition-all"
                 />
             ) : (
                 <div
                     aria-hidden
-                    className="fixed inset-0 z-40 bg-black/45"
+                    className="fixed inset-0 z-[var(--z-tour-backdrop)] bg-black/45"
                 />
             )}
             {/* Key the entire Popover.Root tree on the active step
@@ -588,11 +600,9 @@ export function TourPopover() {
                         align={resolvedAlign}
                         sideOffset={14}
                         collisionPadding={24}
-                        // The tour floats above the backdrop (z-40)
-                        // AND above any popover/menu the active step
-                        // might trigger to open (the overflow menu
-                        // content uses z-50). Bumped to z-60 so the
-                        // tour copy stays visible. The
+                        // The tour floats above the backdrop and
+                        // above any popover/menu the active step
+                        // might trigger to open. The
                         // `max-h-[calc(100vh-32px)] overflow-y-auto`
                         // pair caps the popover at viewport height
                         // so a tall popover (long body copy + 4-line
@@ -602,7 +612,7 @@ export function TourPopover() {
                         // resolve the popper to a y-coord with the
                         // bottom edge below the viewport.
                         className={
-                            "z-[60] w-[min(92vw,360px)] max-h-[calc(100vh-32px)] overflow-y-auto rounded-[var(--tour-radius)] " +
+                            "z-[var(--z-tour-popover)] w-[min(92vw,360px)] max-h-[calc(100vh-32px)] overflow-y-auto rounded-[var(--tour-radius)] " +
                             "border-2 border-[var(--color-tour-border)] " +
                             "bg-[var(--color-tour-bg)] text-[var(--color-tour-text)] " +
                             "shadow-[0_10px_28px_rgba(30,64,175,0.28)] focus:outline-none"

--- a/src/ui/tour/TourPopover.tsx
+++ b/src/ui/tour/TourPopover.tsx
@@ -78,6 +78,11 @@ const SCROLL_BEHAVIOR_SMOOTH: ScrollBehavior = "smooth";
 // isolator can do an O(1) `popoverContent.contains(eventTarget)` check
 // to allow keyboard events that target the popover's own buttons.
 const POPOVER_CONTENT_ATTR = "data-tour-popover-content" as const;
+const TOUR_VIEWPORT_MARGIN = 48;
+const TOUR_STICKY_LEFT_GAP = 16;
+const TOUR_STICKY_LEFT_ATTR = "data-tour-sticky-left" as const;
+const SCROLL_AXIS_X = "x" as const;
+const SCROLL_AXIS_Y = "y" as const;
 
 // `findAnchorElements`, `resolveAnchorToken`, `resolvePopoverAnchorToken`,
 // `resolveSideAndAlign`, `unionRect`, and `pickPopoverRect` are now in
@@ -95,6 +100,81 @@ const fallbackVirtualRect = (): DOMRect => {
     const x = Math.max(w - 320, 16);
     const y = Math.max(h - 240, 16);
     return new DOMRect(x, y, 1, 1);
+};
+
+const clamp = (n: number, min: number, max: number): number =>
+    Math.min(max, Math.max(min, n));
+
+const getStickyLeftClearance = (
+    viewportHeight: number,
+    targetRect: DOMRect,
+): number => {
+    if (typeof document === "undefined") return TOUR_VIEWPORT_MARGIN;
+    let stickyRight = 0;
+    const stickyEls = document.querySelectorAll<HTMLElement>(
+        `[${TOUR_STICKY_LEFT_ATTR}]`,
+    );
+    for (const el of stickyEls) {
+        const rect = el.getBoundingClientRect();
+        const isVisible =
+            rect.width > 0
+            && rect.height > 0
+            && rect.left < TOUR_VIEWPORT_MARGIN
+            && rect.right > 0
+            && rect.top < viewportHeight
+            && rect.bottom > 0
+            && rect.top < targetRect.bottom
+            && rect.bottom > targetRect.top;
+        if (isVisible && rect.right > stickyRight) {
+            stickyRight = rect.right;
+        }
+    }
+    return stickyRight > 0
+        ? Math.max(TOUR_VIEWPORT_MARGIN, stickyRight + TOUR_STICKY_LEFT_GAP)
+        : TOUR_VIEWPORT_MARGIN;
+};
+
+const isPageScroller = (el: HTMLElement): boolean =>
+    typeof document !== "undefined"
+    && (el === document.body || el === document.documentElement);
+
+const pageMaxScroll = (axis: "x" | "y"): number => {
+    if (typeof document === "undefined" || typeof window === "undefined") {
+        return 0;
+    }
+    const body = document.body;
+    const html = document.documentElement;
+    const viewport = axis === "x" ? window.innerWidth : window.innerHeight;
+    const scrollSize = axis === "x"
+        ? Math.max(body.scrollWidth, html.scrollWidth)
+        : Math.max(body.scrollHeight, html.scrollHeight);
+    return Math.max(0, scrollSize - viewport);
+};
+
+const maxScroll = (el: HTMLElement, axis: "x" | "y"): number => {
+    if (isPageScroller(el)) return pageMaxScroll(axis);
+    return axis === "x"
+        ? Math.max(0, el.scrollWidth - el.clientWidth)
+        : Math.max(0, el.scrollHeight - el.clientHeight);
+};
+
+const currentScroll = (el: HTMLElement, axis: "x" | "y"): number => {
+    if (isPageScroller(el) && typeof window !== "undefined") {
+        return axis === "x"
+            ? Math.max(el.scrollLeft, window.scrollX)
+            : Math.max(el.scrollTop, window.scrollY);
+    }
+    return axis === "x" ? el.scrollLeft : el.scrollTop;
+};
+
+const scrollPage = (
+    el: HTMLElement,
+    opts: ScrollToOptions,
+): void => {
+    el.scrollTo(opts);
+    if (isPageScroller(el) && typeof window !== "undefined") {
+        window.scrollTo(opts);
+    }
 };
 
 export function TourPopover() {
@@ -180,13 +260,20 @@ export function TourPopover() {
 
         const scrollSpotlightIntoView = (rect: DOMRect): boolean => {
             if (typeof window === "undefined") return false;
-            const margin = 48;
             const vw = window.innerWidth;
             const vh = window.innerHeight;
+            const margin = TOUR_VIEWPORT_MARGIN;
+            const minVisibleLeft = clamp(
+                getStickyLeftClearance(vh, rect),
+                margin,
+                Math.max(margin, vw - margin),
+            );
+            const maxVisibleRight = vw - margin;
             const inViewVertical =
                 rect.top >= margin && rect.bottom <= vh - margin;
             const inViewHorizontal =
-                rect.left >= margin && rect.right <= vw - margin;
+                rect.left >= minVisibleLeft
+                && rect.right <= maxVisibleRight;
             if (inViewVertical && inViewHorizontal) return false;
             // The page splits scroll: vertical scroll lives on the
             // body when content overflows (the `min-w-max` <main> +
@@ -210,11 +297,14 @@ export function TourPopover() {
                 : rect.height + margin * 2 < vh
                     ? rect.top + rect.height / 2 - vh / 2
                     : rect.top - margin;
+            const unobscuredWidth = maxVisibleRight - minVisibleLeft;
             const dx = inViewHorizontal
                 ? 0
-                : rect.width + margin * 2 < vw
-                    ? rect.left + rect.width / 2 - vw / 2
-                    : rect.left - margin;
+                : rect.width < unobscuredWidth
+                    ? rect.left
+                        + rect.width / 2
+                        - (minVisibleLeft + unobscuredWidth / 2)
+                    : rect.left - minVisibleLeft;
             const behavior: ScrollBehavior = prefersReducedMotion
                 ? SCROLL_BEHAVIOR_AUTO
                 : SCROLL_BEHAVIOR_SMOOTH;
@@ -229,31 +319,32 @@ export function TourPopover() {
                 body.scrollHeight > body.clientHeight ? body : html;
             const horizontalEl =
                 body.scrollWidth > body.clientWidth ? body : html;
+            let didScroll = false;
             if (dy !== 0) {
-                verticalEl.scrollTo({
-                    top: verticalEl.scrollTop + dy,
-                    behavior,
-                });
-                if (verticalEl === html) {
-                    window.scrollTo({
-                        top: window.scrollY + dy,
-                        behavior,
-                    });
+                const currentTop = currentScroll(verticalEl, SCROLL_AXIS_Y);
+                const top = clamp(
+                    currentTop + dy,
+                    0,
+                    maxScroll(verticalEl, SCROLL_AXIS_Y),
+                );
+                if (top !== currentTop) {
+                    scrollPage(verticalEl, { top, behavior });
+                    didScroll = true;
                 }
             }
             if (dx !== 0) {
-                horizontalEl.scrollTo({
-                    left: horizontalEl.scrollLeft + dx,
-                    behavior,
-                });
-                if (horizontalEl === html) {
-                    window.scrollTo({
-                        left: window.scrollX + dx,
-                        behavior,
-                    });
+                const currentLeft = currentScroll(horizontalEl, SCROLL_AXIS_X);
+                const left = clamp(
+                    currentLeft + dx,
+                    0,
+                    maxScroll(horizontalEl, SCROLL_AXIS_X),
+                );
+                if (left !== currentLeft) {
+                    scrollPage(horizontalEl, { left, behavior });
+                    didScroll = true;
                 }
             }
-            return dx !== 0 || dy !== 0;
+            return didScroll;
         };
 
         const recompute = (): void => {

--- a/src/ui/tour/TourState.test.ts
+++ b/src/ui/tour/TourState.test.ts
@@ -57,7 +57,7 @@ describe("saveTourVisited / saveTourDismissed round-trip", () => {
         ).toBe(DateTime.toEpochMillis(t));
     });
 
-    test("save dismissed merges with prior visited timestamp", () => {
+    test("save dismissed records the dismissal as the latest visit", () => {
         const visited = now("2026-04-01T00:00:00Z");
         const dismissed = now("2026-04-29T00:00:00Z");
         saveTourVisited("setup", visited);
@@ -65,7 +65,19 @@ describe("saveTourVisited / saveTourDismissed round-trip", () => {
         const loaded = loadTourState("setup");
         expect(
             DateTime.toEpochMillis(loaded.lastVisitedAt!),
-        ).toBe(DateTime.toEpochMillis(visited));
+        ).toBe(DateTime.toEpochMillis(dismissed));
+        expect(
+            DateTime.toEpochMillis(loaded.lastDismissedAt!),
+        ).toBe(DateTime.toEpochMillis(dismissed));
+    });
+
+    test("save dismissed without a prior visit writes both timestamps", () => {
+        const dismissed = now("2026-04-29T00:00:00Z");
+        saveTourDismissed("setup", dismissed);
+        const loaded = loadTourState("setup");
+        expect(
+            DateTime.toEpochMillis(loaded.lastVisitedAt!),
+        ).toBe(DateTime.toEpochMillis(dismissed));
         expect(
             DateTime.toEpochMillis(loaded.lastDismissedAt!),
         ).toBe(DateTime.toEpochMillis(dismissed));

--- a/src/ui/tour/TourState.ts
+++ b/src/ui/tour/TourState.ts
@@ -133,7 +133,7 @@ export const saveTourVisited = (
 export const saveTourDismissed = (
     screen: ScreenKey,
     now: DateTime.Utc,
-): void => writeMerged(screen, { lastDismissedAt: now });
+): void => writeMerged(screen, { lastVisitedAt: now, lastDismissedAt: now });
 
 /**
  * Wipe every per-screen tour key from localStorage so the next visit

--- a/src/ui/tour/screenKey.test.ts
+++ b/src/ui/tour/screenKey.test.ts
@@ -32,6 +32,16 @@ const seedDismissed = (key: string): void => {
     );
 };
 
+const seedDismissedOnly = (key: string, recent: string): void => {
+    window.localStorage.setItem(
+        key,
+        JSON.stringify({
+            version: 1,
+            lastDismissedAt: recent,
+        }),
+    );
+};
+
 describe("screenKeyForUiMode", () => {
     test("setup uiMode → setup screen", () => {
         expect(screenKeyForUiMode("setup")).toBe("setup");
@@ -157,6 +167,15 @@ describe("pickFirstEligibleScreenKey", () => {
 
     test("both prereqs dismissed → sharing eligible → returns sharing", () => {
         seedDismissed(STORAGE_TOUR_SETUP);
+        seedDismissed(STORAGE_TOUR_CHECKLIST_SUGGEST);
+        expect(pickFirstEligibleScreenKey(["setup", "sharing"], now)).toBe(
+            "sharing",
+        );
+    });
+
+    test("dismissed-only setup state stays suppressed inside the re-engage window", () => {
+        const recent = new Date(DateTime.toEpochMillis(now)).toISOString();
+        seedDismissedOnly(STORAGE_TOUR_SETUP, recent);
         seedDismissed(STORAGE_TOUR_CHECKLIST_SUGGEST);
         expect(pickFirstEligibleScreenKey(["setup", "sharing"], now)).toBe(
             "sharing",

--- a/src/ui/tour/screenKey.ts
+++ b/src/ui/tour/screenKey.ts
@@ -64,8 +64,10 @@ export const uiModeForScreenKey = (screen: ScreenKey): UiMode | undefined => {
  *
  * `TourScreenGate` walks this list and gates the FIRST tour whose
  * prerequisites are met AND whose own re-engage gate says "show". A
- * mode with no eligible tour returns its primary tour anyway so the
- * gate machinery still runs (and just decides not to show).
+ * dismissal without a visit timestamp still keeps the tour closed
+ * until the re-engage window expires. A mode with no eligible tour
+ * returns its primary tour anyway so the gate machinery still runs
+ * (and just decides not to show).
  */
 export const screensForUiMode = (mode: UiMode): ReadonlyArray<ScreenKey> => {
     if (mode === UI_MODE_SETUP) return [SETUP, SHARING];
@@ -96,8 +98,8 @@ export const pickFirstEligibleScreenKey = (
         if (!prereqsAllDismissed) continue;
         const state = loadTourState(candidate);
         if (state.lastDismissedAt === undefined) return candidate;
-        if (state.lastVisitedAt === undefined) return candidate;
-        const elapsed = DateTime.distance(state.lastVisitedAt, now);
+        const referenceAt = state.lastVisitedAt ?? state.lastDismissedAt;
+        const elapsed = DateTime.distance(referenceAt, now);
         if (Duration.isGreaterThan(elapsed, TOUR_RE_ENGAGE_DURATION)) {
             return candidate;
         }

--- a/src/ui/tour/tours.test.ts
+++ b/src/ui/tour/tours.test.ts
@@ -81,6 +81,12 @@ describe("TOURS — setup tour", () => {
         expect(step.sideByViewport?.desktop.side).toBe("left");
         expect(step.sideByViewport?.mobile.side).toBe("top");
     });
+
+    test("setup-start-playing keeps the popover below the near-top CTA", () => {
+        const step = findStep(TOURS.setup, "setup-start-playing");
+        expect(step.side).toBe("bottom");
+        expect(step.align).toBe("end");
+    });
 });
 
 describe("TOURS — checklistSuggest tour", () => {

--- a/src/ui/tour/tours.ts
+++ b/src/ui/tour/tours.ts
@@ -262,7 +262,12 @@ export const TOURS: Record<ScreenKey, ReadonlyArray<TourStep>> = {
             anchor: "setup-start-playing",
             titleKey: "setup.start.title",
             bodyKey: "setup.start.body",
-            side: "top",
+            // This CTA sits near the top of Setup. Keeping the
+            // popover below the button avoids top-edge clipping when
+            // the tour scrolls back up from a deeper table step,
+            // especially on mobile where the header consumes a
+            // meaningful chunk of the viewport.
+            side: "bottom",
             align: "end",
         },
     ],

--- a/src/ui/tour/useTourGate.test.tsx
+++ b/src/ui/tour/useTourGate.test.tsx
@@ -5,17 +5,21 @@
  *   - First visit (no `lastVisitedAt`, no `lastDismissedAt`) shows.
  *   - Visited but never dismissed shows.
  *   - Dismissed within the window does NOT show.
- *   - Dismissed but >= window since the last visit shows again.
+ *   - Dismissed but >= window since the last visit / dismissal shows again.
  *   - Each per-screen storage key is independent (dismissing setup
  *     doesn't suppress checklist).
  */
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { act, render } from "@testing-library/react";
+import { useEffect } from "react";
 import { DateTime, Duration } from "effect";
 import { TelemetryRuntime } from "../../observability/runtime";
 import {
     computeShouldShowTour,
     TOUR_RE_ENGAGE_DURATION,
+    useTourGate,
 } from "./useTourGate";
+import { saveTourDismissed, type ScreenKey } from "./TourState";
 
 const now = DateTime.makeUnsafe(new Date("2026-04-29T00:00:00Z"));
 const FIVE_MIN = Duration.minutes(5);
@@ -71,15 +75,26 @@ describe("computeShouldShowTour", () => {
         expect(result).toBe(true);
     });
 
-    test("dismissed but no `lastVisitedAt` (rare): shows", () => {
-        // Defensive — saving a dismissed timestamp without a visit
-        // shouldn't happen via the hook, but if it ever does we
-        // re-show on the next visit so the user isn't permanently
-        // locked out.
+    test("dismissed but no `lastVisitedAt` (rare): does NOT show inside the window", () => {
+        // Legacy or defensive states may have only `lastDismissedAt`.
+        // A dismissal is still enough to lock the gate until the
+        // re-engage window expires.
         const fiveMinAgo = DateTime.subtractDuration(now, FIVE_MIN);
         const result = TelemetryRuntime.runSync(
             computeShouldShowTour(
                 { lastDismissedAt: fiveMinAgo },
+                now,
+                TOUR_RE_ENGAGE_DURATION,
+            ),
+        );
+        expect(result).toBe(false);
+    });
+
+    test("dismissed but no `lastVisitedAt` and stale: re-engages", () => {
+        const sixWeeksAgo = DateTime.subtractDuration(now, SIX_WEEKS);
+        const result = TelemetryRuntime.runSync(
+            computeShouldShowTour(
+                { lastDismissedAt: sixWeeksAgo },
                 now,
                 TOUR_RE_ENGAGE_DURATION,
             ),
@@ -99,21 +114,43 @@ describe("TOUR_RE_ENGAGE_DURATION", () => {
 describe("useTourGate (integration)", () => {
     beforeEach(() => {
         window.localStorage.clear();
-        vi.useFakeTimers();
-        vi.setSystemTime(new Date("2026-04-29T00:00:00Z"));
     });
 
     afterEach(() => {
-        vi.useRealTimers();
+        window.localStorage.clear();
     });
 
-    // The hook itself is integrated by `TourScreenGate` in
-    // `Clue.tsx`; the gate-logic surface is fully covered by the
-    // pure-Effect tests above. Storage round-trip is exercised by
-    // `TourState.test.ts` (loading + writing under the per-screen
-    // key, multi-screen isolation).
-    test("(placeholder)", () => {
-        expect(true).toBe(true);
+    function GateFiringProbe({
+        screen,
+        onFire,
+    }: {
+        readonly screen: ScreenKey;
+        readonly onFire: (screen: ScreenKey) => void;
+    }): null {
+        const { shouldShow } = useTourGate(screen);
+        useEffect(() => {
+            if (shouldShow) onFire(screen);
+        }, [shouldShow, screen, onFire]);
+        return null;
+    }
+
+    test("does not apply a stale show decision after the screen key changes", async () => {
+        const fired: Array<ScreenKey> = [];
+        const onFire = (screen: ScreenKey): void => {
+            fired.push(screen);
+        };
+        const { rerender } = render(
+            <GateFiringProbe screen="checklistSuggest" onFire={onFire} />,
+        );
+
+        await act(async () => {});
+        expect(fired).toEqual(["checklistSuggest"]);
+
+        saveTourDismissed("setup", DateTime.nowUnsafe());
+        rerender(<GateFiringProbe screen="setup" onFire={onFire} />);
+
+        await act(async () => {});
+        expect(fired).toEqual(["checklistSuggest"]);
     });
 });
 
@@ -122,8 +159,6 @@ describe("useTourGate (integration)", () => {
 // + `TOUR_RE_ENGAGE_DURATION` pair, so a parameterized assertion
 // pins the contract against future ScreenKey additions (M22's new
 // `firstSuggestion` is the first beneficiary).
-import type { ScreenKey } from "./TourState";
-
 describe("computeShouldShowTour — re-engage cadence per ScreenKey", () => {
     const screenKeys: ReadonlyArray<ScreenKey> = [
         "setup",

--- a/src/ui/tour/useTourGate.tsx
+++ b/src/ui/tour/useTourGate.tsx
@@ -6,8 +6,13 @@
  * Gate (read both timestamps before writing the new visit):
  *
  *   show = lastDismissedAt is undefined           // never dismissed
- *       OR lastVisitedAt is undefined             // first visit
- *       OR (now − lastVisitedAt) > DURATION       // dormant returnee
+ *       OR (now − referenceAt) > DURATION         // dormant returnee
+ *
+ * `referenceAt` is `lastVisitedAt` when present, falling back to
+ * `lastDismissedAt`. That fallback matters for older or defensive
+ * states that contain a valid dismissal without a visit timestamp:
+ * the dismissal should still suppress the tour until the re-engage
+ * window expires.
  *
  * Same shape as `useSplashGate` — the splash modal sets the
  * convention for the whole "dismiss + 4-week re-engage" cadence and
@@ -15,7 +20,7 @@
  */
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { DateTime, Duration, Effect } from "effect";
 import { TelemetryRuntime } from "../../observability/runtime";
 import { TOUR_RE_ENGAGE_DURATION } from "./tours";
@@ -37,8 +42,8 @@ export const computeShouldShowTour = Effect.fn("tour.computeGate")(
         duration: Duration.Duration,
     ) {
         if (state.lastDismissedAt === undefined) return true;
-        if (state.lastVisitedAt === undefined) return true;
-        const elapsed = DateTime.distance(state.lastVisitedAt, now);
+        const referenceAt = state.lastVisitedAt ?? state.lastDismissedAt;
+        const elapsed = DateTime.distance(referenceAt, now);
         return Duration.isGreaterThan(elapsed, duration);
     },
 );
@@ -47,6 +52,11 @@ interface UseTourGateOptions {
     /** When false, the gate never fires. Used to defer per-screen tours
      * until the user is actually on that screen. */
     readonly enabled?: boolean;
+}
+
+interface GateDecision {
+    readonly screen: ScreenKey;
+    readonly shouldShow: boolean;
 }
 
 export function useTourGate(
@@ -59,7 +69,10 @@ export function useTourGate(
     readonly dismiss: () => void;
 } {
     const enabled = options.enabled ?? true;
-    const [shouldShow, setShouldShow] = useState(false);
+    const [decision, setDecision] = useState<GateDecision>(() => ({
+        screen,
+        shouldShow: false,
+    }));
 
     useEffect(() => {
         if (!enabled) return;
@@ -73,16 +86,20 @@ export function useTourGate(
         // state from a previous screen visible to the firing
         // effect when the user navigated to a screen whose tour was
         // already dismissed.
-        setShouldShow(should);
+        setDecision({ screen, shouldShow: should });
         // Order is critical: read state and decide BEFORE we overwrite
         // the visit timestamp, otherwise the gap is always 0.
         saveTourVisited(screen, now);
     }, [enabled, screen]);
 
-    const dismiss = () => {
+    const dismiss = useCallback(() => {
         saveTourDismissed(screen, DateTime.nowUnsafe());
-        setShouldShow(false);
-    };
+        setDecision({ screen, shouldShow: false });
+    }, [screen]);
 
-    return { shouldShow, dismiss };
+    return {
+        shouldShow:
+            enabled && decision.screen === screen ? decision.shouldShow : false,
+        dismiss,
+    };
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
         include: [
             "src/**/__tests__/**/*.{ts,tsx}",
             "src/**/?(*.)+(spec|test).{ts,tsx}",
+            "scripts/**/?(*.)+(spec|test).mjs",
         ],
         clearMocks: true,
         coverage: {


### PR DESCRIPTION
Summary
- Update tour scrolling and positioning, setup copy, z-index layering, sticky checklist columns, and share modal UX.
- Render missing-share state in-app with contextual CTAs and analytics.
- Reconcile local and server card packs on sign-in with exact duplicate detection, recency migration, and immediate query updates.
- Tighten local env setup for Docker database, Google OAuth config, preview lifecycle, and auto-port selection.

Verification
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm knip
- pnpm i18n:check

Analytics and observability
- Added share_open_failed.
- Extended local_packs_pushed_on_sign_in with countDeduped and countPulled.
- No production funnel step changes.
- No new Honeycomb spans.

Database
- No migration.