### PR TITLE
Keep "why" popovers alive on the cursor's way into them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,27 @@ Scripts that require `pnpm install`:
 - `pnpm build` — static export
 - `pnpm start` — serve the static export
 
-Claude's `next-dev` preview configured in `.claude/launch.json` runs `pnpm install && exec pnpm dev` itself, so those previews are self-healing and the dev server receives shutdown signals directly. In Codex, use the local preview workflow below. The pre-commit checks above are not self-healing; if any of them fails with a module-not-found error, run `pnpm install` first and retry.
+Claude's `next-dev` preview configured in `.claude/launch.json` runs `pnpm install && exec pnpm dev` itself, so those previews are self-healing for `node_modules` and the dev server receives shutdown signals directly. They are **not** self-healing for `.env.local` — see "Worktree env setup" below. In Codex, use the local preview workflow below. The pre-commit checks above are not self-healing either; if any of them fails with a module-not-found error, run `pnpm install` first and retry.
+
+## Worktree env setup
+
+Both Claude and Codex agents typically work in a worktree under `.claude/worktrees/<name>/`. A fresh worktree starts without a `.env.local`, but `pnpm dev` exits at startup on missing `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` / `DATABASE_URL` (by design — see `src/server/authEnv.ts`). The fix is one shell command:
+
+```sh
+cp "$(git rev-parse --git-common-dir)/../.env.local" .env.local
+```
+
+`git rev-parse --git-common-dir` returns the shared `.git` directory of the worktree, which lives inside the main checkout, so `<git-common-dir>/../.env.local` always resolves to the main checkout's env file regardless of where the worktree sits on disk.
+
+That's it — no `vercel env pull`, no Google Console round-trip. The agent inherits whatever the human dev already configured for the main checkout. If `.env.local` doesn't exist yet in the main checkout, see "First-time setup" in [README.md](README.md) for the one-time bootstrap (it covers creating a localhost-scoped Google OAuth client and seeding `.env.local`).
+
+The committed [env.example](env.example) holds the variable names + non-secret defaults (Docker `DATABASE_URL`, PostHog host) but intentionally leaves the OAuth values blank — GitHub secret scanning rejects any pushed value, and "secrets in tracked files" is a footgun even when the values are dev-only.
+
+Operational notes:
+
+1. **Copy, don't symlink.** Edits to env in the worktree (e.g. swapping a DB URL while testing) would leak into the main checkout if symlinked. `.env.local` is gitignored.
+2. **Restart after editing.** Next.js only reads env at startup, so if you change `.env.local` while the preview is running, restart it (`preview_stop` then `preview_start` for Claude; Ctrl-C and `pnpm dev` for Codex).
+3. **Don't print secrets.** Print only `<set>` / `<empty>` status when inspecting env health. The full `.env.local` should be treated as opaque.
 
 ## Local database and dev server lifecycle
 
@@ -76,18 +96,22 @@ errors in application code; fix the local database/env setup instead.
 
 Before starting the preview in Codex:
 
-1. Make sure `.env.local` points `DATABASE_URL` at the Docker database:
-   `postgres://effect_clue:local_dev_only@localhost:5432/effect_clue`.
-2. Make sure `.env.local` has non-empty `GOOGLE_CLIENT_ID` and
-   `GOOGLE_CLIENT_SECRET`. Missing or blank Google OAuth env vars are
-   startup-time errors by design.
-3. Do not print secret values. If you need to inspect env health, print
-   only `<set>` / `<empty>` status.
-4. Start the local database with `pnpm db:up`.
-5. Start the app with `pnpm dev`, then open the `Local:` URL printed
-   by Next.js in the in-app browser. It is usually
-   `http://localhost:3000`, but the dev script auto-selects the next
-   available port when 3000 is already in use.
+1. **Env file** — see "Worktree env setup" above. One `cp` from the
+   main checkout's `.env.local` is enough; the agent inherits whatever
+   is already working there. Don't fetch new secrets in a worktree —
+   if something is missing, fix it in the main checkout's `.env.local`
+   and re-copy.
+2. **Database** — `pnpm db:up` starts the local Docker Postgres at
+   `postgres://effect_clue:local_dev_only@localhost:5432/effect_clue`
+   (the same URL `env.example` ships with).
+3. **Dev server** — `pnpm dev`. Then open the `Local:` URL printed
+   by Next.js in the in-app browser. Usually `http://localhost:3000`,
+   but the dev script auto-selects the next available port when
+   3000 is already in use.
+
+Claude's `next-dev` preview is the same chain wrapped in
+`.claude/launch.json`. The preview tooling does NOT seed `.env.local`,
+so the env step (1) above still applies before `preview_start`.
 
 Shutdown is part of the workflow. When you start `pnpm dev` from a
 shell session, stop that same session with Ctrl-C before finishing.

