### PR TITLE
Codex: Add checklist cell hypotheses

### DIFF
--- a/docs/shares.md
+++ b/docs/shares.md
@@ -28,7 +28,7 @@ just summarises what's in the link.
 |---|---|---|---|
 | `pack` | Card-pack row in Setup ("Share this pack" button), per-pack share icon in the "All card packs" picker | Card pack only | Picker entry passes `forcedCardPack` so the share contains the *picked* pack rather than the live setup pack |
 | `invite` | Setup pane near the Start playing CTA, overflow menu ("Invite a player") | Card pack + players + hand sizes; optional checkbox adds suggestions + accusations together when at least one of either has been logged | Checkbox is hidden when neither suggestions nor accusations exist. Label adapts to what's there: "Include all N prior suggestions and M failed accusations", "Include all N prior suggestions", or "Include all M prior failed accusations" |
-| `transfer` | Overflow menu only ("Continue on another device") | Everything: card pack + players + hand sizes + known cards + suggestions + accusations | Renders a prominent privacy warning above the CTA — this link discloses your hand |
+| `transfer` | Overflow menu only ("Continue on another device") | Everything: card pack + players + hand sizes + known cards + suggestions + accusations + hypotheses | Renders a prominent privacy warning above the CTA — this link discloses your hand and solver hunches |
 
 The flow taxonomy intentionally hides the underlying column structure
 from the user. Earlier versions of the modal exposed four toggles
@@ -84,7 +84,7 @@ type CreateShareInput =
   | { kind: "invite"; cardPackData; playersData; handSizesData;
       suggestionsData?; accusationsData? }     // pair both or neither
   | { kind: "transfer"; cardPackData; playersData; handSizesData;
-      knownCardsData; suggestionsData; accusationsData };
+      knownCardsData; suggestionsData; accusationsData; hypothesesData? };
 ```
 
 The server whitelists the fields each `kind` is allowed to carry.
@@ -114,7 +114,7 @@ kind is a wire-and-server change, not a schema change.
 
 ## Effect-Schema-validated wire format
 
-All six wire fields round-trip through Effect `Schema` codecs in
+All share wire fields round-trip through Effect `Schema` codecs in
 [src/logic/ShareCodec.ts](../src/logic/ShareCodec.ts):
 
 ```ts
@@ -124,6 +124,7 @@ export const handSizesCodec   = Schema.fromJsonString(...);
 export const knownCardsCodec  = Schema.fromJsonString(...);
 export const suggestionsCodec = Schema.fromJsonString(...);
 export const accusationsCodec = Schema.fromJsonString(...);
