### PR TITLE
Fix built-in card pack save action

### DIFF
--- a/src/ui/components/CardPackRow.test.tsx
+++ b/src/ui/components/CardPackRow.test.tsx
@@ -246,7 +246,7 @@ describe("CardPackRow active-match styling", () => {
             "false",
         );
         expect(
-            screen.getByRole("button", { name: "saveAsCardPack" }),
+            screen.getByRole("button", { name: "saveAsNewCardPack" }),
         ).toHaveAttribute("data-card-pack-save-active", "true");
     });
 
@@ -616,7 +616,7 @@ describe("CardPackRow save-as-pack activates the new pack", () => {
             .spyOn(window, "prompt")
             .mockReturnValue("My New Pack");
         await user.click(
-            screen.getByRole("button", { name: "saveAsCardPack" }),
+            screen.getByRole("button", { name: "saveAsNewCardPack" }),
         );
         promptSpy.mockRestore();
         // Save should no longer be active.
@@ -676,6 +676,75 @@ describe("CardPackRow save-as-pack activates the new pack", () => {
         expect(recorded).toBe(true);
     });
 
+    test("editing a built-in pack only offers Save as new pack and persists a custom copy", async () => {
+        const user = userEvent.setup();
+        renderRowWithMutate();
+
+        await user.click(
+            screen.getByRole("button", { name: "Master Detective" }),
+        );
+        await user.click(screen.getByTestId("mutate"));
+
+        expect(
+            screen.queryByRole("button", { name: /updateCardPack/ }),
+        ).toBeNull();
+        expect(
+            screen.queryByRole("button", { name: "saveAsCardPack" }),
+        ).toBeNull();
+        expect(
+            screen.getAllByRole("button", { name: "saveAsNewCardPack" }),
+        ).toHaveLength(1);
+
+        const promptSpy = vi
+            .spyOn(window, "prompt")
+            .mockReturnValue("Master Fork");
+        await user.click(
+            screen.getByRole("button", { name: "saveAsNewCardPack" }),
+        );
+        promptSpy.mockRestore();
+
+        const presets = JSON.parse(
+            window.localStorage.getItem(
+                "effect-clue.custom-presets.v1",
+            ) ?? "null",
+        );
+        const saved = (presets?.presets ?? []).find(
+            (p: { label: string }) => p.label === "Master Fork",
+        );
+        expect(saved).toBeDefined();
+        expect(saved.id).not.toBe("master-detective");
+        expect(saved.id).toMatch(/^custom-/);
+
+        const usage = JSON.parse(
+            window.localStorage.getItem(
+                "effect-clue.card-pack-usage.v1",
+            ) ?? "null",
+        );
+        expect(
+            (usage?.entries ?? []).some(
+                (e: { id: string }) => e.id === saved.id,
+            ),
+        ).toBe(true);
+    });
+
+    test("editing a custom pack keeps Update primary and Save as new secondary", async () => {
+        const user = userEvent.setup();
+        seedCustomPacks(["Alpha"]);
+        renderRowWithMutate();
+
+        await user.click(screen.getByRole("button", { name: "Alpha" }));
+        await user.click(screen.getByTestId("mutate"));
+
+        expect(
+            screen.getByRole("button", {
+                name: 'updateCardPack:{"label":"Alpha"}',
+            }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "saveAsNewCardPack" }),
+        ).toBeInTheDocument();
+    });
+
     test("saving does not fire cards_dealt or card_pack_selected", async () => {
         // Saving doesn't change the active deck (it only snapshots it),
         // so it shouldn't pollute the deck-swap analytics funnel.
@@ -699,7 +768,7 @@ describe("CardPackRow save-as-pack activates the new pack", () => {
         await user.click(screen.getByTestId("mutate")); // Save now active
         const promptSpy = vi.spyOn(window, "prompt").mockReturnValue(null);
         await user.click(
-            screen.getByRole("button", { name: "saveAsCardPack" }),
+            screen.getByRole("button", { name: "saveAsNewCardPack" }),
         );
         promptSpy.mockRestore();
         // Save still active; no pack-pill activation.
@@ -717,7 +786,7 @@ describe("CardPackRow save-as-pack activates the new pack", () => {
         await user.click(screen.getByTestId("mutate"));
         const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("   ");
         await user.click(
-            screen.getByRole("button", { name: "saveAsCardPack" }),
+            screen.getByRole("button", { name: "saveAsNewCardPack" }),
         );
         promptSpy.mockRestore();
         // Nothing was saved; Save pill stays active.

--- a/src/ui/components/CardPackRow.tsx
+++ b/src/ui/components/CardPackRow.tsx
@@ -192,35 +192,34 @@ export function CardPackRow() {
     const showSaveAsActive = activeMatch === undefined;
 
     /**
-     * The custom pack the user most-recently loaded, regardless of
-     * whether the live deck still matches its contents. This is the
-     * pack the user is conceptually "editing" — when `activeMatch`
-     * is undefined but `loadedCustomPack` is defined, the deck has
-     * diverged from the loaded pack and the save action should
-     * default to "Update [pack name]" instead of creating a new pack.
-     *
-     * Classic doesn't qualify: it's a built-in, not user-owned, so
-     * editing the Classic deck always produces a new custom pack.
+     * The user-owned pack most-recently loaded, regardless of whether
+     * the live deck still matches its contents. Built-ins never qualify:
+     * when a built-in deck diverges, the only available save action is
+     * saving a new custom pack.
      */
     const loadedCustomPack = useMemo<DisplayPack | undefined>(() => {
-        let candidateId: string | undefined;
+        let candidate: DisplayPack | undefined;
         let mostRecent: DateTime.Utc | undefined;
         for (const [id, at] of usage.entries()) {
-            if (id === classic.id) continue;
+            const pack = otherPacks.find(p => p.id === id);
+            if (!pack?.isCustom) continue;
             if (
                 !mostRecent ||
                 DateTime.toEpochMillis(at) > DateTime.toEpochMillis(mostRecent)
             ) {
                 mostRecent = at;
-                candidateId = id;
+                candidate = pack;
             }
         }
-        if (!candidateId) return undefined;
-        return otherPacks.find(p => p.id === candidateId);
-    }, [otherPacks, usage, classic.id]);
+        return candidate;
+    }, [otherPacks, usage]);
 
     const canUpdateLoadedPack =
         showSaveAsActive && loadedCustomPack !== undefined;
+    const saveButtonLabel =
+        showSaveAsActive && !canUpdateLoadedPack
+            ? t("saveAsNewCardPack")
+            : t("saveAsCardPack");
 
     /**
      * Sorted alphabetically with Classic pinned first; this is what
@@ -534,7 +533,7 @@ export function CardPackRow() {
                         ? t("updateCardPack", {
                               label: loadedCustomPack.label,
                           })
-                        : t("saveAsCardPack")}
+                        : saveButtonLabel}
                 </button>
                 {canUpdateLoadedPack ? (
                     <button


### PR DESCRIPTION
## Summary
- prevent edited built-in card packs from showing an in-place update action
- show only the existing + Save as new pack action for edited built-in packs
- preserve custom-pack edit behavior with Update plus Save as new pack

## Verification
- pnpm test -- src/ui/components/CardPackRow.test.tsx
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm knip
- pnpm i18n:check
- local preview route /play?view=setup returned 200 and compiled cleanly; interactive browser automation was unavailable in this environment

## Observability
- no new or changed PostHog events
- no funnel changes
- no new Honeycomb spans