--- a/README.md
+++ b/README.md
@@ -94,10 +94,12 @@ Tests live next to source as `Foo.test.ts(x)` beside `Foo.ts(x)`.
 ### First-time setup
 
 ```bash
-nvm use            # picks the version from .nvmrc
+nvm use                          # picks the version from .nvmrc
 pnpm install
-cp env.example .env.local
-pnpm db:up         # Postgres in Docker; safe to skip if you don't need server features
+cp env.example .env.local        # variable scaffolding + Docker DB defaults
+# Fill in GOOGLE_CLIENT_ID and GOOGLE_CLIENT_SECRET in .env.local
+# (see "Google OAuth — local dev" below for the one-time setup).
+pnpm db:up                       # Postgres in Docker; safe to skip if you don't need server features
 pnpm dev
 ```
 
@@ -105,7 +107,46 @@ Then open the local URL printed by Next.js. It is usually
 <http://localhost:3000>, but Next will automatically pick another
 available port when 3000 is already in use.
 
-The third-party SDKs (Sentry, Honeycomb, PostHog) all no-op when their env vars are unset, and local development falls back to the committed Docker Postgres URL when `DATABASE_URL` is blank, so the app runs end-to-end with an empty `.env.local` after `pnpm db:up`.
+The third-party SDKs (Sentry, Honeycomb, PostHog) all no-op when their env vars are unset, so the app runs end-to-end with everything else blank in `.env.local` once the OAuth values are filled in.
+
+#### Google OAuth — local dev
+
+Better Auth requires `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` even in
+local dev (`pnpm dev` exits at startup if either is empty — see
+[src/server/authEnv.ts](src/server/authEnv.ts)). One-time setup per machine:
+
+1. <https://console.cloud.google.com> → **APIs & Services →
+   Credentials → Create Credentials → OAuth client ID → Web application**.
+2. **Authorized JavaScript origins** — add `http://localhost:3000`
+   (and any other localhost ports you regularly use).
+3. **Authorized redirect URIs** — add
+   `http://localhost:3000/api/auth/callback/google` and matching
+   entries for any other ports.
+4. Copy the resulting client ID + secret into `.env.local`.
+
+This is a localhost-scoped client — keeping the values out of any
+tracked file (including `env.example`) avoids GitHub's secret-scanning
+push protection and the "secrets in repo" footgun.
+
+If you're working on Better Auth / sharing changes against a fully-
+provisioned environment instead, follow [docs/setup-vercel-neon-google.md](docs/setup-vercel-neon-google.md)
+to wire up Vercel + Neon, then `vercel env pull .env.local` to seed
+the file (this also pulls a Neon `DATABASE_URL` that overrides the
+Docker default).
+
+#### Worktrees inherit `.env.local`
+
+Once the main checkout's `.env.local` is configured, every worktree
+spun up via `git worktree add` (or via Claude / Codex agents under
+`.claude/worktrees/<name>/`) can copy that file in one command:
+
+```bash
+cp "$(git rev-parse --git-common-dir)/../.env.local" .env.local
+```
+
+Don't symlink — edits to env in the worktree should not leak back
+into the main checkout. See AGENTS.md "Worktree env setup" for the
+agent-specific lifecycle.
 
 ### Local Postgres via Docker
 