+export const hypothesesCodec = Schema.fromJsonString(...);
 ```
 
 Each codec packages "JSON-string ↔ schema-validated object" into one
@@ -167,7 +168,7 @@ to detect built-ins — the `name` is informational, not authoritative.
      `Card pack: Master Detective` or `Card pack: My Office (custom)`,
      `Players (4): Alice, Bob, Carol, Dana`,
      `Hand sizes`,
-     `Known cards (12)`, etc.
+     `Known cards (12)`, `Hypotheses (3)`, etc.
    - One CTA matched to the inferred receive flow.
 5. Click:
    - Pack-only → decodes `cardPackData`, writes a new custom card pack,
@@ -191,12 +192,14 @@ renders an empty-state message and disables Import.
 
 Migration history:
 - [0004_shares.ts](../src/server/migrations/0004_shares.ts) — initial
-  table with the six nullable snapshot columns + nullable `owner_id`.
+  table with the original six nullable snapshot columns + nullable `owner_id`.
 - [0005_share_expiry_backfill.ts](../src/server/migrations/0005_share_expiry_backfill.ts)
   — sets `expires_at` on legacy rows that pre-dated TTL, plus an
   index for the cron cleanup.
 - [0006_shares_owner_required.ts](../src/server/migrations/0006_shares_owner_required.ts)
   — tightens `owner_id` to `NOT NULL` (M22 universal sign-in).
+- [0007_share_hypotheses.ts](../src/server/migrations/0007_share_hypotheses.ts)
+  — adds nullable `snapshot_hypotheses_data` for transfer shares.
 
 Schema (post-0006):
 
@@ -210,6 +213,7 @@ shares (
   snapshot_known_cards_data   TEXT,
   snapshot_suggestions_data   TEXT,
   snapshot_accusations_data   TEXT,
+  snapshot_hypotheses_data    TEXT,         -- transfer-only JSON-encoded hypotheses
   created_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   expires_at                  TIMESTAMPTZ,  -- NOW() + SHARE_TTL on insert
   -- index: shares_owner_id_idx, shares_expires_at_idx

--- a/messages/en.json
+++ b/messages/en.json
@@ -42,7 +42,7 @@
         "redoAria": "Redo",
         "redoTitle": "Redo (⌘⇧Z / Ctrl+Shift+Z)",
         "newGame": "New game{shortcut}",
-        "newGameConfirm": "Start a new game? This will clear all players, cards, known hands, and suggestions from your current game."
+        "newGameConfirm": "Start a new game? This will clear all players, cards, known hands, suggestions, and hypotheses from your current game."
     },
     "history": {
         "undoTooltip": "Undo: {description}",
@@ -74,7 +74,9 @@
             "updateAccusation": "editing Accusation #{number} by {player} ({cards})",
             "updateAccusationUnknown": "editing an accusation",
             "removeAccusation": "removing Accusation #{number} by {player} ({cards})",
-            "removeAccusationUnknown": "removing an accusation"
+            "removeAccusationUnknown": "removing an accusation",
+            "setHypothesis": "setting a hypothesis that {owner} has {card} = {value}",
+            "clearHypothesis": "clearing the hypothesis for {owner} / {card}"
         }
     },
     "setup": {
@@ -127,6 +129,26 @@
         "whyHeader": "Why this value:",
         "whyLine": "{index}. {headline}{iter, select, none {} other { (iter {iter})}}: {detail}",
         "footnoteLine": "Candidate for suggestion {labels} — refuter's unseen card could be here."
+    },
+    "hypotheses": {
+        "label": "Hypothesis",
+        "off": "Off",
+        "controlAria": "Hypothesis value",
+        "cellAria": "Open notes for {owner} / {card}",
+        "noDeductionYet": "No deduction yet.",
+        "statusOff": "Off",
+        "statusPending": "Checking…",
+        "statusVerified": "{value} is verified by the current evidence.",
+        "statusFalsified": "{value} is falsified by the current evidence.",
+        "statusBlocked": "Resolve the current contradiction first.",
+        "statusPlausible": "{value} is plausible and would reveal {count, plural, =0 {no other cells} one {# other cell} other {# other cells}}.",
+        "summaryLine": "Hypotheses: {parts}",
+        "summary": {
+            "plausible": "{count, plural, one {# plausible} other {# plausible}}",
+            "verified": "{count, plural, one {# verified} other {# verified}}",
+            "falsified": "{count, plural, one {# falsified} other {# falsified}}",
+            "blocked": "{count, plural, one {# blocked} other {# blocked}}"
+        }
     },
     "reasons": {
         "suggestionHeadline": "Suggestion #{number}",
@@ -337,6 +359,7 @@
         "importIncludesKnownCards": "Known cards ({count})",
         "importIncludesSuggestions": "Suggestions ({count})",
         "importIncludesAccusations": "Accusations ({count})",
+        "importIncludesHypotheses": "Hypotheses ({count})",
         "importEmpty": "This share is empty — nothing to import.",
         "missingTitle": "Oops, we couldn't solve this one",
         "missingBody": "This share link doesn't exist, or it expired. Ask your friend to send a new one.",

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -15,9 +15,10 @@
  *                         priorSuggestionEdited
  *   Solve outcome       : caseFileSolved (deducer narrowed every category
  *                         to exactly one candidate), gameAbandoned
- *   Feature usage       : whyTooltipOpened, checklistRowClicked,
- *                         undoUsed, redoUsed, settingsOpened,
- *                         languageChanged, localstorageCleared
+ *   Feature usage       : whyTooltipOpened, hypothesisChanged,
+ *                         checklistRowClicked, undoUsed, redoUsed,
+ *                         settingsOpened, languageChanged,
+ *                         localstorageCleared
  *   Onboarding / splash : splashScreenViewed, splashScreenDismissed,
  *                         youtubeEmbedPlayed, aboutLinkClicked
  *   Onboarding tour     : tourStarted, tourStepAdvanced, tourStepViewed,
@@ -221,6 +222,14 @@ export const whyTooltipOpened = (props: {
     /** See `deductionRevealed.categoryName` — same free-form rationale. */
     categoryName: string;
 }): void => capture("why_tooltip_opened", props);
+
+export const hypothesisChanged = (props: {
+    /** See `deductionRevealed.categoryName` — same free-form rationale. */
+    categoryName: string;
+    selectedValue: "Y" | "N" | "off";
+    status: "verified" | "falsified" | "plausible" | "blocked" | "off";
+    impactCount: number;
+}): void => capture("hypothesis_changed", props);
 
 export const checklistRowClicked = (props: {
     cardType: "suspect" | "weapon" | "room";

--- a/src/logic/ClueState.ts
+++ b/src/logic/ClueState.ts
@@ -1,8 +1,10 @@
 import type { AccusationId } from "./Accusation";
 import type { CardSet } from "./CardSet";
-import type { Card, CardCategory, Player } from "./GameObjects";
+import type { Card, CardCategory, Owner, Player } from "./GameObjects";
 import type { GameSetup } from "./GameSetup";
+import type { CellHypothesis } from "./Hypothesis";
 import type { KnownCard } from "./InitialKnowledge";
+import type { CellValue } from "./Knowledge";
 import type { GameSession } from "./Persistence";
 import type { SuggestionId } from "./Suggestion";
 
@@ -98,6 +100,12 @@ export type ClueAction =
     | { type: "addAccusation"; accusation: DraftAccusation }
     | { type: "updateAccusation"; accusation: DraftAccusation }
     | { type: "removeAccusation"; id: AccusationId }
+    | {
+          type: "setHypothesis";
+          owner: Owner;
+          card: Card;
+          value: CellValue | undefined;
+      }
     | { type: "addPlayer" }
     | { type: "removePlayer"; player: Player }
     | { type: "renamePlayer"; oldName: Player; newName: Player }
@@ -110,5 +118,6 @@ export interface ClueState {
     readonly knownCards: ReadonlyArray<KnownCard>;
     readonly suggestions: ReadonlyArray<DraftSuggestion>;
     readonly accusations: ReadonlyArray<DraftAccusation>;
+    readonly hypotheses: ReadonlyArray<CellHypothesis>;
     readonly uiMode: UiMode;
 }

--- a/src/logic/Hypothesis.test.ts
+++ b/src/logic/Hypothesis.test.ts
@@ -1,0 +1,157 @@
+import { Effect, Result } from "effect";
+import { describe, expect, test } from "vitest";
+import { deduceSync } from "./Deducer";
+import {
+    CellHypothesis,
+    evaluateHypotheses,
+    type CellHypothesis as CellHypothesisType,
+    type HypothesisEvaluation,
+} from "./Hypothesis";
+import { KnownCard, buildInitialKnowledge } from "./InitialKnowledge";
+import { N, Y } from "./Knowledge";
+import { CaseFileOwner, Player, PlayerOwner } from "./GameObjects";
+import { CLASSIC_SETUP_3P } from "./GameSetup";
+import { cardByName } from "./test-utils/CardByName";
+
+const setup = CLASSIC_SETUP_3P;
+const A = Player("Anisha");
+const B = Player("Bob");
+const KNIFE = cardByName(setup, "Knife");
+
+const run = (params: {
+    readonly knownCards?: ReadonlyArray<KnownCard>;
+    readonly hypotheses: ReadonlyArray<CellHypothesisType>;
+}): ReadonlyArray<HypothesisEvaluation> => {
+    const initial = buildInitialKnowledge(
+        setup,
+        params.knownCards ?? [],
+        [],
+    );
+    const factualResult = deduceSync(setup, [], [], initial);
+    return Effect.runSync(
+        evaluateHypotheses({
+            setup,
+            suggestions: [],
+            accusations: [],
+            initialKnowledge: initial,
+            factualResult,
+            hypotheses: params.hypotheses,
+        }),
+    );
+};
+
+describe("evaluateHypotheses", () => {
+    test("marks a hypothesis verified when factual knowledge already matches it", () => {
+        const [evaluation] = run({
+            knownCards: [KnownCard({ player: A, card: KNIFE })],
+            hypotheses: [
+                CellHypothesis({
+                    owner: PlayerOwner(A),
+                    card: KNIFE,
+                    value: Y,
+                }),
+            ],
+        });
+
+        expect(evaluation?.status).toBe("verified");
+        expect(evaluation?.impactCount).toBe(0);
+    });
+
+    test("marks a hypothesis falsified when factual knowledge proves the opposite", () => {
+        const [evaluation] = run({
+            knownCards: [KnownCard({ player: A, card: KNIFE })],
+            hypotheses: [
+                CellHypothesis({
+                    owner: PlayerOwner(A),
+                    card: KNIFE,
+                    value: N,
+                }),
+            ],
+        });
+
+        expect(evaluation?.status).toBe("falsified");
+    });
+
+    test("marks a non-contradictory unknown-cell hypothesis plausible with deterministic impact", () => {
+        const [evaluation] = run({
+            hypotheses: [
+                CellHypothesis({
+                    owner: PlayerOwner(A),
+                    card: KNIFE,
+                    value: Y,
+                }),
+            ],
+        });
+
+        expect(evaluation?.status).toBe("plausible");
+        expect(evaluation?.impactCount).toBeGreaterThan(0);
+    });
+
+    test("marks hypotheses blocked when the real game is already contradictory", () => {
+        const [evaluation] = run({
+            knownCards: [
+                KnownCard({ player: A, card: KNIFE }),
+                KnownCard({ player: B, card: KNIFE }),
+            ],
+            hypotheses: [
+                CellHypothesis({
+                    owner: CaseFileOwner(),
+                    card: KNIFE,
+                    value: Y,
+                }),
+            ],
+        });
+
+        expect(evaluation?.status).toBe("blocked");
+        expect(evaluation?.contradiction).toBeDefined();
+    });
+
+    test("evaluates mutually incompatible hypotheses independently", () => {
+        const evaluations = run({
+            hypotheses: [
+                CellHypothesis({
+                    owner: PlayerOwner(A),
+                    card: KNIFE,
+                    value: Y,
+                }),
+                CellHypothesis({
+                    owner: PlayerOwner(B),
+                    card: KNIFE,
+                    value: Y,
+                }),
+            ],
+        });
+
+        expect(evaluations.map(e => e.status)).toEqual([
+            "plausible",
+            "plausible",
+        ]);
+    });
+
+    test("marks the hypothesis falsified when its solo assumption contradicts deductions", () => {
+        const initial = buildInitialKnowledge(
+            setup,
+            [KnownCard({ player: A, card: KNIFE })],
+            [],
+        );
+        const [evaluation] = Effect.runSync(
+            evaluateHypotheses({
+                setup,
+                suggestions: [],
+                accusations: [],
+                initialKnowledge: initial,
+                factualResult: Result.succeed(initial),
+                hypotheses: [
+                    CellHypothesis({
+                        owner: PlayerOwner(B),
+                        card: KNIFE,
+                        value: Y,
+                    }),
+                ],
+            }),
+        );
+
+        expect(evaluation?.status).toBe("falsified");
+        expect(evaluation?.contradiction).toBeDefined();
+    });
+});

--- a/src/logic/Hypothesis.ts
+++ b/src/logic/Hypothesis.ts
@@ -1,0 +1,208 @@
+import { Data, Effect, Equal, HashMap, Result } from "effect";
+import type { Accusation } from "./Accusation";
+import {
+    allCardIds,
+    GameSetup,
+} from "./GameSetup";
+import {
+    Card,
+    CaseFileOwner,
+    Owner,
+    Player,
+    PlayerOwner,
+} from "./GameObjects";
+import {
+    Cell,
+    CellValue,
+    getCell,
+    Knowledge,
+    setCell,
+} from "./Knowledge";
+import type { Suggestion } from "./Suggestion";
+import { deduceSync, type DeductionResult, type ContradictionTrace } from "./Deducer";
+
+class CellHypothesisImpl extends Data.Class<{
+    readonly owner: Owner;
+    readonly card: Card;
+    readonly value: CellValue;
+}> {}
+
+export type CellHypothesis = CellHypothesisImpl;
+
+export const CellHypothesis = (params: {
+    readonly owner: Owner;
+    readonly card: Card;
+    readonly value: CellValue;
+}): CellHypothesis => new CellHypothesisImpl(params);
+
+export type HypothesisStatus =
+    | "verified"
+    | "falsified"
+    | "plausible"
+    | "blocked";
+
+export interface HypothesisEvaluation {
+    readonly hypothesis: CellHypothesis;
+    readonly status: HypothesisStatus;
+    readonly impactCount: number;
+    readonly contradiction?: ContradictionTrace | undefined;
+}
+
+interface EvaluateHypothesesArgs {
+    readonly setup: GameSetup;
+    readonly suggestions: ReadonlyArray<Suggestion>;
+    readonly accusations: ReadonlyArray<Accusation>;
+    readonly initialKnowledge: Knowledge;
+    readonly factualResult: DeductionResult;
+    readonly hypotheses: ReadonlyArray<CellHypothesis>;
+}
+
+export const cellOfHypothesis = (hypothesis: CellHypothesis): Cell =>
+    Cell(hypothesis.owner, hypothesis.card);
+
+const cellKey = (cell: Cell): string =>
+    cell.owner._tag === "Player"
+        ? `player:${String(cell.owner.player)}:${String(cell.card)}`
+        : `case-file:${String(cell.card)}`;
+
+export const hypothesisKey = (hypothesis: CellHypothesis): string =>
+    cellKey(cellOfHypothesis(hypothesis));
+
+export const findHypothesisForCell = (
+    hypotheses: ReadonlyArray<CellHypothesis>,
+    cell: Cell,
+): CellHypothesis | undefined =>
+    hypotheses.find(h => Equal.equals(cellOfHypothesis(h), cell));
+
+export const findEvaluationForCell = (
+    evaluations: ReadonlyArray<HypothesisEvaluation>,
+    cell: Cell,
+): HypothesisEvaluation | undefined =>
+    evaluations.find(e => Equal.equals(cellOfHypothesis(e.hypothesis), cell));
+
+export const setHypothesisForCell = (
+    hypotheses: ReadonlyArray<CellHypothesis>,
+    cell: Cell,
+    value: CellValue | undefined,
+): ReadonlyArray<CellHypothesis> => {
+    const current = findHypothesisForCell(hypotheses, cell);
+    if (current?.value === value) return hypotheses;
+    if (current === undefined && value === undefined) return hypotheses;
+    const withoutCell = hypotheses.filter(
+        h => !Equal.equals(cellOfHypothesis(h), cell),
+    );
+    if (value === undefined) return withoutCell;
+    return [
+        ...withoutCell,
+        CellHypothesis({ owner: cell.owner, card: cell.card, value }),
+    ];
+};
+
+export const pruneHypothesesToSetup = (
+    setup: GameSetup,
+    hypotheses: ReadonlyArray<CellHypothesis>,
+): ReadonlyArray<CellHypothesis> => {
+    const playerSet = new Set(setup.players.map(p => String(p)));
+    const cardSet = new Set(allCardIds(setup).map(card => String(card)));
+    return hypotheses.filter(h => {
+        if (!cardSet.has(String(h.card))) return false;
+        if (h.owner._tag === "CaseFile") return true;
+        return playerSet.has(String(h.owner.player));
+    });
+};
+
+export const renamePlayerInHypotheses = (
+    hypotheses: ReadonlyArray<CellHypothesis>,
+    oldName: Player,
+    newName: Player,
+): ReadonlyArray<CellHypothesis> =>
+    hypotheses.map(h =>
+        h.owner._tag === "Player" && h.owner.player === oldName
+            ? CellHypothesis({
+                  owner: PlayerOwner(newName),
+                  card: h.card,
+                  value: h.value,
+              })
+            : h,
+    );
+
+export const ownerToPersisted = (
+    owner: Owner,
+): { readonly _tag: "Player"; readonly player: Player } | { readonly _tag: "CaseFile" } =>
+    owner._tag === "Player"
+        ? { _tag: "Player", player: owner.player }
+        : { _tag: "CaseFile" };
+
+export const ownerFromPersisted = (owner:
+    | { readonly _tag: "Player"; readonly player: Player }
+    | { readonly _tag: "CaseFile" }
+): Owner =>
+    owner._tag === "Player"
+        ? PlayerOwner(owner.player)
+        : CaseFileOwner();
+
+const evaluateOne = (
+    args: EvaluateHypothesesArgs,
+    hypothesis: CellHypothesis,
+): HypothesisEvaluation => {
+    if (Result.isFailure(args.factualResult)) {
+        return {
+            hypothesis,
+            status: "blocked",
+            impactCount: 0,
+            contradiction: args.factualResult.failure,
+        };
+    }
+
+    const cell = cellOfHypothesis(hypothesis);
+    const factualKnowledge = args.factualResult.success;
+    const factualValue = getCell(factualKnowledge, cell);
+    if (factualValue === hypothesis.value) {
+        return { hypothesis, status: "verified", impactCount: 0 };
+    }
+    if (factualValue !== undefined) {
+        return { hypothesis, status: "falsified", impactCount: 0 };
+    }
+
+    let assumedInitial: Knowledge;
+    try {
+        assumedInitial = setCell(
+            args.initialKnowledge,
+            cell,
+            hypothesis.value,
+        );
+    } catch {
+        return { hypothesis, status: "falsified", impactCount: 0 };
+    }
+
+    const hypotheticalResult = deduceSync(
+        args.setup,
+        args.suggestions,
+        args.accusations,
+        assumedInitial,
+    );
+    if (Result.isFailure(hypotheticalResult)) {
+        return {
+            hypothesis,
+            status: "falsified",
+            impactCount: 0,
+            contradiction: hypotheticalResult.failure,
+        };
+    }
+
+    let impactCount = 0;
+    HashMap.forEach(hypotheticalResult.success.checklist, (_value, nextCell) => {
+        if (Equal.equals(nextCell, cell)) return;
+        if (getCell(factualKnowledge, nextCell) === undefined) {
+            impactCount += 1;
+        }
+    });
+
+    return { hypothesis, status: "plausible", impactCount };
+};
+
+export const evaluateHypotheses = Effect.fn("hypotheses.evaluate")(
+    function* (args: EvaluateHypothesesArgs) {
+        return args.hypotheses.map(h => evaluateOne(args, h));
+    },
+);

--- a/src/logic/Persistence.test.ts
+++ b/src/logic/Persistence.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { CLASSIC_SETUP_3P } from "./GameSetup";
-import { Player } from "./GameObjects";
+import { Player, PlayerOwner } from "./GameObjects";
+import { CellHypothesis } from "./Hypothesis";
+import { Y } from "./Knowledge";
 import { cardByName } from "./test-utils/CardByName";
 import {
     Accusation,
@@ -16,7 +18,8 @@ import {
     type GameSession,
 } from "./Persistence";
 
-const STORAGE_KEY = "effect-clue.session.v6";
+const STORAGE_KEY = "effect-clue.session.v7";
+const LEGACY_STORAGE_KEY_V6 = "effect-clue.session.v6";
 
 const setup = CLASSIC_SETUP_3P;
 const A = Player("Anisha");
@@ -142,6 +145,21 @@ describe("encode/decode — rich sessions", () => {
         expect(decoded?.accusations[1]?.accuser).toBe(B);
     });
 
+    test("round-trips hypotheses", () => {
+        const decoded = decodeSession(encodeSession({
+            ...minimalSession,
+            hypotheses: [
+                CellHypothesis({
+                    owner: PlayerOwner(A),
+                    card: KNIFE,
+                    value: Y,
+                }),
+            ],
+        }));
+        expect(decoded?.hypotheses).toHaveLength(1);
+        expect(decoded?.hypotheses?.[0]?.value).toBe(Y);
+    });
+
     test("generates a fresh AccusationId when the persisted id is the empty sentinel", () => {
         const encoded = encodeSession({
             ...minimalSession,
@@ -186,11 +204,39 @@ describe("saveToLocalStorage / loadFromLocalStorage", () => {
         expect(loaded?.handSizes).toHaveLength(3);
     });
 
-    test("save writes under the v6-scoped storage key", () => {
+    test("save writes under the v7-scoped storage key", () => {
         saveToLocalStorage(minimalSession);
         const raw = window.localStorage.getItem(STORAGE_KEY);
         expect(raw).not.toBeNull();
-        expect(JSON.parse(raw as string).version).toBe(6);
+        expect(JSON.parse(raw as string).version).toBe(7);
+    });
+
+    test("load accepts legacy v6 sessions and normalizes hypotheses to empty", () => {
+        window.localStorage.setItem(
+            LEGACY_STORAGE_KEY_V6,
+            JSON.stringify({
+                version: 6,
+                setup: {
+                    players: setup.players.map(p => String(p)),
+                    categories: setup.categories.map(c => ({
+                        id: String(c.id),
+                        name: c.name,
+                        cards: c.cards.map(card => ({
+                            id: String(card.id),
+                            name: card.name,
+                        })),
+                    })),
+                },
+                hands: [],
+                handSizes: [],
+                suggestions: [],
+                accusations: [],
+            }),
+        );
+
+        const loaded = loadFromLocalStorage();
+        expect(loaded).toBeDefined();
+        expect(loaded?.hypotheses).toEqual([]);
     });
 
     test("load returns undefined when the key is missing", () => {
@@ -232,4 +278,3 @@ describe("saveToLocalStorage / loadFromLocalStorage", () => {
         expect(loaded?.handSizes[0]?.size).toBe(99);
     });
 });
-

--- a/src/logic/Persistence.ts
+++ b/src/logic/Persistence.ts
@@ -8,8 +8,14 @@ import {
 import { Card, Player } from "./GameObjects";
 import { CardEntry, Category, GameSetup } from "./GameSetup";
 import {
-    decodeV6Unknown,
+    CellHypothesis,
+    ownerFromPersisted,
+} from "./Hypothesis";
+import {
+    decodePersistedSessionUnknown,
+    type PersistedSession,
     type PersistedSessionV6,
+    type PersistedSessionV7,
 } from "./PersistenceSchema";
 import {
     newSuggestionId,
@@ -28,8 +34,8 @@ import {
  * older / malformed blob ever shows up, decode returns undefined
  * and the caller falls back to a fresh session.
  */
-interface PersistedGameV6 {
-    readonly version: 6;
+interface PersistedGameV7 {
+    readonly version: 7;
     readonly setup: {
         readonly players: ReadonlyArray<string>;
         readonly categories: ReadonlyArray<{
@@ -64,9 +70,16 @@ interface PersistedGameV6 {
         readonly cards: ReadonlyArray<string>;
         readonly loggedAt: number;
     }>;
+    readonly hypotheses: ReadonlyArray<{
+        readonly owner:
+            | { readonly _tag: "Player"; readonly player: string }
+            | { readonly _tag: "CaseFile" };
+        readonly card: string;
+        readonly value: "Y" | "N";
+    }>;
 }
 
-type PersistedGame = PersistedGameV6;
+type PersistedGame = PersistedGameV7;
 
 export interface GameSession {
     setup: GameSetup;
@@ -74,10 +87,11 @@ export interface GameSession {
     handSizes: ReadonlyArray<{ player: Player; size: number }>;
     suggestions: ReadonlyArray<Suggestion>;
     accusations: ReadonlyArray<Accusation>;
+    hypotheses?: ReadonlyArray<CellHypothesis>;
 }
 
 export const encodeSession = (session: GameSession): PersistedGame => ({
-    version: 6,
+    version: 7,
     setup: {
         players: session.setup.players.map(p => String(p)),
         categories: session.setup.categories.map(c => ({
@@ -112,6 +126,17 @@ export const encodeSession = (session: GameSession): PersistedGame => ({
         cards: accusationCards(a).map(c => String(c)),
         loggedAt: a.loggedAt,
     })),
+    hypotheses: (session.hypotheses ?? []).map(h => ({
+        owner:
+            h.owner._tag === "Player"
+                ? {
+                      _tag: "Player",
+                      player: String(h.owner.player),
+                  }
+                : { _tag: "CaseFile" },
+        card: String(h.card),
+        value: h.value,
+    })),
 });
 
 /**
@@ -119,7 +144,9 @@ export const encodeSession = (session: GameSession): PersistedGame => ({
  * Branded types already flow through the schema, so this is pure
  * construction — no Player(...) / Card(...) wrapping needed.
  */
-const buildSessionFromV6 = (v6: PersistedSessionV6): GameSession => ({
+const buildSessionBase = (
+    v6: PersistedSessionV6 | PersistedSessionV7,
+): GameSession => ({
     setup: GameSetup({
         players: v6.setup.players,
         categories: v6.setup.categories.map(c => Category({
@@ -155,15 +182,33 @@ const buildSessionFromV6 = (v6: PersistedSessionV6): GameSession => ({
         cards: a.cards,
         loggedAt: a.loggedAt,
     })),
+    hypotheses: [],
 });
 
-export const decodeSession = (data: unknown): GameSession | undefined => {
-    const decoded = decodeV6Unknown(data);
-    if (Result.isFailure(decoded)) return undefined;
-    return buildSessionFromV6(decoded.success);
+const buildHypothesesFromV7 = (
+    v7: PersistedSessionV7,
+): ReadonlyArray<CellHypothesis> =>
+    v7.hypotheses.map(h => CellHypothesis({
+        owner: ownerFromPersisted(h.owner),
+        card: h.card,
+        value: h.value,
+    }));
+
+const buildSessionFromPersisted = (session: PersistedSession): GameSession => {
+    const base = buildSessionBase(session);
+    return session.version === 7
+        ? { ...base, hypotheses: buildHypothesesFromV7(session) }
+        : base;
 };
 
-const STORAGE_KEY = "effect-clue.session.v6";
+export const decodeSession = (data: unknown): GameSession | undefined => {
+    const decoded = decodePersistedSessionUnknown(data);
+    if (Result.isFailure(decoded)) return undefined;
+    return buildSessionFromPersisted(decoded.success);
+};
+
+const STORAGE_KEY = "effect-clue.session.v7";
+const LEGACY_STORAGE_KEY_V6 = "effect-clue.session.v6";
 
 export const saveToLocalStorage = (session: GameSession): void => {
     try {
@@ -176,7 +221,9 @@ export const saveToLocalStorage = (session: GameSession): void => {
 
 export const loadFromLocalStorage = (): GameSession | undefined => {
     try {
-        const raw = window.localStorage.getItem(STORAGE_KEY);
+        const raw =
+            window.localStorage.getItem(STORAGE_KEY) ??
+            window.localStorage.getItem(LEGACY_STORAGE_KEY_V6);
         if (!raw) return undefined;
         return decodeSession(JSON.parse(raw));
     } catch {

--- a/src/logic/PersistenceSchema.test.ts
+++ b/src/logic/PersistenceSchema.test.ts
@@ -2,16 +2,18 @@ import { describe, expect, test } from "vitest";
 import { Result } from "effect";
 import { CLASSIC_SETUP_3P } from "./GameSetup";
 import { decodeSession, encodeSession } from "./Persistence";
-import { decodeV6Unknown } from "./PersistenceSchema";
+import {
+    decodePersistedSessionUnknown,
+    decodeV6Unknown,
+} from "./PersistenceSchema";
 import { Player } from "./GameObjects";
 
 /**
- * The app is pre-production — v6 is the only on-disk format, so
- * there's only one round-trip to cover. Anything that doesn't parse
- * as v6 returns undefined and the caller starts a fresh session.
+ * The app writes v7 but still accepts v6 so existing local games
+ * survive the hypothesis-storage upgrade.
  */
 describe("Schema-backed v6 persistence", () => {
-    test("encode produces version: 6 and round-trips through decode", () => {
+    test("encode produces version: 7 and round-trips through decode", () => {
         const encoded = encodeSession({
             setup: CLASSIC_SETUP_3P,
             hands: [],
@@ -19,7 +21,7 @@ describe("Schema-backed v6 persistence", () => {
             suggestions: [],
             accusations: [],
         });
-        expect(encoded.version).toBe(6);
+        expect(encoded.version).toBe(7);
 
         const decoded = decodeSession(encoded);
         expect(decoded).toBeDefined();
@@ -93,7 +95,7 @@ describe("Schema-backed v6 persistence", () => {
     });
 
     test("non-v6 payloads return undefined", () => {
-        // Older session formats no longer have a migration path. They
+        // Older pre-v6 session formats have no migration path. They
         // are rejected like any other unrecognized input and the caller
         // falls back to a fresh session.
         const legacyV5 = {
@@ -107,5 +109,19 @@ describe("Schema-backed v6 persistence", () => {
         expect(decodeSession(legacyV5)).toBeUndefined();
         expect(decodeSession({ unrelated: true })).toBeUndefined();
         expect(decodeSession(null)).toBeUndefined();
+    });
+
+    test("union decoder still accepts v6 payloads", () => {
+        const legacyV6 = {
+            version: 6,
+            setup: { players: ["Anisha"], categories: [] },
+            hands: [],
+            handSizes: [],
+            suggestions: [],
+            accusations: [],
+        };
+        expect(Result.isSuccess(decodePersistedSessionUnknown(legacyV6)))
+            .toBe(true);
+        expect(Result.isSuccess(decodeV6Unknown(legacyV6))).toBe(true);
     });
 });

--- a/src/logic/PersistenceSchema.ts
+++ b/src/logic/PersistenceSchema.ts
@@ -4,12 +4,13 @@ import { Card, CardCategory, Player } from "./GameObjects";
 import { SuggestionId } from "./Suggestion";
 
 /**
- * Effect Schema definitions for the persisted session shape (v6).
+ * Effect Schema definitions for persisted session shapes.
  *
- * The app is pre-production, so there's a single on-disk format —
- * writes go to v6, reads only accept v6. If an older / malformed blob
- * shows up, decode returns `Result.Failure` and the caller falls back
- * to a fresh session. No migration chain, no legacy schemas.
+ * The app is pre-production, so we keep the migration surface narrow:
+ * writes go to the latest version, reads accept the latest version
+ * plus the immediately-previous format needed for in-place upgrades.
+ * If an older / malformed blob shows up, decode returns
+ * `Result.Failure` and the caller falls back to a fresh session.
  *
  * v6 adds the `loggedAt: number` field to each suggestion + accusation,
  * recording the millisecond timestamp at which it was logged. Powers
@@ -77,6 +78,22 @@ const PersistedAccusationSchema = Schema.Struct({
     loggedAt: Schema.Number,
 });
 
+const PersistedOwnerSchema = Schema.Union([
+    Schema.Struct({
+        _tag: Schema.Literal("Player"),
+        player: PlayerSchema,
+    }),
+    Schema.Struct({
+        _tag: Schema.Literal("CaseFile"),
+    }),
+]);
+
+const PersistedHypothesisSchema = Schema.Struct({
+    owner: PersistedOwnerSchema,
+    card: CardSchema,
+    value: Schema.Literals(["Y", "N"]),
+});
+
 /**
  * Convenience array wrappers for the share codec — the shares wire
  * format ships these as top-level JSON arrays rather than wrapped
@@ -87,6 +104,7 @@ export const HandSizesArraySchema = Schema.Array(PersistedHandSizeSchema);
 export const HandsArraySchema = Schema.Array(PersistedHandSchema);
 export const SuggestionsArraySchema = Schema.Array(PersistedSuggestionSchema);
 export const AccusationsArraySchema = Schema.Array(PersistedAccusationSchema);
+export const HypothesesArraySchema = Schema.Array(PersistedHypothesisSchema);
 
 /**
  * Wire shape for the card-pack half of a share. The `name` field is
@@ -106,7 +124,8 @@ export const CardSetSchema = Schema.Struct({
 });
 
 /**
- * Canonical v6 session shape. The only version the decoder accepts.
+ * Legacy v6 session shape. The v7 decoder path normalizes this to
+ * `hypotheses: []` so older saved games hydrate without data loss.
  */
 const PersistedSessionV6Schema = Schema.Struct({
     version: Schema.Literal(6),
@@ -117,6 +136,21 @@ const PersistedSessionV6Schema = Schema.Struct({
     accusations: Schema.Array(PersistedAccusationSchema),
 });
 
+const PersistedSessionV7Schema = Schema.Struct({
+    version: Schema.Literal(7),
+    setup: PersistedGameSetupSchema,
+    hands: Schema.Array(PersistedHandSchema),
+    handSizes: Schema.Array(PersistedHandSizeSchema),
+    suggestions: Schema.Array(PersistedSuggestionSchema),
+    accusations: Schema.Array(PersistedAccusationSchema),
+    hypotheses: Schema.Array(PersistedHypothesisSchema),
+});
+
+const PersistedSessionSchema = Schema.Union([
+    PersistedSessionV7Schema,
+    PersistedSessionV6Schema,
+]);
+
 /**
  * Result-returning decoder. Hands back `Result<session, SchemaError>` —
  * callers decide whether to surface the error or fall back to a fresh
@@ -126,9 +160,15 @@ export const decodeV6Unknown = Schema.decodeUnknownResult(
     PersistedSessionV6Schema,
 );
 
+export const decodePersistedSessionUnknown = Schema.decodeUnknownResult(
+    PersistedSessionSchema,
+);
+
 /**
  * Runtime type of a decoded v6 session — the branded, Schema-validated
  * payload `decodeV6Unknown` hands back. Callers construct the
  * GameSession domain value from this.
  */
 export type PersistedSessionV6 = Schema.Schema.Type<typeof PersistedSessionV6Schema>;
+export type PersistedSessionV7 = Schema.Schema.Type<typeof PersistedSessionV7Schema>;
+export type PersistedSession = Schema.Schema.Type<typeof PersistedSessionSchema>;

--- a/src/logic/ShareCodec.test.ts
+++ b/src/logic/ShareCodec.test.ts
@@ -21,6 +21,7 @@ import {
     accusationsCodec,
     cardPackCodec,
     handSizesCodec,
+    hypothesesCodec,
     knownCardsCodec,
     playersCodec,
     suggestionsCodec,
@@ -183,6 +184,28 @@ describe("accusationsCodec", () => {
         expect(Result.isSuccess(decoded)).toBe(true);
         if (Result.isSuccess(decoded)) {
             expect(decoded.success[0]!.accuser).toBe(Player("Alice"));
+        }
+    });
+});
+
+describe("hypothesesCodec", () => {
+    test("round-trips a cell hypothesis in the persisted shape", () => {
+        const hypotheses = [
+            {
+                owner: { _tag: "Player" as const, player: Player("Alice") },
+                card: Card("card-scarlet"),
+                value: "Y" as const,
+            },
+        ];
+        const encoded = encode(hypothesesCodec)(hypotheses);
+        const decoded = decode(hypothesesCodec)(encoded);
+        expect(Result.isSuccess(decoded)).toBe(true);
+        if (Result.isSuccess(decoded)) {
+            expect(decoded.success[0]!.owner).toEqual({
+                _tag: "Player",
+                player: Player("Alice"),
+            });
+            expect(decoded.success[0]!.value).toBe("Y");
         }
     });
 });

--- a/src/logic/ShareCodec.ts
+++ b/src/logic/ShareCodec.ts
@@ -1,5 +1,5 @@
 /**
- * Effect-Schema codecs for the six wire fields that flow through
+ * Effect-Schema codecs for the wire fields that flow through
  * the M9 share path.
  *
  * The shares feature serialises sub-slices of a `GameSession` to
@@ -24,6 +24,7 @@ import {
     CardSetSchema,
     HandSizesArraySchema,
     HandsArraySchema,
+    HypothesesArraySchema,
     PlayersArraySchema,
     SuggestionsArraySchema,
 } from "./PersistenceSchema";
@@ -34,3 +35,4 @@ export const handSizesCodec = Schema.fromJsonString(HandSizesArraySchema);
 export const knownCardsCodec = Schema.fromJsonString(HandsArraySchema);
 export const suggestionsCodec = Schema.fromJsonString(SuggestionsArraySchema);
 export const accusationsCodec = Schema.fromJsonString(AccusationsArraySchema);
+export const hypothesesCodec = Schema.fromJsonString(HypothesesArraySchema);

--- a/src/logic/describeAction.test.ts
+++ b/src/logic/describeAction.test.ts
@@ -72,6 +72,7 @@ const baseState: ClueState = {
     ],
     suggestions: [],
     accusations: [],
+    hypotheses: [],
     uiMode: "checklist",
 };
 

--- a/src/logic/describeAction.ts
+++ b/src/logic/describeAction.ts
@@ -5,7 +5,7 @@ import {
     categoryOfCard,
     findCardEntry,
 } from "./GameSetup";
-import type { Card } from "./GameObjects";
+import { ownerLabel, type Card } from "./GameObjects";
 import type { GameSetup } from "./GameSetup";
 import type { ClueAction, ClueState } from "./ClueState";
 
@@ -192,6 +192,17 @@ export const describeAction = (
                 cards: joinCardNames(setup, prior.cards),
             });
         }
+        case "setHypothesis":
+            return action.value === undefined
+                ? t("actions.clearHypothesis", {
+                      owner: ownerLabel(action.owner),
+                      card: cardName(setup, action.card),
+                  })
+                : t("actions.setHypothesis", {
+                      owner: ownerLabel(action.owner),
+                      card: cardName(setup, action.card),
+                      value: action.value,
+                  });
         // Non-undoable actions — should never reach the describer
         // because the history reducer bypasses them.
         case "setSetup":

--- a/src/server/actions/shares.test.ts
+++ b/src/server/actions/shares.test.ts
@@ -21,6 +21,7 @@ import {
     accusationsCodec,
     cardPackCodec,
     handSizesCodec,
+    hypothesesCodec,
     knownCardsCodec,
     playersCodec,
     suggestionsCodec,
@@ -41,6 +42,7 @@ interface RecordedInsert {
     readonly knownCardsData: string | null;
     readonly suggestionsData: string | null;
     readonly accusationsData: string | null;
+    readonly hypothesesData: string | null;
 }
 const recordedInserts: RecordedInsert[] = [];
 
@@ -179,6 +181,13 @@ const SAMPLE_ACCUSATIONS = JSON.stringify([
         loggedAt: 1_700_000_000_000,
     },
 ]);
+const SAMPLE_HYPOTHESES = JSON.stringify([
+    {
+        owner: { _tag: "Player", player: Player("Alice") },
+        card: Card("card-scarlet"),
+        value: "Y",
+    },
+]);
 
 /** Verify a JSON string round-trips through its codec — used in the
  * smoke tests below to make sure SAMPLE_* are valid before we hand
@@ -202,6 +211,7 @@ assertRoundTrips("handSizes", SAMPLE_HAND_SIZES, handSizesCodec);
 assertRoundTrips("knownCards", SAMPLE_KNOWN_CARDS, knownCardsCodec);
 assertRoundTrips("suggestions", SAMPLE_SUGGESTIONS, suggestionsCodec);
 assertRoundTrips("accusations", SAMPLE_ACCUSATIONS, accusationsCodec);
+assertRoundTrips("hypotheses", SAMPLE_HYPOTHESES, hypothesesCodec);
 
 /**
  * Mirror of the action's own column projection. Used by the test
@@ -234,6 +244,10 @@ const projectInsert = (id: string, input: unknown): RecordedInsert => {
         accusationsData:
             kind === "invite" || kind === "transfer"
                 ? ((obj["accusationsData"] as string | undefined) ?? null)
+                : null,
+        hypothesesData:
+            kind === "transfer"
+                ? ((obj["hypothesesData"] as string | undefined) ?? null)
                 : null,
     };
 };
@@ -282,6 +296,7 @@ describe("createShare — universal sign-in", () => {
             knownCardsData: SAMPLE_KNOWN_CARDS,
             suggestionsData: SAMPLE_SUGGESTIONS,
             accusationsData: SAMPLE_ACCUSATIONS,
+            hypothesesData: SAMPLE_HYPOTHESES,
         });
         expect(result).toBeInstanceOf(Error);
         expect((result as Error).message).toContain(
@@ -345,9 +360,10 @@ describe("createShare — kind dispatch (signed-in)", () => {
         expect(insert.suggestionsData).toBe(SAMPLE_SUGGESTIONS);
         expect(insert.accusationsData).toBe(SAMPLE_ACCUSATIONS);
         expect(insert.knownCardsData).toBeNull();
+        expect(insert.hypothesesData).toBeNull();
     });
 
-    test("kind: transfer → all six columns populated", async () => {
+    test("kind: transfer → all transfer columns populated", async () => {
         setMockSession(SIGNED_IN);
         await callCreateShare({
             kind: "transfer",
@@ -357,6 +373,7 @@ describe("createShare — kind dispatch (signed-in)", () => {
             knownCardsData: SAMPLE_KNOWN_CARDS,
             suggestionsData: SAMPLE_SUGGESTIONS,
             accusationsData: SAMPLE_ACCUSATIONS,
+            hypothesesData: SAMPLE_HYPOTHESES,
         });
         const insert = recordedInserts[0]!;
         expect(insert.cardPackData).toBe(SAMPLE_PACK);
@@ -365,6 +382,7 @@ describe("createShare — kind dispatch (signed-in)", () => {
         expect(insert.knownCardsData).toBe(SAMPLE_KNOWN_CARDS);
         expect(insert.suggestionsData).toBe(SAMPLE_SUGGESTIONS);
         expect(insert.accusationsData).toBe(SAMPLE_ACCUSATIONS);
+        expect(insert.hypothesesData).toBe(SAMPLE_HYPOTHESES);
     });
 });
 

--- a/src/server/actions/shares.ts
+++ b/src/server/actions/shares.ts
@@ -32,6 +32,7 @@ import {
     accusationsCodec,
     cardPackCodec,
     handSizesCodec,
+    hypothesesCodec,
     knownCardsCodec,
     playersCodec,
     suggestionsCodec,
@@ -70,6 +71,7 @@ export type CreateShareInput =
           readonly knownCardsData: string;
           readonly suggestionsData: string;
           readonly accusationsData: string;
+          readonly hypothesesData?: string;
       };
 
 interface CreateShareResult {
@@ -84,6 +86,7 @@ interface ShareSnapshot {
     readonly knownCardsData: string | null;
     readonly suggestionsData: string | null;
     readonly accusationsData: string | null;
+    readonly hypothesesData: string | null;
     /**
      * Display name of the share's owner — populated via `LEFT JOIN
      * "user"` in `getShare`. `null` when:
@@ -112,6 +115,7 @@ const F_HAND_SIZES_DATA = "handSizesData";
 const F_KNOWN_CARDS_DATA = "knownCardsData";
 const F_SUGGESTIONS_DATA = "suggestionsData";
 const F_ACCUSATIONS_DATA = "accusationsData";
+const F_HYPOTHESES_DATA = "hypothesesData";
 
 const SUFFIX_UNEXPECTED_FIELD = "unexpected_field";
 const SUFFIX_SUGGESTIONS_PAIR = "suggestions_pair";
@@ -152,6 +156,7 @@ const ALLOWED_KEYS_FOR: Record<string, ReadonlySet<string>> = {
         F_KNOWN_CARDS_DATA,
         F_SUGGESTIONS_DATA,
         F_ACCUSATIONS_DATA,
+        F_HYPOTHESES_DATA,
     ]),
 };
 
@@ -241,12 +246,16 @@ const validateInputShape = (input: unknown): CreateShareInput => {
     const knownCardsData = requireString(F_KNOWN_CARDS_DATA);
     const suggestionsData = requireString(F_SUGGESTIONS_DATA);
     const accusationsData = requireString(F_ACCUSATIONS_DATA);
+    const hypothesesData = optionalString(F_HYPOTHESES_DATA);
     validateJsonField(F_CARD_PACK_DATA, cardPackData, cardPackCodec);
     validateJsonField(F_PLAYERS_DATA, playersData, playersCodec);
     validateJsonField(F_HAND_SIZES_DATA, handSizesData, handSizesCodec);
     validateJsonField(F_KNOWN_CARDS_DATA, knownCardsData, knownCardsCodec);
     validateJsonField(F_SUGGESTIONS_DATA, suggestionsData, suggestionsCodec);
     validateJsonField(F_ACCUSATIONS_DATA, accusationsData, accusationsCodec);
+    if (hypothesesData !== undefined) {
+        validateJsonField(F_HYPOTHESES_DATA, hypothesesData, hypothesesCodec);
+    }
     return {
         kind,
         cardPackData,
@@ -255,6 +264,7 @@ const validateInputShape = (input: unknown): CreateShareInput => {
         knownCardsData,
         suggestionsData,
         accusationsData,
+        ...(hypothesesData !== undefined ? { hypothesesData } : {}),
     };
 };
 
@@ -294,7 +304,7 @@ export async function createShare(
     // INTERVAL receives a clean integer.
     const ttlHours = Math.floor(Duration.toHours(SHARE_TTL));
 
-    // Project the validated input into the six DB columns. Fields the
+    // Project the validated input into the snapshot DB columns. Fields the
     // kind doesn't carry get NULL — the column nullability pattern is
     // the receive-side discriminator (no `kind` column in the table).
     const cardPackData =
@@ -325,6 +335,10 @@ export async function createShare(
             : validated.kind === "invite"
                 ? (validated.accusationsData ?? null)
                 : null;
+    const hypothesesData =
+        validated.kind === "transfer"
+            ? (validated.hypothesesData ?? null)
+            : null;
 
     return withServerAction(
         Effect.gen(function* () {
@@ -338,6 +352,7 @@ export async function createShare(
                     snapshot_known_cards_data,
                     snapshot_suggestions_data,
                     snapshot_accusations_data,
+                    snapshot_hypotheses_data,
                     expires_at
                 ) VALUES (
                     ${id}, ${ownerId},
@@ -347,6 +362,7 @@ export async function createShare(
                     ${knownCardsData},
                     ${suggestionsData},
                     ${accusationsData},
+                    ${hypothesesData},
                     NOW() + (${ttlHours} || ' hours')::INTERVAL
                 )
             `;
