### PR TITLE
Highlight the Classic pill after "New game"

### DIFF
--- a/src/ui/state.test.tsx
+++ b/src/ui/state.test.tsx
@@ -23,6 +23,12 @@ import {
 import { cardByName } from "../logic/test-utils/CardByName";
 import { ClueProvider, useClue } from "./state";
 import { TestQueryClientProvider } from "../test-utils/queryClient";
+import {
+    loadCardPackUsage,
+    recordCardPackUse,
+} from "../logic/CardPackUsage";
+import { CARD_SETS } from "../logic/GameSetup";
+import { DateTime } from "effect";
 
 // -----------------------------------------------------------------------
 // The `reducer` and `initialState` are module-private in state.tsx — the
@@ -93,6 +99,30 @@ describe("setup-side actions", () => {
         // by reference — but it has the same shape (3 categories for the
         // classic deck).
         expect(result.current.state.setup.categories).toHaveLength(3);
+    });
+
+    test("newGame stamps Classic as the most-recently-used card pack", () => {
+        // Pre-seed the recency map so a non-Classic pack is "most
+        // recent" — mirrors the user having clicked Master Detective
+        // (or a custom pack) before hitting New game. Without the
+        // dispatch wrapper's stamp, the pill row would resolve its
+        // active match to that stale entry, find the live setup no
+        // longer matches it, and leave no pill highlighted.
+        recordCardPackUse("master-detective");
+        const { result } = renderClue();
+        act(() => result.current.dispatch({ type: "newGame" }));
+        const usage = loadCardPackUsage();
+        const classicId = CARD_SETS[0]!.id;
+        const classicAt = usage.get(classicId);
+        const masterAt = usage.get("master-detective");
+        expect(classicAt).toBeDefined();
+        // Classic strictly beats master-detective: it must be the
+        // most-recent entry so `activeMatch` in CardPackRow lights
+        // up the Classic pill.
+        expect(masterAt).toBeDefined();
+        expect(
+            DateTime.toEpochMillis(classicAt!),
+        ).toBeGreaterThanOrEqual(DateTime.toEpochMillis(masterAt!));
     });
 
     test("setUiMode changes uiMode and bypasses the undo history", () => {

--- a/src/ui/state.tsx
+++ b/src/ui/state.tsx
@@ -20,6 +20,7 @@ import {
 import {
     allCardEntries,
     CardEntry,
+    CARD_SETS,
     categoryName as resolveCategoryName,
     categoryOfCard,
     Category,
@@ -30,6 +31,11 @@ import {
     GameSetup,
     newGameSetup,
 } from "../logic/GameSetup";
+import {
+    type CardPackUsage,
+    recordCardPackUse,
+} from "../logic/CardPackUsage";
+import { cardPackUsageQueryKey } from "../data/cardPackUsage";
 import { HashMap } from "effect";
 import {
     emptyHypotheses,
@@ -760,6 +766,23 @@ export function ClueProvider({ children }: { children: ReactNode }) {
             // localStorage isn't "the user touched the game".
             if (action.type === "newGame") {
                 markGameCreated(DateTime.nowUnsafe());
+                // Stamp Classic as just-used so the card-pack pill row
+                // re-anchors its active highlight to Classic — matching
+                // the fresh-Classic deck the reducer just loaded. Without
+                // this, whichever pack the user previously loaded stays
+                // most-recent in the usage map, but no pill gets the
+                // active styling because cardSetEquals(setup, that pack)
+                // is now false.
+                const classicId = CARD_SETS[0]!.id;
+                recordCardPackUse(classicId);
+                queryClient.setQueryData<CardPackUsage>(
+                    cardPackUsageQueryKey,
+                    (old) => {
+                        const next = new Map(old ?? new Map());
+                        next.set(classicId, DateTime.nowUnsafe());
+                        return next;
+                    },
+                );
             } else if (
                 action.type !== "setUiMode"
                 && action.type !== "replaceSession"


### PR DESCRIPTION
## Summary

- After "New game", the Classic card-pack pill is highlighted again, regardless of which pack was previously loaded. Before this change, clicking "New game" while Master Detective (or any custom pack) was loaded would correctly reset the board to Classic but leave no pill highlighted, with the "+ Save as card pack" pill mistakenly activating instead — making it look like the user had hand-edited Classic into a non-saved shape.

## Test plan

- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test` (1083 passed) / `pnpm knip` / `pnpm i18n:check` all green.
- [x] Desktop overflow menu: click Master Detective → ⋯ → New game → Confirm → Classic pill is highlighted, usage map has `classic` newer than `master-detective`.
- [x] Mobile BottomNav (375×812): click Master Detective → ⋯ → New game → Confirm → same outcome, no orphan rows or duplicate categories in the table.
- [x] Keyboard hotkey ⌘⇧⌫ on desktop: same outcome.
- [x] No console errors during any of the flows above.

## Commits

- **Highlight the Classic pill after "New game"** — extends the existing `newGame` branch of the dispatch wrapper in `src/ui/state.tsx` to stamp `"classic"` (`CARD_SETS[0]!.id`) into both localStorage (`recordCardPackUse`) and the React Query cache (`queryClient.setQueryData(cardPackUsageQueryKey, ...)`). The reducer is untouched; the side-effect rides alongside the existing `markGameCreated` call. Adds a regression test in `src/ui/state.test.tsx` that pre-seeds `master-detective` in the usage map, dispatches `newGame`, and asserts `classic` becomes the most-recent entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)