@@ -170,7 +211,7 @@ Copy [env.example](env.example) to `.env.local`. All third-party integrations ar
 | `DATABASE_URL_UNPOOLED` | Direct (non-pooler) Postgres URL. Reserved for migration runs that need a stable session. |
 | `BETTER_AUTH_SECRET` | Server-only secret for session JWT signing. Generate with `openssl rand -hex 32`. |
 | `BETTER_AUTH_URL` | Public URL of the deployed app. Leave blank in local dev so auth follows the actual auto-selected localhost port. |
-| `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` | Google OAuth client. Optional in local dev (the dev-only username/password flow covers it); required for previews/production. |
+| `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` | Google OAuth client. **Required in every environment** — `pnpm dev` exits at startup if either is empty. Use a localhost-scoped client locally (see "Google OAuth — local dev" above); previews/production use a separate client in Vercel env vars. |
 
 In CI/production, the build job needs `SENTRY_AUTH_TOKEN` / `SENTRY_ORG` / `SENTRY_PROJECT` to upload source maps. Production also needs the DB and auth vars wired in Vercel — see [docs/setup-vercel-neon-google.md](docs/setup-vercel-neon-google.md).
 

--- a/docs/setup-vercel-neon-google.md
+++ b/docs/setup-vercel-neon-google.md
@@ -102,14 +102,22 @@ automatic port fallback keeps working when 3000 is already occupied.
 
 ## 5. Google OAuth client
 
-Required for previews and production. Local dev can use the dev-only
-username/password path inside the Account modal, so
-`GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` may be left blank when
-running against Docker offline. Production and Vercel previews still
-fail fast when either Google value is missing, which keeps OAuth
-misconfiguration from turning into a confusing missing-provider error.
-The dev credential path tree-shakes out of production bundles, see CI
-assertion below.
+Required in every environment — `pnpm dev` exits at startup if either
+`GOOGLE_CLIENT_ID` or `GOOGLE_CLIENT_SECRET` is missing (see
+`src/server/authEnv.ts`). The committed `env.example` intentionally
+leaves both blank: GitHub secret scanning rejects pushed values, and
+keeping localhost-only credentials out of the repo avoids the "secrets
+in tracked files" footgun. The README's "Google OAuth — local dev"
+section walks through creating a localhost-scoped client and seeding
+`.env.local` once per machine; subsequent worktrees inherit it via
+`cp "$(git rev-parse --git-common-dir)/../.env.local" .env.local`.
+
+The values below configure the **production / preview** OAuth client,
+which is separate from your dev one and lives in Vercel env vars.
+Production and Vercel previews fail fast on the same missing-value
+check, which keeps OAuth misconfiguration from surfacing later as a
+confusing missing-provider error. The dev credential path tree-shakes
+out of production bundles, see CI assertion below.
 
 1. <https://console.cloud.google.com> → **APIs & Services →
    Credentials → Create Credentials → OAuth client ID → Web

--- a/env.example
+++ b/env.example
@@ -1,66 +1,88 @@
+# =============================================================================
+# Local-dev env scaffolding
+#
+# What this file is: the committed set of variable names + the local-dev
+# defaults that aren't secret (Docker Postgres URL, PostHog host, etc.).
+# Secrets that local dev needs (GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET)
+# are intentionally NOT here — they live only in your machine's
+# `.env.local` (which is gitignored).
+#
+# First-time setup: see README "First-time setup" — it walks through
+# creating a dev OAuth client and seeding `.env.local`.
+#
+# Once `.env.local` exists in the main checkout, fresh worktrees skip
+# all of that with a single command (see AGENTS.md "Worktree env setup"):
+#
+#   cp "$(git rev-parse --git-common-dir)/../.env.local" .env.local
+#
+# `pnpm dev` will refuse to start without `GOOGLE_CLIENT_ID`,
+# `GOOGLE_CLIENT_SECRET`, and `DATABASE_URL` — see `src/server/authEnv.ts`.
+# =============================================================================
+
 # ─── Sentry (errors + Web Vitals + Session Replay) ───────────────────────