@@ -369,6 +385,7 @@ export async function getShare(input: {
                 snapshot_known_cards_data: string | null;
                 snapshot_suggestions_data: string | null;
                 snapshot_accusations_data: string | null;
+                snapshot_hypotheses_data: string | null;
                 owner_id: string | null;
                 owner_name: string | null;
                 owner_is_anonymous: boolean | null;
@@ -380,6 +397,7 @@ export async function getShare(input: {
                        s.snapshot_known_cards_data,
                        s.snapshot_suggestions_data,
                        s.snapshot_accusations_data,
+                       s.snapshot_hypotheses_data,
                        s.owner_id,
                        u.name AS owner_name,
                        u.is_anonymous AS owner_is_anonymous
@@ -413,6 +431,7 @@ export async function getShare(input: {
                 knownCardsData: row.snapshot_known_cards_data,
                 suggestionsData: row.snapshot_suggestions_data,
                 accusationsData: row.snapshot_accusations_data,
+                hypothesesData: row.snapshot_hypotheses_data,
                 ownerName,
                 ownerIsAnonymous,
             };

--- a/src/server/migrations/0007_share_hypotheses.ts
+++ b/src/server/migrations/0007_share_hypotheses.ts
@@ -1,0 +1,17 @@
+/**
+ * Add transfer-only hypothesis snapshots to shares.
+ *
+ * Forward-only and backwards-compatible: nullable column, no reads
+ * require it, and older share rows remain valid with NULL.
+ */
+import { Effect } from "effect";
+import { SqlClient } from "effect/unstable/sql";
+
+export default Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+
+    yield* sql`
+        ALTER TABLE shares
+        ADD COLUMN IF NOT EXISTS snapshot_hypotheses_data TEXT
+    `;
+});

--- a/src/server/migrations/index.ts
+++ b/src/server/migrations/index.ts
@@ -21,6 +21,7 @@ import migration0003 from "./0003_card_packs";
 import migration0004 from "./0004_shares";
 import migration0005 from "./0005_share_expiry_backfill";
 import migration0006 from "./0006_shares_owner_required";
+import migration0007 from "./0007_share_hypotheses";
 
 export const migrations: Record<
     string,
@@ -32,4 +33,5 @@ export const migrations: Record<
     "0004_shares": migration0004,
     "0005_share_expiry_backfill": migration0005,
     "0006_shares_owner_required": migration0006,
+    "0007_share_hypotheses": migration0007,
 };

--- a/src/ui/checklistPopoverIntent.test.tsx
+++ b/src/ui/checklistPopoverIntent.test.tsx
@@ -7,6 +7,7 @@ import { SelectionProvider, useSelection } from "./SelectionContext";
 import {
     EXIT_TIMEOUT_MS,
     OPEN_DELAY_MS,
+    SWAP_DELAY_MS,
     useWhyHoverIntent,
 } from "./checklistPopoverIntent";
 
@@ -65,8 +66,8 @@ describe("useWhyHoverIntent — open delay (not yet in popovers mode)", () => {
     });
 });
 
