### PR TITLE
Per-cell footnote chip + CSS Grid layout for cell badges

### DIFF
--- a/src/ui/components/CellLayout.tsx
+++ b/src/ui/components/CellLayout.tsx
@@ -1,0 +1,92 @@
+import type { ReactNode } from "react";
+
+interface CellLayoutProps {
+    /**
+     * Indicator pinned to the cell's top-left corner. Rendered visibly
+     * in column 1 and invisibly mirrored into column 3 so the side
+     * columns end up the same width — that symmetry keeps the centered
+     * content at the cell's true horizontal midpoint regardless of
+     * which corner is wider.
+     */
+    readonly topLeft?: ReactNode;
+    /**
+     * Indicator pinned to the cell's top-right corner. Same mirroring
+     * rule as {@link topLeft}, in the opposite direction.
+     */
+    readonly topRight?: ReactNode;
+    /**
+     * Centered content (glyph, checkbox, etc). Sits in the middle
+     * column, centered both horizontally (within the column) and
+     * vertically (within the cell's full height).
+     */
+    readonly center?: ReactNode;
+}
+
+/**
+ * Three-slot layout for a checklist cell: top-left and top-right corner
+ * indicators flanking a centered piece of content. Content-agnostic —
+ * callers pass whatever React nodes belong in each slot.
+ *
+ * Grid layout:
+ * - 3 columns `1fr | auto | 1fr`. Each visible corner indicator is
+ *   paired with an invisibly mirrored copy in the opposite column so
+ *   both side columns floor to `max(topLeft_w, topRight_w)`; the 1fr
+ *   distribution then keeps them equal width even when the cell is
+ *   forced wider by sibling cells in the same table column. That
+ *   symmetry pins the centered content to the cell's true horizontal
+ *   midpoint regardless of how many digits a corner indicator carries.
+ * - 2 rows `auto | 1fr`. Row 1 sizes to the corner indicators and sits
+ *   at the cell's top edge; row 2 absorbs the remaining height. The
+ *   centered content spans both rows with `place-self-center` so it
+ *   lands at the cell's vertical center.
+ *
+ * No `gap` between tracks — the centered content sits flush against
+ * its column boundaries so the cell is no wider than the indicators
+ * + center actually require. The 2px corner inset comes from the
+ * grid container's padding.
+ */
+export function CellLayout({ topLeft, topRight, center }: CellLayoutProps) {
+    return (
+        // `min-h-9` forces the grid to be at least 36px tall and the
+        // table row honors that as its actual row height — so the
+        // grid's `1fr` row can fill the slack below the corner badges
+        // and the centered content (spanning both rows) lands at the
+        // cell's true vertical midpoint. We can't rely on `h-full`
+        // here because table-cell layout treats `height: 100%` on a
+        // td as a min-height per CSS spec, and the descendants'
+        // percentage heights collapse to their content size.
+        <div className="mx-auto grid h-full min-h-9 min-w-9 grid-cols-[minmax(auto,1fr)_auto_minmax(auto,1fr)] grid-rows-[auto_1fr] p-[2px]">
+            {topLeft != null && (
+                <div className="col-start-1 row-start-1 flex self-start justify-self-start">
+                    {topLeft}
+                </div>
+            )}
+            {topRight != null && (
+                <div
+                    aria-hidden
+                    className="invisible col-start-1 row-start-1 flex self-start justify-self-start"
+                >
+                    {topRight}
+                </div>
+            )}
+            {center != null && (
+                <div className="col-start-2 row-span-2 row-start-1 flex place-self-center items-center justify-center">
+                    {center}
+                </div>
+            )}
+            {topLeft != null && (
+                <div
+                    aria-hidden
+                    className="invisible col-start-3 row-start-1 flex self-start justify-self-end"
+                >
+                    {topLeft}
+                </div>
+            )}
+            {topRight != null && (
+                <div className="col-start-3 row-start-1 flex self-start justify-self-end">
+                    {topRight}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/ui/components/CellWhyPopover.tsx
+++ b/src/ui/components/CellWhyPopover.tsx
@@ -11,7 +11,7 @@ import type {
     HypothesisValue,
 } from "../../logic/Hypothesis";
 import { HashMap } from "effect";
-import { AlertIcon, CheckIcon } from "./Icons";
+import { AlertIcon, CheckIcon, LightbulbIcon } from "./Icons";
 import { HypothesisControl } from "./HypothesisControl";
 
 interface CellWhyPopoverProps {
@@ -23,6 +23,14 @@ interface CellWhyPopoverProps {
     readonly onHypothesisChange: (next: HypothesisValue | undefined) => void;
     /** Multi-line "why" chain text rendered below the control, when present. */
     readonly whyText: string | undefined;
+    /**
+     * "Candidate for suggestion #N — refuter's unseen card could be here."
+     * Rendered with the same lightbulb glyph as the in-cell footnote chip
+     * so users can match the chip to its explanation. Independent of
+     * `whyText`: a blank cell can be a refuter-candidate without having a
+     * deduction chain.
+     */
+    readonly footnoteText: string | undefined;
 }
 
 /**
@@ -41,6 +49,7 @@ export function CellWhyPopover({
     hypothesisValue,
     onHypothesisChange,
     whyText,
+    footnoteText,
 }: CellWhyPopoverProps) {
     const t = useTranslations("hypothesis");
 
@@ -144,17 +153,28 @@ export function CellWhyPopover({
                         card: cardLabel,
                     })}
                 </div>
-                {whyText !== undefined && (
+                {(whyText !== undefined || footnoteText !== undefined) && (
                     <div className="flex flex-col gap-2">
                         <div className="text-[11px] font-semibold uppercase tracking-wide text-fg">
                             {t("hardFactsLabel")}
                         </div>
-                        <div className="whitespace-pre-line">{whyText}</div>
+                        {whyText !== undefined && (
+                            <div className="whitespace-pre-line">{whyText}</div>
+                        )}
+                        {footnoteText !== undefined && (
+                            <div className="flex items-start gap-1.5 text-accent">
+                                <LightbulbIcon
+                                    size={14}
+                                    className="mt-[2px] flex-shrink-0"
+                                />
+                                <span>{footnoteText}</span>
+                            </div>
+                        )}
                     </div>
                 )}
                 <div
                     className={
-                        whyText !== undefined
+                        whyText !== undefined || footnoteText !== undefined
                             ? "flex flex-col gap-2 border-t border-border pt-3"
                             : "flex flex-col gap-2"
                     }
@@ -178,11 +198,13 @@ export function CellWhyPopover({
                             ))}
                         </ul>
                     )}
-                    {whyText === undefined && status.kind === "off" && (
-                        <div className="text-[12px] text-muted">
-                            {t("emptyHint")}
-                        </div>
-                    )}
+                    {whyText === undefined &&
+                        footnoteText === undefined &&
+                        status.kind === "off" && (
+                            <div className="text-[12px] text-muted">
+                                {t("emptyHint")}
+                            </div>
+                        )}
                 </div>
             </div>
         </div>

--- a/src/ui/components/Checklist.setup.test.tsx
+++ b/src/ui/components/Checklist.setup.test.tsx
@@ -311,9 +311,13 @@ describe("Checklist — setup mode — player cell interactions", () => {
         );
         expect(checkbox).toBeDefined();
         if (!checkbox) return;
-        expect(checkbox.parentElement?.className).toContain("mx-auto");
-        expect(checkbox.parentElement?.parentElement?.parentElement?.className)
-            .toContain("mx-auto");
+        // The checkbox sits inside CellLayout's center slot — a flex
+        // wrapper with place-self-center that lands at the cell's
+        // horizontal + vertical midpoint.
+        const centerWrapper = checkbox.parentElement;
+        expect(centerWrapper?.className).toContain("place-self-center");
+        expect(centerWrapper?.className).toContain("col-start-2");
+        expect(centerWrapper?.className).toContain("flex");
     });
 });
 

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -8,6 +8,7 @@ import {
     type HypothesisStatus,
     type HypothesisValue,
 } from "../../logic/Hypothesis";
+import { CellLayout } from "./CellLayout";
 import { CellWhyPopover, hypothesisValueFor } from "./CellWhyPopover";
 
 // Analytics enum tag for the "no hypothesis" baseline. Module-scope
@@ -598,10 +599,14 @@ export function Checklist() {
     const renderColumnReveal = (children: ReactNode, className?: string) => (
         renderDimensionReveal(TABLE_AXIS_COLUMN, children, className)
     );
+    // Body cells pass a `<CellLayout />` here, which already provides
+    // the grid container — so this helper just wraps the content in
+    // the row/column reveal animations. Empty cells (e.g. the setup-
+    // mode add-player case-file slot) pass `null`.
     const renderTableCellContent = (children: ReactNode) =>
         renderColumnReveal(
             renderRowReveal(
-                <div className={CELL_CONTENT}>{children}</div>,
+                children,
                 undefined,
                 tableEntryTransition,
             ),
@@ -1341,7 +1346,35 @@ export function Checklist() {
                                             tDeduce: t,
                                             tReasons,
                                         });
-                                        const cellContent = setupCheckbox ? (
+                                        const showChip =
+                                            footnoteNumbers.length > 0
+                                            && value === undefined;
+                                        const topLeft = showChip ? (
+                                            <span
+                                                aria-hidden
+                                                className="inline-flex items-center gap-[2px] rounded-[3px] border border-accent/40 px-[3px] py-px text-[10px] font-semibold leading-none text-accent tabular-nums"
+                                            >
+                                                <LightbulbIcon size={9} />
+                                                {footnoteNumbers.join(",")}
+                                            </span>
+                                        ) : null;
+                                        // Corner badge marking the cell as
+                                        // the source of a hypothesis (vs. a
+                                        // cell whose value follows from one).
+                                        // Tone reflects the HYPOTHESIS value,
+                                        // not the cell's displayed value: a
+                                        // cell that's been deduced Y but
+                                        // hypothesised N shows a red badge
+                                        // against a green cell, making the
+                                        // disagreement visible at a glance.
+                                        const topRight =
+                                            hypothesisValue !== undefined ? (
+                                                <HypothesisBadge
+                                                    value={hypothesisValue}
+                                                    status={hypothesisStatus}
+                                                />
+                                            ) : null;
+                                        const center = setupCheckbox ? (
                                             <input
                                                 type="checkbox"
                                                 aria-hidden
@@ -1351,32 +1384,17 @@ export function Checklist() {
                                                 readOnly
                                             />
                                         ) : (
-                                            <>
-                                                <AnimatedCellGlyph
-                                                    display={display}
-                                                    status={hypothesisStatus}
-                                                />
-                                                {footnoteNumbers.length > 0 &&
-                                                    value === undefined && (
-                                                        <span
-                                                            aria-hidden
-                                                            className="pointer-events-none absolute left-[3px] top-[3px] inline-flex items-center gap-[2px] rounded-[3px] border border-accent/40 px-[3px] py-px text-[10px] font-semibold leading-none text-accent tabular-nums"
-                                                        >
-                                                            <LightbulbIcon
-                                                                size={9}
-                                                            />
-                                                            {footnoteNumbers.join(
-                                                                ",",
-                                                            )}
-                                                        </span>
-                                                    )}
-                                                {hypothesisValue !== undefined && (
-                                                    <HypothesisBadge
-                                                        value={hypothesisValue}
-                                                        status={hypothesisStatus}
-                                                    />
-                                                )}
-                                            </>
+                                            <AnimatedCellGlyph
+                                                display={display}
+                                                status={hypothesisStatus}
+                                            />
+                                        );
+                                        const cellContent = (
+                                            <CellLayout
+                                                topLeft={topLeft}
+                                                topRight={topRight}
+                                                center={center}
+                                            />
                                         );
                                         // A cell needs the interactive
                                         // ring style when the user can
@@ -2723,11 +2741,16 @@ function AnimatedCellGlyph({
 }
 
 const ADD_PLAYER_COLUMN_KEY = "add-player-col";
+// `align-top` (vertical-align: top) anchors the row/column reveal
+// motion.div — and thus CellLayout's grid — to the cell's top edge.
+// Table-cell percentage-height inheritance is unreliable (CSS spec
+// treats `height: 100%` on a td as a min-height rather than a real
+// height), so we can't make the inner wrappers stretch to fill;
+// instead, we let them content-size and pin them to the top so the
+// corner badges in CellLayout's row 1 sit at the cell's true top
+// edge with the grid's 2px padding as their corner inset.
 const CELL_BASE =
-    "border-r border-b border-border text-center font-semibold relative overflow-hidden";
-const CELL_CONTENT =
-    "mx-auto flex h-full w-9 min-w-9 items-center justify-center px-2 py-1";
-
+    "border-r border-b border-border text-center font-semibold relative overflow-hidden align-top";
 const STICKY_FIRST_COL =
     "sticky left-0 z-[var(--z-checklist-sticky-column)]";
 

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -85,7 +85,7 @@ import { useConfetti } from "../hooks/useConfetti";
 import { useShareContext } from "../share/ShareProvider";
 import { CardPackRow } from "./CardPackRow";
 import { ShareIcon } from "./ShareIcon";
-import { AlertIcon, Envelope } from "./Icons";
+import { AlertIcon, Envelope, LightbulbIcon } from "./Icons";
 import { HypothesisBadge } from "./HypothesisBadge";
 import { InfoPopover } from "./InfoPopover";
 
@@ -1330,7 +1330,7 @@ export function Checklist() {
                                         // opens the deduction-chain popover.
                                         const playInteractive =
                                             !inSetup && isPlayerCell;
-                                        const tooltipText = buildCellTitle({
+                                        const cellWhy = buildCellWhy({
                                             provenance,
                                             suggestions,
                                             accusations,
@@ -1358,11 +1358,17 @@ export function Checklist() {
                                                 />
                                                 {footnoteNumbers.length > 0 &&
                                                     value === undefined && (
-                                                        <sup className="ml-0.5 text-[9px] font-normal text-accent">
+                                                        <span
+                                                            aria-hidden
+                                                            className="pointer-events-none absolute left-[3px] top-[3px] inline-flex items-center gap-[2px] rounded-[3px] border border-accent/40 px-[3px] py-px text-[10px] font-semibold leading-none text-accent tabular-nums"
+                                                        >
+                                                            <LightbulbIcon
+                                                                size={9}
+                                                            />
                                                             {footnoteNumbers.join(
                                                                 ",",
                                                             )}
-                                                        </sup>
+                                                        </span>
                                                     )}
                                                 {hypothesisValue !== undefined && (
                                                     <HypothesisBadge
@@ -1613,7 +1619,8 @@ export function Checklist() {
                                                             });
                                                         }
                                                     }}
-                                                    whyText={tooltipText}
+                                                    whyText={cellWhy.chainText}
+                                                    footnoteText={cellWhy.footnoteText}
                                                 />
                                             );
                                             cell = (
@@ -2249,7 +2256,14 @@ const resolveReasonCopy = (
     }
 };
 
-const buildCellTitle = (args: {
+interface CellWhy {
+    /** "Hard facts" deduction chain — rendered as plain text in the popover. */
+    readonly chainText: string | undefined;
+    /** Footnote candidate-for-suggestion line — rendered with a lightbulb icon. */
+    readonly footnoteText: string | undefined;
+}
+
+const buildCellWhy = (args: {
     provenance: Provenance | undefined;
     suggestions: ReadonlyArray<Suggestion>;
     accusations: ReadonlyArray<Accusation>;
@@ -2259,7 +2273,7 @@ const buildCellTitle = (args: {
     footnoteNumbers: ReadonlyArray<number>;
     tDeduce: ReturnType<typeof useTranslations<"deduce">>;
     tReasons: ReturnType<typeof useTranslations<"reasons">>;
-}): string | undefined => {
+}): CellWhy => {
     const {
         provenance,
         suggestions,
@@ -2272,7 +2286,7 @@ const buildCellTitle = (args: {
         tReasons,
     } = args;
 
-    const footnoteLine =
+    const footnoteText =
         footnoteNumbers.length > 0
             ? tDeduce("footnoteLine", {
                   labels: footnoteNumbers.map(n => `#${n}`).join(", "),
@@ -2303,11 +2317,9 @@ const buildCellTitle = (args: {
     // popover now renders a "Hard facts" section heading above it
     // (parallel to the "Hypothesis" heading), so the prefix is
     // redundant here.
-    const parts: string[] = [];
-    if (chainLines.length > 0) parts.push(...chainLines);
-    if (footnoteLine) parts.push(footnoteLine);
+    const chainText = chainLines.length > 0 ? chainLines.join("\n") : undefined;
 
-    return parts.length > 0 ? parts.join("\n") : undefined;
+    return { chainText, footnoteText };
 };
 
 // Motion-only constants (non user-facing). The "unsolved" color

--- a/src/ui/components/HypothesisBadge.tsx
+++ b/src/ui/components/HypothesisBadge.tsx
@@ -15,19 +15,32 @@ interface HypothesisBadgeProps {
 // Glyph reflects the resolved status — a check mark when the
 // hypothesis has been confirmed by real facts, a question mark while
 // it's still active, jointly conflicting, or directly contradicted.
+//
+// Positioning is the caller's responsibility. The badge sits in the
+// `topRight` slot of `CellLayout`, which handles corner placement and
+// the `auto`-column mirror trick that keeps the central glyph centered.
 export function HypothesisBadge({ value, status }: HypothesisBadgeProps) {
     const tone = value === Y ? "text-yes" : "text-no";
     const confirmed = status.kind === "confirmed";
+    // ViewBox is "3 3 18 18" so the visible rounded square fills the
+    // SVG's bounding box edge-to-edge. Without this, the rect at
+    // (3,3) inside a "0 0 24 24" viewBox renders ~2px inside the SVG
+    // box, leaving a phantom transparent border that makes the
+    // badge sit visually further from the cell corner than the
+    // footnote chip on the opposite side. Inner glyph coordinates
+    // (?/check) stay at their original 24x24-relative positions
+    // because the viewBox shift translates them — they still center
+    // inside the rect.
     return (
         <svg
             xmlns="http://www.w3.org/2000/svg"
             width={14}
             height={14}
-            viewBox="0 0 24 24"
+            viewBox="3 3 18 18"
             aria-hidden="true"
             focusable="false"
             data-glyph={confirmed ? "check" : "question"}
-            className={`absolute right-0.5 top-0.5 ${tone}`}
+            className={tone}
         >
             <rect
                 x="3"

--- a/src/ui/components/Icons.tsx
+++ b/src/ui/components/Icons.tsx
@@ -259,6 +259,34 @@ export function AlertIcon({ className, size = 14 }: IconProps) {
     );
 }
 
+/**
+ * Lightbulb — paired with the per-cell "candidate for suggestion N"
+ * footnote affordance so the same glyph appears in the cell chip and
+ * the why-popover explanation, tying them together visually.
+ */
+export function LightbulbIcon({ className, size = 14 }: IconProps) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+            focusable="false"
+            className={className}
+        >
+            <path d="M9 18h6" />
+            <path d="M10 22h4" />
+            <path d="M15.09 14a5 5 0 1 0-6.18 0c.55.45 1.09 1.21 1.09 2v2h4v-2c0-.79.54-1.55 1.09-2z" />
+        </svg>
+    );
+}
+
 /** Arrow leaving a frame — paired with links that open in a new tab. */
 export function ExternalLinkIcon({ className, size = 14 }: IconProps) {
     return (


### PR DESCRIPTION
## Summary

Two related improvements to the per-cell badges on the checklist's body cells.

**Per-cell suggestion-number footnotes.** The "this cell could still be the refuter's unseen card for suggestion #N" footnote — previously a near-invisible 9px inline superscript — now renders as a small bordered chip with a lightbulb icon in the cell's top-left corner (e.g. `[💡 1, 2]`). The why-popover's *Hard Facts* section prefixes the matching "Candidate for suggestion #N — refuter's unseen card could be here." line with the same lightbulb glyph so the in-cell chip and the popover's prose explanation read as the same affordance.

**CSS Grid layout for cell corners.** Lifted the cell's three slots (top-left chip, top-right hypothesis badge, central glyph) into a content-agnostic `CellLayout` component. The slots can never overlap each other regardless of cell width — fixes a mobile bug where the chip and badge collided into the same corner — and the central glyph stays at the cell's true horizontal + vertical midpoint even when the corner indicators have different widths (e.g. multi-digit footnote chip + single-icon hypothesis badge). The chip and badge sit at matched 2px from the cell's top and side borders.

## Test plan

- [x] All five pre-commit checks green: `pnpm typecheck`, `pnpm lint`, `pnpm test` (1091 / 1091, includes 6 upstream `HypothesisBadge` tests), `pnpm knip`, `pnpm i18n:check`
- [x] Verified in `next-dev` preview at desktop (1280×800) and mobile (375×812):
  - Single-digit chip ("1") and multi-digit chip ("12,13") both render legibly in the top-left corner with `tabular-nums` keeping the comma readable
  - Chip + hypothesis badge + central glyph all sit in disjoint grid areas — no overlap on mobile where cells are at their `min-w-9` floor
  - Glyph stays at cell horizontal + vertical center regardless of corner widths (verified via `preview_inspect` on cells with chip-only, badge-only, both, and neither)
  - Cell click target still opens the why-popover after the layout refactor
  - Why-popover renders the lightbulb-prefixed footnote line next to the existing deduction chain
- [x] Rebased onto latest `origin/main` (covers PRs #129, #130, #131). Conflicts in `Icons.tsx` (upstream removed `BoxedQuestionMarkIcon` for the new `HypothesisBadge` while this branch added `LightbulbIcon`) and `Checklist.tsx` (upstream's `HypothesisBadge` swap met this branch's `CellLayout` extraction) resolved in favor of upstream's component split — `HypothesisBadge` is now placed in `CellLayout`'s `topRight` slot, with its hardcoded `absolute right-0.5 top-0.5` stripped so the parent slot owns positioning.

## Commits

- **`Make per-cell suggestion-number footnotes legible`** — Changes the footnote from a 9px `<sup>` to a bordered chip with a lightbulb icon in the top-left corner, and refactors `buildCellTitle` → `buildCellWhy` to return `chainText` and `footnoteText` separately so `CellWhyPopover` can render the footnote line as JSX (with the matching `LightbulbIcon` prefix) below the deduction chain. Adds `LightbulbIcon` to the shared `Icons` module.
- **`Lay out cell badges in a CSS Grid so they never overlap`** — Extracts the cell's slot layout into a new `CellLayout` component with `topLeft` / `topRight` / `center` props; the component handles a 3-column × 2-row grid where each visible corner indicator is paired with an invisibly mirrored copy in the opposite column to keep the side columns symmetric. Sets `min-h-9` on the grid so the table row honors a real height (working around the table-cell `height: 100%` quirk), `align-top` on the td so the grid pins to the cell's top edge, and shifts `HypothesisBadge`'s SVG viewBox to `"3 3 18 18"` so its visible rounded square aligns with the chip's visible border at exactly 2px from the cell corner.

## Observability

No new events. The chip remains a "what cells are still candidates" affordance — a derived rendering of state we already track. No funnel changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)