-# Public DSN. Safe to expose. Get from sentry.io → Project → Settings → DSN.
+# Optional in local dev. Public DSN — safe to expose. Get from
+# sentry.io → Project → Settings → DSN. Leave blank for local dev.
 NEXT_PUBLIC_SENTRY_DSN=
 
-# Source map upload at build time. Private auth token, set in Vercel and
-# GitHub Actions secrets — never commit.
+# Production-only build-time secret (source map upload). Set in Vercel
+# and GitHub Actions secrets — never commit, never set locally.
 SENTRY_AUTH_TOKEN=
 SENTRY_ORG=
 SENTRY_PROJECT=
 
 # ─── Honeycomb (Effect OTel traces + metrics + logs) ─────────────────────
-# Ingest-only key — write-only, safe for the browser. Get from
-# Honeycomb → Environment Settings → API Keys → Create Ingest Key.
+# Optional in local dev. Ingest-only key — write-only, safe for the
+# browser. Get from Honeycomb → Environment Settings → API Keys →
+# Create Ingest Key. Leave blank for local dev.
 NEXT_PUBLIC_HONEYCOMB_API_KEY=
 
 # ─── PostHog (product analytics) ─────────────────────────────────────────
-# Public project API key. Get from PostHog → Project Settings.
+# Optional in local dev. Public project API key from PostHog → Project
+# Settings. Leave blank for local dev.
 NEXT_PUBLIC_POSTHOG_KEY=
 # Region host: https://us.i.posthog.com (US) or https://eu.i.posthog.com (EU).
 NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 
 # ─── Postgres (M6+) ──────────────────────────────────────────────────────
-# Pulled from Neon via the Vercel Marketplace integration. The pooled URL
-# is what `@effect/sql-pg` connects through; the unpooled variant exists
-# for migration runs that need a stable session.
+# REQUIRED for local dev. Pre-filled with the local Docker Postgres URL
+# that `pnpm db:up` brings up — not a secret, just a localhost default.
+# Production / Preview pull a Neon URL from the Vercel Marketplace
+# integration via `vercel env pull` and override these.
 #
-# `vercel env pull .env.development.local` writes both for local dev.
-#
-# LOCAL DOCKER DEFAULT FOR AGENTS: run `pnpm db:up` and use this URL in
-# `.env.local` for Codex/Claude preview work — no Vercel/Neon login
-# needed. Stop it with `pnpm db:down` when the session is done:
-#   DATABASE_URL=postgres://effect_clue:local_dev_only@localhost:5432/effect_clue
-DATABASE_URL=
-DATABASE_URL_UNPOOLED=
+# The pooled URL is what `@effect/sql-pg` connects through; the
+# unpooled variant exists for migration runs that need a stable session.
+DATABASE_URL=postgres://effect_clue:local_dev_only@localhost:5432/effect_clue
+DATABASE_URL_UNPOOLED=postgres://effect_clue:local_dev_only@localhost:5432/effect_clue
 
 # ─── better-auth (M7+) ───────────────────────────────────────────────────
-# Server-only secret used to sign session JWTs. Generate with
-# `openssl rand -hex 32` and set in Vercel + .env.local. Do NOT commit.
+# Production-only. Server-only secret used to sign session JWTs.
+# Generate with `openssl rand -hex 32` and set in Vercel env vars only.
+# Local dev tolerates an empty value — login flows that depend on
+# signed JWTs simply won't validate, but the app boots.
 BETTER_AUTH_SECRET=
+
 # Public URL of the deployed app. better-auth uses this to build OAuth
 # callback URLs. Per environment:
-#   Production:   https://winclue.vercel.app
-#   Preview:      https://$VERCEL_URL  (Vercel system var)
+#   Production:   https://winclue.vercel.app  (set in Vercel)
+#   Preview:      https://$VERCEL_URL         (Vercel system var)
 #   Development:  leave blank so auth follows Next's actual localhost port
 BETTER_AUTH_URL=
-# Set to 1 to enable Better Auth debug-level server logs locally.
+
+# Optional. Set to 1 to enable Better Auth debug-level server logs locally.
 AUTH_DEBUG=
 