-describe("useWhyHoverIntent — popovers mode: immediate swap on enter", () => {
-    test("hovering another cell swaps the popover immediately (no delay)", () => {
+describe("useWhyHoverIntent — popovers mode: delayed swap on enter", () => {
+    test("hovering another cell swaps the popover after SWAP_DELAY_MS", () => {
         const { result } = renderHook(() => useHarness(), { wrapper: Wrapper });
         act(() => {
             result.current.intent.onCellPointerEnter(cellA);
@@ -76,7 +77,48 @@ describe("useWhyHoverIntent — popovers mode: immediate swap on enter", () => {
         act(() => {
             result.current.intent.onCellPointerEnter(cellB);
         });
+        expect(result.current.popoverCell).toEqual(cellA);
+        act(() => {
+            vi.advanceTimersByTime(SWAP_DELAY_MS - 1);
+        });
+        expect(result.current.popoverCell).toEqual(cellA);
+        act(() => {
+            vi.advanceTimersByTime(1);
+        });
         expect(result.current.popoverCell).toEqual(cellB);
+    });
+
+    test("leaving the transit cell before SWAP_DELAY_MS cancels the swap", () => {
+        const { result } = renderHook(() => useHarness(), { wrapper: Wrapper });
+        act(() => {
+            result.current.intent.onCellPointerEnter(cellA);
+            vi.advanceTimersByTime(OPEN_DELAY_MS);
+        });
+        expect(result.current.popoverCell).toEqual(cellA);
+        act(() => {
+            result.current.intent.onCellPointerEnter(cellB);
+            vi.advanceTimersByTime(SWAP_DELAY_MS - 1);
+            result.current.intent.onCellPointerLeave();
+            vi.advanceTimersByTime(SWAP_DELAY_MS);
+        });
+        expect(result.current.popoverCell).toEqual(cellA);
+    });
+
+    test("explicitly-opened popovers ignore intermediate cell hover", () => {
+        const { result } = renderHook(() => useHarness(), { wrapper: Wrapper });
+        act(() => {
+            result.current.intent.onExplicitOpen(cellA);
+        });
+        expect(result.current.popoverCell).toEqual(cellA);
+        act(() => {
+            result.current.intent.onCellPointerEnter(cellB);
+            vi.advanceTimersByTime(SWAP_DELAY_MS * 2);
+        });
+        expect(result.current.popoverCell).toEqual(cellA);
+        act(() => {
+            result.current.intent.onExplicitClose();
+        });
+        expect(result.current.popoverCell).toBeNull();
     });
 });
 
@@ -98,10 +140,10 @@ describe("useWhyHoverIntent — exit timer (any cell-enter cancels)", () => {
             vi.advanceTimersByTime(200);
             result.current.intent.onCellPointerEnter(cellB);
         });
-        // Even past the original 900ms boundary the popover stays
-        // open on B because the exit timer is gone.
+        // The old popover stays open because the exit timer is gone;
+        // then the pointer's rest on B retargets after SWAP_DELAY_MS.
         act(() => {
-            vi.advanceTimersByTime(EXIT_TIMEOUT_MS * 2);
+            vi.advanceTimersByTime(SWAP_DELAY_MS);
         });
         expect(result.current.popoverCell).toEqual(cellB);
     });
@@ -133,7 +175,7 @@ describe("useWhyHoverIntent — exit timer (any cell-enter cancels)", () => {
             vi.advanceTimersByTime(50);
             result.current.intent.onCellPointerEnter(cellA);
         });
-        expect(result.current.popoverCell).toEqual(cellA);
+        expect(result.current.popoverCell).not.toBeNull();
     });
 
     test("entering then leaving re-arms the exit timer from the most recent leave", () => {
@@ -146,14 +188,15 @@ describe("useWhyHoverIntent — exit timer (any cell-enter cancels)", () => {
         act(() => {
             result.current.intent.onCellPointerLeave();
         });
-        // Enter B at t=200 (cancels exit), leave B at t=300.
+        // Enter B at t=200 (cancels exit), rest long enough to
+        // retarget, then leave B.
         act(() => {
             vi.advanceTimersByTime(200);
             result.current.intent.onCellPointerEnter(cellB);
-            vi.advanceTimersByTime(100);
+            vi.advanceTimersByTime(SWAP_DELAY_MS);
             result.current.intent.onCellPointerLeave();
         });
-        // From the second leave (t=300), exit fires at t=300+900=1200.
+        // From the second leave, exit fires after a fresh 900ms budget.
         // Originally — under the old "exit fires from first leave"
         // rule — it would have fired at t=900, before this point.
         act(() => {

--- a/src/ui/checklistPopoverIntent.ts
+++ b/src/ui/checklistPopoverIntent.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { Duration, Equal } from "effect";
 import { useCallback, useEffect, useRef } from "react";
 import type { Cell } from "../logic/Knowledge";
 import { useSelection } from "./SelectionContext";
@@ -26,16 +27,24 @@ export const OPEN_DELAY_MS = 300;
 export const EXIT_TIMEOUT_MS = 900;
 
 /**
+ * Delay before an already-open hover popover retargets to a newly
+ * hovered cell. This keeps a transit cell from stealing the popover
+ * while the pointer is moving from the trigger toward the portaled
+ * content, but still lets intentional cell-to-cell browsing feel
+ * responsive once the pointer rests on a new target.
+ */
+export const SWAP_DELAY_MS = Duration.toMillis(Duration.millis(140));
+
+/**
  * Hover-intent driver for the checklist "why" popovers.
  *
  * ## State: popovers mode
  *
  * `popoverCell` (on `SelectionContext`) is the currently-open cell, or
  * `null` when no popover is visible. "Popovers mode" is the condition
- * `popoverCell !== null`. While in popovers mode, hovering any new
- * cell swaps the popover immediately (no settle delay) — once the
- * user has committed to reading, every cell-hover counts as continued
- * engagement.
+ * `popoverCell !== null`. Hover-opened popovers retarget after
+ * `SWAP_DELAY_MS` on a new cell; explicitly-opened popovers are
+ * pinned so the user can move into their controls.
  *
  * ## Enter popovers mode (any one of)
  *
@@ -44,9 +53,8 @@ export const EXIT_TIMEOUT_MS = 900;
  *    and sets `popoverCell` to that cell.
  * 2. **Click or tap.** Clicking/tapping a deducible cell. Flows through
  *    Radix's trigger → `onOpenChange(true)` in the parent, which calls
- *    `setPopoverCell(thisCell)` directly. Parent should also call
- *    `cancelExitTimer()` (exposed from this hook) so any in-flight
- *    decay cannot close the popover the user just explicitly requested.
+ *    `onExplicitOpen(thisCell)`. That pins the popover to the cell
+ *    until explicit close, outside click, Escape, or grid leave.
  * 3. **Keyboard activation.** Enter or Space on a focused cell. The
  *    existing Checklist keybinding synthesizes a click on the cell,
  *    which reuses path (2).
@@ -62,9 +70,9 @@ export const EXIT_TIMEOUT_MS = 900;
  *    dismiss path → `onOpenChange(false)` → parent calls
  *    `setPopoverCell(null)`. Immediate exit.
  * 4. **Exit timer fires.** Started on `onCellPointerLeave` while in
- *    popovers mode; `EXIT_TIMEOUT_MS` (900 ms). Canceled by ANY
- *    cell-enter while in mode — the user just has to land on another
- *    cell within the budget; they don't need to linger on it.
+ *    hover-opened popovers mode; `EXIT_TIMEOUT_MS` (900 ms). Canceled
+ *    by ANY cell-enter while in mode — the user just has to land on
+ *    another cell within the budget; they don't need to linger on it.
  *
  * ## Timers (private refs)
  *
@@ -72,22 +80,21 @@ export const EXIT_TIMEOUT_MS = 900;
  *   mode. Started on cell-enter, canceled on cell-leave or grid-leave.
  *   Opens the popover (entering popovers mode) when it fires.
  * - `exitTimer`: `EXIT_TIMEOUT_MS`. Runs only while IN popovers mode.
- *   Started on cell-leave (only if not already armed). Canceled by
- *   any cell-enter while in mode, by explicit `cancelExitTimer`, or
- *   by grid-leave. Closes the popover when it fires.
- *
- * The previous "settle" timer (a 300 ms continuous-hover requirement
- * before a new cell counted as engagement) was removed: it caused a
- * race where rapid lateral mouse movement across cells would never
- * settle and the original exit timer would fire under the cursor,
- * making the popover disappear mid-hover. Without settle, the rule
- * becomes "while in mode, hovering any cell keeps the popover alive"
- * — trivially correct.
+ *   Started on cell-leave for hover-opened popovers (only if not
+ *   already armed). Canceled by any cell-enter while in mode, by
+ *   explicit `cancelExitTimer`, or by grid-leave. Closes the popover
+ *   when it fires.
+ * - `swapTimer`: `SWAP_DELAY_MS`. Runs while an unpinned popover is
+ *   open and the pointer enters another cell. Entering the portaled
+ *   content cancels it, so transit cells do not steal interactive
+ *   popovers.
  */
 interface WhyHoverIntent {
     readonly onCellPointerEnter: (cell: Cell) => void;
     readonly onCellPointerLeave: () => void;
     readonly onGridLeave: () => void;
+    readonly onExplicitOpen: (cell: Cell) => void;
+    readonly onExplicitClose: () => void;
     readonly cancelExitTimer: () => void;
 }
 
@@ -95,6 +102,8 @@ export function useWhyHoverIntent(): WhyHoverIntent {
     const { popoverCell, setPopoverCell } = useSelection();
     const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const exitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const swapTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const pinnedCellRef = useRef<Cell | null>(null);
 
     const clearOpen = useCallback(() => {
         if (openTimerRef.current !== null) {
@@ -103,27 +112,43 @@ export function useWhyHoverIntent(): WhyHoverIntent {
         }
     }, []);
 
+    const clearSwap = useCallback(() => {
+        if (swapTimerRef.current !== null) {
+            clearTimeout(swapTimerRef.current);
+            swapTimerRef.current = null;
+        }
+    }, []);
+
     const cancelExitTimer = useCallback(() => {
         if (exitTimerRef.current !== null) {
             clearTimeout(exitTimerRef.current);
             exitTimerRef.current = null;
         }
-    }, []);
+        clearSwap();
+    }, [clearSwap]);
 
     const onCellPointerEnter = useCallback(
         (cell: Cell) => {
             if (popoverCell !== null) {
-                // Already in popovers mode: swap the visible popover
-                // to the new cell immediately AND cancel any pending
-                // exit. Hovering any cell counts as engagement.
+                // Already in popovers mode: any cell-enter keeps the
+                // current popover alive. Hover-opened popovers retarget
+                // only after a short rest on the new cell; explicitly
+                // opened popovers stay pinned for interacting with
+                // their controls.
                 clearOpen();
                 cancelExitTimer();
-                setPopoverCell(cell);
+                if (pinnedCellRef.current !== null) return;
+                if (Equal.equals(cell, popoverCell)) return;
+                swapTimerRef.current = setTimeout(() => {
+                    swapTimerRef.current = null;
+                    setPopoverCell(cell);
+                }, SWAP_DELAY_MS);
             } else {
                 // Not in popovers mode: start the open-delay timer.
                 clearOpen();
                 openTimerRef.current = setTimeout(() => {
                     openTimerRef.current = null;
+                    pinnedCellRef.current = null;
                     setPopoverCell(cell);
                 }, OPEN_DELAY_MS);
             }
@@ -133,18 +158,43 @@ export function useWhyHoverIntent(): WhyHoverIntent {
 
     const onCellPointerLeave = useCallback(() => {
         // Cancel any pending open that was racing to fire. If we're
-        // in popovers mode and no exit timer is already armed, start
-        // one now.
+        // in hover-opened popovers mode and no exit timer is already
+        // armed, start one now. Pinned popovers behave like dialogs:
+        // they stay up until explicit close, outside click, Escape, or
+        // a true grid leave.
         clearOpen();
-        if (popoverCell !== null && exitTimerRef.current === null) {
+        clearSwap();
+        if (
+            popoverCell !== null
+            && pinnedCellRef.current === null
+            && exitTimerRef.current === null
+        ) {
             exitTimerRef.current = setTimeout(() => {
                 exitTimerRef.current = null;
                 setPopoverCell(null);
             }, EXIT_TIMEOUT_MS);
         }
-    }, [popoverCell, setPopoverCell, clearOpen]);
+    }, [popoverCell, setPopoverCell, clearOpen, clearSwap]);
 
     const onGridLeave = useCallback(() => {
+        pinnedCellRef.current = null;
+        clearOpen();
+        cancelExitTimer();
+        setPopoverCell(null);
+    }, [setPopoverCell, clearOpen, cancelExitTimer]);
+
+    const onExplicitOpen = useCallback(
+        (cell: Cell) => {
+            pinnedCellRef.current = cell;
+            clearOpen();
+            cancelExitTimer();
+            setPopoverCell(cell);
+        },
+        [setPopoverCell, clearOpen, cancelExitTimer],
+    );
+
+    const onExplicitClose = useCallback(() => {
+        pinnedCellRef.current = null;
         clearOpen();
         cancelExitTimer();
         setPopoverCell(null);
@@ -152,6 +202,7 @@ export function useWhyHoverIntent(): WhyHoverIntent {
 
     useEffect(
         () => () => {
+            pinnedCellRef.current = null;
             clearOpen();
             cancelExitTimer();
         },
@@ -162,6 +213,8 @@ export function useWhyHoverIntent(): WhyHoverIntent {
         onCellPointerEnter,
         onCellPointerLeave,
         onGridLeave,
+        onExplicitOpen,
+        onExplicitClose,
         cancelExitTimer,
     };
 }

--- a/src/ui/components/Checklist.deduce.test.tsx
+++ b/src/ui/components/Checklist.deduce.test.tsx
@@ -60,7 +60,7 @@ vi.mock("motion/react", () => {
     };
 });
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { Clue } from "../Clue";
 import { TestQueryClientProvider } from "../../test-utils/queryClient";
 import { seedOnboardingDismissed } from "../../test-utils/onboardingSeed";
@@ -130,6 +130,63 @@ describe("Checklist — deduce mode — cell affordances", () => {
         }
         // At least one body cell exists.
         expect(bodyCells.length).toBeGreaterThan(0);
+    });
+
+    test("blank play cells open a hypothesis control and render a badge without the contradiction banner", async () => {
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        await waitForDeduceChecklist();
+        const cell = document.querySelector<HTMLElement>(
+            "[data-cell-row='0'][data-cell-col='0']",
+        );
+        expect(cell).not.toBeNull();
+
+        fireEvent.click(cell!);
+        await screen.findByText("noDeductionYet");
+        fireEvent.click(screen.getByRole("button", { name: "Y" }));
+
+        await waitFor(() => {
+            const updatedCell = document.querySelector<HTMLElement>(
+                "[data-cell-row='0'][data-cell-col='0']",
+            );
+            expect(updatedCell?.textContent).toContain("Y?");
+        });
+        expect(screen.queryByText("bannerTitle")).toBeNull();
+    });
+
+    test("moving from a cell into the hypothesis popover keeps it open so its buttons are clickable", async () => {
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        await waitForDeduceChecklist();
+        const cell = document.querySelector<HTMLElement>(
+            "[data-cell-row='0'][data-cell-col='0']",
+        );
+        const transitCell = document.querySelector<HTMLElement>(
+            "[data-cell-row='1'][data-cell-col='0']",
+        );
+        const checklist = document.getElementById("checklist");
+        expect(cell).not.toBeNull();
+        expect(transitCell).not.toBeNull();
+        expect(checklist).not.toBeNull();
+
+        fireEvent.click(cell!);
+        const contentText = await screen.findByText("noDeductionYet");
+        const content = contentText.closest<HTMLElement>(
+            '[data-popover-zone="checklist"]',
+        );
+        expect(content).not.toBeNull();
+
+        fireEvent.pointerLeave(cell!, { relatedTarget: content });
+        fireEvent.pointerEnter(transitCell!, { relatedTarget: cell });
+        fireEvent.pointerLeave(transitCell!, { relatedTarget: content });
+        fireEvent.mouseLeave(checklist!, { relatedTarget: content });
+        fireEvent.pointerEnter(content!, { relatedTarget: cell });
+        fireEvent.click(screen.getByRole("button", { name: "Y" }));
+
+        await waitFor(() => {
+            const updatedCell = document.querySelector<HTMLElement>(
+                "[data-cell-row='0'][data-cell-col='0']",
+            );
+            expect(updatedCell?.textContent).toContain("Y?");
+        });
     });
 });
 
@@ -308,38 +365,20 @@ describe("Checklist — case-file deduction popover", () => {
         );
     });
 
-    test("an undeduced case-file cell stays non-interactive (no popover affordance)", async () => {
-        // Same session as above, but deuce-mode renders just the
-        // empty checklist by default — no deductions firing. Look at
-        // a row whose case-file cell has no value: it should NOT
-        // expose role=button or aria-haspopup.
-        // Reuse the empty fresh state by doing nothing extra.
+    test("an undeduced case-file cell exposes the hypothesis popover affordance", async () => {
+        // Empty checklist: no deduction has fired yet, but play-mode
+        // cells still open the contextual popover so the user can add
+        // a hypothesis.
         render(<Clue />, { wrapper: TestQueryClientProvider });
         await waitForDeduceChecklist();
-        const allBodyCells = Array.from(
-            document.querySelectorAll<HTMLElement>("[data-cell-row][data-cell-col]"),
+        const rowCells = Array.from(
+            document.querySelectorAll<HTMLElement>("[data-cell-row='0']"),
         );
-        // The case-file column won't advertise data-cell-col when
-        // there's no deduction (it falls back to the plain-td path).
-        // Check: at least one row exists with NO data-cell-col on its
-        // last cell — i.e. the case-file column for an empty state.
-        const lastTrs = Array.from(document.querySelectorAll<HTMLElement>("tr"));
-        const anyRowWithUndeducedCaseFile = lastTrs.some(tr => {
-            const tds = Array.from(tr.querySelectorAll("td"));
-            const last = tds[tds.length - 1];
-            // Plain td case-file cell — no data-cell-col set, no
-            // role attribute.
-            return (
-                last !== undefined
-                && last.getAttribute("data-cell-col") === null
-                && last.getAttribute("role") === null
-            );
-        });
-        expect(anyRowWithUndeducedCaseFile).toBe(true);
-        // Sanity: the body cells we DID find still cover the player
-        // columns (so the assertion above isn't accidentally passing
-        // because of a totally empty grid).
-        expect(allBodyCells.length).toBeGreaterThan(0);
+        const caseFileCell = rowCells[rowCells.length - 1];
+        expect(caseFileCell).toBeDefined();
+        expect(caseFileCell?.getAttribute("role")).toBe("button");
+        expect(caseFileCell?.getAttribute("aria-haspopup")).toBe("dialog");
+        expect(caseFileCell?.getAttribute("data-cell-col")).not.toBeNull();
     });
 });
 

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -30,6 +30,13 @@ import {
     N,
     Y,
 } from "../../logic/Knowledge";
+import {
+    findEvaluationForCell,
+    findHypothesisForCell,
+    type CellHypothesis,
+    type HypothesisEvaluation,
+    type HypothesisStatus,
+} from "../../logic/Hypothesis";
 import { footnotesForCell } from "../../logic/Footnotes";
 import { KnownCard } from "../../logic/InitialKnowledge";
 import {
@@ -216,6 +223,7 @@ export function Checklist() {
     const tSetup = useTranslations("setup");
     const tShare = useTranslations("share");
     const tReasons = useTranslations("reasons");
+    const tHypotheses = useTranslations("hypotheses");
     const { openInvitePlayer } = useShareContext();
     const hasKeyboard = useHasKeyboard();
     const { state, dispatch, derived } = useClue();
@@ -223,13 +231,14 @@ export function Checklist() {
         activeSuggestionIndex,
         activeAccusationIndex,
         popoverCell,
-        setPopoverCell,
     } = useSelection();
     const {
         onCellPointerEnter,
         onCellPointerLeave,
         onGridLeave,
         cancelExitTimer,
+        onExplicitOpen,
+        onExplicitClose,
     } = useWhyHoverIntent();
     const confirm = useConfirm();
     const inSetup = state.uiMode === "setup";
@@ -238,6 +247,7 @@ export function Checklist() {
     const result = derived.deductionResult;
     const footnotes = derived.footnotes;
     const provenance = derived.provenance;
+    const hypothesisEvaluations = derived.hypothesisEvaluations;
     const suggestions = derived.suggestionsAsData;
     const accusations = derived.accusationsAsData;
 
@@ -1108,6 +1118,19 @@ export function Checklist() {
                                         // opens the deduction-chain popover.
                                         const playInteractive =
                                             !inSetup && isPlayerCell;
+                                        const thisCellForHover = Cell(
+                                            owner,
+                                            entry.id,
+                                        );
+                                        const hypothesis = findHypothesisForCell(
+                                            state.hypotheses,
+                                            thisCellForHover,
+                                        );
+                                        const hypothesisEvaluation =
+                                            findEvaluationForCell(
+                                                hypothesisEvaluations,
+                                                thisCellForHover,
+                                            );
                                         const tooltipText = buildCellTitle({
                                             provenance,
                                             suggestions,
@@ -1119,7 +1142,22 @@ export function Checklist() {
                                             tDeduce: t,
                                             tReasons,
                                         });
-                                        const tooltipContent = tooltipText ? (
+                                        const tooltipContent = !inSetup ? (
+                                            <CellPopoverContent
+                                                whyText={tooltipText}
+                                                hypothesis={hypothesis}
+                                                evaluation={hypothesisEvaluation}
+                                                tHypotheses={tHypotheses}
+                                                onSetHypothesis={value =>
+                                                    dispatch({
+                                                        type: "setHypothesis",
+                                                        owner,
+                                                        card: entry.id,
+                                                        value,
+                                                    })
+                                                }
+                                            />
+                                        ) : tooltipText ? (
                                             <div className="whitespace-pre-line">
                                                 {tooltipText}
                                             </div>
@@ -1159,9 +1197,7 @@ export function Checklist() {
                                         // not exploring the deduction
                                         // chain.
                                         const popoverInteractive =
-                                            tooltipContent !== undefined
-                                            && !inSetup
-                                            && (playInteractive || !isPlayerCell);
+                                            !inSetup;
                                         const tdClassName = cellClass(
                                             value,
                                             setupInteractive
@@ -1169,9 +1205,16 @@ export function Checklist() {
                                                 || popoverInteractive,
                                             isHighlighted,
                                         );
-                                        const thisCellForHover = Cell(
-                                            owner,
-                                            entry.id,
+                                        const renderedCellContent = (
+                                            <>
+                                                {renderTableCellContent(cellContent)}
+                                                {!inSetup && hypothesis !== undefined ? (
+                                                    <HypothesisBadge
+                                                        hypothesis={hypothesis}
+                                                        evaluation={hypothesisEvaluation}
+                                                    />
+                                                ) : null}
+                                            </>
                                         );
                                         // Hover handlers are provided for
                                         // every cell so the grid-leave /
@@ -1308,7 +1351,7 @@ export function Checklist() {
                                                     }}
                                                     {...hoverHandlers}
                                                 >
-                                                    {renderTableCellContent(cellContent)}
+                                                    {renderedCellContent}
                                                 </motion.td>
                                             );
                                         } else if (popoverInteractive) {
@@ -1346,7 +1389,8 @@ export function Checklist() {
                                                 <InfoPopover
                                                     key={ownerCellKey}
                                                     content={tooltipContent}
-                                                    variant="accent"
+                                                    variant="default"
+                                                    maxWidthPx={360}
                                                     open={isOpen}
                                                     onOpenChange={open => {
                                                         if (open) {
@@ -1360,14 +1404,11 @@ export function Checklist() {
                                                             // in-flight
                                                             // exit
                                                             // timer.
-                                                            cancelExitTimer();
-                                                            setPopoverCell(
+                                                            onExplicitOpen(
                                                                 thisCell,
                                                             );
                                                         } else {
-                                                            setPopoverCell(
-                                                                null,
-                                                            );
+                                                            onExplicitClose();
                                                         }
                                                     }}
                                                     onContentPointerEnter={
@@ -1385,6 +1426,16 @@ export function Checklist() {
                                                         role="button"
                                                         tabIndex={0}
                                                         aria-haspopup={ARIA_HASPOPUP_DIALOG}
+                                                        aria-label={tHypotheses(
+                                                            "cellAria",
+                                                            {
+                                                                owner:
+                                                                    ownerLabel(
+                                                                        owner,
+                                                                    ),
+                                                                card: entry.name,
+                                                            },
+                                                        )}
                                                         data-cell-row={rowIdx}
                                                         data-cell-col={colIdx}
                                                         {...firstCellAnchorAttr}
@@ -1408,7 +1459,7 @@ export function Checklist() {
                                                         }}
                                                         {...hoverHandlers}
                                                     >
-                                                        {renderTableCellContent(cellContent)}
+                                                        {renderedCellContent}
                                                     </motion.td>
                                                 </InfoPopover>
                                             );
@@ -1432,7 +1483,7 @@ export function Checklist() {
                                                     onKeyDown={onGridArrowKey}
                                                     {...hoverHandlers}
                                                 >
-                                                    {renderTableCellContent(cellContent)}
+                                                    {renderedCellContent}
                                                 </motion.td>
                                             );
                                         } else {
@@ -1445,7 +1496,7 @@ export function Checklist() {
                                                     {...firstCellAnchorAttr}
                                                     {...hoverHandlers}
                                                 >
-                                                    {renderTableCellContent(cellContent)}
+                                                    {renderedCellContent}
                                                 </motion.td>
                                             );
                                         }
@@ -1962,6 +2013,176 @@ const buildCellTitle = (args: {
     return parts.length > 0 ? parts.join("\n") : undefined;
 };
 
+function CellPopoverContent({
+    whyText,
+    hypothesis,
+    evaluation,
+    tHypotheses,
+    onSetHypothesis,
+}: {
+    readonly whyText: string | undefined;
+    readonly hypothesis: CellHypothesis | undefined;
+    readonly evaluation: HypothesisEvaluation | undefined;
+    readonly tHypotheses: ReturnType<typeof useTranslations<"hypotheses">>;
+    readonly onSetHypothesis: (value: CellValue | undefined) => void;
+}) {
+    const selected = hypothesis?.value;
+    const statusText = hypothesisStatusText(
+        hypothesis,
+        evaluation,
+        tHypotheses,
+    );
+    return (
+        <div className="min-w-60 space-y-2">
+            <div className="whitespace-pre-line">
+                {whyText ?? tHypotheses("noDeductionYet")}
+            </div>
+            <div className="border-t border-border/70 pt-2">
+                <div className="mb-1.5 flex items-center justify-between gap-3">
+                    <span className="text-[11px] font-semibold uppercase tracking-[0.05em] text-muted">
+                        {tHypotheses("label")}
+                    </span>
+                    <div
+                        role="group"
+                        aria-label={tHypotheses("controlAria")}
+                        className="inline-flex overflow-hidden rounded-[var(--radius)] border border-border bg-white"
+                    >
+                        <HypothesisOptionButton
+                            label={tHypotheses("off")}
+                            active={selected === undefined}
+                            onClick={() => onSetHypothesis(undefined)}
+                        />
+                        <HypothesisOptionButton
+                            label={Y}
+                            active={selected === Y}
+                            onClick={() => onSetHypothesis(Y)}
+                        />
+                        <HypothesisOptionButton
+                            label={N}
+                            active={selected === N}
+                            onClick={() => onSetHypothesis(N)}
+                        />
+                    </div>
+                </div>
+                <div className="text-[12px] leading-snug text-muted">
+                    {statusText}
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function HypothesisOptionButton({
+    label,
+    active,
+    onClick,
+}: {
+    readonly label: string;
+    readonly active: boolean;
+    readonly onClick: () => void;
+}) {
+    return (
+        <button
+            type="button"
+            aria-pressed={active}
+            onClick={onClick}
+            className={
+                "cursor-pointer border-0 border-r border-border px-2 py-1 text-[12px] font-semibold last:border-r-0 " +
+                (active
+                    ? "bg-accent text-white"
+                    : "bg-white text-[#2a1f12] hover:bg-hover")
+            }
+        >
+            {label}
+        </button>
+    );
+}
+
+const hypothesisStatusText = (
+    hypothesis: CellHypothesis | undefined,
+    evaluation: HypothesisEvaluation | undefined,
+    tHypotheses: ReturnType<typeof useTranslations<"hypotheses">>,
+): string => {
+    if (hypothesis === undefined) return tHypotheses("statusOff");
+    if (evaluation === undefined) return tHypotheses("statusPending");
+    switch (evaluation.status) {
+        case "verified":
+            return tHypotheses("statusVerified", {
+                value: hypothesis.value,
+            });
+        case "falsified":
+            return tHypotheses("statusFalsified", {
+                value: hypothesis.value,
+            });
+        case "blocked":
+            return tHypotheses("statusBlocked");
+        case "plausible":
+            return tHypotheses("statusPlausible", {
+                value: hypothesis.value,
+                count: evaluation.impactCount,
+            });
+    }
+};
+
+function HypothesisBadge({
+    hypothesis,
+    evaluation,
+}: {
+    readonly hypothesis: CellHypothesis;
+    readonly evaluation: HypothesisEvaluation | undefined;
+}) {
+    const status: HypothesisStatus =
+        evaluation?.status ?? HYPOTHESIS_STATUS_PLAUSIBLE;
+    const glyph =
+        status === "verified"
+            ? `${hypothesis.value}✓`
+            : status === "falsified"
+                ? `${hypothesis.value}×`
+                : status === "blocked"
+                    ? `${hypothesis.value}!`
+                    : `${hypothesis.value}?`;
+    const tone =
+        status === "verified"
+            ? "border-yes-bg bg-yes-bg text-yes"
+            : status === "falsified"
+                ? "border-danger-border bg-danger-bg text-danger"
+                : status === "blocked"
+                    ? "border-border bg-row-alt text-muted"
+                    : "border-warning-border bg-warning-bg text-warning";
+    return (
+        <span
+            aria-hidden
+            className={
+                "pointer-events-none absolute right-0.5 top-0.5 rounded border px-0.5 text-[9px] leading-[11px] " +
+                tone
+            }
+        >
+            {glyph}
+        </span>
+    );
+}
+
+const hypothesisSummaryText = (
+    evaluations: ReadonlyArray<HypothesisEvaluation>,
+    tHypotheses: ReturnType<typeof useTranslations<"hypotheses">>,
+): string | undefined => {
+    if (evaluations.length === 0) return undefined;
+    const counts = new Map<HypothesisStatus, number>();
+    for (const evaluation of evaluations) {
+        counts.set(
+            evaluation.status,
+            (counts.get(evaluation.status) ?? 0) + 1,
+        );
+    }
+    const parts: string[] = [];
+    for (const status of HYPOTHESIS_SUMMARY_ORDER) {
+        const count = counts.get(status) ?? 0;
+        if (count === 0) continue;
+        parts.push(tHypotheses(`summary.${status}`, { count }));
+    }
+    return tHypotheses("summaryLine", { parts: parts.join(" · ") });
+};
+
 // Motion-only constants (non user-facing). The "unsolved" color
 // is the app's body ink; motion can't animate "inherit" so we
 // resolve it here.
@@ -1983,6 +2204,8 @@ const TABLE_ROW_ENTRY_DURATION = Duration.millis(300);
 const TABLE_DANGER_FADE_DURATION = Duration.millis(120);
 const TABLE_DANGER_HOLD_DURATION = Duration.millis(240);
 const TABLE_COLLAPSE_DURATION = Duration.millis(180);
+const CASE_FILE_WIGGLE_RESET_DELAY = Duration.millis(700);
+const CASE_FILE_CELEBRATE_RESET_DELAY = Duration.millis(900);
 const TABLE_REDUCED_DANGER_FADE_MS = Duration.toMillis(
     Duration.millis(80),
 );
@@ -2011,12 +2234,24 @@ const TABLE_COLUMN_HIDDEN = { maxWidth: 0, opacity: 0 } as const;
 const TABLE_COLUMN_VISIBLE = { maxWidth: CELL_EXPAND_CAP_PX, opacity: 1 } as const;
 const STYLE_OVERFLOW_HIDDEN = { overflow: "hidden" } as const;
 const STYLE_COLUMN_CELL_VISIBLE = { maxWidth: CELL_EXPAND_CAP_PX } as const;
+const HYPOTHESIS_STATUS_PLAUSIBLE: HypothesisStatus = "plausible";
+const HYPOTHESIS_SUMMARY_ORDER: ReadonlyArray<HypothesisStatus> = [
+    "plausible",
+    "verified",
+    "falsified",
+    "blocked",
+];
 
 function CaseFileHeader({ knowledge }: { knowledge: Knowledge }) {
     const t = useTranslations("deduce");
-    const { state } = useClue();
+    const tHypotheses = useTranslations("hypotheses");
+    const { state, derived } = useClue();
     const setup = state.setup;
     const progress = caseFileProgress(setup, knowledge);
+    const hypothesisSummary = hypothesisSummaryText(
+        derived.hypothesisEvaluations,
+        tHypotheses,
+    );
     const headerRef = useRef<HTMLDivElement>(null);
     const fireConfetti = useConfetti();
     const wiggleTransition = useReducedTransition(T_WIGGLE);
@@ -2057,7 +2292,10 @@ function CaseFileHeader({ knowledge }: { knowledge: Knowledge }) {
         prevSolvedRef.current = new Map(solvedByCategory);
         if (newlySolved.length === 0) return;
         setWigglingIds(new Set(newlySolved));
-        const timeout = setTimeout(() => setWigglingIds(new Set()), 700);
+        const timeout = setTimeout(
+            () => setWigglingIds(new Set()),
+            Duration.toMillis(CASE_FILE_WIGGLE_RESET_DELAY),
+        );
         return () => clearTimeout(timeout);
     }, [solvedByCategory]);
 
@@ -2075,7 +2313,10 @@ function CaseFileHeader({ knowledge }: { knowledge: Knowledge }) {
         if (allSolved && !wasAllSolvedRef.current) {
             setIsCelebrating(true);
             fireConfetti(headerRef.current);
-            const timeout = setTimeout(() => setIsCelebrating(false), 900);
+            const timeout = setTimeout(
+                () => setIsCelebrating(false),
+                Duration.toMillis(CASE_FILE_CELEBRATE_RESET_DELAY),
+            );
             wasAllSolvedRef.current = true;
             return () => clearTimeout(timeout);
         }
@@ -2127,6 +2368,11 @@ function CaseFileHeader({ knowledge }: { knowledge: Knowledge }) {
                     />
                 </div>
             </div>
+            {hypothesisSummary !== undefined ? (
+                <div className="mb-2.5 text-[12px] text-muted">
+                    {hypothesisSummary}
+                </div>
+            ) : null}
             <div
                 className="grid gap-2"
                 style={{

--- a/src/ui/share/ShareCreateModal.test.tsx
+++ b/src/ui/share/ShareCreateModal.test.tsx
@@ -103,6 +103,11 @@ import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { ClueProvider } from "../state";
 import { TestQueryClientProvider } from "../../test-utils/queryClient";
 import { ShareCreateModal, pickProgressLabelKey } from "./ShareCreateModal";
+import { DEFAULT_SETUP } from "../../logic/GameSetup";
+import { PlayerOwner } from "../../logic/GameObjects";
+import { CellHypothesis } from "../../logic/Hypothesis";
+import { encodeSession } from "../../logic/Persistence";
+import { Y } from "../../logic/Knowledge";
 
 const mountModal = (
     variant: "pack" | "invite" | "transfer",
@@ -124,6 +129,30 @@ const findCta = (): HTMLButtonElement => {
     ) as HTMLButtonElement | null;
     if (!el) throw new Error("Share CTA not found");
     return el;
+};
+
+const seedSessionWithHypothesis = (): void => {
+    const player = DEFAULT_SETUP.players[0]!;
+    const card = DEFAULT_SETUP.categories[0]!.cards[0]!.id;
+    window.localStorage.setItem(
+        "effect-clue.session.v7",
+        JSON.stringify(
+            encodeSession({
+                setup: DEFAULT_SETUP,
+                hands: [],
+                handSizes: [],
+                suggestions: [],
+                accusations: [],
+                hypotheses: [
+                    CellHypothesis({
+                        owner: PlayerOwner(player),
+                        card,
+                        value: Y,
+                    }),
+                ],
+            }),
+        ),
+    );
 };
 
 beforeEach(() => {
@@ -287,9 +316,10 @@ describe("ShareCreateModal — wire payload by variant", () => {
         expect(payload.suggestionsData).toBeUndefined();
         expect(payload.accusationsData).toBeUndefined();
         expect(payload.knownCardsData).toBeUndefined();
+        expect(payload.hypothesesData).toBeUndefined();
     });
 
-    test("transfer variant sends kind: 'transfer' with all six fields", async () => {
+    test("transfer variant sends kind: 'transfer' and omits empty hypothesis data", async () => {
         mockSession = {
             data: { user: { id: "u1", isAnonymous: false } },
         };
@@ -308,6 +338,25 @@ describe("ShareCreateModal — wire payload by variant", () => {
         expect(payload.knownCardsData).toBeTypeOf("string");
         expect(payload.suggestionsData).toBeTypeOf("string");
         expect(payload.accusationsData).toBeTypeOf("string");
+        expect(payload.hypothesesData).toBeUndefined();
+    });
+
+    test("transfer variant includes hypothesis data when present", async () => {
+        mockSession = {
+            data: { user: { id: "u1", isAnonymous: false } },
+        };
+        seedSessionWithHypothesis();
+        mountModal("transfer");
+        await act(async () => {});
+        await act(async () => {
+            fireEvent.click(findCta());
+        });
+        await waitFor(() => {
+            expect(createShareMock).toHaveBeenCalled();
+        });
+        const payload = createShareMock.mock.calls[0]?.[0];
+        expect(payload.kind).toBe("transfer");
+        expect(payload.hypothesesData).toBeTypeOf("string");
     });
 });
 

--- a/src/ui/share/ShareCreateModal.tsx
+++ b/src/ui/share/ShareCreateModal.tsx
@@ -10,8 +10,9 @@
  *                   any. Entries: setup pane, overflow menu.
  *   - "transfer"  — move this game to another device. Sends
  *                   everything (pack + players + hand sizes + known
- *                   cards + suggestions + accusations). Renders the
- *                   privacy warning. Entry: overflow menu only.
+ *                   cards + suggestions + accusations + hypotheses).
+ *                   Renders the privacy warning. Entry: overflow
+ *                   menu only.
  *
  * Universal sign-in: the server requires every share to have an
  * authenticated, non-anonymous owner regardless of variant. The CTA
@@ -59,10 +60,12 @@ import {
     accusationsCodec,
     cardPackCodec,
     handSizesCodec,
+    hypothesesCodec,
     knownCardsCodec,
     playersCodec,
     suggestionsCodec,
 } from "../../logic/ShareCodec";
+import { ownerToPersisted } from "../../logic/Hypothesis";
 import {
     createShare,
     type CreateShareInput,
@@ -234,6 +237,14 @@ const projectAccusation = (a: GameSession["accusations"][number]) => ({
     loggedAt: a.loggedAt,
 });
 
+const projectHypothesis = (
+    h: NonNullable<GameSession["hypotheses"]>[number],
+) => ({
+    owner: ownerToPersisted(h.owner),
+    card: h.card,
+    value: h.value,
+});
+
 /**
  * Build the wire payload for a `pack` share — pack only, no game
  * state. Used by the card-pack-row and per-pack-picker entries.
@@ -281,26 +292,36 @@ const buildInviteInput = (
 
 /**
  * Build the wire payload for a `transfer` share — everything,
- * including known cards. Same projection as invite plus knownCards.
+ * including known cards and private hypotheses when any exist.
  */
 const buildTransferInput = (
     session: GameSession,
     packName: string | undefined,
-): CreateShareInput => ({
-    kind: VARIANT_TRANSFER,
-    cardPackData: Schema.encodeSync(cardPackCodec)(
-        projectCardSet(session.setup.cardSet, packName),
-    ),
-    playersData: Schema.encodeSync(playersCodec)(session.setup.players),
-    handSizesData: Schema.encodeSync(handSizesCodec)(session.handSizes),
-    knownCardsData: Schema.encodeSync(knownCardsCodec)(session.hands),
-    suggestionsData: Schema.encodeSync(suggestionsCodec)(
-        session.suggestions.map(projectSuggestion),
-    ),
-    accusationsData: Schema.encodeSync(accusationsCodec)(
-        session.accusations.map(projectAccusation),
-    ),
-});
+): CreateShareInput => {
+    const hypotheses = session.hypotheses ?? [];
+    return {
+        kind: VARIANT_TRANSFER,
+        cardPackData: Schema.encodeSync(cardPackCodec)(
+            projectCardSet(session.setup.cardSet, packName),
+        ),
+        playersData: Schema.encodeSync(playersCodec)(session.setup.players),
+        handSizesData: Schema.encodeSync(handSizesCodec)(session.handSizes),
+        knownCardsData: Schema.encodeSync(knownCardsCodec)(session.hands),
+        suggestionsData: Schema.encodeSync(suggestionsCodec)(
+            session.suggestions.map(projectSuggestion),
+        ),
+        accusationsData: Schema.encodeSync(accusationsCodec)(
+            session.accusations.map(projectAccusation),
+        ),
+        ...(hypotheses.length > 0
+            ? {
+                  hypothesesData: Schema.encodeSync(hypothesesCodec)(
+                      hypotheses.map(projectHypothesis),
+                  ),
+              }
+            : {}),
+    };
+};
 
 interface ShareCreateModalProps {
     readonly open: boolean;
@@ -423,6 +444,7 @@ export function ShareCreateModal({
             })),
             suggestions: derived.suggestionsAsData,
             accusations: derived.accusationsAsData,
+            hypotheses: state.hypotheses,
         };
         if (variant === VARIANT_INVITE) {
             return buildInviteInput(
@@ -439,6 +461,7 @@ export function ShareCreateModal({
         forcedCardPackLabel,
         includeProgress,
         state.handSizes,
+        state.hypotheses,
         state.knownCards,
         state.setup,
         variant,

--- a/src/ui/share/ShareImportPage.test.tsx
+++ b/src/ui/share/ShareImportPage.test.tsx
@@ -84,6 +84,7 @@ import { CARD_SETS } from "../../logic/GameSetup";
 import {
     cardPackCodec,
     handSizesCodec,
+    hypothesesCodec,
     knownCardsCodec,
     playersCodec,
     suggestionsCodec,
@@ -176,6 +177,13 @@ const ACCUSATIONS_PAYLOAD = Schema.encodeSync(accusationsCodec)([
         loggedAt: 3,
     },
 ]);
+const HYPOTHESES_PAYLOAD = Schema.encodeSync(hypothesesCodec)([
+    {
+        owner: { _tag: "Player", player: Player("Alice") },
+        card: Card("card-pam"),
+        value: "Y",
+    },
+]);
 
 interface SnapshotOverrides {
     cardPackData?: string | null;
@@ -184,6 +192,7 @@ interface SnapshotOverrides {
     knownCardsData?: string | null;
     suggestionsData?: string | null;
     accusationsData?: string | null;
+    hypothesesData?: string | null;
     ownerName?: string | null;
     ownerIsAnonymous?: boolean | null;
 }
@@ -196,6 +205,7 @@ const buildSnapshot = (overrides: SnapshotOverrides) => ({
     knownCardsData: null,
     suggestionsData: null,
     accusationsData: null,
+    hypothesesData: null,
     ownerName: null,
     ownerIsAnonymous: null,
     ...overrides,
@@ -364,7 +374,7 @@ describe("ShareImportPage — bullet list", () => {
         ).toBeNull();
     });
 
-    test("transfer share → all 6 bullets present with counts", () => {
+    test("transfer share → progress bullets present with counts", () => {
         renderImportPage(
             buildSnapshot({
                     cardPackData: CUSTOM_PACK_PAYLOAD,
@@ -373,6 +383,7 @@ describe("ShareImportPage — bullet list", () => {
                     knownCardsData: KNOWN_CARDS_PAYLOAD,
                     suggestionsData: SUGGESTIONS_PAYLOAD,
                     accusationsData: ACCUSATIONS_PAYLOAD,
+                    hypothesesData: HYPOTHESES_PAYLOAD,
             }),
         );
         const knownBullet = document.querySelector(
@@ -388,6 +399,10 @@ describe("ShareImportPage — bullet list", () => {
             "[data-share-import-bullet='accusations']",
         );
         expect(accuBullet?.textContent).toContain("\"count\":1");
+        const hypothesesBullet = document.querySelector(
+            "[data-share-import-bullet='hypotheses']",
+        );
+        expect(hypothesesBullet?.textContent).toContain("\"count\":1");
     });
 
     test("more than 4 player names → uses overflow copy with '+N more'", () => {

--- a/src/ui/share/ShareImportPage.tsx
+++ b/src/ui/share/ShareImportPage.tsx
@@ -60,6 +60,7 @@ interface ShareSnapshot {
     readonly knownCardsData: string | null;
     readonly suggestionsData: string | null;
     readonly accusationsData: string | null;
+    readonly hypothesesData: string | null;
     readonly ownerName: string | null;
     readonly ownerIsAnonymous: boolean | null;
 }
@@ -237,11 +238,12 @@ export function ShareImportPage({
     const hasKnown = snapshot.knownCardsData !== null;
     const hasSugg = snapshot.suggestionsData !== null;
     const hasAccu = snapshot.accusationsData !== null;
+    const hasHypotheses = snapshot.hypothesesData !== null;
     const isEmpty = !hasPack && !hasPlayers;
     const receiveFlow: ReceiveFlow =
         !hasPlayers
             ? RECEIVE_FLOW_PACK
-            : hasKnown || hasSugg || hasAccu
+            : hasKnown || hasSugg || hasAccu || hasHypotheses
                 ? RECEIVE_FLOW_TRANSFER
                 : RECEIVE_FLOW_INVITE;
 
@@ -266,6 +268,13 @@ export function ShareImportPage({
         () =>
             hasAccu ? countJsonArrayItems(snapshot.accusationsData!) : null,
         [hasAccu, snapshot.accusationsData],
+    );
+    const hypothesesCount = useMemo(
+        () =>
+            hasHypotheses
+                ? countJsonArrayItems(snapshot.hypothesesData!)
+                : null,
+        [hasHypotheses, snapshot.hypothesesData],
     );
 
     useEffect(() => {
@@ -463,6 +472,14 @@ export function ShareImportPage({
                                         <li data-share-import-bullet="accusations">
                                             {t("importIncludesAccusations", {
                                                 count: accuCount,
+                                            })}
+                                        </li>
+                                    ) : null}
+                                    {hasHypotheses &&
+                                    hypothesesCount !== null ? (
+                                        <li data-share-import-bullet="hypotheses">
+                                            {t("importIncludesHypotheses", {
+                                                count: hypothesesCount,
                                             })}
                                         </li>
                                     ) : null}

--- a/src/ui/share/useApplyShareSnapshot.test.ts
+++ b/src/ui/share/useApplyShareSnapshot.test.ts
@@ -25,6 +25,7 @@ import {
     accusationsCodec,
     cardPackCodec,
     handSizesCodec,
+    hypothesesCodec,
     knownCardsCodec,
     playersCodec,
     suggestionsCodec,
@@ -84,6 +85,7 @@ const sampleSnapshot = (overrides: {
     knownCards?: boolean;
     suggestions?: boolean;
     accusations?: boolean;
+    hypotheses?: boolean;
 }): ShareSnapshotForHydration => ({
     cardPackData:
         overrides.cardPack !== false
@@ -134,6 +136,16 @@ const sampleSnapshot = (overrides: {
                       accuser: Player("Alice"),
                       cards: [Card("card-scarlet")],
                       loggedAt: 1_700_000_000_000,
+                  },
+              ])
+            : null,
+    hypothesesData:
+        overrides.hypotheses === true
+            ? Schema.encodeSync(hypothesesCodec)([
+                  {
+                      owner: { _tag: "Player", player: Player("Alice") },
+                      card: Card("card-scarlet"),
+                      value: "Y",
                   },
               ])
             : null,
@@ -200,7 +212,7 @@ describe("buildSessionFromSnapshot — variant shapes", () => {
         expect(session.hands).toEqual([]);
     });
 
-    test("transfer snapshot → all six slices populated", () => {
+    test("transfer snapshot → all slices populated, including hypotheses", () => {
         const session = apply(
             sampleSnapshot({
                 cardPack: true,
@@ -209,6 +221,7 @@ describe("buildSessionFromSnapshot — variant shapes", () => {
                 knownCards: true,
                 suggestions: true,
                 accusations: true,
+                hypotheses: true,
             }),
         );
         expect(session.setup.players.length).toBe(2);
@@ -217,6 +230,8 @@ describe("buildSessionFromSnapshot — variant shapes", () => {
         expect(session.hands[0]!.cards[0]).toBe(Card("card-scarlet"));
         expect(session.suggestions.length).toBe(1);
         expect(session.accusations.length).toBe(1);
+        expect(session.hypotheses).toHaveLength(1);
+        expect(session.hypotheses?.[0]?.value).toBe("Y");
     });
 
     test("empty snapshot (no pack) → falls back to receiver pack + receiver players + blank slices", () => {
@@ -343,6 +358,7 @@ describe("saveCardPackFromSnapshot — pack-only receive", () => {
             handSizes: [{ player: Player("Original-Receiver-1"), size: 1 }],
             suggestions: [],
             accusations: [],
+            hypotheses: [],
         };
         saveToLocalStorage(currentSession);
 

--- a/src/ui/share/useApplyShareSnapshot.ts
+++ b/src/ui/share/useApplyShareSnapshot.ts
@@ -24,7 +24,7 @@
  *
  * Persistence side effects: the share landing page intentionally sits
  * outside the play shell, so it must not call `useClue()`. Instead it
- * writes the decoded session directly to the v6 persistence slot; the
+ * writes the decoded session directly to the current persistence slot; the
  * next `/play` mount reads it through the normal `<ClueProvider>`
  * hydration path.
  */
@@ -53,10 +53,15 @@ import {
     accusationsCodec,
     cardPackCodec,
     handSizesCodec,
+    hypothesesCodec,
     knownCardsCodec,
     playersCodec,
     suggestionsCodec,
 } from "../../logic/ShareCodec";
+import {
+    CellHypothesis,
+    ownerFromPersisted,
+} from "../../logic/Hypothesis";
 import { newSuggestionId, Suggestion } from "../../logic/Suggestion";
 
 export interface ShareSnapshotForHydration {
@@ -66,6 +71,7 @@ export interface ShareSnapshotForHydration {
     readonly knownCardsData: string | null;
     readonly suggestionsData: string | null;
     readonly accusationsData: string | null;
+    readonly hypothesesData?: string | null;
 }
 
 // Wire-format field names. Module-scope so they don't trip the
@@ -77,6 +83,7 @@ const F_HAND_SIZES_DATA = "handSizesData";
 const F_KNOWN_CARDS_DATA = "knownCardsData";
 const F_SUGGESTIONS_DATA = "suggestionsData";
 const F_ACCUSATIONS_DATA = "accusationsData";
+const F_HYPOTHESES_DATA = "hypothesesData";
 
 const DECODE_ERROR_PREFIX = "share snapshot decode failed: ";
 
@@ -235,12 +242,28 @@ export const buildSessionFromSnapshot = (
               )
             : [];
 
+    const hypotheses =
+        snapshot.hypothesesData != null
+            ? decodeField(
+                  F_HYPOTHESES_DATA,
+                  snapshot.hypothesesData,
+                  hypothesesCodec,
+              ).map((h) =>
+                  CellHypothesis({
+                      owner: ownerFromPersisted(h.owner),
+                      card: h.card,
+                      value: h.value,
+                  }),
+              )
+            : [];
+
     return {
         setup,
         hands,
         handSizes,
         suggestions,
         accusations,
+        hypotheses,
     };
 };
 

--- a/src/ui/state.test.tsx
+++ b/src/ui/state.test.tsx
@@ -3,7 +3,7 @@ import { HashMap } from "effect";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-import { Player } from "../logic/GameObjects";
+import { Player, PlayerOwner } from "../logic/GameObjects";
 import { CLASSIC_SETUP_3P, DEFAULT_SETUP } from "../logic/GameSetup";
 import { KnownCard } from "../logic/InitialKnowledge";
 import type { GameSession } from "../logic/Persistence";
@@ -47,6 +47,97 @@ const silenceConsoleError = () => vi.spyOn(console, "error").mockImplementation(
 
 beforeEach(() => {
     window.localStorage.clear();
+});
+
+describe("hypothesis actions", () => {
+    test("setHypothesis creates, updates, and clears one hypothesis per cell", () => {
+        const { result } = renderClue();
+        const knife = cardByName(DEFAULT_SETUP, "Knife");
+        const owner = PlayerOwner(Player("Player 1"));
+
+        act(() =>
+            result.current.dispatch({
+                type: "setHypothesis",
+                owner,
+                card: knife,
+                value: Y_VAL,
+            }),
+        );
+        expect(result.current.state.hypotheses).toHaveLength(1);
+        expect(result.current.state.hypotheses[0]?.value).toBe(Y_VAL);
+        expect(result.current.derived.hypothesisEvaluations[0]?.status).toBe(
+            "plausible",
+        );
+
+        act(() =>
+            result.current.dispatch({
+                type: "setHypothesis",
+                owner,
+                card: knife,
+                value: N_VAL,
+            }),
+        );
+        expect(result.current.state.hypotheses).toHaveLength(1);
+        expect(result.current.state.hypotheses[0]?.value).toBe(N_VAL);
+
+        act(() =>
+            result.current.dispatch({
+                type: "setHypothesis",
+                owner,
+                card: knife,
+                value: undefined,
+            }),
+        );
+        expect(result.current.state.hypotheses).toEqual([]);
+    });
+
+    test("hypothesis changes participate in undo and redo", () => {
+        const { result } = renderClue();
+        const knife = cardByName(DEFAULT_SETUP, "Knife");
+        const owner = PlayerOwner(Player("Player 1"));
+
+        act(() =>
+            result.current.dispatch({
+                type: "setHypothesis",
+                owner,
+                card: knife,
+                value: Y_VAL,
+            }),
+        );
+        expect(result.current.canUndo).toBe(true);
+        expect(result.current.state.hypotheses).toHaveLength(1);
+
+        act(() => result.current.undo());
+        expect(result.current.state.hypotheses).toEqual([]);
+        expect(result.current.canRedo).toBe(true);
+
+        act(() => result.current.redo());
+        expect(result.current.state.hypotheses[0]?.value).toBe(Y_VAL);
+    });
+
+    test("setup pruning removes hypotheses for deleted players or cards", () => {
+        const { result } = renderClue();
+        const knife = cardByName(DEFAULT_SETUP, "Knife");
+        const owner = PlayerOwner(Player("Player 1"));
+
+        act(() =>
+            result.current.dispatch({
+                type: "setHypothesis",
+                owner,
+                card: knife,
+                value: Y_VAL,
+            }),
+        );
+        expect(result.current.state.hypotheses).toHaveLength(1);
+
+        act(() =>
+            result.current.dispatch({
+                type: "removePlayer",
+                player: Player("Player 1"),
+            }),
+        );
+        expect(result.current.state.hypotheses).toEqual([]);
+    });
 });
 
 describe("useClue — context wiring", () => {

--- a/src/ui/state.tsx
+++ b/src/ui/state.tsx
@@ -37,6 +37,7 @@ import {
     deductionRevealed,
     gameSetupStarted,
     gameStarted,
+    hypothesisChanged,
 } from "../analytics/events";
 import {
     claimCaseFileSolved,
@@ -46,7 +47,7 @@ import {
     setupDurationMs,
     startSetup,
 } from "../analytics/gameSession";
-import type { Cell, CellValue, Knowledge } from "../logic/Knowledge";
+import { Cell, type CellValue, type Knowledge } from "../logic/Knowledge";
 import { chainFor } from "../logic/Provenance";
 import {
     buildInitialKnowledge,
@@ -70,6 +71,17 @@ import {
     loadFromLocalStorage,
     saveToLocalStorage,
 } from "../logic/Persistence";
+import {
+    cellOfHypothesis,
+    evaluateHypotheses,
+    findEvaluationForCell,
+    hypothesisKey,
+    pruneHypothesesToSetup,
+    renamePlayerInHypotheses,
+    setHypothesisForCell,
+    type CellHypothesis,
+    type HypothesisEvaluation,
+} from "../logic/Hypothesis";
 import {
     loadGameLifecycleState,
     markGameCreated,
@@ -141,6 +153,7 @@ const initialState: ClueState = {
     knownCards: [],
     suggestions: [],
     accusations: [],
+    hypotheses: [],
     uiMode: "setup",
 };
 
@@ -169,6 +182,7 @@ const reducer = (state: ClueState, action: ClueAction): ClueState => {
                 handSizes: [],
                 suggestions: [],
                 accusations: [],
+                hypotheses: [],
             };
 
         case "setSetup":
@@ -380,6 +394,17 @@ const reducer = (state: ClueState, action: ClueAction): ClueState => {
                 ),
             };
 
+        case "setHypothesis": {
+            const nextHypotheses = setHypothesisForCell(
+                state.hypotheses,
+                Cell(action.owner, action.card),
+                action.value,
+            );
+            return nextHypotheses === state.hypotheses
+                ? state
+                : { ...state, hypotheses: nextHypotheses };
+        }
+
         case "addPlayer": {
             const existing = new Set(
                 state.setup.players.map(p => String(p)),
@@ -409,6 +434,11 @@ const reducer = (state: ClueState, action: ClueAction): ClueState => {
                 ),
                 handSizes: state.handSizes.filter(
                     ([p]) => p !== action.player,
+                ),
+                hypotheses: state.hypotheses.filter(
+                    h =>
+                        h.owner._tag !== "Player" ||
+                        h.owner.player !== action.player,
                 ),
                 suggestions: state.suggestions
                     .filter(s => s.suggester !== action.player)
@@ -446,6 +476,11 @@ const reducer = (state: ClueState, action: ClueAction): ClueState => {
                         (p === oldName
                             ? ([newName, size] as const)
                             : ([p, size] as const)),
+                ),
+                hypotheses: renamePlayerInHypotheses(
+                    state.hypotheses,
+                    oldName,
+                    newName,
                 ),
                 suggestions: state.suggestions.map(s => ({
                     ...s,
@@ -492,6 +527,10 @@ const reducer = (state: ClueState, action: ClueAction): ClueState => {
                     accuser: a.accuser,
                     cards: Array.from(a.cards),
                 })),
+                hypotheses: pruneHypothesesToSetup(
+                    session.setup,
+                    session.hypotheses ?? [],
+                ),
             };
         }
     }
@@ -512,6 +551,7 @@ interface ClueDerived {
     readonly deductionResult: DeductionResult;
     readonly provenance: Provenance | undefined;
     readonly footnotes: FootnoteMap;
+    readonly hypothesisEvaluations: ReadonlyArray<HypothesisEvaluation>;
 }
 
 const deriveState = (
@@ -763,8 +803,14 @@ export function ClueProvider({ children }: { children: ReactNode }) {
         gameStartedRef.current =
             state.knownCards.length > 0
             || state.suggestions.length > 0
-            || state.accusations.length > 0;
-    }, [state.knownCards, state.suggestions, state.accusations]);
+            || state.accusations.length > 0
+            || state.hypotheses.length > 0;
+    }, [
+        state.knownCards,
+        state.suggestions,
+        state.accusations,
+        state.hypotheses,
+    ]);
 
     // Keyboard bindings wired via the central keyMap module. Each
     // useGlobalShortcut installs one window keydown listener that only
@@ -964,6 +1010,28 @@ export function ClueProvider({ children }: { children: ReactNode }) {
         [suggestionsAsData, initialKnowledge, deductionResult, deduceLayer],
     );
 
+    const hypothesisEvaluations = useMemo(
+        () =>
+            TelemetryRuntime.runSync(
+                evaluateHypotheses({
+                    setup: state.setup,
+                    suggestions: suggestionsAsData,
+                    accusations: accusationsAsData,
+                    initialKnowledge,
+                    factualResult: deductionResult,
+                    hypotheses: state.hypotheses,
+                }),
+            ),
+        [
+            state.setup,
+            state.hypotheses,
+            suggestionsAsData,
+            accusationsAsData,
+            initialKnowledge,
+            deductionResult,
+        ],
+    );
+
     const derived: ClueDerived = useMemo(
         () => ({
             suggestionsAsData,
@@ -972,6 +1040,7 @@ export function ClueProvider({ children }: { children: ReactNode }) {
             deductionResult,
             provenance,
             footnotes,
+            hypothesisEvaluations,
         }),
         [
             suggestionsAsData,
@@ -980,6 +1049,7 @@ export function ClueProvider({ children }: { children: ReactNode }) {
             deductionResult,
             provenance,
             footnotes,
+            hypothesisEvaluations,
         ],
     );
 
@@ -1088,6 +1158,7 @@ export function ClueProvider({ children }: { children: ReactNode }) {
             })),
             suggestions: suggestionsAsData,
             accusations: accusationsAsData,
+            hypotheses: state.hypotheses,
         };
         saveToLocalStorage(session);
         queryClient.setQueryData(gameSessionQueryKey, session);
@@ -1185,11 +1256,70 @@ export function ClueProvider({ children }: { children: ReactNode }) {
         state.suggestions.length,
     ]);
 
+    const prevHypothesesForAnalyticsRef =
+        useRef<ReadonlyArray<ReturnType<typeof hypothesisSnapshot>> | null>(
+            null,
+        );
+    useEffect(() => {
+        if (!hydrated) return;
+        const current = state.hypotheses.map(hypothesisSnapshot);
+        const prev = prevHypothesesForAnalyticsRef.current;
+        prevHypothesesForAnalyticsRef.current = current;
+        if (prev === null) return;
+
+        const prevByKey = new Map(prev.map(h => [h.key, h.value] as const));
+        const currentByKey = new Map(
+            current.map(h => [h.key, h.value] as const),
+        );
+        const changedKeys = new Set([
+            ...prevByKey.keys(),
+            ...currentByKey.keys(),
+        ]);
+        for (const key of changedKeys) {
+            const previousValue = prevByKey.get(key);
+            const currentValue = currentByKey.get(key);
+            if (previousValue === currentValue) continue;
+
+            const hypothesis = state.hypotheses.find(
+                h => hypothesisKey(h) === key,
+            );
+            const cell =
+                hypothesis !== undefined ? cellOfHypothesis(hypothesis) : null;
+            const card =
+                hypothesis?.card ?? prev.find(h => h.key === key)?.card;
+            const catId =
+                card === undefined
+                    ? undefined
+                    : categoryOfCard(state.setup.cardSet, card);
+            const evaluation =
+                cell === null
+                    ? undefined
+                    : findEvaluationForCell(
+                          derived.hypothesisEvaluations,
+                          cell,
+                      );
+            hypothesisChanged({
+                categoryName: catId
+                    ? resolveCategoryName(state.setup.cardSet, catId)
+                    : "",
+                selectedValue: currentValue ?? "off",
+                status: evaluation?.status ?? "off",
+                impactCount: evaluation?.impactCount ?? 0,
+            });
+        }
+    }, [
+        hydrated,
+        state.hypotheses,
+        state.setup.cardSet,
+        derived.hypothesisEvaluations,
+    ]);
+
     const hasGameData = useCallback((): boolean => {
         if (state.knownCards.length > 0) return true;
         if (state.handSizes.length > 0) return true;
         if (state.suggestions.length > 0) return true;
         if (state.accusations.length > 0) return true;
+        if (state.hypotheses.length > 0) return true;
         const players = state.setup.players;
         if (players.length !== DEFAULT_SETUP.players.length) return true;
         for (let i = 0; i < players.length; i++) {
@@ -1266,6 +1396,12 @@ const groupKnownCardsByPlayer = (
     return Array.from(by.entries(), ([player, cards]) => ({ player, cards }));
 };
 
+const hypothesisSnapshot = (hypothesis: CellHypothesis) => ({
+    key: hypothesisKey(hypothesis),
+    card: hypothesis.card,
+    value: hypothesis.value,
+});
+
 /**
  * When the user edits the setup (e.g. removes a card), filter out
  * references to players/cards that no longer exist. Suggestions whose
@@ -1315,5 +1451,6 @@ const pruneSessionToSetup = (
         accusations: state.accusations
             .filter(a => playerSet.has(String(a.accuser)))
             .filter(a => a.cards.every(c => cardIdSet.has(String(c)))),
+        hypotheses: pruneHypothesesToSetup(setup, state.hypotheses),
     };
 };


### PR DESCRIPTION
Summary
- Add independent per-cell checklist hypotheses entered from the why popover, with verified, falsified, plausible, and blocked evaluations.
- Persist hypotheses in session v7, include them only in transfer shares, and add the nullable forward-only share snapshot column.
- Add subtle cell badges, a Case File summary, typed hypothesis_changed analytics, and the hypotheses.evaluate span.
- Fix interactive hypothesis popovers so portaled controls stay usable while moving from a cell to the popover.

Tests
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm knip
- pnpm i18n:check

Observability
- New event: hypothesis_changed with category, selected value/off, resulting status, and impact count.
- New span: hypotheses.evaluate.
- No existing PostHog funnel steps changed.

Migration
- Adds snapshot_hypotheses_data as a nullable column on shares.
- Single-step, forward-only, backwards-compatible addition.