### PR TITLE
Show ✓ on hypothesis cell badge once real facts confirm the hunch

### DIFF
--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -85,7 +85,8 @@ import { useConfetti } from "../hooks/useConfetti";
 import { useShareContext } from "../share/ShareProvider";
 import { CardPackRow } from "./CardPackRow";
 import { ShareIcon } from "./ShareIcon";
-import { AlertIcon, BoxedQuestionMarkIcon, Envelope } from "./Icons";
+import { AlertIcon, Envelope } from "./Icons";
+import { HypothesisBadge } from "./HypothesisBadge";
 import { InfoPopover } from "./InfoPopover";
 
 /**
@@ -1320,28 +1321,9 @@ export function Checklist() {
                                                         </sup>
                                                     )}
                                                 {hypothesisValue !== undefined && (
-                                                    // Corner badge marking the
-                                                    // cell as the source of a
-                                                    // hypothesis (vs. a cell
-                                                    // whose value follows from
-                                                    // one). Tone reflects the
-                                                    // HYPOTHESIS value, not the
-                                                    // cell's displayed value:
-                                                    // a cell that's been
-                                                    // deduced Y but
-                                                    // hypothesised N shows a
-                                                    // red badge against a
-                                                    // green cell, making the
-                                                    // disagreement visible at
-                                                    // a glance.
-                                                    <BoxedQuestionMarkIcon
-                                                        size={14}
-                                                        className={
-                                                            "absolute right-0.5 top-0.5 " +
-                                                            (hypothesisValue === Y
-                                                                ? "text-yes"
-                                                                : "text-no")
-                                                        }
+                                                    <HypothesisBadge
+                                                        value={hypothesisValue}
+                                                        status={hypothesisStatus}
                                                     />
                                                 )}
                                             </>

--- a/src/ui/components/HypothesisBadge.test.tsx
+++ b/src/ui/components/HypothesisBadge.test.tsx
@@ -1,0 +1,84 @@
+import { render } from "@testing-library/react";
+import { describe, expect, test } from "vitest";
+import { N, Y } from "../../logic/Knowledge";
+import { HypothesisBadge } from "./HypothesisBadge";
+
+const findBadge = (container: HTMLElement) =>
+    container.querySelector("svg[data-glyph]") as SVGElement;
+
+describe("HypothesisBadge", () => {
+    test("renders the check glyph when the hypothesis is confirmed", () => {
+        const { container } = render(
+            <HypothesisBadge
+                value={Y}
+                status={{ kind: "confirmed", value: Y }}
+            />,
+        );
+        const badge = findBadge(container);
+        expect(badge.getAttribute("data-glyph")).toBe("check");
+    });
+
+    test("renders the question glyph for the active state", () => {
+        const { container } = render(
+            <HypothesisBadge
+                value={Y}
+                status={{ kind: "active", value: Y }}
+            />,
+        );
+        expect(findBadge(container).getAttribute("data-glyph")).toBe(
+            "question",
+        );
+    });
+
+    test("renders the question glyph when directly contradicted", () => {
+        const { container } = render(
+            <HypothesisBadge
+                value={Y}
+                status={{
+                    kind: "directlyContradicted",
+                    hypothesis: Y,
+                    real: N,
+                }}
+            />,
+        );
+        expect(findBadge(container).getAttribute("data-glyph")).toBe(
+            "question",
+        );
+    });
+
+    test("renders the question glyph when jointly conflicting", () => {
+        const { container } = render(
+            <HypothesisBadge
+                value={Y}
+                status={{ kind: "jointlyConflicts", value: Y }}
+            />,
+        );
+        expect(findBadge(container).getAttribute("data-glyph")).toBe(
+            "question",
+        );
+    });
+
+    test("tones the badge by the hypothesis value (Y → text-yes)", () => {
+        const { container } = render(
+            <HypothesisBadge
+                value={Y}
+                status={{ kind: "confirmed", value: Y }}
+            />,
+        );
+        expect(findBadge(container).getAttribute("class")).toContain(
+            "text-yes",
+        );
+    });
+
+    test("tones the badge by the hypothesis value (N → text-no)", () => {
+        const { container } = render(
+            <HypothesisBadge
+                value={N}
+                status={{ kind: "confirmed", value: N }}
+            />,
+        );
+        expect(findBadge(container).getAttribute("class")).toContain(
+            "text-no",
+        );
+    });
+});

--- a/src/ui/components/HypothesisBadge.tsx
+++ b/src/ui/components/HypothesisBadge.tsx
@@ -1,0 +1,73 @@
+import { Y } from "../../logic/Knowledge";
+import type {
+    HypothesisStatus,
+    HypothesisValue,
+} from "../../logic/Hypothesis";
+
+interface HypothesisBadgeProps {
+    value: HypothesisValue;
+    status: HypothesisStatus;
+}
+
+// Tone reflects the HYPOTHESIS value, not the cell's displayed value:
+// a cell that's been deduced Y but hypothesised N shows a red badge
+// against a green cell, making the disagreement visible at a glance.
+// Glyph reflects the resolved status — a check mark when the
+// hypothesis has been confirmed by real facts, a question mark while
+// it's still active, jointly conflicting, or directly contradicted.
+export function HypothesisBadge({ value, status }: HypothesisBadgeProps) {
+    const tone = value === Y ? "text-yes" : "text-no";
+    const confirmed = status.kind === "confirmed";
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={14}
+            height={14}
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+            focusable="false"
+            data-glyph={confirmed ? "check" : "question"}
+            className={`absolute right-0.5 top-0.5 ${tone}`}
+        >
+            <rect
+                x="3"
+                y="3"
+                width="18"
+                height="18"
+                rx="3"
+                fill="currentColor"
+            />
+            {confirmed ? (
+                <polyline
+                    points="7 12 11 16 17 8"
+                    fill="none"
+                    stroke="white"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                />
+            ) : (
+                <>
+                    <path
+                        d="M9.5 9a2.5 2.5 0 1 1 3.5 2.3c-.6.3-1 .9-1 1.7"
+                        fill="none"
+                        stroke="white"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                    />
+                    <line
+                        x1="12"
+                        y1="17"
+                        x2="12.01"
+                        y2="17"
+                        stroke="white"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                    />
+                </>
+            )}
+        </svg>
+    );
+}

--- a/src/ui/components/Icons.tsx
+++ b/src/ui/components/Icons.tsx
@@ -259,55 +259,6 @@ export function AlertIcon({ className, size = 14 }: IconProps) {
     );
 }
 
-/**
- * Solid rounded square with a "?" cut into it — used as a small
- * corner badge on checklist cells the user has pinned a hypothesis
- * on. The fill is `currentColor` so the parent's `text-*` class
- * picks the tone (typically `text-yes` or `text-no` matching the
- * hypothesis value). The inner "?" strokes in white so it stays
- * legible regardless of fill colour.
- */
-export function BoxedQuestionMarkIcon({ className, size = 12 }: IconProps) {
-    return (
-        <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width={size}
-            height={size}
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-            focusable="false"
-            className={className}
-        >
-            <rect
-                x="3"
-                y="3"
-                width="18"
-                height="18"
-                rx="3"
-                fill="currentColor"
-            />
-            <path
-                d="M9.5 9a2.5 2.5 0 1 1 3.5 2.3c-.6.3-1 .9-1 1.7"
-                fill="none"
-                stroke="white"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-            />
-            <line
-                x1="12"
-                y1="17"
-                x2="12.01"
-                y2="17"
-                stroke="white"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-            />
-        </svg>
-    );
-}
-
 /** Arrow leaving a frame — paired with links that open in a new tab. */
 export function ExternalLinkIcon({ className, size = 14 }: IconProps) {
     return (


### PR DESCRIPTION
## Summary

Until now, every cell with a user-set hypothesis showed the same boxed `?` badge in its top-right corner regardless of how the hypothesis had resolved. Now the badge flips to a `✓` once the hypothesis is confirmed by real facts — matching the popover's *Confirmed by real facts* success line at a glance — and keeps the `?` for active, directly-contradicted, and jointly-conflicting states.

Tone is preserved: a confirmed N still tones red, a confirmed Y still tones green. Only the glyph changes.

## Verification

- All five green checks pass: `pnpm typecheck`, `pnpm lint`, `pnpm test` (1088 tests, including 6 new for `HypothesisBadge`), `pnpm knip`, `pnpm i18n:check`.
- Manually exercised the preview at desktop (1280×800) and mobile (375×812). For each state, confirmed via `preview_inspect` that the SVG carries the right `data-glyph` and tone:
  - `confirmed` → `data-glyph="check"`, popover reads "Confirmed by real facts — you can turn this hypothesis off."
  - `directlyContradicted` → `data-glyph="question"`, popover reads "Contradicts a real fact — your hypothesis can't be true."
  - `jointlyConflicts` → `data-glyph="question"`, popover lists the conflicting hypotheses.
  - `active` → `data-glyph="question"`, no status block in the popover.
- Console clean — no errors or warnings.

## Commits

- **Show ✓ on hypothesis cell badge once real facts confirm the hunch** — Lift the badge into a hypothesis-specific `HypothesisBadge` component that owns its corner positioning, value-based tone (`text-yes` / `text-no`), and status-driven glyph in one place. Pick the check polyline glyph when `hypothesisStatus.kind === "confirmed"`, otherwise the existing question-mark glyph. Drop the now-unused `BoxedQuestionMarkIcon` — it had a single caller and existed for this exact use case. Add `HypothesisBadge.test.tsx` covering all four resolved states and both tones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)