-# Google OAuth client ID + secret. Create at
-# https://console.cloud.google.com → APIs & Services → Credentials.
-# Authorised redirect URIs must include each environment's auth callback URL.
-# If testing Google OAuth locally, include the active localhost port printed by
-# `pnpm dev`, e.g. `http://localhost:3000/api/auth/callback/google`.
-#
-# Required in every environment. The app fails at startup when either
-# value is missing so OAuth misconfiguration is loud instead of
-# surfacing later as a missing-provider error.
+# REQUIRED for local dev — `pnpm dev` exits at startup if either is
+# missing (see `src/server/authEnv.ts`). Intentionally blank in this
+# tracked file (GitHub secret scanning would reject any committed
+# value); fill in your dev-only `.env.local` once per machine. See
+# README "First-time setup" for how to create a localhost-scoped
+# OAuth client at console.cloud.google.com.
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 
 # ─── Cron secret (M17+) ──────────────────────────────────────────────────
-# Shared secret Vercel cron jobs send via the `Authorization: Bearer`
-# header. Generate with `openssl rand -hex 32`. Set in all three
-# Vercel envs (Production, Preview, Development). Local dev only
-# needs it if you're testing the cron route by hand via curl.
+# Production-only. Shared secret Vercel cron jobs send via the
+# `Authorization: Bearer` header. Generate with `openssl rand -hex 32`
+# and set in all three Vercel envs (Production, Preview, Development).
+# Local dev only needs it when manually testing the cron route via curl.
 CRON_SECRET=

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -163,6 +163,11 @@ export default [
                             "side",
                             "align",
                             "variant",
+                            // Internal discriminator on `<InfoPopover>`
+                            // — names a hover-zone identifier that
+                            // parent focus-blur logic reads via
+                            // `data-popover-zone`. Not user copy.
+                            "popoverZone",
                             // `<AboutContent context="page" | "modal" />`
                             // — discriminator for which surface fired
                             // an analytics event, not user copy.

--- a/src/ui/checklistPopoverIntent.test.tsx
+++ b/src/ui/checklistPopoverIntent.test.tsx
@@ -231,6 +231,51 @@ describe("useWhyHoverIntent — cancelExitTimer integration", () => {
         });
         expect(result.current.popoverCell).toEqual(cellA);
     });
+
+    test("cell → popover → cell flow keeps popover alive across portal traversal", () => {
+        // Scenario: user opens popover on cellA, moves cursor across the
+        // gap onto the portaled popover content, lingers, then moves
+        // off it. The Checklist wires `onContentPointerEnter` →
+        // `cancelExitTimer` and `onContentPointerLeave` →
+        // `onCellPointerLeave`. We exercise that handshake here through
+        // the hook's public API (no DOM needed).
+        const { result } = renderHook(() => useHarness(), { wrapper: Wrapper });
+        // Open popover.
+        act(() => {
+            result.current.intent.onCellPointerEnter(cellA);
+            vi.advanceTimersByTime(OPEN_DELAY_MS);
+        });
+        expect(result.current.popoverCell).toEqual(cellA);
+        // Pointer leaves cellA — exit timer arms.
+        act(() => {
+            result.current.intent.onCellPointerLeave();
+        });
+        // Pointer enters popover content (or its hover bridge) within
+        // the grace window — Checklist calls cancelExitTimer.
+        act(() => {
+            vi.advanceTimersByTime(200);
+            result.current.intent.cancelExitTimer();
+        });
+        // Popover stays open well past the original exit budget.
+        act(() => {
+            vi.advanceTimersByTime(EXIT_TIMEOUT_MS * 2);
+        });
+        expect(result.current.popoverCell).toEqual(cellA);
+        // Pointer leaves popover content — Checklist calls
+        // onCellPointerLeave, which arms the exit timer again.
+        act(() => {
+            result.current.intent.onCellPointerLeave();
+        });
+        // Without re-engagement, popover closes after the exit budget.
+        act(() => {
+            vi.advanceTimersByTime(EXIT_TIMEOUT_MS - 1);
+        });
+        expect(result.current.popoverCell).toEqual(cellA);
+        act(() => {
+            vi.advanceTimersByTime(1);
+        });
+        expect(result.current.popoverCell).toBeNull();
+    });
 });
 
 describe("useWhyHoverIntent — unmount cleanup", () => {

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -634,14 +634,27 @@ export function Checklist() {
             // breakpoint is active.
             data-tour-anchor="desktop-checklist-area"
             className="min-w-max rounded-[var(--radius)] border border-border bg-panel p-4"
-            onMouseLeave={onGridLeave}
+            onMouseLeave={onCellPointerLeave}
             onBlur={e => {
                 // Focus left the checklist root entirely (relatedTarget
                 // is outside the section). Exit popovers mode so the
                 // tab key moving focus away from the grid doesn't
                 // leave a stranded popover + suggestion highlight.
+                //
+                // Special-case: focus moving INTO the portaled popover
+                // content counts as still-engaged. The popover lives in
+                // `document.body`, so `currentTarget.contains` returns
+                // false even when the user is interacting with it; we
+                // identify it via the `data-popover-zone="checklist"`
+                // marker that the InfoPopover stamps on its Content.
                 const next = e.relatedTarget as Node | null;
                 if (next && e.currentTarget.contains(next)) return;
+                if (
+                    next instanceof Element
+                    && next.closest('[data-popover-zone="checklist"]')
+                ) {
+                    return;
+                }
                 onGridLeave();
             }}
         >
@@ -1357,6 +1370,13 @@ export function Checklist() {
                                                             );
                                                         }
                                                     }}
