### PR TITLE
Claude: Per-cell "what-if" hypotheses with keyboard shortcuts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,6 +13,8 @@
       "Bash(pnpm knip)",
       "Bash(pnpm lint)",
       "Bash(pnpm i18n:check)",
+      "Bash(pnpm db:up)",
+      "Bash(pnpm db:down)",
       "Bash(pnpm view *)",
       "Bash(git add)",
       "Bash(git add *)",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,12 +113,28 @@ Claude's `next-dev` preview is the same chain wrapped in
 `.claude/launch.json`. The preview tooling does NOT seed `.env.local`,
 so the env step (1) above still applies before `preview_start`.
 
-Shutdown is part of the workflow. When you start `pnpm dev` from a
-shell session, stop that same session with Ctrl-C before finishing.
-Then run `pnpm db:down` so the Docker Postgres container is not left
-running after the agent/session is done. The only exception is an
-explicit user request to leave the preview running for handoff; in that
-case, say which server/database processes were intentionally left up.
+Leave the dev server up for the duration of a session. Once you've
+started `pnpm dev` (or `preview_start next-dev` for Claude), keep it
+running so the user can manually exercise the app between turns —
+don't stop it after each verification round just to "clean up". Many
+sessions make several preview-driven changes back-to-back; tearing
+down between them is wasted work and steals the user's ability to
+re-test what's already in flight.
+
+Tear it down only when:
+
+1. The user explicitly asks you to (handoff, end of session, etc.).
+2. Something is broken (port collision, hung process, env change that
+   needs `pnpm dev` restarted to pick up). Restart, don't just stop.
+3. The session is genuinely ending — your next reply is the last one,
+   the work is wrapped up, and there's no plausible reason for the
+   server to keep running.
+
+Teardown sequence when it does apply: stop the same `pnpm dev` shell
+session with Ctrl-C (Codex) or `preview_stop` (Claude), then
+`pnpm db:down` so the Docker Postgres container isn't left running.
+If you're explicitly leaving things up at the user's request, say
+which server / database processes were intentionally left up.
 
 ## Verification checks
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -126,14 +126,15 @@
         "title": "Deduction grid",
         "caseFileProgress": "Case file · {percent}% solved",
         "candidatesCount": "{count, plural, one {# candidate} other {# candidates}}",
-        "whyHeader": "Why this value:",
         "whyLine": "{index}. {headline}{iter, select, none {} other { (iter {iter})}}: {detail}",
         "footnoteLine": "Candidate for suggestion {labels} — refuter's unseen card could be here."
     },
     "hypothesis": {
         "groupLabel": "Hypothesis",
         "sectionLabel": "Hypothesis · {owner} / {card}",
-        "optionOff": "—",
+        "hardFactsLabel": "Hard facts",
+        "helpText": "Have a hunch? Set it here to treat it like a soft deduction — we'll tell you when it's confirmed, plausible, or rejected.",
+        "optionOff": "Off",
         "optionY": "Y",
         "optionN": "N",
         "statusConfirmed": "Confirmed by real facts. You can clear this hypothesis.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -140,7 +140,7 @@
         "statusConfirmed": "Confirmed by real facts. You can clear this hypothesis.",
         "statusDirectlyContradicted": "Contradicts a real fact — your hypothesis can't be true.",
         "statusJointlyConflicts": "Conflicts with another hypothesis. These can't all be true together — drop one to resolve.",
-        "statusDerived": "This value follows from one of your active hypotheses. Open a ‘?’ cell to see which.",
+        "statusDerived": "This value follows from your active hypotheses:",
         "emptyHint": "Set a hypothesis to explore what would follow."
     },
     "reasons": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -131,7 +131,8 @@
     },
     "hypothesis": {
         "groupLabel": "Hypothesis",
-        "sectionLabel": "Hypothesis · {owner} / {card}",
+        "cellHeading": "{owner} / {card}",
+        "hypothesisLabel": "Hypothesis",
         "hardFactsLabel": "Hard facts",
         "helpText": "Have a hunch? Set it here to treat it like a soft deduction — we'll tell you when it's confirmed, plausible, or rejected.",
         "optionOff": "Off",

--- a/messages/en.json
+++ b/messages/en.json
@@ -137,6 +137,7 @@
         "optionOff": "Off",
         "optionY": "Y",
         "optionN": "N",
+        "shortcutHint": "Type ({y}, {n}, or {off}) to toggle.",
         "statusConfirmed": "Confirmed by real facts. You can clear this hypothesis.",
         "statusDirectlyContradicted": "Contradicts a real fact — your hypothesis can't be true.",
         "statusJointlyConflicts": "Conflicts with another hypothesis. These can't all be true together — drop one to resolve.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -138,7 +138,7 @@
         "optionY": "Y",
         "optionN": "N",
         "shortcutHint": "Type ({y}, {n}, or {off}) to toggle.",
-        "statusConfirmed": "Confirmed by real facts. You can clear this hypothesis.",
+        "statusConfirmed": "Confirmed by real facts — you can turn this hypothesis off.",
         "statusDirectlyContradicted": "Contradicts a real fact — your hypothesis can't be true.",
         "statusJointlyConflicts": "Conflicts with another hypothesis. These can't all be true together — drop one to resolve.",
         "statusDerived": "This value follows from your active hypotheses:",

--- a/messages/en.json
+++ b/messages/en.json
@@ -141,6 +141,7 @@
         "statusDirectlyContradicted": "Contradicts a real fact — your hypothesis can't be true.",
         "statusJointlyConflicts": "Conflicts with another hypothesis. These can't all be true together — drop one to resolve.",
         "statusDerived": "This value follows from your active hypotheses:",
+        "statusDerivedSingular": "This value follows from your active hypothesis ({description}).",
         "emptyHint": "Set a hypothesis to explore what would follow."
     },
     "reasons": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -74,7 +74,9 @@
             "updateAccusation": "editing Accusation #{number} by {player} ({cards})",
             "updateAccusationUnknown": "editing an accusation",
             "removeAccusation": "removing Accusation #{number} by {player} ({cards})",
