### PR TITLE
Claude: Track hypothesis usage + popover engagement in PostHog

### DIFF
--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -217,10 +217,81 @@ export const gameAbandoned = (props: {
 
 // ── Feature usage ─────────────────────────────────────────────────────────
 
+/**
+ * Status of the cell at popover-open time. Mirrors `HypothesisStatus`
+ * in `src/logic/Hypothesis.ts` but flattened to a string so the
+ * PostHog funnel can group by it without joining anything else.
+ *
+ *   - `off`           : no hypothesis on this cell, no derivation.
+ *   - `active`        : direct hypothesis, joint deduction succeeds.
+ *   - `derived`       : value follows from another active hypothesis.
+ *   - `confirmed`     : real facts independently prove the hypothesis right.
+ *   - `directlyContradicted` : real facts prove the hypothesis wrong.
+ *   - `jointlyConflicts`     : solo-OK hypothesis that's part of a conflicting set.
+ */
+export type CellHypothesisStatus =
+    | "off"
+    | "active"
+    | "derived"
+    | "confirmed"
+    | "directlyContradicted"
+    | "jointlyConflicts";
+
 export const whyTooltipOpened = (props: {
     /** See `deductionRevealed.categoryName` — same free-form rationale. */
     categoryName: string;
+    /**
+     * `true` when the cell has a real-fact deduction at popover-open
+     * time. Now that the popover opens on every play-mode cell (not
+     * just deducible ones), this lets the funnel separate "user
+     * inspecting a known cell" from "user opening the popover to
+     * pin a hypothesis on a blank".
+     */
+    hasDeduction: boolean;
+    /**
+     * `true` when the user has already pinned a hypothesis on this
+     * exact cell. Lets the funnel measure follow-up engagement —
+     * are users re-opening hypothesis cells to revisit them, or
+     * setting and forgetting?
+     */
+    hasHypothesis: boolean;
+    status: CellHypothesisStatus;
 }): void => capture("why_tooltip_opened", props);
+
+/**
+ * Fires every time the user pins or changes a hypothesis (Y / N)
+ * via the segmented control or a Y/N keyboard shortcut.
+ *
+ *   - `value`         : the new value (Y | N).
+ *   - `previousValue` : "off" for a fresh pin, "Y" / "N" for a flip.
+ *   - `cellStatus`    : the cell's {@link CellHypothesisStatus} *before*
+ *                       the action — answers "what was the user looking
+ *                       at when they decided to pin?". To recover the
+ *                       post-action status, join in PostHog with the
+ *                       next `why_tooltip_opened` on the same cell,
+ *                       which fires when the user re-inspects it.
+ *   - `source`        : "click" (segmented control) | "keyboard"
+ *                       (Y / N bare-key shortcuts).
+ */
+export const hypothesisSet = (props: {
+    value: "Y" | "N";
+    previousValue: "off" | "Y" | "N";
+    cellStatus: CellHypothesisStatus;
+    source: "click" | "keyboard";
+}): void => capture("hypothesis_set", props);
+
+/**
+ * Fires when the user clears a hypothesis (Off via segmented control
+ * or the `O` keyboard shortcut). `cellStatus` is the status the cell
+ * had immediately before the clear — useful for read-rate dashboards
+ * ("are users clearing confirmed hypotheses to tidy up, or clearing
+ * contradicted ones to revise?").
+ */
+export const hypothesisCleared = (props: {
+    previousValue: "Y" | "N";
+    cellStatus: CellHypothesisStatus;
+    source: "click" | "keyboard";
+}): void => capture("hypothesis_cleared", props);
 
 export const checklistRowClicked = (props: {
     cardType: "suspect" | "weapon" | "room";

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -9,8 +9,18 @@ import {
     type HypothesisValue,
 } from "../../logic/Hypothesis";
 import { CellWhyPopover, hypothesisValueFor } from "./CellWhyPopover";
+
+// Analytics enum tag for the "no hypothesis" baseline. Module-scope
+// so the `no-literal-string` lint rule reads it as code, not UI text.
+const ANALYTICS_PREV_OFF = "off" as const;
 import { useTranslations } from "next-intl";
-import { playerAdded, whyTooltipOpened } from "../../analytics/events";
+import {
+    hypothesisCleared,
+    hypothesisSet,
+    playerAdded,
+    whyTooltipOpened,
+    type CellHypothesisStatus,
+} from "../../analytics/events";
 import {
     useEffect,
     useLayoutEffect,
@@ -288,6 +298,21 @@ export function Checklist() {
     //   - no why popover is open (`popoverCell === null`).
     const popoverCellRef = useRef<Cell | null>(popoverCell);
     popoverCellRef.current = popoverCell;
+    // Analytics context: snapshot the inputs `statusFor` needs so the
+    // keyboard handler can read them at action time without bloating
+    // the useEffect dep list.
+    const analyticsCtxRef = useRef({
+        hypotheses,
+        realKnowledge,
+        jointKnowledge,
+        jointFailed,
+    });
+    analyticsCtxRef.current = {
+        hypotheses,
+        realKnowledge,
+        jointKnowledge,
+        jointFailed,
+    };
     useEffect(() => {
         const onKeyDown = (e: KeyboardEvent) => {
             const target = e.target as Element | null;
@@ -300,15 +325,43 @@ export function Checklist() {
             }
             const cell = popoverCellRef.current;
             if (cell === null) return;
+            const ctx = analyticsCtxRef.current;
+            const prevValue = hypothesisValueFor(ctx.hypotheses, cell);
+            const cellStatus = statusFor(
+                cell,
+                ctx.realKnowledge,
+                ctx.jointKnowledge,
+                ctx.hypotheses,
+                ctx.jointFailed,
+            ).kind as CellHypothesisStatus;
             if (matches("hypothesis.setOff", e)) {
                 e.preventDefault();
                 dispatch({ type: "clearHypothesis", cell });
+                if (prevValue !== undefined) {
+                    hypothesisCleared({
+                        previousValue: prevValue,
+                        cellStatus,
+                        source: "keyboard",
+                    });
+                }
             } else if (matches("hypothesis.setY", e)) {
                 e.preventDefault();
                 dispatch({ type: "setHypothesis", cell, value: Y });
+                hypothesisSet({
+                    value: Y,
+                    previousValue: prevValue ?? ANALYTICS_PREV_OFF,
+                    cellStatus,
+                    source: "keyboard",
+                });
             } else if (matches("hypothesis.setN", e)) {
                 e.preventDefault();
                 dispatch({ type: "setHypothesis", cell, value: N });
+                hypothesisSet({
+                    value: N,
+                    previousValue: prevValue ?? ANALYTICS_PREV_OFF,
+                    cellStatus,
+                    source: "keyboard",
+                });
             }
         };
         window.addEventListener("keydown", onKeyDown);
@@ -326,13 +379,38 @@ export function Checklist() {
         prevPopoverCellRef.current = popoverCell;
         if (popoverCell !== null && popoverCell !== prev) {
             const catId = categoryOfCard(setup.cardSet, popoverCell.card);
+            const popoverStatus = statusFor(
+                popoverCell,
+                realKnowledge,
+                jointKnowledge,
+                hypotheses,
+                jointFailed,
+            );
+            const realValue = realKnowledge
+                ? getCellByOwnerCard(
+                      realKnowledge,
+                      popoverCell.owner,
+                      popoverCell.card,
+                  )
+                : undefined;
             whyTooltipOpened({
                 categoryName: catId
                     ? categoryName(setup.cardSet, catId)
                     : "",
+                hasDeduction: realValue !== undefined,
+                hasHypothesis:
+                    hypothesisValueFor(hypotheses, popoverCell) !== undefined,
+                status: popoverStatus.kind as CellHypothesisStatus,
             });
         }
-    }, [popoverCell, setup.cardSet]);
+    }, [
+        popoverCell,
+        setup.cardSet,
+        realKnowledge,
+        jointKnowledge,
+        hypotheses,
+        jointFailed,
+    ]);
 
     const owners: ReadonlyArray<Owner> = allOwners(setup);
 
@@ -1480,16 +1558,32 @@ export function Checklist() {
                                                     onHypothesisChange={(
                                                         next: HypothesisValue | undefined,
                                                     ) => {
+                                                        const prevValue = hypothesisValue;
+                                                        const cellStatusKind = hypothesisStatus.kind as CellHypothesisStatus;
                                                         if (next === undefined) {
                                                             dispatch({
                                                                 type: "clearHypothesis",
                                                                 cell: thisCell,
                                                             });
+                                                            if (prevValue !== undefined) {
+                                                                hypothesisCleared({
+                                                                    previousValue: prevValue,
+                                                                    cellStatus: cellStatusKind,
+                                                                    source: "click",
+                                                                });
+                                                            }
                                                         } else {
                                                             dispatch({
                                                                 type: "setHypothesis",
                                                                 cell: thisCell,
                                                                 value: next,
+                                                            });
+                                                            hypothesisSet({
+                                                                value: next,
+                                                                previousValue:
+                                                                    prevValue ?? ANALYTICS_PREV_OFF,
+                                                                cellStatus: cellStatusKind,
+                                                                source: "click",
                                                             });
                                                         }
                                                     }}


### PR DESCRIPTION
## Summary

Wires product analytics for the hypothesis feature ([#125](https://github.com/LetsGetIntoIt/effect-clue/pull/125)). Three things change:

- **New** `hypothesis_set` event — fires every time the user pins or flips a hypothesis (Y / N) via the segmented control or the Y / N bare-key shortcut. Carries `value`, `previousValue`, `cellStatus` (the cell's status before the action), and `source` (`click` / `keyboard`).
- **New** `hypothesis_cleared` event — fires when the user sets the cell back to Off (control or `O` shortcut). Carries `previousValue`, `cellStatus`, and `source`.
- **Extended** `why_tooltip_opened` event — three new properties (`hasDeduction`, `hasHypothesis`, `status`) so the funnel can separate "user inspecting a known cell" from "user opening the popover to pin a hypothesis on a blank".

The `cellStatus` field on every event is the status the cell had **before** the action — easy to compute from current state with `statusFor`, no extra `deduce` call. The **post-action** status is recoverable in PostHog by joining each event with the next `why_tooltip_opened` on the same cell, since the user re-opens the popover to inspect what their hypothesis did.

`CellHypothesisStatus` is exported as a flat string-union type (`off` | `active` | `derived` | `confirmed` | `directlyContradicted` | `jointlyConflicts`) so PostHog funnels can group by it without joins.

## PostHog setup (do this after the merge lands in production)

### 1. Hypothesis-engagement funnel

**Insights → New → Funnel**

Steps (in order):

1. `why_tooltip_opened`
2. `hypothesis_set`
3. `why_tooltip_opened` (re-open on the same cell — measures whether users come back to inspect what their hypothesis did)

Suggested filters:
- Filter step 1 to `hasDeduction = false` to focus on blank-cell pinning specifically.
- Breakdown step 2 by `cellStatus` to see what state users are pinning over (`off` is typical; high `derived` would say users are doubling down on consequences).

### 2. Hypothesis-outcome dashboard

**Insights → New → Trends**

- **Series 1**: `hypothesis_set` total count.
- **Series 2**: `why_tooltip_opened` filtered to `hasHypothesis = true AND status = confirmed` — proxy for "hypothesis turned out right".
- **Series 3**: same with `status = directlyContradicted` — proxy for "hypothesis turned out wrong".
- **Series 4**: same with `status = jointlyConflicts` — proxy for "hypothesis collided with another".

Group all four by week. Stack to read out the relative outcome mix.

### 3. Action-source breakdown

**Insights → New → Trends**

- **Series 1**: `hypothesis_set` breakdown by `source` (`click` vs `keyboard`).
- **Series 2**: `hypothesis_cleared` breakdown by `source`.

Tells us whether users discover and use the keyboard shortcuts or stick to clicking. If keyboard adoption is low we know to lean harder on the helper text under the segmented control.

### 4. Why-popover engagement (extends existing event)

If a `why_tooltip_opened` Trends insight already exists, edit it to add three breakdown panels for the new properties — don't duplicate the chart:

- Breakdown by `hasDeduction`: blank-cell popovers vs deducible-cell popovers.
- Breakdown by `hasHypothesis`: fresh inspection vs returning to a pinned cell.
- Breakdown by `status`: distribution of cell states at popover-open time.

The existing `solver_engagement` funnel (`game_started → why_tooltip_opened → case_file_solved`) keeps its semantics — the new properties are additive and don't break the funnel definition.

### 5. Hypothesis-power-user cohort (optional, for later)

If we later want to separate hypothesis users from non-users:

- **Cohorts → New cohort**: any user who has fired `hypothesis_set` ≥ 5 times.
- Compare that cohort's `case_file_solved` rate vs everyone else in the **Solver engagement** funnel.

No code change needed for this — PostHog computes the cohort from event history. Document it now in case we want it later.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm knip && pnpm i18n:check` all green (1082 tests).
- [ ] After deploy: confirm in **Activity → Live Events** that `hypothesis_set` / `hypothesis_cleared` fire with the documented payloads on click and on keyboard input.
- [ ] After deploy: confirm `why_tooltip_opened` carries `hasDeduction`, `hasHypothesis`, and `status` on real opens.
- [ ] After deploy: build the four insights above on the production project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)