+                                                    onContentPointerEnter={
+                                                        cancelExitTimer
+                                                    }
+                                                    onContentPointerLeave={
+                                                        onCellPointerLeave
+                                                    }
+                                                    popoverZone="checklist"
                                                 >
                                                     <motion.td
                                                         className={tdClassName}

--- a/src/ui/components/InfoPopover.test.tsx
+++ b/src/ui/components/InfoPopover.test.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, test, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { InfoPopover } from "./InfoPopover";
+
+vi.mock("next-intl", () => ({
+    useTranslations: () => (key: string) => key,
+}));
+
+describe("InfoPopover — content pointer-event hooks", () => {
+    test("onContentPointerEnter fires when pointer enters the popover content", () => {
+        const onEnter = vi.fn();
+        render(
+            <InfoPopover
+                content="why"
+                open
+                onContentPointerEnter={onEnter}
+            >
+                <button type="button">trigger</button>
+            </InfoPopover>,
+        );
+        const content = screen.getByRole("dialog");
+        fireEvent.pointerEnter(content);
+        expect(onEnter).toHaveBeenCalledTimes(1);
+    });
+
+    test("onContentPointerLeave fires when pointer leaves the popover content", () => {
+        const onLeave = vi.fn();
+        render(
+            <InfoPopover
+                content="why"
+                open
+                onContentPointerLeave={onLeave}
+            >
+                <button type="button">trigger</button>
+            </InfoPopover>,
+        );
+        const content = screen.getByRole("dialog");
+        fireEvent.pointerLeave(content);
+        expect(onLeave).toHaveBeenCalledTimes(1);
+    });
+
+    test("absent handlers don't crash on pointer events", () => {
+        render(
+            <InfoPopover content="why" open>
+                <button type="button">trigger</button>
+            </InfoPopover>,
+        );
+        const content = screen.getByRole("dialog");
+        expect(() => {
+            fireEvent.pointerEnter(content);
+            fireEvent.pointerLeave(content);
+        }).not.toThrow();
+    });
+});
+
+describe("InfoPopover — popoverZone marker", () => {
+    test("renders data-popover-zone on the content when set", () => {
+        render(
+            <InfoPopover content="why" open popoverZone="checklist">
+                <button type="button">trigger</button>
+            </InfoPopover>,
+        );
+        const content = screen.getByRole("dialog");
+        expect(content.getAttribute("data-popover-zone")).toBe("checklist");
+    });
+
+    test("omits data-popover-zone when not set", () => {
+        render(
+            <InfoPopover content="why" open>
+                <button type="button">trigger</button>
+            </InfoPopover>,
+        );
+        const content = screen.getByRole("dialog");
+        expect(content.hasAttribute("data-popover-zone")).toBe(false);
+    });
+});
+
+describe("InfoPopover — hover bridge", () => {
+    // The `before:` pseudo-element extending toward the trigger lets the
+    // cursor cross the gap from cell to popover without hitting cells in
+    // between. jsdom can't pixel-test the bridge — we just confirm the
+    // CSS classes that drive it are present on the Content element so
+    // they get shipped to the browser.
+    test("Content carries the bridge `before:` classes for every side", () => {
+        render(
+            <InfoPopover content="why" open>
+                <button type="button">trigger</button>
+            </InfoPopover>,
+        );
+        const content = screen.getByRole("dialog");
+        const cls = content.className;
+        expect(cls).toContain("before:absolute");
+        expect(cls).toContain("before:content-['']");
+        expect(cls).toContain("data-[side=top]:before:bottom-[-10px]");
+        expect(cls).toContain("data-[side=bottom]:before:top-[-10px]");
+        expect(cls).toContain("data-[side=left]:before:right-[-10px]");
+        expect(cls).toContain("data-[side=right]:before:left-[-10px]");
+    });
+});