-            "removeAccusationUnknown": "removing an accusation"
+            "removeAccusationUnknown": "removing an accusation",
+            "setHypothesis": "setting hypothesis: {owner} {value, select, Y {owns} other {doesn't own}} {card}",
+            "clearHypothesis": "clearing hypothesis on {owner} / {card}"
         }
     },
     "setup": {
@@ -127,6 +129,18 @@
         "whyHeader": "Why this value:",
         "whyLine": "{index}. {headline}{iter, select, none {} other { (iter {iter})}}: {detail}",
         "footnoteLine": "Candidate for suggestion {labels} — refuter's unseen card could be here."
+    },
+    "hypothesis": {
+        "groupLabel": "Hypothesis",
+        "sectionLabel": "Hypothesis · {owner} / {card}",
+        "optionOff": "—",
+        "optionY": "Y",
+        "optionN": "N",
+        "statusConfirmed": "Confirmed by real facts. You can clear this hypothesis.",
+        "statusDirectlyContradicted": "Contradicts a real fact — your hypothesis can't be true.",
+        "statusJointlyConflicts": "Conflicts with another hypothesis. These can't all be true together — drop one to resolve.",
+        "statusDerived": "This value follows from one of your active hypotheses. Open a ‘?’ cell to see which.",
+        "emptyHint": "Set a hypothesis to explore what would follow."
     },
     "reasons": {
         "suggestionHeadline": "Suggestion #{number}",

--- a/src/logic/ClueState.ts
+++ b/src/logic/ClueState.ts
@@ -2,7 +2,9 @@ import type { AccusationId } from "./Accusation";
 import type { CardSet } from "./CardSet";
 import type { Card, CardCategory, Player } from "./GameObjects";
 import type { GameSetup } from "./GameSetup";
+import type { HypothesisMap, HypothesisValue } from "./Hypothesis";
 import type { KnownCard } from "./InitialKnowledge";
+import type { Cell } from "./Knowledge";
 import type { GameSession } from "./Persistence";
 import type { SuggestionId } from "./Suggestion";
 
@@ -102,6 +104,8 @@ export type ClueAction =
     | { type: "removePlayer"; player: Player }
     | { type: "renamePlayer"; oldName: Player; newName: Player }
     | { type: "setUiMode"; mode: UiMode }
+    | { type: "setHypothesis"; cell: Cell; value: HypothesisValue }
+    | { type: "clearHypothesis"; cell: Cell }
     | { type: "replaceSession"; session: GameSession };
 
 export interface ClueState {
@@ -111,4 +115,12 @@ export interface ClueState {
     readonly suggestions: ReadonlyArray<DraftSuggestion>;
     readonly accusations: ReadonlyArray<DraftAccusation>;
     readonly uiMode: UiMode;
+    /**
+     * User-entered "what-if" assumptions, one per cell. Soft facts: the
+     * deducer runs a parallel "joint" deduction over `realFacts ∪
+     * hypotheses` so the user can see what their hunches would imply,
+     * without polluting the canonical fact set or raising the global
+     * contradiction banner. See {@link Hypothesis} for the model.
+     */
+    readonly hypotheses: HypothesisMap;
 }

--- a/src/logic/Hypothesis.test.ts
+++ b/src/logic/Hypothesis.test.ts
@@ -1,0 +1,199 @@
+import { HashMap, Result } from "effect";
+import { describe, expect, test } from "vitest";
+import { CaseFileOwner, PlayerOwner } from "./GameObjects";
+import { CLASSIC_SETUP_3P } from "./GameSetup";
+import {
+    displayFor,
+    emptyHypotheses,
+    foldHypothesesInto,
+    statusFor,
+    type HypothesisMap,
+} from "./Hypothesis";
+import { Cell, emptyKnowledge, Knowledge, N, setCell, Y } from "./Knowledge";
+import { Player } from "./GameObjects";
+import { cardByName } from "./test-utils/CardByName";
+
+const setup = CLASSIC_SETUP_3P;
+const A = Player("Anisha");
+const B = Player("Bob");
+const SCARLET = cardByName(setup, "Miss Scarlet");
+
+const cellAScarlet = Cell(PlayerOwner(A), SCARLET);
+const cellBScarlet = Cell(PlayerOwner(B), SCARLET);
+const cellCaseFileScarlet = Cell(CaseFileOwner(), SCARLET);
+
+const hypothesisMap = (
+    entries: ReadonlyArray<readonly [Cell, "Y" | "N"]>,
+): HypothesisMap => {
+    let m: HypothesisMap = emptyHypotheses;
+    for (const [cell, value] of entries) m = HashMap.set(m, cell, value);
+    return m;
+};
+
+describe("foldHypothesesInto", () => {
+    test("empty map returns the input knowledge unchanged", () => {
+        const result = foldHypothesesInto(emptyKnowledge, emptyHypotheses);
+        expect(Result.isSuccess(result)).toBe(true);
+        if (Result.isSuccess(result)) {
+            expect(result.success).toBe(emptyKnowledge);
+        }
+    });
+
+    test("hypothesis matching an existing initial cell is a no-op", () => {
+        const initial: Knowledge = setCell(emptyKnowledge, cellAScarlet, Y);
+        const result = foldHypothesesInto(
+            initial,
+            hypothesisMap([[cellAScarlet, Y]]),
+        );
+        expect(Result.isSuccess(result)).toBe(true);
+    });
+
+    test("hypothesis disagreeing with an existing initial cell returns Failure", () => {
+        const initial: Knowledge = setCell(emptyKnowledge, cellAScarlet, Y);
+        const result = foldHypothesesInto(
+            initial,
+            hypothesisMap([[cellAScarlet, N]]),
+        );
+        expect(Result.isFailure(result)).toBe(true);
+        if (Result.isFailure(result)) {
+            expect(result.failure.offendingCells).toContainEqual(cellAScarlet);
+        }
+    });
+
+    test("multiple compatible hypotheses fold cleanly", () => {
+        const result = foldHypothesesInto(
+            emptyKnowledge,
+            hypothesisMap([
+                [cellAScarlet, Y],
+                [cellBScarlet, N],
+            ]),
+        );
+        expect(Result.isSuccess(result)).toBe(true);
+    });
+});
+
+describe("statusFor", () => {
+    test("undefined real knowledge → suppress to off", () => {
+        expect(
+            statusFor(
+                cellAScarlet,
+                undefined,
+                undefined,
+                hypothesisMap([[cellAScarlet, Y]]),
+                false,
+            ).kind,
+        ).toBe("off");
+    });
+
+    test("no hypothesis on cell, real proves nothing, joint absent → off", () => {
+        const real = emptyKnowledge;
+        expect(
+            statusFor(
+                cellAScarlet,
+                real,
+                undefined,
+                emptyHypotheses,
+                false,
+            ).kind,
+        ).toBe("off");
+    });
+
+    test("active: hypothesis on a cell real doesn't yet prove, joint succeeds", () => {
+        const real = emptyKnowledge;
+        const joint = setCell(emptyKnowledge, cellAScarlet, Y);
+        const status = statusFor(
+            cellAScarlet,
+            real,
+            joint,
+            hypothesisMap([[cellAScarlet, Y]]),
+            false,
+        );
+        expect(status.kind).toBe("active");
+        if (status.kind === "active") expect(status.value).toBe(Y);
+    });
+
+    test("confirmed: real proves the hypothesis right", () => {
+        const real = setCell(emptyKnowledge, cellAScarlet, Y);
+        expect(
+            statusFor(
+                cellAScarlet,
+                real,
+                undefined,
+                hypothesisMap([[cellAScarlet, Y]]),
+                false,
+            ).kind,
+        ).toBe("confirmed");
+    });
+
+    test("directlyContradicted: real proves the opposite", () => {
+        const real = setCell(emptyKnowledge, cellAScarlet, Y);
+        const status = statusFor(
+            cellAScarlet,
+            real,
+            undefined,
+            hypothesisMap([[cellAScarlet, N]]),
+            false,
+        );
+        expect(status.kind).toBe("directlyContradicted");
+        if (status.kind === "directlyContradicted") {
+            expect(status.real).toBe(Y);
+            expect(status.hypothesis).toBe(N);
+        }
+    });
+
+    test("jointlyConflicts: hypothesis on cell, joint deduction failed", () => {
+        const real = emptyKnowledge;
+        expect(
+            statusFor(
+                cellAScarlet,
+                real,
+                undefined,
+                hypothesisMap([[cellAScarlet, Y]]),
+                true,
+            ).kind,
+        ).toBe("jointlyConflicts");
+    });
+
+    test("derived: no direct hypothesis, joint deduction proves a value real doesn't", () => {
+        const real = emptyKnowledge;
+        const joint = setCell(emptyKnowledge, cellCaseFileScarlet, N);
+        // The hypothesis lives on a different cell — this cell's value
+        // arises from deduction over the augmented set.
+        const status = statusFor(
+            cellCaseFileScarlet,
+            real,
+            joint,
+            hypothesisMap([[cellAScarlet, Y]]),
+            false,
+        );
+        expect(status.kind).toBe("derived");
+        if (status.kind === "derived") expect(status.value).toBe(N);
+    });
+});
+
+describe("displayFor", () => {
+    test("real value wins over hypothesis", () => {
+        expect(
+            displayFor(Y, { kind: "directlyContradicted", hypothesis: N, real: Y }),
+        ).toEqual({ tag: "real", value: Y });
+    });
+
+    test("hypothesis with no real → hypothesis tag (renders ?)", () => {
+        expect(displayFor(undefined, { kind: "active", value: Y })).toEqual({
+            tag: "hypothesis",
+            value: Y,
+        });
+    });
+
+    test("derived → derived tag", () => {
+        expect(
+            displayFor(undefined, { kind: "derived", value: N }),
+        ).toEqual({ tag: "derived", value: N });
+    });
+
+    test("off + no real → blank", () => {
+        expect(displayFor(undefined, { kind: "off" })).toEqual({
+            tag: "blank",
+        });
+    });
+});

--- a/src/logic/Hypothesis.ts
+++ b/src/logic/Hypothesis.ts
@@ -1,0 +1,177 @@
+import { HashMap, Option, Result } from "effect";
+import { Cell, Contradiction, getCell, Knowledge, setCell, type CellValue } from "./Knowledge";
+import type { ContradictionTrace } from "./Deducer";
+
+/**
+ * A "hypothesis" is a per-cell what-if assumption the user toggles on
+ * to explore what the deducer would derive if that assumption were
+ * true. Hypotheses are SOFT: they don't enter the canonical fact set
+ * (so they don't raise the global contradiction banner), and the
+ * underlying real-only deduction always continues to run alongside.
+ *
+ * Encoded as `HashMap<Cell, "Y" | "N">` mirroring the Knowledge
+ * checklist shape — "off" is encoded by absence, just like an unknown
+ * cell in `Knowledge.checklist`.
+ */
+export type HypothesisValue = CellValue;
+export type HypothesisMap = HashMap.HashMap<Cell, HypothesisValue>;
+export const emptyHypotheses: HypothesisMap = HashMap.empty();
+
+/**
+ * Per-cell relation to the active hypothesis set. Drives both the
+ * cell's visual treatment and the why-popover's microcopy.
+ *
+ * - `off`: no hypothesis touches this cell directly or indirectly.
+ * - `active`: the user placed a hypothesis on this cell and the joint
+ *   deduction (real ∪ hypotheses) succeeded.
+ * - `derived`: the user did not place a hypothesis here, but the joint
+ *   deduction proves a value the real-only deduction couldn't — i.e.
+ *   "this would follow if your hypotheses are true".
+ * - `confirmed`: the user placed a hypothesis here and the real-only
+ *   deduction independently proves the same value (the hypothesis is
+ *   correct; the user can clear it as redundant).
+ * - `directlyContradicted`: the user placed a hypothesis here, but the
+ *   real-only deduction proves the OPPOSITE value (the hypothesis can
+ *   never be true). The cell shows the real value; the popover surfaces
+ *   the contradiction.
+ * - `jointlyConflicts`: the user placed a hypothesis here, real proves
+ *   nothing yet, but the joint deduction over the whole hypothesis set
+ *   contradicts. We don't single out a culprit — every active hypothesis
+ *   in this state contributes to the contradiction.
+ */
+export type HypothesisStatus =
+    | { readonly kind: "off" }
+    | { readonly kind: "active"; readonly value: HypothesisValue }
+    | { readonly kind: "derived"; readonly value: CellValue }
+    | { readonly kind: "confirmed"; readonly value: HypothesisValue }
+    | {
+          readonly kind: "directlyContradicted";
+          readonly hypothesis: HypothesisValue;
+          readonly real: CellValue;
+      }
+    | {
+          readonly kind: "jointlyConflicts";
+          readonly value: HypothesisValue;
+      };
+
+const traceFromContradiction = (e: Contradiction): ContradictionTrace => ({
+    reason: e.reason,
+    offendingCells: e.offendingCells,
+    offendingSuggestionIndices:
+        e.suggestionIndex !== undefined ? [e.suggestionIndex] : [],
+    offendingAccusationIndices:
+        e.accusationIndex !== undefined ? [e.accusationIndex] : [],
+    sliceLabel: e.sliceLabel,
+    contradictionKind: e.contradictionKind,
+});
+
+/**
+ * Fold every hypothesis into an initial Knowledge as if it were a
+ * known cell. `setCell` throws `Contradiction` if a hypothesis disagrees
+ * with a value already present in `initial` (i.e. a known card), and
+ * we materialise that into a `Result.Failure` so the joint-deduction
+ * caller can branch on it without a try/catch.
+ *
+ * Cells whose hypothesis matches an existing initial value are no-ops
+ * (setCell returns the same Knowledge unchanged).
+ */
+export const foldHypothesesInto = (
+    initial: Knowledge,
+    hypotheses: HypothesisMap,
+): Result.Result<Knowledge, ContradictionTrace> => {
+    let k = initial;
+    try {
+        for (const [cell, value] of hypotheses) {
+            k = setCell(k, cell, value);
+        }
+        return Result.succeed(k);
+    } catch (e) {
+        if (e instanceof Contradiction) {
+            return Result.fail(traceFromContradiction(e));
+        }
+        throw e;
+    }
+};
+
+/**
+ * Compute a single cell's hypothesis status from the two deduction
+ * results plus the user's hypothesis map. Pure and cheap — called once
+ * per visible cell on every render.
+ *
+ * `realKnowledge` is undefined when the real-only deduction failed —
+ * in that case the global contradiction banner is showing and we
+ * suppress hypothesis status entirely (return "off").
+ *
+ * `jointKnowledge` is undefined when either no hypotheses are active
+ * (in which case we'd never reach this function with a non-off result)
+ * or the joint deduction failed (`jointFailed === true`). The cell
+ * still shows whatever the real-only render would, plus the
+ * jointly-conflicts marker on each direct-hypothesis cell.
+ */
+export const statusFor = (
+    cell: Cell,
+    realKnowledge: Knowledge | undefined,
+    jointKnowledge: Knowledge | undefined,
+    hypotheses: HypothesisMap,
+    jointFailed: boolean,
+): HypothesisStatus => {
+    if (realKnowledge === undefined) return { kind: "off" };
+
+    const real = getCell(realKnowledge, cell);
+    const hyp = HashMap.get(hypotheses, cell);
+
+    if (Option.isSome(hyp)) {
+        const h = hyp.value;
+        if (real !== undefined && real !== h) {
+            return { kind: "directlyContradicted", hypothesis: h, real };
+        }
+        if (real !== undefined && real === h) {
+            return { kind: "confirmed", value: h };
+        }
+        if (jointFailed) {
+            return { kind: "jointlyConflicts", value: h };
+        }
+        return { kind: "active", value: h };
+    }
+
+    // No direct hypothesis on this cell. Is its value derived from one?
+    if (real !== undefined) return { kind: "off" };
+    if (jointKnowledge === undefined) return { kind: "off" };
+    const joint = getCell(jointKnowledge, cell);
+    if (joint === undefined) return { kind: "off" };
+    return { kind: "derived", value: joint };
+};
+
+/**
+ * What the cell should *visually* display, factoring real value and
+ * hypothesis status. Drives the cell's background color + glyph.
+ *
+ * - `real`: the real-only deduced value wins (Y/N from the canonical
+ *   fact set). Direct-hypothesis cells where the hypothesis is
+ *   confirmed or contradicted fall into this branch — the user sees
+ *   the real fact, with a status marker in the popover.
+ * - `hypothesis`: a direct hypothesis on a cell real doesn't yet
+ *   prove. Cell shows `?` over the hypothesis value's color.
+ * - `derived`: real proves nothing here, but joint does. Cell shows
+ *   `?` over the joint-derived value's color.
+ * - `blank`: neither real nor any hypothesis says anything.
+ */
+export type CellDisplay =
+    | { readonly tag: "real"; readonly value: CellValue }
+    | { readonly tag: "hypothesis"; readonly value: HypothesisValue }
+    | { readonly tag: "derived"; readonly value: CellValue }
+    | { readonly tag: "blank" };
+
+export const displayFor = (
+    real: CellValue | undefined,
+    status: HypothesisStatus,
+): CellDisplay => {
+    if (real !== undefined) return { tag: "real", value: real };
+    if (status.kind === "active" || status.kind === "jointlyConflicts") {
+        return { tag: "hypothesis", value: status.value };
+    }
+    if (status.kind === "derived") {
+        return { tag: "derived", value: status.value };
+    }
+    return { tag: "blank" };
+};

--- a/src/logic/Persistence.test.ts
+++ b/src/logic/Persistence.test.ts
@@ -15,8 +15,10 @@ import {
     saveToLocalStorage,
     type GameSession,
 } from "./Persistence";
+import { emptyHypotheses } from "./Hypothesis";
 
-const STORAGE_KEY = "effect-clue.session.v6";
+const STORAGE_KEY = "effect-clue.session.v7";
+const LEGACY_STORAGE_KEY_V6 = "effect-clue.session.v6";
 
 const setup = CLASSIC_SETUP_3P;
 const A = Player("Anisha");
@@ -38,6 +40,7 @@ const minimalSession: GameSession = {
     ],
     suggestions: [],
     accusations: [],
+    hypotheses: emptyHypotheses,
 };
 
 const richSession = (): GameSession => ({
@@ -89,6 +92,7 @@ const richSession = (): GameSession => ({
             cards: [MUSTARD, KNIFE, KITCHEN],
         }),
     ],
+    hypotheses: emptyHypotheses,
 });
 
 describe("encode/decode — rich sessions", () => {
@@ -186,11 +190,29 @@ describe("saveToLocalStorage / loadFromLocalStorage", () => {
         expect(loaded?.handSizes).toHaveLength(3);
     });
 
-    test("save writes under the v6-scoped storage key", () => {
+    test("save writes under the v7-scoped storage key", () => {
         saveToLocalStorage(minimalSession);
         const raw = window.localStorage.getItem(STORAGE_KEY);
         expect(raw).not.toBeNull();
-        expect(JSON.parse(raw as string).version).toBe(6);
+        expect(JSON.parse(raw as string).version).toBe(7);
+    });
+
+    test("loads a v6 blob (no hypotheses field) and lifts to v7 with empty hypotheses", () => {
+        const v6Payload = {
+            version: 6,
+            setup: { players: ["Anisha"], categories: [] },
+            hands: [],
+            handSizes: [],
+            suggestions: [],
+            accusations: [],
+        };
+        window.localStorage.setItem(
+            LEGACY_STORAGE_KEY_V6,
+            JSON.stringify(v6Payload),
+        );
+        const loaded = loadFromLocalStorage();
+        expect(loaded).toBeDefined();
+        expect(loaded?.hypotheses).toBeDefined();
     });
 
     test("load returns undefined when the key is missing", () => {

--- a/src/logic/Persistence.ts
+++ b/src/logic/Persistence.ts
@@ -1,15 +1,29 @@
-import { Result } from "effect";
+import { HashMap, Result } from "effect";
 import {
     Accusation,
     AccusationId,
     accusationCards,
     newAccusationId,
 } from "./Accusation";
-import { Card, Player } from "./GameObjects";
+import {
+    CaseFileOwner,
+    Card,
+    Player,
+    PlayerOwner,
+} from "./GameObjects";
 import { CardEntry, Category, GameSetup } from "./GameSetup";
 import {
+    emptyHypotheses,
+    type HypothesisMap,
+    type HypothesisValue,
+} from "./Hypothesis";
+import { Cell } from "./Knowledge";
+import {
     decodeV6Unknown,
+    decodeV7Unknown,
+    type PersistedHypothesis,
     type PersistedSessionV6,
+    type PersistedSessionV7,
 } from "./PersistenceSchema";
 import {
     newSuggestionId,
@@ -24,12 +38,12 @@ import {
  * the mutable inputs are serialized; derived knowledge is cheap to
  * recompute, so there's no need to persist it.
  *
- * The app is pre-production, so there's one on-disk format. If an
- * older / malformed blob ever shows up, decode returns undefined
- * and the caller falls back to a fresh session.
+ * v7 (current) adds `hypotheses` — per-cell what-if assumptions.
+ * v6 reads still work via {@link decodeV6Unknown}; they're auto-lifted
+ * to v7 with `hypotheses: []`. Writes always produce v7.
  */
-interface PersistedGameV6 {
-    readonly version: 6;
+interface PersistedGameV7 {
+    readonly version: 7;
     readonly setup: {
         readonly players: ReadonlyArray<string>;
         readonly categories: ReadonlyArray<{
@@ -64,9 +78,14 @@ interface PersistedGameV6 {
         readonly cards: ReadonlyArray<string>;
         readonly loggedAt: number;
     }>;
+    readonly hypotheses: ReadonlyArray<{
+        readonly player: string | null;
+        readonly card: string;
+        readonly value: "Y" | "N";
+    }>;
 }
 
-type PersistedGame = PersistedGameV6;
+type PersistedGame = PersistedGameV7;
 
 export interface GameSession {
     setup: GameSetup;
@@ -74,10 +93,37 @@ export interface GameSession {
     handSizes: ReadonlyArray<{ player: Player; size: number }>;
     suggestions: ReadonlyArray<Suggestion>;
     accusations: ReadonlyArray<Accusation>;
+    hypotheses: HypothesisMap;
 }
 
+const encodeHypotheses = (
+    hypotheses: HypothesisMap,
+): PersistedGameV7["hypotheses"] => {
+    const out: Array<PersistedGameV7["hypotheses"][number]> = [];
+    for (const [cell, value] of hypotheses) {
+        const player =
+            cell.owner._tag === "Player"
+                ? String(cell.owner.player)
+                : null;
+        out.push({ player, card: String(cell.card), value });
+    }
+    return out;
+};
+
+const decodeHypotheses = (
+    raw: ReadonlyArray<PersistedHypothesis>,
+): HypothesisMap => {
+    let m: HypothesisMap = emptyHypotheses;
+    for (const h of raw) {
+        const owner =
+            h.player !== null ? PlayerOwner(h.player) : CaseFileOwner();
+        m = HashMap.set(m, Cell(owner, h.card), h.value as HypothesisValue);
+    }
+    return m;
+};
+
 export const encodeSession = (session: GameSession): PersistedGame => ({
-    version: 6,
+    version: 7,
     setup: {
         players: session.setup.players.map(p => String(p)),
         categories: session.setup.categories.map(c => ({
@@ -112,14 +158,53 @@ export const encodeSession = (session: GameSession): PersistedGame => ({
         cards: accusationCards(a).map(c => String(c)),
         loggedAt: a.loggedAt,
     })),
+    hypotheses: encodeHypotheses(session.hypotheses),
+});
+
+const buildSessionFromV7 = (v7: PersistedSessionV7): GameSession => ({
+    setup: GameSetup({
+        players: v7.setup.players,
+        categories: v7.setup.categories.map(c => Category({
+            id: c.id,
+            name: c.name,
+            cards: c.cards.map(card => CardEntry({
+                id: card.id,
+                name: card.name,
+            })),
+        })),
+    }),
+    hands: v7.hands.map(h => ({ player: h.player, cards: h.cards })),
+    handSizes: v7.handSizes.map(h => ({
+        player: h.player,
+        size: h.size,
+    })),
+    suggestions: v7.suggestions.map(s => Suggestion({
+        id: s.id === undefined || s.id === SuggestionId("")
+            ? newSuggestionId()
+            : s.id,
+        suggester: s.suggester,
+        cards: s.cards,
+        nonRefuters: s.nonRefuters,
+        refuter: s.refuter === null ? undefined : s.refuter,
+        seenCard: s.seenCard === null ? undefined : s.seenCard,
+        loggedAt: s.loggedAt,
+    })),
+    accusations: v7.accusations.map(a => Accusation({
+        id: a.id === undefined || a.id === AccusationId("")
+            ? newAccusationId()
+            : a.id,
+        accuser: a.accuser,
+        cards: a.cards,
+        loggedAt: a.loggedAt,
+    })),
+    hypotheses: decodeHypotheses(v7.hypotheses),
 });
 
 /**
- * Convert a Schema-validated v6 payload into the domain GameSession.
- * Branded types already flow through the schema, so this is pure
- * construction — no Player(...) / Card(...) wrapping needed.
+ * Lift a v6 payload to v7 by attaching an empty hypothesis set.
+ * Forward-only and lossless — v7 is a strict superset of v6.
  */
-const buildSessionFromV6 = (v6: PersistedSessionV6): GameSession => ({
+const liftV6ToV7 = (v6: PersistedSessionV6): GameSession => ({
     setup: GameSetup({
         players: v6.setup.players,
         categories: v6.setup.categories.map(c => Category({
@@ -155,15 +240,19 @@ const buildSessionFromV6 = (v6: PersistedSessionV6): GameSession => ({
         cards: a.cards,
         loggedAt: a.loggedAt,
     })),
+    hypotheses: emptyHypotheses,
 });
 
 export const decodeSession = (data: unknown): GameSession | undefined => {
-    const decoded = decodeV6Unknown(data);
-    if (Result.isFailure(decoded)) return undefined;
-    return buildSessionFromV6(decoded.success);
+    const v7 = decodeV7Unknown(data);
+    if (Result.isSuccess(v7)) return buildSessionFromV7(v7.success);
+    const v6 = decodeV6Unknown(data);
+    if (Result.isSuccess(v6)) return liftV6ToV7(v6.success);
+    return undefined;
 };
 
-const STORAGE_KEY = "effect-clue.session.v6";
+const STORAGE_KEY = "effect-clue.session.v7";
+const LEGACY_STORAGE_KEY_V6 = "effect-clue.session.v6";
 
 export const saveToLocalStorage = (session: GameSession): void => {
     try {
@@ -176,9 +265,11 @@ export const saveToLocalStorage = (session: GameSession): void => {
 
 export const loadFromLocalStorage = (): GameSession | undefined => {
     try {
-        const raw = window.localStorage.getItem(STORAGE_KEY);
-        if (!raw) return undefined;
-        return decodeSession(JSON.parse(raw));
+        const rawV7 = window.localStorage.getItem(STORAGE_KEY);
+        if (rawV7) return decodeSession(JSON.parse(rawV7));
+        const rawV6 = window.localStorage.getItem(LEGACY_STORAGE_KEY_V6);
+        if (rawV6) return decodeSession(JSON.parse(rawV6));
+        return undefined;
     } catch {
         return undefined;
     }

--- a/src/logic/PersistenceSchema.test.ts
+++ b/src/logic/PersistenceSchema.test.ts
@@ -1,25 +1,28 @@
 import { describe, expect, test } from "vitest";
 import { Result } from "effect";
 import { CLASSIC_SETUP_3P } from "./GameSetup";
+import { emptyHypotheses } from "./Hypothesis";
 import { decodeSession, encodeSession } from "./Persistence";
 import { decodeV6Unknown } from "./PersistenceSchema";
 import { Player } from "./GameObjects";
 
 /**
- * The app is pre-production — v6 is the only on-disk format, so
- * there's only one round-trip to cover. Anything that doesn't parse
- * as v6 returns undefined and the caller starts a fresh session.
+ * v7 is the canonical on-disk format; v6 reads still work via a
+ * read-side fallback (auto-lifted with empty hypotheses). Anything
+ * that doesn't parse as either returns undefined and the caller
+ * starts a fresh session.
  */
-describe("Schema-backed v6 persistence", () => {
-    test("encode produces version: 6 and round-trips through decode", () => {
+describe("Schema-backed persistence", () => {
+    test("encode produces version: 7 and round-trips through decode", () => {
         const encoded = encodeSession({
             setup: CLASSIC_SETUP_3P,
             hands: [],
             handSizes: [{ player: Player("Anisha"), size: 6 }],
             suggestions: [],
             accusations: [],
+            hypotheses: emptyHypotheses,
         });
-        expect(encoded.version).toBe(6);
+        expect(encoded.version).toBe(7);
 
         const decoded = decodeSession(encoded);
         expect(decoded).toBeDefined();

--- a/src/logic/PersistenceSchema.ts
+++ b/src/logic/PersistenceSchema.ts
@@ -4,17 +4,18 @@ import { Card, CardCategory, Player } from "./GameObjects";
 import { SuggestionId } from "./Suggestion";
 
 /**
- * Effect Schema definitions for the persisted session shape (v6).
+ * Effect Schema definitions for the persisted session shape.
  *
- * The app is pre-production, so there's a single on-disk format —
- * writes go to v6, reads only accept v6. If an older / malformed blob
- * shows up, decode returns `Result.Failure` and the caller falls back
- * to a fresh session. No migration chain, no legacy schemas.
+ * The current canonical version is v7 (adds `hypotheses`). Reads accept
+ * v7 first, then fall back to v6 (auto-lifting with `hypotheses: []`)
+ * so that users who roll back-and-forward between builds don't lose
+ * suggestion / accusation state. Writes always go to v7.
  *
- * v6 adds the `loggedAt: number` field to each suggestion + accusation,
- * recording the millisecond timestamp at which it was logged. Powers
- * the combined chronological prior-log UI in `SuggestionLogPanel` —
- * suggestions and accusations are interleaved by `loggedAt`.
+ * v6 added the `loggedAt: number` field to each suggestion + accusation,
+ * recording the millisecond timestamp at which it was logged.
+ *
+ * v7 adds `hypotheses: Array<{ owner, card, value }>` — per-cell what-if
+ * assumptions the user toggles on. See `src/logic/Hypothesis.ts`.
  *
  * Branded strings (Player, Card, CardCategory, SuggestionId,
  * AccusationId) are decoded straight into their nominal types via
@@ -78,15 +79,29 @@ const PersistedAccusationSchema = Schema.Struct({
 });
 
 /**
+ * Persisted owner: a single `player` field that's null when the cell
+ * belongs to the case file. Flat encoding (vs a discriminated `kind`
+ * tag) keeps the schema's `DecodingServices` channel clean — Schema's
+ * `Union` widens services to `unknown`, which incompatibilises the
+ * outer struct with `decodeUnknownResult`'s `Decoder<unknown>` constraint.
+ */
+const PersistedHypothesisSchema = Schema.Struct({
+    player: Schema.NullOr(PlayerSchema),
+    card: CardSchema,
+    value: Schema.Literals(["Y", "N"]),
+});
+
+/**
  * Convenience array wrappers for the share codec — the shares wire
  * format ships these as top-level JSON arrays rather than wrapped
- * inside a v6-style envelope.
+ * inside a versioned envelope.
  */
 export const PlayersArraySchema = Schema.Array(PlayerSchema);
 export const HandSizesArraySchema = Schema.Array(PersistedHandSizeSchema);
 export const HandsArraySchema = Schema.Array(PersistedHandSchema);
 export const SuggestionsArraySchema = Schema.Array(PersistedSuggestionSchema);
 export const AccusationsArraySchema = Schema.Array(PersistedAccusationSchema);
+export const HypothesesArraySchema = Schema.Array(PersistedHypothesisSchema);
 
 /**
  * Wire shape for the card-pack half of a share. The `name` field is
@@ -106,7 +121,7 @@ export const CardSetSchema = Schema.Struct({
 });
 
 /**
- * Canonical v6 session shape. The only version the decoder accepts.
+ * v6 session shape — kept for back-compat reads. v7 supersedes it.
  */
 const PersistedSessionV6Schema = Schema.Struct({
     version: Schema.Literal(6),
@@ -118,17 +133,37 @@ const PersistedSessionV6Schema = Schema.Struct({
 });
 
 /**
- * Result-returning decoder. Hands back `Result<session, SchemaError>` —
+ * Canonical v7 session shape. Adds `hypotheses` — per-cell what-if
+ * assumptions. See `src/logic/Hypothesis.ts`.
+ */
+const PersistedSessionV7Schema = Schema.Struct({
+    version: Schema.Literal(7),
+    setup: PersistedGameSetupSchema,
+    hands: Schema.Array(PersistedHandSchema),
+    handSizes: Schema.Array(PersistedHandSizeSchema),
+    suggestions: Schema.Array(PersistedSuggestionSchema),
+    accusations: Schema.Array(PersistedAccusationSchema),
+    hypotheses: HypothesesArraySchema,
+});
+
+/**
+ * Result-returning decoders. Hand back `Result<session, SchemaError>` —
  * callers decide whether to surface the error or fall back to a fresh
  * session.
  */
 export const decodeV6Unknown = Schema.decodeUnknownResult(
     PersistedSessionV6Schema,
 );
+export const decodeV7Unknown = Schema.decodeUnknownResult(
+    PersistedSessionV7Schema,
+);
 
 /**
- * Runtime type of a decoded v6 session — the branded, Schema-validated
- * payload `decodeV6Unknown` hands back. Callers construct the
+ * Runtime types of decoded sessions — the branded, Schema-validated
+ * payload `decodeV{6,7}Unknown` hand back. Callers construct the
  * GameSession domain value from this.
  */
 export type PersistedSessionV6 = Schema.Schema.Type<typeof PersistedSessionV6Schema>;
+export type PersistedSessionV7 = Schema.Schema.Type<typeof PersistedSessionV7Schema>;
+
+export type PersistedHypothesis = Schema.Schema.Type<typeof PersistedHypothesisSchema>;

--- a/src/logic/ShareCodec.ts
+++ b/src/logic/ShareCodec.ts
@@ -24,6 +24,7 @@ import {
     CardSetSchema,
     HandSizesArraySchema,
     HandsArraySchema,
+    HypothesesArraySchema,
     PlayersArraySchema,
     SuggestionsArraySchema,
 } from "./PersistenceSchema";
@@ -34,3 +35,12 @@ export const handSizesCodec = Schema.fromJsonString(HandSizesArraySchema);
 export const knownCardsCodec = Schema.fromJsonString(HandsArraySchema);
 export const suggestionsCodec = Schema.fromJsonString(SuggestionsArraySchema);
 export const accusationsCodec = Schema.fromJsonString(AccusationsArraySchema);
+
+/**
+ * Hypotheses codec — only used by the `transfer` share kind ("move my
+ * game to another device"). `pack` and `invite` shares deliberately
+ * omit hypotheses since those flows go to other people; hypotheses are
+ * personal scratchwork. See `docs/shares.md` for the kind-discriminated
+ * wire-format rule.
+ */
+export const hypothesesCodec = Schema.fromJsonString(HypothesesArraySchema);

--- a/src/logic/describeAction.test.ts
+++ b/src/logic/describeAction.test.ts
@@ -8,6 +8,7 @@ import type {
 } from "./ClueState";
 import { AccusationId } from "./Accusation";
 import { Card, CardCategory, Player } from "./GameObjects";
+import { emptyHypotheses } from "./Hypothesis";
 import { GameSetup, CardEntry, Category } from "./GameSetup";
 import { KnownCard } from "./InitialKnowledge";
 import { SuggestionId } from "./Suggestion";
@@ -73,6 +74,7 @@ const baseState: ClueState = {
     suggestions: [],
     accusations: [],
     uiMode: "checklist",
+    hypotheses: emptyHypotheses,
 };
 
 const accusationA: DraftAccusation = {

--- a/src/logic/describeAction.ts
+++ b/src/logic/describeAction.ts
@@ -5,7 +5,7 @@ import {
     categoryOfCard,
     findCardEntry,
 } from "./GameSetup";
-import type { Card } from "./GameObjects";
+import { ownerLabel, type Card } from "./GameObjects";
 import type { GameSetup } from "./GameSetup";
 import type { ClueAction, ClueState } from "./ClueState";
 
@@ -192,6 +192,21 @@ export const describeAction = (
                 cards: joinCardNames(setup, prior.cards),
             });
         }
+        case "setHypothesis":
+            return t("actions.setHypothesis", {
+                owner: ownerLabel(action.cell.owner),
+                card:
+                    findCardEntry(setup, action.cell.card)?.name ??
+                    String(action.cell.card),
+                value: action.value,
+            });
+        case "clearHypothesis":
+            return t("actions.clearHypothesis", {
+                owner: ownerLabel(action.cell.owner),
+                card:
+                    findCardEntry(setup, action.cell.card)?.name ??
+                    String(action.cell.card),
+            });
         // Non-undoable actions — should never reach the describer
         // because the history reducer bypasses them.
         case "setSetup":

--- a/src/server/actions/shares.test.ts
+++ b/src/server/actions/shares.test.ts
@@ -21,6 +21,7 @@ import {
     accusationsCodec,
     cardPackCodec,
     handSizesCodec,
+    hypothesesCodec,
     knownCardsCodec,
     playersCodec,
     suggestionsCodec,
@@ -41,6 +42,7 @@ interface RecordedInsert {
     readonly knownCardsData: string | null;
     readonly suggestionsData: string | null;
     readonly accusationsData: string | null;
+    readonly hypothesesData: string | null;
 }
 const recordedInserts: RecordedInsert[] = [];
 
@@ -180,6 +182,14 @@ const SAMPLE_ACCUSATIONS = JSON.stringify([
     },
 ]);
 
+const SAMPLE_HYPOTHESES = JSON.stringify([
+    {
+        player: Player("Alice"),
+        card: Card("card-scarlet"),
+        value: "Y",
+    },
+]);
+
 /** Verify a JSON string round-trips through its codec — used in the
  * smoke tests below to make sure SAMPLE_* are valid before we hand
  * them to the action. If a constant ever drifts out of shape, the
@@ -202,6 +212,7 @@ assertRoundTrips("handSizes", SAMPLE_HAND_SIZES, handSizesCodec);
 assertRoundTrips("knownCards", SAMPLE_KNOWN_CARDS, knownCardsCodec);
 assertRoundTrips("suggestions", SAMPLE_SUGGESTIONS, suggestionsCodec);
 assertRoundTrips("accusations", SAMPLE_ACCUSATIONS, accusationsCodec);
+assertRoundTrips("hypotheses", SAMPLE_HYPOTHESES, hypothesesCodec);
 
 /**
  * Mirror of the action's own column projection. Used by the test
@@ -234,6 +245,10 @@ const projectInsert = (id: string, input: unknown): RecordedInsert => {
         accusationsData:
             kind === "invite" || kind === "transfer"
                 ? ((obj["accusationsData"] as string | undefined) ?? null)
+                : null,
+        hypothesesData:
+            kind === "transfer"
+                ? ((obj["hypothesesData"] as string | undefined) ?? null)
                 : null,
     };
 };
@@ -347,7 +362,7 @@ describe("createShare — kind dispatch (signed-in)", () => {
         expect(insert.knownCardsData).toBeNull();
     });
 
-    test("kind: transfer → all six columns populated", async () => {
+    test("kind: transfer → all seven columns populated, including hypotheses", async () => {
         setMockSession(SIGNED_IN);
         await callCreateShare({
             kind: "transfer",
@@ -357,6 +372,7 @@ describe("createShare — kind dispatch (signed-in)", () => {
             knownCardsData: SAMPLE_KNOWN_CARDS,
             suggestionsData: SAMPLE_SUGGESTIONS,
             accusationsData: SAMPLE_ACCUSATIONS,
+            hypothesesData: SAMPLE_HYPOTHESES,
         });
         const insert = recordedInserts[0]!;
         expect(insert.cardPackData).toBe(SAMPLE_PACK);
@@ -365,6 +381,29 @@ describe("createShare — kind dispatch (signed-in)", () => {
         expect(insert.knownCardsData).toBe(SAMPLE_KNOWN_CARDS);
         expect(insert.suggestionsData).toBe(SAMPLE_SUGGESTIONS);
         expect(insert.accusationsData).toBe(SAMPLE_ACCUSATIONS);
+        expect(insert.hypothesesData).toBe(SAMPLE_HYPOTHESES);
+    });
+
+    test("kind: pack rejects extraneous hypothesesData", async () => {
+        setMockSession(SIGNED_IN);
+        const result = await callCreateShare({
+            kind: "pack",
+            cardPackData: SAMPLE_PACK,
+            hypothesesData: SAMPLE_HYPOTHESES,
+        });
+        expect(result).toBeInstanceOf(Error);
+    });
+
+    test("kind: invite rejects extraneous hypothesesData", async () => {
+        setMockSession(SIGNED_IN);
+        const result = await callCreateShare({
+            kind: "invite",
+            cardPackData: SAMPLE_PACK,
+            playersData: SAMPLE_PLAYERS,
+            handSizesData: SAMPLE_HAND_SIZES,
+            hypothesesData: SAMPLE_HYPOTHESES,
+        });
+        expect(result).toBeInstanceOf(Error);
     });
 });
 

--- a/src/server/actions/shares.ts
+++ b/src/server/actions/shares.ts
@@ -32,6 +32,7 @@ import {
     accusationsCodec,
     cardPackCodec,
     handSizesCodec,
+    hypothesesCodec,
     knownCardsCodec,
     playersCodec,
     suggestionsCodec,
@@ -70,6 +71,13 @@ export type CreateShareInput =
           readonly knownCardsData: string;
           readonly suggestionsData: string;
           readonly accusationsData: string;
+          /**
+           * Per-cell what-if assumptions. Carried only by the
+           * `transfer` kind ("move my game to another device" —
+           * same user); `pack` and `invite` shares deliberately omit
+           * hypotheses since those flows go to other people.
+           */
+          readonly hypothesesData: string;
       };
 
 interface CreateShareResult {
@@ -84,6 +92,7 @@ interface ShareSnapshot {
     readonly knownCardsData: string | null;
     readonly suggestionsData: string | null;
     readonly accusationsData: string | null;
+    readonly hypothesesData: string | null;
     /**
      * Display name of the share's owner — populated via `LEFT JOIN
      * "user"` in `getShare`. `null` when:
@@ -112,6 +121,7 @@ const F_HAND_SIZES_DATA = "handSizesData";
 const F_KNOWN_CARDS_DATA = "knownCardsData";
 const F_SUGGESTIONS_DATA = "suggestionsData";
 const F_ACCUSATIONS_DATA = "accusationsData";
+const F_HYPOTHESES_DATA = "hypothesesData";
 
 const SUFFIX_UNEXPECTED_FIELD = "unexpected_field";
 const SUFFIX_SUGGESTIONS_PAIR = "suggestions_pair";
@@ -152,6 +162,7 @@ const ALLOWED_KEYS_FOR: Record<string, ReadonlySet<string>> = {
         F_KNOWN_CARDS_DATA,
         F_SUGGESTIONS_DATA,
         F_ACCUSATIONS_DATA,
+        F_HYPOTHESES_DATA,
     ]),
 };
 
@@ -241,12 +252,14 @@ const validateInputShape = (input: unknown): CreateShareInput => {
     const knownCardsData = requireString(F_KNOWN_CARDS_DATA);
     const suggestionsData = requireString(F_SUGGESTIONS_DATA);
     const accusationsData = requireString(F_ACCUSATIONS_DATA);
+    const hypothesesData = requireString(F_HYPOTHESES_DATA);
     validateJsonField(F_CARD_PACK_DATA, cardPackData, cardPackCodec);
     validateJsonField(F_PLAYERS_DATA, playersData, playersCodec);
     validateJsonField(F_HAND_SIZES_DATA, handSizesData, handSizesCodec);
     validateJsonField(F_KNOWN_CARDS_DATA, knownCardsData, knownCardsCodec);
     validateJsonField(F_SUGGESTIONS_DATA, suggestionsData, suggestionsCodec);
     validateJsonField(F_ACCUSATIONS_DATA, accusationsData, accusationsCodec);
+    validateJsonField(F_HYPOTHESES_DATA, hypothesesData, hypothesesCodec);
     return {
         kind,
         cardPackData,
@@ -255,6 +268,7 @@ const validateInputShape = (input: unknown): CreateShareInput => {
         knownCardsData,
         suggestionsData,
         accusationsData,
+        hypothesesData,
     };
 };
 
@@ -325,6 +339,11 @@ export async function createShare(
             : validated.kind === "invite"
                 ? (validated.accusationsData ?? null)
                 : null;
+    // Hypotheses ride along with `transfer` shares only ("move my game
+    // to another device" — same user). Pack and invite shares always
+    // store NULL since those flows go to other people.
+    const hypothesesData =
+        validated.kind === "transfer" ? validated.hypothesesData : null;
 
     return withServerAction(
         Effect.gen(function* () {
@@ -338,6 +357,7 @@ export async function createShare(
                     snapshot_known_cards_data,
                     snapshot_suggestions_data,
                     snapshot_accusations_data,
+                    snapshot_hypotheses_data,
                     expires_at
                 ) VALUES (
                     ${id}, ${ownerId},
@@ -347,6 +367,7 @@ export async function createShare(
                     ${knownCardsData},
                     ${suggestionsData},
                     ${accusationsData},
+                    ${hypothesesData},
                     NOW() + (${ttlHours} || ' hours')::INTERVAL
                 )
             `;
@@ -369,6 +390,7 @@ export async function getShare(input: {
                 snapshot_known_cards_data: string | null;
                 snapshot_suggestions_data: string | null;
                 snapshot_accusations_data: string | null;
+                snapshot_hypotheses_data: string | null;
                 owner_id: string | null;
                 owner_name: string | null;
                 owner_is_anonymous: boolean | null;
@@ -380,6 +402,7 @@ export async function getShare(input: {
                        s.snapshot_known_cards_data,
                        s.snapshot_suggestions_data,
                        s.snapshot_accusations_data,
+                       s.snapshot_hypotheses_data,
                        s.owner_id,
                        u.name AS owner_name,
                        u.is_anonymous AS owner_is_anonymous
@@ -413,6 +436,7 @@ export async function getShare(input: {
                 knownCardsData: row.snapshot_known_cards_data,
                 suggestionsData: row.snapshot_suggestions_data,
                 accusationsData: row.snapshot_accusations_data,
+                hypothesesData: row.snapshot_hypotheses_data,
                 ownerName,
                 ownerIsAnonymous,
             };

--- a/src/server/migrations/0007_shares_hypotheses.ts
+++ b/src/server/migrations/0007_shares_hypotheses.ts
@@ -1,0 +1,31 @@
+/**
+ * Add `snapshot_hypotheses_data` to the `shares` table.
+ *
+ * Hypotheses are per-cell what-if assumptions the user toggles on
+ * locally. Only the `transfer` share kind ("move my game to another
+ * device" — same user) carries them; `pack` and `invite` shares
+ * deliberately omit hypotheses since those flows go to other people
+ * and hypotheses are personal scratchwork.
+ *
+ * Forward-only additive migration (CLAUDE.md migration rules):
+ *   - Nullable, no default — old `pack` / `invite` rows naturally
+ *     have NULL here.
+ *   - The application code that READS the column is deployed in the
+ *     same release as this migration. Reading a NULL column from old
+ *     `transfer` rows is handled the same way other nullable
+ *     snapshot columns are: receiver decodes only when the value is
+ *     non-null.
+ *   - Old app instances served from cached deploys never query this
+ *     column, so the additive change is invisible to them.
+ */
+import { Effect } from "effect";
+import { SqlClient } from "effect/unstable/sql";
+
+export default Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient;
+
+    yield* sql`
+        ALTER TABLE shares
+        ADD COLUMN snapshot_hypotheses_data TEXT
+    `;
+});

--- a/src/server/migrations/index.ts
+++ b/src/server/migrations/index.ts
@@ -21,6 +21,7 @@ import migration0003 from "./0003_card_packs";
 import migration0004 from "./0004_shares";
 import migration0005 from "./0005_share_expiry_backfill";
 import migration0006 from "./0006_shares_owner_required";
+import migration0007 from "./0007_shares_hypotheses";
 
 export const migrations: Record<
     string,
@@ -32,4 +33,5 @@ export const migrations: Record<
     "0004_shares": migration0004,
     "0005_share_expiry_backfill": migration0005,
     "0006_shares_owner_required": migration0006,
+    "0007_shares_hypotheses": migration0007,
 };

--- a/src/ui/Clue.test.tsx
+++ b/src/ui/Clue.test.tsx
@@ -239,6 +239,9 @@ describe("Clue — URL-based view hydration", () => {
         // — the smart-default path in `ClueProvider` flips uiMode to
         // "checklist" when hydration finds suggestions but no explicit
         // view param.
+        const { emptyHypotheses } = await import(
+            "../logic/Hypothesis"
+        );
         const { saveToLocalStorage } = await import(
             "../logic/Persistence"
         );
@@ -267,6 +270,7 @@ describe("Clue — URL-based view hydration", () => {
                 }),
             ],
             accusations: [],
+            hypotheses: emptyHypotheses,
         });
         render(<Clue />, { wrapper: TestQueryClientProvider });
         await waitFor(() => {

--- a/src/ui/components/CellWhyPopover.tsx
+++ b/src/ui/components/CellWhyPopover.tsx
@@ -11,7 +11,7 @@ import type {
     HypothesisValue,
 } from "../../logic/Hypothesis";
 import { HashMap } from "effect";
-import { AlertIcon } from "./Icons";
+import { AlertIcon, CheckIcon } from "./Icons";
 import { HypothesisControl } from "./HypothesisControl";
 
 interface CellWhyPopoverProps {
@@ -121,6 +121,20 @@ export function CellWhyPopover({
                         return (
                             <div className="flex items-start gap-2 rounded-[var(--radius)] border border-danger-border bg-danger-bg p-2 text-[12px] text-danger">
                                 <AlertIcon
+                                    size={14}
+                                    className="mt-[1px] flex-shrink-0"
+                                />
+                                <span>{statusMessage}</span>
+                            </div>
+                        );
+                    }
+                    if (status.kind === "confirmed") {
+                        // Mirror the contradiction panel but in the
+                        // success palette so the affirmative status
+                        // reads with matching weight.
+                        return (
+                            <div className="flex items-start gap-2 rounded-[var(--radius)] border border-yes/40 bg-yes-bg p-2 text-[12px] text-yes">
+                                <CheckIcon
                                     size={14}
                                     className="mt-[1px] flex-shrink-0"
                                 />

--- a/src/ui/components/CellWhyPopover.tsx
+++ b/src/ui/components/CellWhyPopover.tsx
@@ -114,24 +114,34 @@ export function CellWhyPopover({
                     const isContradicted =
                         status.kind === "directlyContradicted" ||
                         status.kind === "jointlyConflicts";
+                    // Joint-conflict popovers render the list of
+                    // colliding hypotheses INSIDE the red box so the
+                    // bullets read as part of the warning, not as a
+                    // separate factoid below it.
+                    const listInsideBox =
+                        status.kind === "jointlyConflicts" &&
+                        activeHypothesisLabels.length > 0;
                     if (isContradicted) {
-                        // Connect the dots to the cell's alert icon: a
-                        // bordered red panel with the same warning icon
-                        // makes the cause visible at popover-open time.
                         return (
                             <div className="flex items-start gap-2 rounded-[var(--radius)] border border-danger-border bg-danger-bg p-2 text-[12px] text-danger">
                                 <AlertIcon
                                     size={14}
                                     className="mt-[1px] flex-shrink-0"
                                 />
-                                <span>{statusMessage}</span>
+                                <div className="flex flex-col gap-1">
+                                    <span>{statusMessage}</span>
+                                    {listInsideBox && (
+                                        <ul className="ml-3 list-disc">
+                                            {activeHypothesisLabels.map(lbl => (
+                                                <li key={lbl}>{lbl}</li>
+                                            ))}
+                                        </ul>
+                                    )}
+                                </div>
                             </div>
                         );
                     }
                     if (status.kind === "confirmed") {
-                        // Mirror the contradiction panel but in the
-                        // success palette so the affirmative status
-                        // reads with matching weight.
                         return (
                             <div className="flex items-start gap-2 rounded-[var(--radius)] border border-yes/40 bg-yes-bg p-2 text-[12px] text-yes">
                                 <CheckIcon
@@ -148,13 +158,15 @@ export function CellWhyPopover({
                         </div>
                     );
                 })()}
-                {renderListBelow && activeHypothesisLabels.length > 0 && (
-                    <ul className="ml-3 list-disc text-[12px] text-muted">
-                        {activeHypothesisLabels.map(label => (
-                            <li key={label}>{label}</li>
-                        ))}
-                    </ul>
-                )}
+                {renderListBelow &&
+                    activeHypothesisLabels.length > 0 &&
+                    status.kind !== "jointlyConflicts" && (
+                        <ul className="ml-3 list-disc text-[12px] text-muted">
+                            {activeHypothesisLabels.map(lbl => (
+                                <li key={lbl}>{lbl}</li>
+                            ))}
+                        </ul>
+                    )}
                 {whyText !== undefined && (
                     <div className="flex flex-col gap-2 border-t border-border/50 pt-2">
                         <div className="text-[11px] font-semibold uppercase tracking-wide text-muted">

--- a/src/ui/components/CellWhyPopover.tsx
+++ b/src/ui/components/CellWhyPopover.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { ownerLabel } from "../../logic/GameObjects";
+import type { GameSetup } from "../../logic/GameSetup";
+import type { Cell } from "../../logic/Knowledge";
+import { findCardEntry } from "../../logic/GameSetup";
+import type {
+    HypothesisMap,
+    HypothesisStatus,
+    HypothesisValue,
+} from "../../logic/Hypothesis";
+import { HashMap } from "effect";
+import { HypothesisControl } from "./HypothesisControl";
+
+interface CellWhyPopoverProps {
+    readonly cell: Cell;
+    readonly setup: GameSetup;
+    readonly status: HypothesisStatus;
+    readonly hypotheses: HypothesisMap;
+    readonly hypothesisValue: HypothesisValue | undefined;
+    readonly onHypothesisChange: (next: HypothesisValue | undefined) => void;
+    /** Multi-line "why" chain text rendered below the control, when present. */
+    readonly whyText: string | undefined;
+}
+
+/**
+ * Structured content for the why popover. The hypothesis control sits
+ * at the top so the popover always offers a useful action — even on
+ * blank cells where the deducer has nothing to say. Status microcopy
+ * surfaces below the control when the hypothesis warrants explanation
+ * (confirmed, contradicted, jointly conflicts, derived). The existing
+ * deduction "why" chain follows.
+ */
+export function CellWhyPopover({
+    cell,
+    setup,
+    status,
+    hypotheses,
+    hypothesisValue,
+    onHypothesisChange,
+    whyText,
+}: CellWhyPopoverProps) {
+    const t = useTranslations("hypothesis");
+
+    const statusMessage = (() => {
+        switch (status.kind) {
+            case "off":
+            case "active":
+                return undefined;
+            case "confirmed":
+                return t("statusConfirmed");
+            case "directlyContradicted":
+                return t("statusDirectlyContradicted");
+            case "jointlyConflicts":
+                return t("statusJointlyConflicts");
+            case "derived":
+                return t("statusDerived");
+        }
+    })();
+
+    const cardLabel =
+        findCardEntry(setup, cell.card)?.name ?? String(cell.card);
+
+    // For the joint-conflict copy, list every active hypothesis so the
+    // user can quickly see which assumptions are interacting.
+    const activeHypothesisLabels: ReadonlyArray<string> = (() => {
+        if (status.kind !== "jointlyConflicts") return [];
+        const out: Array<string> = [];
+        for (const [c, v] of hypotheses) {
+            const cardName = findCardEntry(setup, c.card)?.name ?? String(c.card);
+            out.push(`${ownerLabel(c.owner)} / ${cardName} = ${v}`);
+        }
+        return out;
+    })();
+
+    return (
+        <div className="contents">
+            <div className="flex flex-col gap-2">
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-muted">
+                    {t("sectionLabel", {
+                        owner: ownerLabel(cell.owner),
+                        card: cardLabel,
+                    })}
+                </div>
+                <HypothesisControl
+                    value={hypothesisValue}
+                    onChange={onHypothesisChange}
+                    status={status}
+                />
+                {statusMessage !== undefined && (
+                    <div
+                        className={
+                            "text-[12px] " +
+                            (status.kind === "directlyContradicted" ||
+                            status.kind === "jointlyConflicts"
+                                ? "text-danger"
+                                : "text-muted")
+                        }
+                    >
+                        {statusMessage}
+                    </div>
+                )}
+                {status.kind === "jointlyConflicts" &&
+                    activeHypothesisLabels.length > 0 && (
+                        <ul className="ml-3 list-disc text-[12px] text-muted">
+                            {activeHypothesisLabels.map(label => (
+                                <li key={label}>{label}</li>
+                            ))}
+                        </ul>
+                    )}
+                {whyText !== undefined && (
+                    <div className="border-t border-border/50 pt-2 whitespace-pre-line">
+                        {whyText}
+                    </div>
+                )}
+                {whyText === undefined && status.kind === "off" && (
+                    <div className="text-[12px] text-muted">
+                        {t("emptyHint")}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}
+
+// Re-export so Checklist consumers can import the helper from one
+// place rather than digging for the in-list direct lookup.
+export const hypothesisValueFor = (
+    hypotheses: HypothesisMap,
+    cell: Cell,
+): HypothesisValue | undefined => {
+    const opt = HashMap.get(hypotheses, cell);
+    return opt._tag === "Some" ? opt.value : undefined;
+};

--- a/src/ui/components/CellWhyPopover.tsx
+++ b/src/ui/components/CellWhyPopover.tsx
@@ -43,22 +43,6 @@ export function CellWhyPopover({
 }: CellWhyPopoverProps) {
     const t = useTranslations("hypothesis");
 
-    const statusMessage = (() => {
-        switch (status.kind) {
-            case "off":
-            case "active":
-                return undefined;
-            case "confirmed":
-                return t("statusConfirmed");
-            case "directlyContradicted":
-                return t("statusDirectlyContradicted");
-            case "jointlyConflicts":
-                return t("statusJointlyConflicts");
-            case "derived":
-                return t("statusDerived");
-        }
-    })();
-
     const cardLabel =
         findCardEntry(setup, cell.card)?.name ?? String(cell.card);
 
@@ -78,6 +62,34 @@ export function CellWhyPopover({
             out.push(`${ownerLabel(c.owner)} / ${cardName} = ${v}`);
         }
         return out;
+    })();
+
+    // For a `derived` popover with exactly one active hypothesis,
+    // collapse the heading + bulleted list into a single inline
+    // sentence ("from your active hypothesis (Player 1 / Miss Scarlet
+    // = Y)."). Reads better when there's only one source to cite.
+    const useDerivedSingular =
+        status.kind === "derived" && activeHypothesisLabels.length === 1;
+    const renderListBelow = showHypothesisList && !useDerivedSingular;
+
+    const statusMessage = (() => {
+        switch (status.kind) {
+            case "off":
+            case "active":
+                return undefined;
+            case "confirmed":
+                return t("statusConfirmed");
+            case "directlyContradicted":
+                return t("statusDirectlyContradicted");
+            case "jointlyConflicts":
+                return t("statusJointlyConflicts");
+            case "derived":
+                return useDerivedSingular
+                    ? t("statusDerivedSingular", {
+                          description: activeHypothesisLabels[0]!,
+                      })
+                    : t("statusDerived");
+        }
     })();
 
     return (
@@ -110,7 +122,7 @@ export function CellWhyPopover({
                         {statusMessage}
                     </div>
                 )}
-                {showHypothesisList && activeHypothesisLabels.length > 0 && (
+                {renderListBelow && activeHypothesisLabels.length > 0 && (
                     <ul className="ml-3 list-disc text-[12px] text-muted">
                         {activeHypothesisLabels.map(label => (
                             <li key={label}>{label}</li>

--- a/src/ui/components/CellWhyPopover.tsx
+++ b/src/ui/components/CellWhyPopover.tsx
@@ -93,93 +93,97 @@ export function CellWhyPopover({
         }
     })();
 
+    const isContradicted =
+        status.kind === "directlyContradicted" ||
+        status.kind === "jointlyConflicts";
+    const isJointConflict = status.kind === "jointlyConflicts";
+    // The conflict list lives INSIDE the danger box for joint
+    // conflicts (so the bullets read as part of the warning) and
+    // BELOW the popover body for derived cells (where they're
+    // explanatory, not part of an alert).
+    const renderListInsideDanger =
+        isJointConflict && activeHypothesisLabels.length > 0;
+    const renderListOutside =
+        renderListBelow && !renderListInsideDanger && activeHypothesisLabels.length > 0;
+
+    const statusBox = statusMessage === undefined ? null : isContradicted ? (
+        // Connect the dots to the cell's alert icon: a bordered red
+        // panel with the same warning icon makes the cause visible at
+        // popover-open time. Joint-conflict lists live inside this
+        // box so the bullets read as part of the warning.
+        <div className="flex items-start gap-2 rounded-[var(--radius)] border border-danger-border bg-danger-bg p-2 text-[12px] text-danger">
+            <AlertIcon size={14} className="mt-[1px] flex-shrink-0" />
+            <div className="flex flex-col gap-1">
+                <span>{statusMessage}</span>
+                {renderListInsideDanger && (
+                    <ul className="ml-3 list-disc">
+                        {activeHypothesisLabels.map(lbl => (
+                            <li key={lbl}>{lbl}</li>
+                        ))}
+                    </ul>
+                )}
+            </div>
+        </div>
+    ) : status.kind === "confirmed" ? (
+        // Mirror the contradiction panel but in the success palette
+        // so the affirmative status reads with matching weight.
+        <div className="flex items-start gap-2 rounded-[var(--radius)] border border-yes/40 bg-yes-bg p-2 text-[12px] text-yes">
+            <CheckIcon size={14} className="mt-[1px] flex-shrink-0" />
+            <span>{statusMessage}</span>
+        </div>
+    ) : (
+        <div className="text-[12px] text-muted">{statusMessage}</div>
+    );
+
     return (
         <div className="contents">
-            <div className="flex flex-col gap-2">
-                <div className="text-[11px] font-semibold uppercase tracking-wide text-muted">
-                    {t("sectionLabel", {
+            <div className="flex flex-col gap-3">
+                <div className="text-[14px] font-semibold uppercase tracking-wide text-fg">
+                    {t("cellHeading", {
                         owner: ownerLabel(cell.owner),
                         card: cardLabel,
                     })}
                 </div>
-                <p className="text-[12px] leading-snug text-muted">
-                    {t("helpText")}
-                </p>
-                <HypothesisControl
-                    value={hypothesisValue}
-                    onChange={onHypothesisChange}
-                    status={status}
-                />
-                {statusMessage !== undefined && (() => {
-                    const isContradicted =
-                        status.kind === "directlyContradicted" ||
-                        status.kind === "jointlyConflicts";
-                    // Joint-conflict popovers render the list of
-                    // colliding hypotheses INSIDE the red box so the
-                    // bullets read as part of the warning, not as a
-                    // separate factoid below it.
-                    const listInsideBox =
-                        status.kind === "jointlyConflicts" &&
-                        activeHypothesisLabels.length > 0;
-                    if (isContradicted) {
-                        return (
-                            <div className="flex items-start gap-2 rounded-[var(--radius)] border border-danger-border bg-danger-bg p-2 text-[12px] text-danger">
-                                <AlertIcon
-                                    size={14}
-                                    className="mt-[1px] flex-shrink-0"
-                                />
-                                <div className="flex flex-col gap-1">
-                                    <span>{statusMessage}</span>
-                                    {listInsideBox && (
-                                        <ul className="ml-3 list-disc">
-                                            {activeHypothesisLabels.map(lbl => (
-                                                <li key={lbl}>{lbl}</li>
-                                            ))}
-                                        </ul>
-                                    )}
-                                </div>
-                            </div>
-                        );
-                    }
-                    if (status.kind === "confirmed") {
-                        return (
-                            <div className="flex items-start gap-2 rounded-[var(--radius)] border border-yes/40 bg-yes-bg p-2 text-[12px] text-yes">
-                                <CheckIcon
-                                    size={14}
-                                    className="mt-[1px] flex-shrink-0"
-                                />
-                                <span>{statusMessage}</span>
-                            </div>
-                        );
-                    }
-                    return (
-                        <div className="text-[12px] text-muted">
-                            {statusMessage}
+                {whyText !== undefined && (
+                    <div className="flex flex-col gap-2">
+                        <div className="text-[11px] font-semibold uppercase tracking-wide text-fg">
+                            {t("hardFactsLabel")}
                         </div>
-                    );
-                })()}
-                {renderListBelow &&
-                    activeHypothesisLabels.length > 0 &&
-                    status.kind !== "jointlyConflicts" && (
+                        <div className="whitespace-pre-line">{whyText}</div>
+                    </div>
+                )}
+                <div
+                    className={
+                        whyText !== undefined
+                            ? "flex flex-col gap-2 border-t border-border pt-3"
+                            : "flex flex-col gap-2"
+                    }
+                >
+                    <div className="text-[11px] font-semibold uppercase tracking-wide text-fg">
+                        {t("hypothesisLabel")}
+                    </div>
+                    <p className="text-[12px] leading-snug text-muted">
+                        {t("helpText")}
+                    </p>
+                    <HypothesisControl
+                        value={hypothesisValue}
+                        onChange={onHypothesisChange}
+                        status={status}
+                    />
+                    {statusBox}
+                    {renderListOutside && (
                         <ul className="ml-3 list-disc text-[12px] text-muted">
                             {activeHypothesisLabels.map(lbl => (
                                 <li key={lbl}>{lbl}</li>
                             ))}
                         </ul>
                     )}
-                {whyText !== undefined && (
-                    <div className="flex flex-col gap-2 border-t border-border/50 pt-2">
-                        <div className="text-[11px] font-semibold uppercase tracking-wide text-muted">
-                            {t("hardFactsLabel")}
+                    {whyText === undefined && status.kind === "off" && (
+                        <div className="text-[12px] text-muted">
+                            {t("emptyHint")}
                         </div>
-                        <div className="whitespace-pre-line">{whyText}</div>
-                    </div>
-                )}
-                {whyText === undefined && status.kind === "off" && (
-                    <div className="text-[12px] text-muted">
-                        {t("emptyHint")}
-                    </div>
-                )}
+                    )}
+                </div>
             </div>
         </div>
     );

--- a/src/ui/components/CellWhyPopover.tsx
+++ b/src/ui/components/CellWhyPopover.tsx
@@ -62,10 +62,16 @@ export function CellWhyPopover({
     const cardLabel =
         findCardEntry(setup, cell.card)?.name ?? String(cell.card);
 
-    // For the joint-conflict copy, list every active hypothesis so the
-    // user can quickly see which assumptions are interacting.
+    // For derived + joint-conflict popovers, list every active
+    // hypothesis by name so the user knows which assumption(s) are
+    // shaping this cell. The deducer doesn't currently track per-cell
+    // provenance for hypotheses, so we list the full active set rather
+    // than narrowing to the specific subset that drove this value —
+    // good-enough until we wire up leave-one-out attribution.
+    const showHypothesisList =
+        status.kind === "jointlyConflicts" || status.kind === "derived";
     const activeHypothesisLabels: ReadonlyArray<string> = (() => {
-        if (status.kind !== "jointlyConflicts") return [];
+        if (!showHypothesisList) return [];
         const out: Array<string> = [];
         for (const [c, v] of hypotheses) {
             const cardName = findCardEntry(setup, c.card)?.name ?? String(c.card);
@@ -104,14 +110,13 @@ export function CellWhyPopover({
                         {statusMessage}
                     </div>
                 )}
-                {status.kind === "jointlyConflicts" &&
-                    activeHypothesisLabels.length > 0 && (
-                        <ul className="ml-3 list-disc text-[12px] text-muted">
-                            {activeHypothesisLabels.map(label => (
-                                <li key={label}>{label}</li>
-                            ))}
-                        </ul>
-                    )}
+                {showHypothesisList && activeHypothesisLabels.length > 0 && (
+                    <ul className="ml-3 list-disc text-[12px] text-muted">
+                        {activeHypothesisLabels.map(label => (
+                            <li key={label}>{label}</li>
+                        ))}
+                    </ul>
+                )}
                 {whyText !== undefined && (
                     <div className="flex flex-col gap-2 border-t border-border/50 pt-2">
                         <div className="text-[11px] font-semibold uppercase tracking-wide text-muted">

--- a/src/ui/components/CellWhyPopover.tsx
+++ b/src/ui/components/CellWhyPopover.tsx
@@ -83,6 +83,9 @@ export function CellWhyPopover({
                         card: cardLabel,
                     })}
                 </div>
+                <p className="text-[12px] leading-snug text-muted">
+                    {t("helpText")}
+                </p>
                 <HypothesisControl
                     value={hypothesisValue}
                     onChange={onHypothesisChange}
@@ -110,8 +113,11 @@ export function CellWhyPopover({
                         </ul>
                     )}
                 {whyText !== undefined && (
-                    <div className="border-t border-border/50 pt-2 whitespace-pre-line">
-                        {whyText}
+                    <div className="flex flex-col gap-2 border-t border-border/50 pt-2">
+                        <div className="text-[11px] font-semibold uppercase tracking-wide text-muted">
+                            {t("hardFactsLabel")}
+                        </div>
+                        <div className="whitespace-pre-line">{whyText}</div>
                     </div>
                 )}
                 {whyText === undefined && status.kind === "off" && (

--- a/src/ui/components/CellWhyPopover.tsx
+++ b/src/ui/components/CellWhyPopover.tsx
@@ -11,6 +11,7 @@ import type {
     HypothesisValue,
 } from "../../logic/Hypothesis";
 import { HashMap } from "effect";
+import { AlertIcon } from "./Icons";
 import { HypothesisControl } from "./HypothesisControl";
 
 interface CellWhyPopoverProps {
@@ -109,19 +110,30 @@ export function CellWhyPopover({
                     onChange={onHypothesisChange}
                     status={status}
                 />
-                {statusMessage !== undefined && (
-                    <div
-                        className={
-                            "text-[12px] " +
-                            (status.kind === "directlyContradicted" ||
-                            status.kind === "jointlyConflicts"
-                                ? "text-danger"
-                                : "text-muted")
-                        }
-                    >
-                        {statusMessage}
-                    </div>
-                )}
+                {statusMessage !== undefined && (() => {
+                    const isContradicted =
+                        status.kind === "directlyContradicted" ||
+                        status.kind === "jointlyConflicts";
+                    if (isContradicted) {
+                        // Connect the dots to the cell's alert icon: a
+                        // bordered red panel with the same warning icon
+                        // makes the cause visible at popover-open time.
+                        return (
+                            <div className="flex items-start gap-2 rounded-[var(--radius)] border border-danger-border bg-danger-bg p-2 text-[12px] text-danger">
+                                <AlertIcon
+                                    size={14}
+                                    className="mt-[1px] flex-shrink-0"
+                                />
+                                <span>{statusMessage}</span>
+                            </div>
+                        );
+                    }
+                    return (
+                        <div className="text-[12px] text-muted">
+                            {statusMessage}
+                        </div>
+                    );
+                })()}
                 {renderListBelow && activeHypothesisLabels.length > 0 && (
                     <ul className="ml-3 list-disc text-[12px] text-muted">
                         {activeHypothesisLabels.map(label => (

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -1,6 +1,14 @@
 "use client";
 
 import { Duration, Equal, Result } from "effect";
+import {
+    displayFor,
+    statusFor,
+    type CellDisplay,
+    type HypothesisStatus,
+    type HypothesisValue,
+} from "../../logic/Hypothesis";
+import { CellWhyPopover, hypothesisValueFor } from "./CellWhyPopover";
 import { useTranslations } from "next-intl";
 import { playerAdded, whyTooltipOpened } from "../../analytics/events";
 import {
@@ -240,6 +248,17 @@ export function Checklist() {
     const provenance = derived.provenance;
     const suggestions = derived.suggestionsAsData;
     const accusations = derived.accusationsAsData;
+    const hypotheses = derived.hypotheses;
+    const jointDeductionResult = derived.jointDeductionResult;
+    const realKnowledge = Result.isSuccess(result) ? result.success : undefined;
+    const jointKnowledge =
+        jointDeductionResult !== undefined &&
+        Result.isSuccess(jointDeductionResult)
+            ? jointDeductionResult.success
+            : undefined;
+    const jointFailed =
+        jointDeductionResult !== undefined &&
+        Result.isFailure(jointDeductionResult);
 
     // Fire `why_tooltip_opened` whenever the popover transitions from
     // closed (or another cell) to open on a new cell. Cells are fresh
@@ -1068,9 +1087,25 @@ export function Checklist() {
                                             owner,
                                             entry.id,
                                         );
+                                        const cellRef = Cell(owner, entry.id);
+                                        const hypothesisValue = hypothesisValueFor(
+                                            hypotheses,
+                                            cellRef,
+                                        );
+                                        const hypothesisStatus = statusFor(
+                                            cellRef,
+                                            realKnowledge,
+                                            jointKnowledge,
+                                            hypotheses,
+                                            jointFailed,
+                                        );
+                                        const display = displayFor(
+                                            value,
+                                            hypothesisStatus,
+                                        );
                                         const footnoteNumbers = footnotesForCell(
                                             footnotes,
-                                            Cell(owner, entry.id),
+                                            cellRef,
                                         );
                                         const isPlayerCell = owner._tag === "Player";
                                         const isHighlighted = cellIsHighlighted(
@@ -1119,11 +1154,6 @@ export function Checklist() {
                                             tDeduce: t,
                                             tReasons,
                                         });
-                                        const tooltipContent = tooltipText ? (
-                                            <div className="whitespace-pre-line">
-                                                {tooltipText}
-                                            </div>
-                                        ) : undefined;
                                         const cellContent = setupCheckbox ? (
                                             <input
                                                 type="checkbox"
@@ -1135,7 +1165,7 @@ export function Checklist() {
                                             />
                                         ) : (
                                             <>
-                                                <AnimatedCellGlyph value={value} />
+                                                <AnimatedCellGlyph display={display} />
                                                 {footnoteNumbers.length > 0 &&
                                                     value === undefined && (
                                                         <sup className="ml-0.5 text-[9px] font-normal text-accent">
@@ -1158,16 +1188,22 @@ export function Checklist() {
                                         // setup is for entering inputs,
                                         // not exploring the deduction
                                         // chain.
+                                        // Drop the deduction-content gate so the
+                                        // popover opens on every play-mode player
+                                        // cell (and play-mode case-file cell). Even
+                                        // a blank cell now hosts the hypothesis
+                                        // control via `<CellWhyPopover>`, so the
+                                        // popover always has something to show.
                                         const popoverInteractive =
-                                            tooltipContent !== undefined
-                                            && !inSetup
+                                            !inSetup
                                             && (playInteractive || !isPlayerCell);
                                         const tdClassName = cellClass(
-                                            value,
+                                            display,
                                             setupInteractive
                                                 || playInteractive
                                                 || popoverInteractive,
                                             isHighlighted,
+                                            hypothesisStatus,
                                         );
                                         const thisCellForHover = Cell(
                                             owner,
@@ -1342,11 +1378,37 @@ export function Checklist() {
                                                 popoverCell,
                                                 thisCell,
                                             );
+                                            const popoverBody = (
+                                                <CellWhyPopover
+                                                    cell={thisCell}
+                                                    setup={setup}
+                                                    status={hypothesisStatus}
+                                                    hypotheses={hypotheses}
+                                                    hypothesisValue={hypothesisValue}
+                                                    onHypothesisChange={(
+                                                        next: HypothesisValue | undefined,
+                                                    ) => {
+                                                        if (next === undefined) {
+                                                            dispatch({
+                                                                type: "clearHypothesis",
+                                                                cell: thisCell,
+                                                            });
+                                                        } else {
+                                                            dispatch({
+                                                                type: "setHypothesis",
+                                                                cell: thisCell,
+                                                                value: next,
+                                                            });
+                                                        }
+                                                    }}
+                                                    whyText={tooltipText}
+                                                />
+                                            );
                                             cell = (
                                                 <InfoPopover
                                                     key={ownerCellKey}
-                                                    content={tooltipContent}
-                                                    variant="accent"
+                                                    content={popoverBody}
+                                                    variant="default"
                                                     open={isOpen}
                                                     onOpenChange={open => {
                                                         if (open) {
@@ -2272,17 +2334,33 @@ const cellLabel = (value: CellValue | undefined): string => {
     return "";
 };
 
+const displayGlyph = (display: CellDisplay): string => {
+    switch (display.tag) {
+        case "real":
+            return cellLabel(display.value);
+        case "hypothesis":
+        case "derived":
+            return "?";
+        case "blank":
+            return "";
+    }
+};
+
 /**
- * Cell Y/N/blank glyph with a short pop-in/out as the value changes.
+ * Cell Y/N/?/blank glyph with a short pop-in/out as the value changes.
  * Using `AnimatePresence` keyed on the glyph means each state swap
  * renders a fresh `<motion.span>` that scales in while the outgoing
  * one scales out — the tween is fast (120ms) so the cell still feels
  * snappy, not animated-heavy. The cell background transition stays
  * in CSS (`transition-colors`) so motion only owns the glyph.
  */
-function AnimatedCellGlyph({ value }: { readonly value: CellValue | undefined }) {
+function AnimatedCellGlyph({
+    display,
+}: {
+    readonly display: CellDisplay;
+}) {
     const transition = useReducedTransition(T_FAST);
-    const glyph = cellLabel(value);
+    const glyph = displayGlyph(display);
     return (
         <AnimatePresence mode={MOTION_POP_LAYOUT} initial={false}>
             {glyph !== "" && (
@@ -2350,16 +2428,37 @@ const CELL_HIGHLIGHTED =
     " z-[var(--z-checklist-cell-hover)] ring-2 ring-accent ring-offset-1 ring-offset-panel";
 
 const cellClass = (
-    value: CellValue | undefined,
+    display: CellDisplay,
     interactive: boolean,
     highlighted: boolean,
+    status: HypothesisStatus,
 ): string => {
     let base = interactive ? `${CELL_BASE}${CELL_INTERACTIVE}` : CELL_BASE;
     if (highlighted) base += CELL_HIGHLIGHTED;
-    // Bg + matching ring-offset color so the focus ring's offset
-    // blends into the cell's own background (mimics the transparent
-    // gap of the outline-based indicator we replaced).
-    if (value === Y) return `${base} bg-yes-bg text-yes focus-visible:ring-offset-yes-bg`;
-    if (value === N) return `${base} bg-no-bg text-no focus-visible:ring-offset-no-bg`;
+    // Direct contradiction (real proves the hypothesis wrong) and
+    // joint conflict get a danger / warning halo so the user can spot
+    // them at a glance even when the cell value matches the real
+    // deduction. The popover surfaces the explanatory copy.
+    if (status.kind === "directlyContradicted") {
+        base += " ring-2 ring-danger ring-inset";
+    } else if (status.kind === "jointlyConflicts") {
+        base += " ring-2 ring-danger/60 ring-inset";
+    }
+    // Pick the color tone from the displayed value (real wins; otherwise
+    // the hypothesis or derived-from-hypothesis value).
+    const tone: CellValue | undefined =
+        display.tag === "real"
+            ? display.value
+            : display.tag === "hypothesis"
+              ? display.value
+              : display.tag === "derived"
+                ? display.value
+                : undefined;
+    if (tone === Y) {
+        return `${base} bg-yes-bg text-yes focus-visible:ring-offset-yes-bg`;
+    }
+    if (tone === N) {
+        return `${base} bg-no-bg text-no focus-visible:ring-offset-no-bg`;
+    }
     return `${base} bg-white focus-visible:ring-offset-white`;
 };

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -2564,15 +2564,12 @@ const cellClass = (
 ): string => {
     let base = interactive ? `${CELL_BASE}${CELL_INTERACTIVE}` : CELL_BASE;
     if (highlighted) base += CELL_HIGHLIGHTED;
-    // Direct contradiction (real proves the hypothesis wrong) and
-    // joint conflict get a danger / warning halo so the user can spot
-    // them at a glance even when the cell value matches the real
-    // deduction. The popover surfaces the explanatory copy.
-    if (status.kind === "directlyContradicted") {
-        base += " ring-2 ring-danger ring-inset";
-    } else if (status.kind === "jointlyConflicts") {
-        base += " ring-2 ring-danger/60 ring-inset";
-    }
+    // Contradiction states are conveyed by the AlertIcon that
+    // replaces the central glyph (`directlyContradicted` and
+    // `jointlyConflicts` both render `<AlertIcon>`) and by the
+    // boxed status panel inside the popover, so no extra cell ring
+    // is needed here.
+    void status;
     // Pick the color tone from the displayed value (real wins; otherwise
     // the hypothesis or derived-from-hypothesis value).
     const tone: CellValue | undefined =

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Duration, Equal, Result } from "effect";
+import { Duration, Equal, HashMap, Result } from "effect";
 import {
     displayFor,
     statusFor,
@@ -259,6 +259,18 @@ export function Checklist() {
     const jointFailed =
         jointDeductionResult !== undefined &&
         Result.isFailure(jointDeductionResult);
+    // When the popover is open on a derived-from-hypothesis cell, we
+    // light up every direct-hypothesis cell so the user can see the
+    // assumption(s) that produced the value they're inspecting.
+    const popoverIsOnDerivedCell =
+        popoverCell !== null &&
+        statusFor(
+            popoverCell,
+            realKnowledge,
+            jointKnowledge,
+            hypotheses,
+            jointFailed,
+        ).kind === "derived";
 
     // Fire `why_tooltip_opened` whenever the popover transitions from
     // closed (or another cell) to open on a new cell. Cells are fresh
@@ -576,6 +588,15 @@ export function Checklist() {
      * hover-only today.
      */
     const cellIsHighlighted = (owner: Owner, card: Card): boolean => {
+        // Hypothesis cross-highlight: when the popover is open on a
+        // cell whose value follows from an active hypothesis, light up
+        // every cell the user has pinned a hypothesis on.
+        if (
+            popoverIsOnDerivedCell &&
+            HashMap.has(hypotheses, Cell(owner, card))
+        ) {
+            return true;
+        }
         if (activeSuggestionIndex === null && activeAccusationIndex === null) {
             return false;
         }
@@ -2335,15 +2356,21 @@ function useStablePlayerColumnKeys(
 // Discriminator constants for the cell's primary glyph slot. Module-
 // scope so the `no-literal-string` lint rule reads them as code, not
 // UI text. The matching presentation lives in `renderGlyphNode`.
+//
+// `questionDirect` vs `questionDerived` distinguishes a cell the user
+// pinned a hypothesis on (rendered bolder so it reads as the source)
+// from a cell whose `?` follows from one of those hypotheses.
 const GLYPH_YES = "yes" as const;
 const GLYPH_NO = "no" as const;
-const GLYPH_QUESTION = "question" as const;
+const GLYPH_QUESTION_DIRECT = "questionDirect" as const;
+const GLYPH_QUESTION_DERIVED = "questionDerived" as const;
 const GLYPH_ALERT = "alert" as const;
 const GLYPH_BLANK = "blank" as const;
 type GlyphKind =
     | typeof GLYPH_YES
     | typeof GLYPH_NO
-    | typeof GLYPH_QUESTION
+    | typeof GLYPH_QUESTION_DIRECT
+    | typeof GLYPH_QUESTION_DERIVED
     | typeof GLYPH_ALERT
     | typeof GLYPH_BLANK;
 
@@ -2366,8 +2393,9 @@ const glyphKindFor = (
             if (display.value === N) return GLYPH_NO;
             return GLYPH_BLANK;
         case "hypothesis":
+            return GLYPH_QUESTION_DIRECT;
         case "derived":
-            return GLYPH_QUESTION;
+            return GLYPH_QUESTION_DERIVED;
         case "blank":
             return GLYPH_BLANK;
     }
@@ -2379,7 +2407,13 @@ const renderGlyphNode = (kind: GlyphKind): ReactNode => {
             return "✓";
         case GLYPH_NO:
             return "·";
-        case GLYPH_QUESTION:
+        case GLYPH_QUESTION_DIRECT:
+            // Direct hypothesis cells render the "?" heavier than the
+            // surrounding cell weight (`font-semibold` on the <td>) so
+            // they read as the source the derived `?` cells follow
+            // from.
+            return <span className="font-extrabold">?</span>;
+        case GLYPH_QUESTION_DERIVED:
             return "?";
         case GLYPH_ALERT:
             return <AlertIcon size={14} className="text-danger" />;

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -75,7 +75,7 @@ import { useConfetti } from "../hooks/useConfetti";
 import { useShareContext } from "../share/ShareProvider";
 import { CardPackRow } from "./CardPackRow";
 import { ShareIcon } from "./ShareIcon";
-import { AlertIcon, Envelope } from "./Icons";
+import { AlertIcon, BoxedQuestionMarkIcon, Envelope } from "./Icons";
 import { InfoPopover } from "./InfoPopover";
 
 /**
@@ -1198,6 +1198,22 @@ export function Checklist() {
                                                             )}
                                                         </sup>
                                                     )}
+                                                {hypothesisValue !== undefined && (
+                                                    // Corner badge marking the
+                                                    // cell as the source of a
+                                                    // hypothesis (vs. a cell
+                                                    // whose value follows from
+                                                    // one). Renders alongside
+                                                    // the central glyph in
+                                                    // every direct-hypothesis
+                                                    // status (active,
+                                                    // confirmed, contradicted,
+                                                    // conflicting).
+                                                    <BoxedQuestionMarkIcon
+                                                        size={10}
+                                                        className="absolute right-0.5 top-0.5 opacity-70"
+                                                    />
+                                                )}
                                             </>
                                         );
                                         // A cell needs the interactive
@@ -2357,20 +2373,18 @@ function useStablePlayerColumnKeys(
 // scope so the `no-literal-string` lint rule reads them as code, not
 // UI text. The matching presentation lives in `renderGlyphNode`.
 //
-// `questionDirect` vs `questionDerived` distinguishes a cell the user
-// pinned a hypothesis on (rendered bolder so it reads as the source)
-// from a cell whose `?` follows from one of those hypotheses.
+// Direct-hypothesis cells use the same "?" glyph as derived cells —
+// the visual distinction lives in a separate corner badge rendered
+// alongside the glyph (see `cellContent` below).
 const GLYPH_YES = "yes" as const;
 const GLYPH_NO = "no" as const;
-const GLYPH_QUESTION_DIRECT = "questionDirect" as const;
-const GLYPH_QUESTION_DERIVED = "questionDerived" as const;
+const GLYPH_QUESTION = "question" as const;
 const GLYPH_ALERT = "alert" as const;
 const GLYPH_BLANK = "blank" as const;
 type GlyphKind =
     | typeof GLYPH_YES
     | typeof GLYPH_NO
-    | typeof GLYPH_QUESTION_DIRECT
-    | typeof GLYPH_QUESTION_DERIVED
+    | typeof GLYPH_QUESTION
     | typeof GLYPH_ALERT
     | typeof GLYPH_BLANK;
 
@@ -2393,9 +2407,8 @@ const glyphKindFor = (
             if (display.value === N) return GLYPH_NO;
             return GLYPH_BLANK;
         case "hypothesis":
-            return GLYPH_QUESTION_DIRECT;
         case "derived":
-            return GLYPH_QUESTION_DERIVED;
+            return GLYPH_QUESTION;
         case "blank":
             return GLYPH_BLANK;
     }
@@ -2407,13 +2420,7 @@ const renderGlyphNode = (kind: GlyphKind): ReactNode => {
             return "✓";
         case GLYPH_NO:
             return "·";
-        case GLYPH_QUESTION_DIRECT:
-            // Direct hypothesis cells render the "?" heavier than the
-            // surrounding cell weight (`font-semibold` on the <td>) so
-            // they read as the source the derived `?` cells follow
-            // from.
-            return <span className="font-extrabold">?</span>;
-        case GLYPH_QUESTION_DERIVED:
+        case GLYPH_QUESTION:
             return "?";
         case GLYPH_ALERT:
             return <AlertIcon size={14} className="text-danger" />;

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -1246,15 +1246,24 @@ export function Checklist() {
                                                     // cell as the source of a
                                                     // hypothesis (vs. a cell
                                                     // whose value follows from
-                                                    // one). Renders alongside
-                                                    // the central glyph in
-                                                    // every direct-hypothesis
-                                                    // status (active,
-                                                    // confirmed, contradicted,
-                                                    // conflicting).
+                                                    // one). Tone reflects the
+                                                    // HYPOTHESIS value, not the
+                                                    // cell's displayed value:
+                                                    // a cell that's been
+                                                    // deduced Y but
+                                                    // hypothesised N shows a
+                                                    // red badge against a
+                                                    // green cell, making the
+                                                    // disagreement visible at
+                                                    // a glance.
                                                     <BoxedQuestionMarkIcon
-                                                        size={10}
-                                                        className="absolute right-0.5 top-0.5 opacity-70"
+                                                        size={14}
+                                                        className={
+                                                            "absolute right-0.5 top-0.5 " +
+                                                            (hypothesisValue === Y
+                                                                ? "text-yes"
+                                                                : "text-no")
+                                                        }
                                                     />
                                                 )}
                                             </>

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -75,7 +75,7 @@ import { useConfetti } from "../hooks/useConfetti";
 import { useShareContext } from "../share/ShareProvider";
 import { CardPackRow } from "./CardPackRow";
 import { ShareIcon } from "./ShareIcon";
-import { Envelope } from "./Icons";
+import { AlertIcon, Envelope } from "./Icons";
 import { InfoPopover } from "./InfoPopover";
 
 /**
@@ -1165,7 +1165,10 @@ export function Checklist() {
                                             />
                                         ) : (
                                             <>
-                                                <AnimatedCellGlyph display={display} />
+                                                <AnimatedCellGlyph
+                                                    display={display}
+                                                    status={hypothesisStatus}
+                                                />
                                                 {footnoteNumbers.length > 0 &&
                                                     value === undefined && (
                                                         <sup className="ml-0.5 text-[9px] font-normal text-accent">
@@ -2014,11 +2017,12 @@ const buildCellTitle = (args: {
         });
     });
 
+    // The "Why this value:" prefix used to lead the chain text, but the
+    // popover now renders a "Hard facts" section heading above it
+    // (parallel to the "Hypothesis" heading), so the prefix is
+    // redundant here.
     const parts: string[] = [];
-    if (chainLines.length > 0) {
-        parts.push(tDeduce("whyHeader"));
-        parts.push(...chainLines);
-    }
+    if (chainLines.length > 0) parts.push(...chainLines);
     if (footnoteLine) parts.push(footnoteLine);
 
     return parts.length > 0 ? parts.join("\n") : undefined;
@@ -2328,51 +2332,92 @@ function useStablePlayerColumnKeys(
     }, [players]);
 }
 
-const cellLabel = (value: CellValue | undefined): string => {
-    if (value === Y) return "✓";
-    if (value === N) return "·";
-    return "";
-};
+// Discriminator constants for the cell's primary glyph slot. Module-
+// scope so the `no-literal-string` lint rule reads them as code, not
+// UI text. The matching presentation lives in `renderGlyphNode`.
+const GLYPH_YES = "yes" as const;
+const GLYPH_NO = "no" as const;
+const GLYPH_QUESTION = "question" as const;
+const GLYPH_ALERT = "alert" as const;
+const GLYPH_BLANK = "blank" as const;
+type GlyphKind =
+    | typeof GLYPH_YES
+    | typeof GLYPH_NO
+    | typeof GLYPH_QUESTION
+    | typeof GLYPH_ALERT
+    | typeof GLYPH_BLANK;
 
-const displayGlyph = (display: CellDisplay): string => {
+const glyphKindFor = (
+    display: CellDisplay,
+    status: HypothesisStatus,
+): GlyphKind => {
+    // Contradicted hypotheses (directly or jointly) replace whatever
+    // glyph would have rendered with the alert icon, so the conflict
+    // reads at a glance.
+    if (
+        status.kind === "directlyContradicted" ||
+        status.kind === "jointlyConflicts"
+    ) {
+        return GLYPH_ALERT;
+    }
     switch (display.tag) {
         case "real":
-            return cellLabel(display.value);
+            if (display.value === Y) return GLYPH_YES;
+            if (display.value === N) return GLYPH_NO;
+            return GLYPH_BLANK;
         case "hypothesis":
         case "derived":
-            return "?";
+            return GLYPH_QUESTION;
         case "blank":
-            return "";
+            return GLYPH_BLANK;
+    }
+};
+
+const renderGlyphNode = (kind: GlyphKind): ReactNode => {
+    switch (kind) {
+        case GLYPH_YES:
+            return "✓";
+        case GLYPH_NO:
+            return "·";
+        case GLYPH_QUESTION:
+            return "?";
+        case GLYPH_ALERT:
+            return <AlertIcon size={14} className="text-danger" />;
+        case GLYPH_BLANK:
+            return null;
     }
 };
 
 /**
- * Cell Y/N/?/blank glyph with a short pop-in/out as the value changes.
- * Using `AnimatePresence` keyed on the glyph means each state swap
- * renders a fresh `<motion.span>` that scales in while the outgoing
- * one scales out — the tween is fast (120ms) so the cell still feels
- * snappy, not animated-heavy. The cell background transition stays
- * in CSS (`transition-colors`) so motion only owns the glyph.
+ * Cell glyph with a short pop-in/out as the value changes.
+ * Using `AnimatePresence` keyed on the glyph kind means each state
+ * swap renders a fresh `<motion.span>` that scales in while the
+ * outgoing one scales out — the tween is fast (120ms) so the cell
+ * still feels snappy, not animated-heavy. The cell background
+ * transition stays in CSS (`transition-colors`) so motion only owns
+ * the glyph.
  */
 function AnimatedCellGlyph({
     display,
+    status,
 }: {
     readonly display: CellDisplay;
+    readonly status: HypothesisStatus;
 }) {
     const transition = useReducedTransition(T_FAST);
-    const glyph = displayGlyph(display);
+    const kind = glyphKindFor(display, status);
     return (
         <AnimatePresence mode={MOTION_POP_LAYOUT} initial={false}>
-            {glyph !== "" && (
+            {kind !== GLYPH_BLANK && (
                 <motion.span
-                    key={glyph}
+                    key={kind}
                     initial={{ scale: 0.5, opacity: 0 }}
                     animate={{ scale: 1, opacity: 1 }}
                     exit={{ scale: 0.5, opacity: 0 }}
                     transition={transition}
-                    className="inline-block"
+                    className="inline-flex items-center justify-center"
                 >
-                    {glyph}
+                    {renderGlyphNode(kind)}
                 </motion.span>
             )}
         </AnimatePresence>

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -272,6 +272,49 @@ export function Checklist() {
             jointFailed,
         ).kind === "derived";
 
+    // Hypothesis keyboard shortcuts (bare letter keys: O / Y / N).
+    // Implemented as a single window-level listener instead of three
+    // `useGlobalShortcut` calls so the gates run BEFORE
+    // `e.preventDefault()`. The shared helper unconditionally
+    // preventDefault's any matching event, which would swallow plain
+    // typing in setup-mode inputs (e.g. renaming "Miss Scarlet" to
+    // "Ms. Scarlet" — the "n" / "o" / "y" characters never reach the
+    // input).
+    //
+    // The handler bails early — without preventDefault — when:
+    //   - the keystroke target is a text input / textarea / content-
+    //     editable element (defensive: a focused suggestion-form input
+    //     could share the page with an open popover);
+    //   - no why popover is open (`popoverCell === null`).
+    const popoverCellRef = useRef<Cell | null>(popoverCell);
+    popoverCellRef.current = popoverCell;
+    useEffect(() => {
+        const onKeyDown = (e: KeyboardEvent) => {
+            const target = e.target as Element | null;
+            if (
+                target instanceof HTMLInputElement
+                || target instanceof HTMLTextAreaElement
+                || (target instanceof HTMLElement && target.isContentEditable)
+            ) {
+                return;
+            }
+            const cell = popoverCellRef.current;
+            if (cell === null) return;
+            if (matches("hypothesis.setOff", e)) {
+                e.preventDefault();
+                dispatch({ type: "clearHypothesis", cell });
+            } else if (matches("hypothesis.setY", e)) {
+                e.preventDefault();
+                dispatch({ type: "setHypothesis", cell, value: Y });
+            } else if (matches("hypothesis.setN", e)) {
+                e.preventDefault();
+                dispatch({ type: "setHypothesis", cell, value: N });
+            }
+        };
+        window.addEventListener("keydown", onKeyDown);
+        return () => window.removeEventListener("keydown", onKeyDown);
+    }, [dispatch]);
+
     // Fire `why_tooltip_opened` whenever the popover transitions from
     // closed (or another cell) to open on a new cell. Cells are fresh
     // `Cell(owner, card)` instances on each open, so reference equality

--- a/src/ui/components/HypothesisControl.test.tsx
+++ b/src/ui/components/HypothesisControl.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, test, vi } from "vitest";
+import { HypothesisControl } from "./HypothesisControl";
+
+vi.mock("next-intl", () => ({
+    useTranslations: () => (key: string): string => key,
+}));
+
+const renderControl = (
+    value: "Y" | "N" | undefined,
+    onChange = vi.fn(),
+) => {
+    render(
+        <HypothesisControl
+            value={value}
+            onChange={onChange}
+            status={{ kind: "off" }}
+        />,
+    );
+    return { onChange };
+};
+
+describe("HypothesisControl", () => {
+    test("renders three radio buttons in a radiogroup", () => {
+        renderControl(undefined);
+        expect(screen.getByRole("radiogroup")).toBeInTheDocument();
+        expect(screen.getAllByRole("radio")).toHaveLength(3);
+    });
+
+    test("the off button is checked when value is undefined", () => {
+        renderControl(undefined);
+        const radios = screen.getAllByRole("radio");
+        expect(radios[0]).toHaveAttribute("aria-checked", "true");
+        expect(radios[1]).toHaveAttribute("aria-checked", "false");
+        expect(radios[2]).toHaveAttribute("aria-checked", "false");
+    });
+
+    test("clicking Y fires onChange('Y')", () => {
+        const { onChange } = renderControl(undefined);
+        const radios = screen.getAllByRole("radio");
+        fireEvent.click(radios[1]!);
+        expect(onChange).toHaveBeenCalledWith("Y");
+    });
+
+    test("clicking N fires onChange('N')", () => {
+        const { onChange } = renderControl(undefined);
+        const radios = screen.getAllByRole("radio");
+        fireEvent.click(radios[2]!);
+        expect(onChange).toHaveBeenCalledWith("N");
+    });
+
+    test("clicking off when Y is selected fires onChange(undefined)", () => {
+        const { onChange } = renderControl("Y");
+        const radios = screen.getAllByRole("radio");
+        fireEvent.click(radios[0]!);
+        expect(onChange).toHaveBeenCalledWith(undefined);
+    });
+
+    test("ArrowRight from off lands on Y and fires onChange('Y')", () => {
+        const { onChange } = renderControl(undefined);
+        const radios = screen.getAllByRole("radio");
+        fireEvent.keyDown(radios[0]!, { key: "ArrowRight" });
+        expect(onChange).toHaveBeenCalledWith("Y");
+    });
+
+    test("ArrowLeft from off wraps to N", () => {
+        const { onChange } = renderControl(undefined);
+        const radios = screen.getAllByRole("radio");
+        fireEvent.keyDown(radios[0]!, { key: "ArrowLeft" });
+        expect(onChange).toHaveBeenCalledWith("N");
+    });
+
+    test("Home jumps to off, End jumps to N", () => {
+        const onChange = vi.fn();
+        render(
+            <HypothesisControl
+                value="Y"
+                onChange={onChange}
+                status={{ kind: "off" }}
+            />,
+        );
+        const radios = screen.getAllByRole("radio");
+        fireEvent.keyDown(radios[1]!, { key: "Home" });
+        expect(onChange).toHaveBeenLastCalledWith(undefined);
+        fireEvent.keyDown(radios[1]!, { key: "End" });
+        expect(onChange).toHaveBeenLastCalledWith("N");
+    });
+});

--- a/src/ui/components/HypothesisControl.tsx
+++ b/src/ui/components/HypothesisControl.tsx
@@ -3,6 +3,8 @@
 import { useTranslations } from "next-intl";
 import { useCallback, useId, useRef } from "react";
 import type { HypothesisStatus, HypothesisValue } from "../../logic/Hypothesis";
+import { useHasKeyboard } from "../hooks/useHasKeyboard";
+import { label } from "../keyMap";
 
 interface HypothesisControlProps {
     readonly value: HypothesisValue | undefined;
@@ -18,6 +20,12 @@ const OPT_OFF = "off" as const;
 const OPT_Y = "Y" as const;
 const OPT_N = "N" as const;
 type Option = typeof OPT_OFF | typeof OPT_Y | typeof OPT_N;
+
+// Keymap binding IDs. Hoisted so the `no-literal-string` lint rule
+// reads them as code, not UI text.
+const SHORTCUT_OFF = "hypothesis.setOff" as const;
+const SHORTCUT_Y = "hypothesis.setY" as const;
+const SHORTCUT_N = "hypothesis.setN" as const;
 
 const OPTIONS: ReadonlyArray<Option> = [OPT_OFF, OPT_Y, OPT_N];
 
@@ -65,6 +73,7 @@ export function HypothesisControl({
     const groupId = useId();
     const buttonRefs = useRef<Array<HTMLButtonElement | null>>([]);
     const current = optionFromValue(value);
+    const hasKeyboard = useHasKeyboard();
 
     const focusOption = useCallback((option: Option) => {
         const idx = OPTIONS.indexOf(option);
@@ -100,51 +109,61 @@ export function HypothesisControl({
         [onChange, focusOption],
     );
 
-    const labelFor = (option: Option): string =>
-        option === OPT_OFF
-            ? t("optionOff")
-            : option === OPT_Y
-              ? t("optionY")
-              : t("optionN");
+    const labelFor = (option: Option): string => {
+        if (option === OPT_OFF) return t("optionOff");
+        if (option === OPT_Y) return t("optionY");
+        return t("optionN");
+    };
 
     const isContradicted =
         status.kind === "directlyContradicted" ||
         status.kind === "jointlyConflicts";
 
     return (
-        <div
-            role="radiogroup"
-            aria-label={t("groupLabel")}
-            aria-describedby={`${groupId}-status`}
-            className="inline-flex w-full overflow-hidden rounded-[var(--radius)]"
-        >
-            {OPTIONS.map((option, idx) => {
-                const isSelected = current === option;
-                const className =
-                    baseButtonClass +
-                    (isSelected ? selectedClassFor(option) : "") +
-                    (isSelected && isContradicted
-                        ? " ring-2 ring-danger ring-inset"
-                        : "");
-                return (
-                    <button
-                        key={option}
-                        ref={el => {
-                            buttonRefs.current[idx] = el;
-                        }}
-                        type="button"
-                        role="radio"
-                        aria-checked={isSelected}
-                        tabIndex={isSelected ? 0 : -1}
-                        disabled={disabled}
-                        className={className}
-                        onClick={() => onChange(valueFromOption(option))}
-                        onKeyDown={e => onKeyDown(e, option)}
-                    >
-                        {labelFor(option)}
-                    </button>
-                );
-            })}
+        <div className="flex flex-col gap-1">
+            <div
+                role="radiogroup"
+                aria-label={t("groupLabel")}
+                aria-describedby={`${groupId}-status`}
+                className="inline-flex w-full overflow-hidden rounded-[var(--radius)]"
+            >
+                {OPTIONS.map((option, idx) => {
+                    const isSelected = current === option;
+                    const className =
+                        baseButtonClass +
+                        (isSelected ? selectedClassFor(option) : "") +
+                        (isSelected && isContradicted
+                            ? " ring-2 ring-danger ring-inset"
+                            : "");
+                    return (
+                        <button
+                            key={option}
+                            ref={el => {
+                                buttonRefs.current[idx] = el;
+                            }}
+                            type="button"
+                            role="radio"
+                            aria-checked={isSelected}
+                            tabIndex={isSelected ? 0 : -1}
+                            disabled={disabled}
+                            className={className}
+                            onClick={() => onChange(valueFromOption(option))}
+                            onKeyDown={e => onKeyDown(e, option)}
+                        >
+                            {labelFor(option)}
+                        </button>
+                    );
+                })}
+            </div>
+            {hasKeyboard && (
+                <p className="text-[11px] text-muted">
+                    {t("shortcutHint", {
+                        off: label(SHORTCUT_OFF),
+                        y: label(SHORTCUT_Y),
+                        n: label(SHORTCUT_N),
+                    })}
+                </p>
+            )}
         </div>
     );
 }

--- a/src/ui/components/HypothesisControl.tsx
+++ b/src/ui/components/HypothesisControl.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useCallback, useId, useRef } from "react";
+import type { HypothesisStatus, HypothesisValue } from "../../logic/Hypothesis";
+
+interface HypothesisControlProps {
+    readonly value: HypothesisValue | undefined;
+    readonly onChange: (next: HypothesisValue | undefined) => void;
+    readonly status: HypothesisStatus;
+    readonly disabled?: boolean;
+}
+
+// Internal tags for the three option positions. Module-scope so the
+// `no-literal-string` lint rule sees them as code identifiers, not UI
+// text — the user-visible labels come from the i18n namespace below.
+const OPT_OFF = "off" as const;
+const OPT_Y = "Y" as const;
+const OPT_N = "N" as const;
+type Option = typeof OPT_OFF | typeof OPT_Y | typeof OPT_N;
+
+const OPTIONS: ReadonlyArray<Option> = [OPT_OFF, OPT_Y, OPT_N];
+
+const optionFromValue = (value: HypothesisValue | undefined): Option =>
+    value === undefined ? OPT_OFF : value;
+
+const valueFromOption = (option: Option): HypothesisValue | undefined =>
+    option === OPT_OFF ? undefined : option;
+
+const baseButtonClass =
+    "flex-1 px-3 py-1 text-[12px] font-semibold cursor-pointer " +
+    "border border-border bg-panel text-muted " +
+    "transition-colors " +
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:z-10 " +
+    "disabled:cursor-default disabled:opacity-50";
+
+const selectedClassFor = (option: Option): string => {
+    switch (option) {
+        case OPT_Y:
+            return " bg-yes-bg text-yes border-yes/40";
+        case OPT_N:
+            return " bg-no-bg text-no border-no/40";
+        case OPT_OFF:
+            return " bg-bg text-fg border-fg/40";
+    }
+};
+
+/**
+ * Three-button segmented control for the per-cell hypothesis value:
+ * `—` (off — no hypothesis), `Y` (assume the cell is Y), `N` (assume
+ * the cell is N).
+ *
+ * Implements the WAI-ARIA radiogroup pattern: tab into the group lands
+ * on the currently-selected option, ArrowLeft/Right cycle through
+ * options, Home/End jump to the ends, Space/Enter commit the focused
+ * option (and a click acts the same).
+ */
+export function HypothesisControl({
+    value,
+    onChange,
+    status,
+    disabled = false,
+}: HypothesisControlProps) {
+    const t = useTranslations("hypothesis");
+    const groupId = useId();
+    const buttonRefs = useRef<Array<HTMLButtonElement | null>>([]);
+    const current = optionFromValue(value);
+
+    const focusOption = useCallback((option: Option) => {
+        const idx = OPTIONS.indexOf(option);
+        const el = buttonRefs.current[idx];
+        if (el) el.focus();
+    }, []);
+
+    const onKeyDown = useCallback(
+        (e: React.KeyboardEvent<HTMLButtonElement>, option: Option) => {
+            const idx = OPTIONS.indexOf(option);
+            if (e.key === "ArrowLeft" || e.key === "ArrowUp") {
+                e.preventDefault();
+                const next = OPTIONS[(idx - 1 + OPTIONS.length) % OPTIONS.length]!;
+                onChange(valueFromOption(next));
+                focusOption(next);
+            } else if (e.key === "ArrowRight" || e.key === "ArrowDown") {
+                e.preventDefault();
+                const next = OPTIONS[(idx + 1) % OPTIONS.length]!;
+                onChange(valueFromOption(next));
+                focusOption(next);
+            } else if (e.key === "Home") {
+                e.preventDefault();
+                const next = OPTIONS[0]!;
+                onChange(valueFromOption(next));
+                focusOption(next);
+            } else if (e.key === "End") {
+                e.preventDefault();
+                const next = OPTIONS[OPTIONS.length - 1]!;
+                onChange(valueFromOption(next));
+                focusOption(next);
+            }
+        },
+        [onChange, focusOption],
+    );
+
+    const labelFor = (option: Option): string =>
+        option === OPT_OFF
+            ? t("optionOff")
+            : option === OPT_Y
+              ? t("optionY")
+              : t("optionN");
+
+    const isContradicted =
+        status.kind === "directlyContradicted" ||
+        status.kind === "jointlyConflicts";
+
+    return (
+        <div
+            role="radiogroup"
+            aria-label={t("groupLabel")}
+            aria-describedby={`${groupId}-status`}
+            className="inline-flex w-full overflow-hidden rounded-[var(--radius)]"
+        >
+            {OPTIONS.map((option, idx) => {
+                const isSelected = current === option;
+                const className =
+                    baseButtonClass +
+                    (isSelected ? selectedClassFor(option) : "") +
+                    (isSelected && isContradicted
+                        ? " ring-2 ring-danger ring-inset"
+                        : "");
+                return (
+                    <button
+                        key={option}
+                        ref={el => {
+                            buttonRefs.current[idx] = el;
+                        }}
+                        type="button"
+                        role="radio"
+                        aria-checked={isSelected}
+                        tabIndex={isSelected ? 0 : -1}
+                        disabled={disabled}
+                        className={className}
+                        onClick={() => onChange(valueFromOption(option))}
+                        onKeyDown={e => onKeyDown(e, option)}
+                    >
+                        {labelFor(option)}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/src/ui/components/HypothesisControl.tsx
+++ b/src/ui/components/HypothesisControl.tsx
@@ -37,19 +37,37 @@ const valueFromOption = (option: Option): HypothesisValue | undefined =>
 
 const baseButtonClass =
     "flex-1 px-3 py-1 text-[12px] font-semibold cursor-pointer " +
-    "border border-border bg-panel text-muted " +
+    "border-2 border-border bg-panel text-muted " +
     "transition-colors " +
     "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:z-10 " +
     "disabled:cursor-default disabled:opacity-50";
 
+// The `!` prefix forces these utilities to !important. Without it,
+// Tailwind's CSS source order has `.bg-panel` (from the base class)
+// win against `.bg-no-bg` and `.bg-row-header`, since `--color-panel`
+// is declared earlier in the @theme block than those tokens —
+// same-specificity ties go to the later rule, but here our overrides
+// come earlier. `bg-yes-bg` happens to be declared after `bg-panel`
+// so it wins naturally; the `!` on the other two just makes them
+// consistent.
+const SELECTED_Y_CLASSES = " bg-yes-bg text-yes !border-yes";
+const SELECTED_N_CLASSES = " !bg-no-bg text-no !border-no";
+const SELECTED_OFF_CLASSES = " !bg-row-header text-fg !border-muted";
+
+// Border-collapse helpers (extracted so the no-literal-string lint
+// rule reads them as code rather than UI text).
+const COLLAPSE_CLASS_FIRST = " relative";
+const COLLAPSE_CLASS_INNER = " -ml-[2px] relative";
+const STACK_CLASS_SELECTED = " z-[1]";
+
 const selectedClassFor = (option: Option): string => {
     switch (option) {
         case OPT_Y:
-            return " bg-yes-bg text-yes border-yes/40";
+            return SELECTED_Y_CLASSES;
         case OPT_N:
-            return " bg-no-bg text-no border-no/40";
+            return SELECTED_N_CLASSES;
         case OPT_OFF:
-            return " bg-bg text-fg border-fg/40";
+            return SELECTED_OFF_CLASSES;
     }
 };
 
@@ -129,12 +147,23 @@ export function HypothesisControl({
             >
                 {OPTIONS.map((option, idx) => {
                     const isSelected = current === option;
+                    // Border-collapse: pull each button after the
+                    // first 2px to the left so adjacent borders
+                    // overlap (no double-thick seam between buttons).
+                    // The selected button needs `z-10` so its
+                    // coloured border paints on top of its neighbours'
+                    // grey borders.
+                    const collapseClass =
+                        idx > 0 ? COLLAPSE_CLASS_INNER : COLLAPSE_CLASS_FIRST;
+                    const stackClass = isSelected ? STACK_CLASS_SELECTED : "";
                     const className =
                         baseButtonClass +
                         (isSelected ? selectedClassFor(option) : "") +
                         (isSelected && isContradicted
                             ? " ring-2 ring-danger ring-inset"
-                            : "");
+                            : "") +
+                        collapseClass +
+                        stackClass;
                     return (
                         <button
                             key={option}

--- a/src/ui/components/Icons.tsx
+++ b/src/ui/components/Icons.tsx
@@ -260,10 +260,12 @@ export function AlertIcon({ className, size = 14 }: IconProps) {
 }
 
 /**
- * Rounded square framing a question mark — used as a small corner
- * badge on checklist cells the user has pinned a hypothesis on, to
- * distinguish them from the cells whose value follows from those
- * hypotheses. Renders in `currentColor` so the parent picks the tone.
+ * Solid rounded square with a "?" cut into it — used as a small
+ * corner badge on checklist cells the user has pinned a hypothesis
+ * on. The fill is `currentColor` so the parent's `text-*` class
+ * picks the tone (typically `text-yes` or `text-no` matching the
+ * hypothesis value). The inner "?" strokes in white so it stays
+ * legible regardless of fill colour.
  */
 export function BoxedQuestionMarkIcon({ className, size = 12 }: IconProps) {
     return (
@@ -272,18 +274,36 @@ export function BoxedQuestionMarkIcon({ className, size = 12 }: IconProps) {
             width={size}
             height={size}
             viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
             aria-hidden="true"
             focusable="false"
             className={className}
         >
-            <rect x="3" y="3" width="18" height="18" rx="3" />
-            <path d="M9.5 9a2.5 2.5 0 1 1 3.5 2.3c-.6.3-1 .9-1 1.7" />
-            <line x1="12" y1="17" x2="12.01" y2="17" />
+            <rect
+                x="3"
+                y="3"
+                width="18"
+                height="18"
+                rx="3"
+                fill="currentColor"
+            />
+            <path
+                d="M9.5 9a2.5 2.5 0 1 1 3.5 2.3c-.6.3-1 .9-1 1.7"
+                fill="none"
+                stroke="white"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+            <line
+                x1="12"
+                y1="17"
+                x2="12.01"
+                y2="17"
+                stroke="white"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
         </svg>
     );
 }

--- a/src/ui/components/Icons.tsx
+++ b/src/ui/components/Icons.tsx
@@ -259,6 +259,35 @@ export function AlertIcon({ className, size = 14 }: IconProps) {
     );
 }
 
+/**
+ * Rounded square framing a question mark — used as a small corner
+ * badge on checklist cells the user has pinned a hypothesis on, to
+ * distinguish them from the cells whose value follows from those
+ * hypotheses. Renders in `currentColor` so the parent picks the tone.
+ */
+export function BoxedQuestionMarkIcon({ className, size = 12 }: IconProps) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+            focusable="false"
+            className={className}
+        >
+            <rect x="3" y="3" width="18" height="18" rx="3" />
+            <path d="M9.5 9a2.5 2.5 0 1 1 3.5 2.3c-.6.3-1 .9-1 1.7" />
+            <line x1="12" y1="17" x2="12.01" y2="17" />
+        </svg>
+    );
+}
+
 /** Arrow leaving a frame — paired with links that open in a new tab. */
 export function ExternalLinkIcon({ className, size = 14 }: IconProps) {
     return (

--- a/src/ui/components/Icons.tsx
+++ b/src/ui/components/Icons.tsx
@@ -230,6 +230,35 @@ export function UserIcon({ className, size = 18 }: IconProps) {
 }
 
 
+/**
+ * Filled triangle with an exclamation mark — used to flag a hypothesis
+ * cell whose state is contradicted (either directly by a real fact, or
+ * jointly by another hypothesis). `currentColor` lets the parent style
+ * the tone (typically `text-danger`).
+ */
+export function AlertIcon({ className, size = 14 }: IconProps) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+            focusable="false"
+            className={className}
+        >
+            <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+            <line x1="12" y1="9" x2="12" y2="13" />
+            <line x1="12" y1="17" x2="12.01" y2="17" />
+        </svg>
+    );
+}
+
 /** Arrow leaving a frame — paired with links that open in a new tab. */
 export function ExternalLinkIcon({ className, size = 14 }: IconProps) {
     return (

--- a/src/ui/components/SuggestionLogPanel.editMode.test.tsx
+++ b/src/ui/components/SuggestionLogPanel.editMode.test.tsx
@@ -75,6 +75,7 @@ vi.mock("../hooks/useHasKeyboard", () => ({
 
 import { fireEvent, render, waitFor, within } from "@testing-library/react";
 import { saveToLocalStorage } from "../../logic/Persistence";
+import { emptyHypotheses } from "../../logic/Hypothesis";
 import { Player } from "../../logic/GameObjects";
 import { CLASSIC_SETUP_3P } from "../../logic/GameSetup";
 import {
@@ -114,6 +115,7 @@ const seedOneSuggestionAndMount = async (
             }),
         ],
         accusations: [],
+        hypotheses: emptyHypotheses,
     });
     if (view === "suggest") {
         // The mobile play layout only mounts the active pane, so

--- a/src/ui/keyMap.ts
+++ b/src/ui/keyMap.ts
@@ -109,6 +109,12 @@ type BindingId =
     | "global.gotoAccusation"
     | "global.gotoChecklist"
     | "global.gotoPriorLog"
+    // Hypothesis controls — only active when a checklist "why"
+    // popover is open. Modeled as global bindings (window-level
+    // keydown) but their handler gates on `popoverCell !== null`.
+    | "hypothesis.setOff"
+    | "hypothesis.setY"
+    | "hypothesis.setN"
     // Navigation primitives (scoped)
     | "nav.up"
     | "nav.down"
@@ -165,6 +171,28 @@ const DEFAULT_KEY_MAP: Record<BindingId, KeyBinding> = {
         id: "global.gotoPriorLog",
         description: "Jump to the prior suggestions log",
         combos: [combo.mod("l", "⌘L")],
+    },
+    // Hypothesis shortcuts are bare letter keys that intentionally
+    // shadow regular typing — the call site gates them on
+    // `popoverCell !== null` and on the event target not being a text
+    // input, so they only fire when the user has the why popover open
+    // on a cell. Modifier-based equivalents (Cmd+Shift+N etc.) all
+    // collide with browser shortcuts (incognito, reopen-tab, …); bare
+    // keys also keep the button labels self-documenting (Y/N/0).
+    "hypothesis.setOff": {
+        id: "hypothesis.setOff",
+        description: "Clear the hypothesis on the open cell",
+        combos: [combo.bareCI("o", "O")],
+    },
+    "hypothesis.setY": {
+        id: "hypothesis.setY",
+        description: "Set the hypothesis on the open cell to Y",
+        combos: [combo.bareCI("y", "Y")],
+    },
+    "hypothesis.setN": {
+        id: "hypothesis.setN",
+        description: "Set the hypothesis on the open cell to N",
+        combos: [combo.bareCI("n", "N")],
     },
     "nav.up": {
         id: "nav.up",

--- a/src/ui/share/ShareCreateModal.tsx
+++ b/src/ui/share/ShareCreateModal.tsx
@@ -55,10 +55,12 @@ import {
     suggestionCards,
     suggestionNonRefuters,
 } from "../../logic/Suggestion";
+import type { Card, Player } from "../../logic/GameObjects";
 import {
     accusationsCodec,
     cardPackCodec,
     handSizesCodec,
+    hypothesesCodec,
     knownCardsCodec,
     playersCodec,
     suggestionsCodec,
@@ -280,8 +282,33 @@ const buildInviteInput = (
 };
 
 /**
+ * Project the in-memory hypothesis HashMap into the wire shape for
+ * sharing. The wire codec re-applies branded types on decode, so the
+ * sender doesn't have to brand on the way out — encodeSync accepts
+ * plain strings and the receiver gets back proper Player/Card brands.
+ */
+type ProjectedHypothesis = {
+    readonly player: Player | null;
+    readonly card: Card;
+    readonly value: "Y" | "N";
+};
+
+const projectHypotheses = (
+    hypotheses: GameSession["hypotheses"],
+): ReadonlyArray<ProjectedHypothesis> => {
+    const out: Array<ProjectedHypothesis> = [];
+    for (const [cell, value] of hypotheses) {
+        const player =
+            cell.owner._tag === "Player" ? cell.owner.player : null;
+        out.push({ player, card: cell.card, value });
+    }
+    return out;
+};
+
+/**
  * Build the wire payload for a `transfer` share — everything,
- * including known cards. Same projection as invite plus knownCards.
+ * including known cards and the user's active hypotheses (transfer is
+ * the "move my game to another device" flow, same user).
  */
 const buildTransferInput = (
     session: GameSession,
@@ -299,6 +326,9 @@ const buildTransferInput = (
     ),
     accusationsData: Schema.encodeSync(accusationsCodec)(
         session.accusations.map(projectAccusation),
+    ),
+    hypothesesData: Schema.encodeSync(hypothesesCodec)(
+        projectHypotheses(session.hypotheses),
     ),
 });
 
@@ -423,6 +453,7 @@ export function ShareCreateModal({
             })),
             suggestions: derived.suggestionsAsData,
             accusations: derived.accusationsAsData,
+            hypotheses: state.hypotheses,
         };
         if (variant === VARIANT_INVITE) {
             return buildInviteInput(

--- a/src/ui/share/ShareImportPage.test.tsx
+++ b/src/ui/share/ShareImportPage.test.tsx
@@ -196,6 +196,7 @@ const buildSnapshot = (overrides: SnapshotOverrides) => ({
     knownCardsData: null,
     suggestionsData: null,
     accusationsData: null,
+    hypothesesData: null,
     ownerName: null,
     ownerIsAnonymous: null,
     ...overrides,

--- a/src/ui/share/ShareImportPage.tsx
+++ b/src/ui/share/ShareImportPage.tsx
@@ -60,6 +60,7 @@ interface ShareSnapshot {
     readonly knownCardsData: string | null;
     readonly suggestionsData: string | null;
     readonly accusationsData: string | null;
+    readonly hypothesesData: string | null;
     readonly ownerName: string | null;
     readonly ownerIsAnonymous: boolean | null;
 }

--- a/src/ui/share/useApplyShareSnapshot.test.ts
+++ b/src/ui/share/useApplyShareSnapshot.test.ts
@@ -16,6 +16,7 @@
 import { Schema } from "effect";
 import { beforeEach, describe, expect, test } from "vitest";
 import { Card, CardCategory, Player } from "../../logic/GameObjects";
+import { emptyHypotheses } from "../../logic/Hypothesis";
 import { newAccusationId } from "../../logic/Accusation";
 import { newSuggestionId } from "../../logic/Suggestion";
 import { GameSetup } from "../../logic/GameSetup";
@@ -137,6 +138,7 @@ const sampleSnapshot = (overrides: {
                   },
               ])
             : null,
+    hypothesesData: null,
 });
 
 const apply = (
@@ -227,6 +229,7 @@ describe("buildSessionFromSnapshot — variant shapes", () => {
             knownCardsData: null,
             suggestionsData: null,
             accusationsData: null,
+            hypothesesData: null,
         });
         expect(session.setup.cardSet).toBe(RECEIVER_FALLBACK_PACK);
         expect(session.setup.players).toEqual(
@@ -247,6 +250,7 @@ describe("buildSessionFromSnapshot — decode failures", () => {
                 knownCardsData: null,
                 suggestionsData: null,
                 accusationsData: null,
+                hypothesesData: null,
             }),
         ).toThrow(ShareSnapshotDecodeError);
         try {
@@ -257,6 +261,7 @@ describe("buildSessionFromSnapshot — decode failures", () => {
                 knownCardsData: null,
                 suggestionsData: null,
                 accusationsData: null,
+                hypothesesData: null,
             });
         } catch (e) {
             expect((e as ShareSnapshotDecodeError).field).toBe("cardPackData");
@@ -281,6 +286,7 @@ describe("buildSessionFromSnapshot — decode failures", () => {
                 },
             ]),
             accusationsData: null,
+            hypothesesData: null,
         });
         expect(session.suggestions[0]!.id).toBeTruthy();
         expect(String(session.suggestions[0]!.id).length).toBeGreaterThan(0);
@@ -317,6 +323,7 @@ describe("applyShareSnapshotToLocalStorage — receive page handoff", () => {
             handSizes: [],
             suggestions: [],
             accusations: [],
+            hypotheses: emptyHypotheses,
         });
 
         const session = applyShareSnapshotToLocalStorage(
@@ -343,6 +350,7 @@ describe("saveCardPackFromSnapshot — pack-only receive", () => {
             handSizes: [{ player: Player("Original-Receiver-1"), size: 1 }],
             suggestions: [],
             accusations: [],
+            hypotheses: emptyHypotheses,
         };
         saveToLocalStorage(currentSession);
 
@@ -366,6 +374,7 @@ describe("saveCardPackFromSnapshot — pack-only receive", () => {
                 knownCardsData: null,
                 suggestionsData: null,
                 accusationsData: null,
+                hypothesesData: null,
             }),
         ).toThrow(ShareSnapshotDecodeError);
         expect(loadCustomCardSets()).toEqual([]);
@@ -383,6 +392,7 @@ describe("share receive dirty-state detection", () => {
             handSizes: [],
             suggestions: [],
             accusations: [],
+            hypotheses: emptyHypotheses,
         };
 
         expect(sessionHasGameData(clean)).toBe(false);
@@ -401,6 +411,7 @@ describe("share receive dirty-state detection", () => {
                 handSizes: [{ player: Player("Player 1"), size: 4 }],
                 suggestions: [],
                 accusations: [],
+                hypotheses: emptyHypotheses,
             }),
         ).toBe(true);
         expect(
@@ -415,6 +426,7 @@ describe("share receive dirty-state detection", () => {
                 handSizes: [],
                 suggestions: [],
                 accusations: [],
+                hypotheses: emptyHypotheses,
             }),
         ).toBe(true);
     });
@@ -430,6 +442,7 @@ describe("share receive dirty-state detection", () => {
             handSizes: [],
             suggestions: [],
             accusations: [],
+            hypotheses: emptyHypotheses,
         });
         expect(hasPersistedGameData()).toBe(true);
     });

--- a/src/ui/share/useApplyShareSnapshot.ts
+++ b/src/ui/share/useApplyShareSnapshot.ts
@@ -38,6 +38,17 @@ import {
     Category,
 } from "../../logic/CardSet";
 import { DEFAULT_SETUP, GameSetup } from "../../logic/GameSetup";
+import { HashMap } from "effect";
+import {
+    CaseFileOwner,
+    PlayerOwner,
+} from "../../logic/GameObjects";
+import {
+    emptyHypotheses,
+    type HypothesisMap,
+    type HypothesisValue,
+} from "../../logic/Hypothesis";
+import { Cell } from "../../logic/Knowledge";
 import {
     loadFromLocalStorage,
     saveToLocalStorage,
@@ -53,6 +64,7 @@ import {
     accusationsCodec,
     cardPackCodec,
     handSizesCodec,
+    hypothesesCodec,
     knownCardsCodec,
     playersCodec,
     suggestionsCodec,
@@ -66,6 +78,7 @@ export interface ShareSnapshotForHydration {
     readonly knownCardsData: string | null;
     readonly suggestionsData: string | null;
     readonly accusationsData: string | null;
+    readonly hypothesesData: string | null;
 }
 
 // Wire-format field names. Module-scope so they don't trip the
@@ -77,6 +90,7 @@ const F_HAND_SIZES_DATA = "handSizesData";
 const F_KNOWN_CARDS_DATA = "knownCardsData";
 const F_SUGGESTIONS_DATA = "suggestionsData";
 const F_ACCUSATIONS_DATA = "accusationsData";
+const F_HYPOTHESES_DATA = "hypothesesData";
 
 const DECODE_ERROR_PREFIX = "share snapshot decode failed: ";
 
@@ -235,12 +249,37 @@ export const buildSessionFromSnapshot = (
               )
             : [];
 
+    const hypotheses: HypothesisMap =
+        snapshot.hypothesesData !== null
+            ? (() => {
+                  const decoded = decodeField(
+                      F_HYPOTHESES_DATA,
+                      snapshot.hypothesesData,
+                      hypothesesCodec,
+                  );
+                  let m: HypothesisMap = emptyHypotheses;
+                  for (const h of decoded) {
+                      const owner =
+                          h.player !== null
+                              ? PlayerOwner(h.player)
+                              : CaseFileOwner();
+                      m = HashMap.set(
+                          m,
+                          Cell(owner, h.card),
+                          h.value as HypothesisValue,
+                      );
+                  }
+                  return m;
+              })()
+            : emptyHypotheses;
+
     return {
         setup,
         hands,
         handSizes,
         suggestions,
         accusations,
+        hypotheses,
     };
 };
 

--- a/src/ui/state.test.tsx
+++ b/src/ui/state.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import { Player } from "../logic/GameObjects";
 import { CLASSIC_SETUP_3P, DEFAULT_SETUP } from "../logic/GameSetup";
+import { emptyHypotheses } from "../logic/Hypothesis";
 import { KnownCard } from "../logic/InitialKnowledge";
 import type { GameSession } from "../logic/Persistence";
 import { CaseFileOwner } from "../logic/GameObjects";
@@ -543,6 +544,7 @@ describe("replaceSession", () => {
                 }),
             ],
             accusations: [],
+            hypotheses: emptyHypotheses,
         };
         act(() => result.current.dispatch({ type: "replaceSession", session }));
         expect(result.current.state.setup).toBe(CLASSIC_SETUP_3P);
@@ -564,6 +566,7 @@ describe("replaceSession", () => {
                 handSizes: [],
                 suggestions: [],
                 accusations: [],
+                hypotheses: emptyHypotheses,
             },
         }));
         // Even though state changed, canUndo remains false for the
@@ -759,6 +762,7 @@ describe("accusations end-to-end", () => {
                     ],
                     suggestions: [],
                     accusations: [],
+                    hypotheses: emptyHypotheses,
                 },
             }),
         );
@@ -856,6 +860,7 @@ describe("accusations end-to-end", () => {
                     ],
                     suggestions: [],
                     accusations: [],
+                    hypotheses: emptyHypotheses,
                 },
             }),
         );

--- a/src/ui/state.tsx
+++ b/src/ui/state.tsx
@@ -31,6 +31,11 @@ import {
     newGameSetup,
 } from "../logic/GameSetup";
 import { HashMap } from "effect";
+import {
+    emptyHypotheses,
+    foldHypothesesInto,
+    type HypothesisMap,
+} from "../logic/Hypothesis";
 import { caseFileProgress } from "../logic/Recommender";
 import {
     caseFileSolved,
@@ -142,6 +147,7 @@ const initialState: ClueState = {
     suggestions: [],
     accusations: [],
     uiMode: "setup",
+    hypotheses: emptyHypotheses,
 };
 
 const reducer = (state: ClueState, action: ClueAction): ClueState => {
@@ -157,8 +163,9 @@ const reducer = (state: ClueState, action: ClueAction): ClueState => {
 
         case "loadCardSet":
             // Swap the deck; keep the current player roster. Hand
-            // sizes, known cards, suggestions, and accusations
-            // reference card ids from the old deck and are discarded.
+            // sizes, known cards, suggestions, accusations, and
+            // hypotheses reference card ids from the old deck and are
+            // discarded.
             return {
                 ...state,
                 setup: GameSetup({
@@ -169,6 +176,7 @@ const reducer = (state: ClueState, action: ClueAction): ClueState => {
                 handSizes: [],
                 suggestions: [],
                 accusations: [],
+                hypotheses: emptyHypotheses,
             };
 
         case "setSetup":
@@ -464,6 +472,22 @@ const reducer = (state: ClueState, action: ClueAction): ClueState => {
             };
         }
 
+        case "setHypothesis":
+            return {
+                ...state,
+                hypotheses: HashMap.set(
+                    state.hypotheses,
+                    action.cell,
+                    action.value,
+                ),
+            };
+
+        case "clearHypothesis":
+            return {
+                ...state,
+                hypotheses: HashMap.remove(state.hypotheses, action.cell),
+            };
+
         case "replaceSession": {
             const { session } = action;
             return {
@@ -492,6 +516,7 @@ const reducer = (state: ClueState, action: ClueAction): ClueState => {
                     accuser: a.accuser,
                     cards: Array.from(a.cards),
                 })),
+                hypotheses: session.hypotheses,
             };
         }
     }
@@ -512,6 +537,21 @@ interface ClueDerived {
     readonly deductionResult: DeductionResult;
     readonly provenance: Provenance | undefined;
     readonly footnotes: FootnoteMap;
+    /**
+     * Active hypothesis map (mirrored from `state.hypotheses` so
+     * components can read the canonical input alongside the
+     * `jointDeductionResult` it produced).
+     */
+    readonly hypotheses: HypothesisMap;
+    /**
+     * The joint deduction over `realFacts ∪ hypotheses`, when at least
+     * one hypothesis is active. `undefined` when no hypotheses are
+     * active (consumers can fall back to `deductionResult`). Failure
+     * branch represents either a fold-time direct conflict (a
+     * hypothesis disagreed with a known cell of `initialKnowledge`) or
+     * a runtime contradiction inside the deducer's fixed-point loop.
+     */
+    readonly jointDeductionResult: DeductionResult | undefined;
 }
 
 const deriveState = (
@@ -953,6 +993,24 @@ export function ClueProvider({ children }: { children: ReactNode }) {
         [deduceLayer, initialKnowledge],
     );
 
+    // Joint deduction: real facts ∪ hypotheses. Sentinel-undefined when
+    // no hypotheses are active, so the common path skips the extra
+    // deduce call entirely. When hypotheses ARE active, this is a
+    // second `deduce` against an augmented initial knowledge — its
+    // failure does NOT feed the global contradiction banner (which
+    // reads `deductionResult` only); the cell renderer surfaces
+    // contradictions inline via the per-cell hypothesis status.
+    const jointDeductionResult = useMemo<DeductionResult | undefined>(() => {
+        if (HashMap.size(state.hypotheses) === 0) return undefined;
+        const folded = foldHypothesesInto(initialKnowledge, state.hypotheses);
+        if (Result.isFailure(folded)) return folded;
+        return TelemetryRuntime.runSync(
+            Effect.result(deduce(folded.success)).pipe(
+                Effect.provide(deduceLayer),
+            ),
+        );
+    }, [deduceLayer, initialKnowledge, state.hypotheses]);
+
     const { provenance, footnotes } = useMemo(
         () =>
             deriveState(
@@ -972,6 +1030,8 @@ export function ClueProvider({ children }: { children: ReactNode }) {
             deductionResult,
             provenance,
             footnotes,
+            hypotheses: state.hypotheses,
+            jointDeductionResult,
         }),
         [
             suggestionsAsData,
@@ -980,6 +1040,8 @@ export function ClueProvider({ children }: { children: ReactNode }) {
             deductionResult,
             provenance,
             footnotes,
+            state.hypotheses,
+            jointDeductionResult,
         ],
     );
 
@@ -1088,6 +1150,7 @@ export function ClueProvider({ children }: { children: ReactNode }) {
             })),
             suggestions: suggestionsAsData,
             accusations: accusationsAsData,
+            hypotheses: state.hypotheses,
         };
         saveToLocalStorage(session);
         queryClient.setQueryData(gameSessionQueryKey, session);
@@ -1282,6 +1345,16 @@ const pruneSessionToSetup = (
     const cardIdSet = new Set(
         allCardEntries(setup).map(e => String(e.id)),
     );
+    let prunedHypotheses = state.hypotheses;
+    for (const [cell] of state.hypotheses) {
+        const cardOk = cardIdSet.has(String(cell.card));
+        const ownerOk =
+            cell.owner._tag === "CaseFile" ||
+            playerSet.has(String(cell.owner.player));
+        if (!cardOk || !ownerOk) {
+            prunedHypotheses = HashMap.remove(prunedHypotheses, cell);
+        }
+    }
     return {
         ...state,
         setup,
@@ -1315,5 +1388,6 @@ const pruneSessionToSetup = (
         accusations: state.accusations
             .filter(a => playerSet.has(String(a.accuser)))
             .filter(a => a.cards.every(c => cardIdSet.has(String(c)))),
+        hypotheses: prunedHypotheses,
     };
 };


### PR DESCRIPTION
## Summary

Adds **hypotheses** to the checklist — per-cell "what-if" assumptions the user can toggle on to see what the deducer would derive if the assumption were true. Hypotheses are *soft*: contradictions don't disrupt the user's real-fact state and don't raise the global contradiction banner. Multiple hypotheses can be active at once, and the popover surfaces which ones are in play.

The feature is intentionally tucked into the existing **why** popover. Today that popover only opens on cells with a deduction; we extend it to open on any play-mode cell so hypotheses can be entered on blanks too. The popover gets a structured layout with a top-level cell label, then a **Hard facts** section (real-fact deduction chain), then a **Hypothesis** section (segmented `Off / Y / N` control + status panel + active-hypothesis list).

## How it reads

- **Direct hypothesis cells** show a `?` glyph on the Y/N color, plus a **solid corner `[?]` badge tinted by the hypothesis value** (green for Y, red for N) — so a hypothesis that disagrees with the deduced cell value reads as red-on-green at a glance.
- **Derived cells** (whose value follows from a hypothesis) also show `?`, but with no corner badge — so direct sources are visually distinct from their consequences.
- **Confirmed** (real proves the hypothesis right): cell shows the real ✓/·, popover surfaces a green-bordered "Confirmed by real facts — you can turn this hypothesis off." panel.
- **Directly contradicted** (real proves the hypothesis wrong) and **jointly conflicts** (multiple hypotheses can't all be true): cell shows the alert icon, popover surfaces a red-bordered danger panel; for joint conflicts the colliding hypotheses list inside the same panel.
- **Highlighting**: opening the popover on a derived cell lights up the source hypothesis cells with the existing accent ring.

## Keyboard

When a why popover is open, bare `Y` / `N` / `O` keys set / clear the hypothesis. Helper text under the segmented control reads *"Type (Y, N, or O) to toggle."* — only on devices with keyboard input.

## Persistence + Sharing

- Hypotheses ride along in the v7 localStorage session (v6 reads still work, auto-lifted with empty hypotheses).
- "Move to another device" `transfer` shares carry hypotheses. `pack` / `invite` shares deliberately omit them — hypotheses are personal scratchwork, not for sending to someone else.
- New migration `0007_shares_hypotheses.ts` adds a nullable `snapshot_hypotheses_data TEXT` column.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm knip && pnpm i18n:check` all green (1082 tests pass).
- [x] Manual `next-dev` walk at desktop (1280×800):
  - Click a blank play-mode cell → popover opens with the new structure (top-level cell label / Hard Facts / Hypothesis).
  - Tap `Y` / press `Y` → cell shows `?` on green with a green corner badge; same-row cells across other players also pick up `?` (deducer fires); their cells stay green/tan but get no corner badge.
  - Switch to `N` → cell shows `?` on tan with a red corner badge; derived cells flip too.
  - Press `O` (or click `Off`) → hypothesis clears; cells revert.
  - Cmd+Z / Cmd+Shift+Z reverse + replay each toggle.
  - Set Player 1 = real Y AND hypothesis N on the same cell → cell shows the alert icon (green bg from real Y) with a red corner badge; popover renders the contradiction in the red panel with the same alert icon.
  - Set two hypotheses that jointly impossible → both cells show alert icon + red badge; popover lists the colliding hypotheses inside the red panel.
  - Reload page → all hypotheses persist (saved as v7).
  - Seed a v6 blob in localStorage → auto-lifts to v7 with empty hypotheses on next read.
  - `GlobalContradictionBanner` does NOT mount during any hypothesis use.
  - No console errors.
- [ ] Manual walk at mobile (375×812) — for popover positioning across the four tour scripts. *(Recommend before promoting to production.)*

## Commits

- **Add per-cell "what-if" hypotheses to the checklist.** Foundation: new `Hypothesis.ts` with `HypothesisMap` + `foldHypothesesInto` + `statusFor` + `displayFor`. `ClueState` gains `hypotheses` field and `setHypothesis` / `clearHypothesis` actions. `state.tsx` adds a `jointDeductionResult` `useMemo` that re-runs `deduce` over `initial ∪ hypotheses` only when at least one hypothesis is active; the real-only `deductionResult` is unchanged and continues to feed `GlobalContradictionBanner`. Persistence bumps to v7 with read-side v6 fallback. Sharing extends `transfer`-kind only, with new `hypothesesCodec` and migration `0007_shares_hypotheses.ts`.
- **Polish hypothesis popover and contradicted-cell glyph.** Help text above the toggle, "Off" label (was `—`), `<AlertIcon>` from the icon pack replaces a Unicode `⚠` for cell + popover warnings, "Hard facts" section heading.
- **Surface hypothesis sources on derived cells.** Popover lists hypothesis cells by name, hypothesis cells light up via the accent ring when the popover is open on a derived cell.
- **Inline single-hypothesis message on derived popovers.** Collapse heading + bullet to one inline sentence when there's only one source.
- **Tighten hypothesis cell + popover visual cues.** Replace bold treatment with the boxed `[?]` corner badge; wrap contradiction status in a red-bordered panel that mirrors the cell's alert icon.
- **Add keyboard shortcuts for hypothesis controls.** Bare `Y` / `N` / `O` when a popover is open. Custom listener gates on `popoverCell !== null` and on the event target not being a text input *before* `preventDefault` (so plain typing in setup-mode inputs isn't swallowed).
- **Boxed green confirmed status with check icon.** Match the danger-panel treatment for the affirmative side.
- **Distinct selected styling for each hypothesis toggle.** Off (tan + muted border), Y (saturated green), N (deep red border). Border-collapse via `-ml-[2px]` so adjacent borders don't double.
- **Drop the danger ring on contradicted cells.** Alert icon + popover panel already convey the state; the ring was redundant.
- **Move joint-conflict hypothesis list inside the danger panel.** Bullets read as part of the warning, not as a stand-alone factoid below it.
- **Restructure why popover.** Top-level `Player / Card` header, Hard Facts above Hypothesis with a horizontal separator between them, both subheaders in `text-fg` for legible contrast.
- **Tone the hypothesis corner badge by the hypothesis value.** Green for Y, red for N, regardless of the cell's deduced tone — so a contradicting hypothesis reads as red-on-green at a glance. Badge fills with `currentColor` and a white `?` cuts into it; size bumped from 10 to 14 px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)