--- a/src/ui/components/InfoPopover.tsx
+++ b/src/ui/components/InfoPopover.tsx
@@ -37,6 +37,21 @@ interface InfoPopoverProps {
      * or pinning the corresponding cell's selection).
      */
     readonly onOpenChange?: (open: boolean) => void;
+    /**
+     * Pointer-event handlers forwarded to the popover content. Lets a
+     * parent driving the open state via hover-intent (e.g. the
+     * Checklist) treat the portaled content as part of its hover zone:
+     * entering it cancels the parent's exit timer, leaving it re-arms.
+     */
+    readonly onContentPointerEnter?: () => void;
+    readonly onContentPointerLeave?: () => void;
+    /**
+     * Optional `data-popover-zone` attribute on the popover content.
+     * Lets a parent's focus-blur handler recognize that focus has moved
+     * into the portaled popover (which lives in `document.body`, not
+     * inside the parent) via `closest("[data-popover-zone='...']")`.
+     */
+    readonly popoverZone?: string;
 }
 
 /**
@@ -60,6 +75,9 @@ export function InfoPopover({
     maxWidthPx = 320,
     open: controlledOpen,
     onOpenChange,
+    onContentPointerEnter,
+    onContentPointerLeave,
+    popoverZone,
 }: InfoPopoverProps) {
     const tCommon = useTranslations("common");
     const [uncontrolledOpen, setUncontrolledOpen] = useState(false);
@@ -101,9 +119,29 @@ export function InfoPopover({
                     sideOffset={6}
                     collisionPadding={8}
                     onOpenAutoFocus={e => e.preventDefault()}
+                    onPointerEnter={onContentPointerEnter}
+                    onPointerLeave={onContentPointerLeave}
+                    data-popover-zone={popoverZone}
+                    // The `before:` rules render an invisible 10px hover
+                    // bridge in the gap between the popover and its
+                    // trigger. `data-side` is set by Radix per
+                    // collision-resolved placement; the bridge always
+                    // points at the trigger. Pseudo-elements participate
+                    // in their parent's pointer-event hit-testing, so
+                    // cursor-in-bridge fires `onPointerEnter` on Content
+                    // — keeping the popover alive AND preventing the
+                    // cell beneath the bridge from receiving its own
+                    // hover (which would otherwise swap the popover
+                    // mid-transit when the user is heading from cell to
+                    // popover).
                     className={
                         "z-[var(--z-popover)] rounded-[var(--radius)] border px-3 py-2 text-[12px] leading-snug shadow-[0_6px_16px_rgba(0,0,0,0.18)] " +
                         "focus:outline-none " +
+                        "before:absolute before:content-[''] " +
+                        "data-[side=top]:before:left-0 data-[side=top]:before:right-0 data-[side=top]:before:bottom-[-10px] data-[side=top]:before:h-[10px] " +
+                        "data-[side=bottom]:before:left-0 data-[side=bottom]:before:right-0 data-[side=bottom]:before:top-[-10px] data-[side=bottom]:before:h-[10px] " +
+                        "data-[side=left]:before:top-0 data-[side=left]:before:bottom-0 data-[side=left]:before:right-[-10px] data-[side=left]:before:w-[10px] " +
+                        "data-[side=right]:before:top-0 data-[side=right]:before:bottom-0 data-[side=right]:before:left-[-10px] data-[side=right]:before:w-[10px] " +
                         toneClasses
                     }
                     style={{ maxWidth: maxWidthPx }}


### PR DESCRIPTION
## Summary

- Hovering a deducible cell opens a "why" popover, but the cursor couldn't reach the popover content — it dismissed before you got there, and any cell the cursor crossed mid-transit replaced it. Now you can move onto the popover, hover it as long as you like, and it stays open until you actually move away.
- Worktree env setup collapses to a single command: `cp "$(git rev-parse --git-common-dir)/../.env.local" .env.local` from inside any worktree, and `pnpm dev` works. No more chasing missing OAuth credentials per worktree.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm knip && pnpm i18n:check` all green.
- [x] Manual `next-dev` walk at desktop (1280×800) and mobile (375×812):
  - Click a deducible cell → popover opens.
  - Section mouseleave → popover stays open for the 900ms grace window (was: immediate close).
  - Cursor on popover content → exit timer cancels via the bridge handshake; popover stays alive past 1100ms.
  - Cursor leaves popover with no re-engagement → closes after 900ms.
  - No console errors.
- [ ] Walk it yourself once on real Chrome at desktop and mobile to sanity-check that a real cursor passing over an intermediate cell doesn't swap the popover (jsdom and synthesised pointer events can't reproduce real-mouse hit-testing of pseudo-elements).

## Commits

- **Keep checklist "why" popovers alive when cursor moves into them.** Section's `onMouseLeave` switches from `onGridLeave` (immediate close) to `onCellPointerLeave` (arms the existing 900ms exit timer). `InfoPopover` gains optional `onContentPointerEnter` / `onContentPointerLeave` / `popoverZone` props plus a transparent ~10px hover-bridge `::before` driven by Radix's `data-side` attribute. The bridge sits on top of the cells beneath it, so cursor-in-bridge fires `onPointerEnter` on the popover (cancelling the exit timer via the parent's `cancelExitTimer`) and prevents the cell underneath from receiving its own hover (no mid-transit swap). The section's `onBlur` also recognises focus moving into the portaled popover via the new `data-popover-zone="checklist"` marker, so future focusable popover content (hypothesis buttons etc.) survives keyboard navigation. New `InfoPopover.test.tsx` and an extended `checklistPopoverIntent.test.tsx` scenario cover the wiring. `eslint.config.mjs` adds `popoverZone` to the i18next no-literal-string attribute exemption list.
- **Make worktree env setup a one-line copy from main checkout.** A fresh worktree gets a working `.env.local` via `cp "$(git rev-parse --git-common-dir)/../.env.local" .env.local`. `env.example` stays as the variable-name scaffolding plus non-secret defaults (Docker `DATABASE_URL`, PostHog host) — `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` intentionally stay out of any tracked file (GitHub secret scanning would reject pushed values, and tracked secrets are a footgun even when localhost-scoped). README.md gains a "Google OAuth — local dev" walkthrough plus a "Worktrees inherit `.env.local`" section, and the env-vars table is corrected — `GOOGLE_CLIENT_ID`/`SECRET` were misleadingly marked optional locally but `pnpm dev` exits at startup if either is empty. `AGENTS.md` "Worktree env setup" replaces the prior `cp env.example .env.local` flow with the git-common-dir copy. `docs/setup-vercel-neon-google.md` Section 5 reframes itself as the production / preview OAuth setup and points local dev at the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)