### PR TITLE
Fix mobile why-popover behavior + show focus ring on the cell anchoring it

### DIFF
--- a/src/ui/components/Checklist.deduce.test.tsx
+++ b/src/ui/components/Checklist.deduce.test.tsx
@@ -298,14 +298,21 @@ describe("Checklist — case-file deduction popover", () => {
         // column boundary; box-shadow doesn't. 3px width matches the
         // global *:focus-visible outline so it reads at the same
         // weight as every other focusable element on the page.
-        // Pinned via classes so a future regression to outline-* (or
-        // a thinner ring) trips the test.
-        expect(caseFileCell.className).toMatch(/focus-visible:ring-\[3px\]/);
-        expect(caseFileCell.className).toMatch(/focus-visible:ring-accent/);
-        expect(caseFileCell.className).toMatch(/focus-visible:outline-none/);
+        //
+        // The trigger is `:focus` (not `:focus-visible`) so the ring
+        // shows on touch/mouse activation too — that lets the user
+        // see which cell anchors the portaled popover. Pinned via
+        // classes so a regression to outline-* (or a thinner ring,
+        // or back to focus-visible-only) trips the test.
+        expect(caseFileCell.className).toMatch(/(?:^|\s)focus:ring-\[3px\]/);
+        expect(caseFileCell.className).toMatch(/(?:^|\s)focus:ring-accent/);
+        expect(caseFileCell.className).toMatch(/(?:^|\s)focus:outline-none/);
         expect(caseFileCell.className).not.toMatch(
-            /focus-visible:outline-1\b/,
+            /(?:^|\s)focus:outline-1\b/,
         );
+        // Hard regression: the focus ring must NOT be gated by
+        // :focus-visible (which excludes touch and mouse focus).
+        expect(caseFileCell.className).not.toMatch(/focus-visible:ring-/);
     });
 
     test("an undeduced case-file cell stays non-interactive (no popover affordance)", async () => {

--- a/src/ui/components/Checklist.setup.test.tsx
+++ b/src/ui/components/Checklist.setup.test.tsx
@@ -560,9 +560,12 @@ describe("Checklist — setup mode — scope of rendered controls", () => {
         expect(caseFileCell.getAttribute("aria-haspopup")).toBeNull();
         expect(caseFileCell.getAttribute("tabindex")).toBeNull();
         expect(caseFileCell.getAttribute("data-cell-col")).toBeNull();
-        // No focus-visible ring class either — the styling for
-        // interactive cells comes via CELL_INTERACTIVE which the gate
-        // skips for setup-mode case-file cells.
-        expect(caseFileCell.className).not.toMatch(/focus-visible:ring-1/);
+        // No focus ring class either — the styling for interactive
+        // cells comes via CELL_INTERACTIVE which the gate skips for
+        // setup-mode case-file cells. (The offset color
+        // `focus:ring-offset-*` is set per-tone unconditionally and
+        // is harmless without an actual `ring-*`.)
+        expect(caseFileCell.className).not.toMatch(/focus:ring-accent/);
+        expect(caseFileCell.className).not.toMatch(/focus:ring-\[/);
     });
 });

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -298,6 +298,22 @@ export function Checklist() {
     //   - no why popover is open (`popoverCell === null`).
     const popoverCellRef = useRef<Cell | null>(popoverCell);
     popoverCellRef.current = popoverCell;
+    // Touch-only "first tap dismisses, second tap opens" gate. On
+    // touch, tapping a cell while a popover is already open on a
+    // different cell should dismiss the open popover and NOT swap
+    // it onto the freshly tapped cell — the user has to tap the new
+    // cell a second time to see its popover. Mouse and keyboard
+    // continue to swap on hover / open on click as before; on those
+    // input types, peeking at adjacent cells is cheap and useful.
+    //
+    // The pointerdown handler on each popover-interactive cell sets
+    // this flag when the conditions match. Radix's
+    // `onPointerDownOutside` then closes the previously-open popover,
+    // and the click that follows would normally fire `onOpenChange(true)`
+    // on the freshly tapped cell — we consume the flag there to
+    // suppress that open. The flag self-resets at the start of every
+    // pointerdown so a stale value can never carry over.
+    const dismissNextTouchOpenRef = useRef(false);
     // Analytics context: snapshot the inputs `statusFor` needs so the
     // keyboard handler can read them at action time without bloating
     // the useEffect dep list.
@@ -1598,6 +1614,28 @@ export function Checklist() {
                                                     open={isOpen}
                                                     onOpenChange={open => {
                                                         if (open) {
+                                                            if (
+                                                                dismissNextTouchOpenRef.current
+                                                            ) {
+                                                                // Touch tap
+                                                                // on a different
+                                                                // cell while a
+                                                                // popover was
+                                                                // open: the
+                                                                // open popover
+                                                                // already closed
+                                                                // via Radix's
+                                                                // pointerdown-outside
+                                                                // path; suppress
+                                                                // this open so
+                                                                // the user has
+                                                                // to tap again
+                                                                // to see the
+                                                                // new cell's
+                                                                // popover.
+                                                                dismissNextTouchOpenRef.current = false;
+                                                                return;
+                                                            }
                                                             // Explicit
                                                             // activation
                                                             // (click /
@@ -1637,6 +1675,45 @@ export function Checklist() {
                                                         data-cell-col={colIdx}
                                                         {...firstCellAnchorAttr}
                                                         onFocus={onCellFocus}
+                                                        onPointerDown={e => {
+                                                            // Reset any stale
+                                                            // flag from a prior
+                                                            // gesture that
+                                                            // didn't complete a
+                                                            // click.
+                                                            dismissNextTouchOpenRef.current =
+                                                                false;
+                                                            if (
+                                                                e.pointerType
+                                                                    !== "touch"
+                                                            )
+                                                                return;
+                                                            // Touch tap on a
+                                                            // different cell
+                                                            // while a popover
+                                                            // is open: arm the
+                                                            // dismiss-not-open
+                                                            // gate. The flag
+                                                            // is consumed by
+                                                            // this cell's
+                                                            // onOpenChange a
+                                                            // few events later
+                                                            // when the click
+                                                            // would otherwise
+                                                            // open the new
+                                                            // popover.
+                                                            if (
+                                                                popoverCellRef.current
+                                                                    !== null
+                                                                && !Equal.equals(
+                                                                    popoverCellRef.current,
+                                                                    thisCell,
+                                                                )
+                                                            ) {
+                                                                dismissNextTouchOpenRef.current =
+                                                                    true;
+                                                            }
+                                                        }}
                                                         onKeyDown={e => {
                                                             // Enter/Space should open the
                                                             // info popover. Radix binds

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -314,6 +314,15 @@ export function Checklist() {
     // suppress that open. The flag self-resets at the start of every
     // pointerdown so a stale value can never carry over.
     const dismissNextTouchOpenRef = useRef(false);
+    // Map from `ownerCellKey` to the popover-interactive cell's DOM
+    // node. Each such cell registers itself via a callback ref. The
+    // popover-cell-changed effect below uses this map to move focus
+    // onto the cell whose popover just opened — important for the
+    // mouse hover-intent path, which sets `popoverCell` after a
+    // 300 ms hover but never naturally moves focus. With the cell
+    // focused, the `:focus` ring outlines the popover's anchor cell
+    // even when the popover content is portaled away from it.
+    const cellNodesByKeyRef = useRef<Map<string, HTMLElement>>(new Map());
     // Analytics context: snapshot the inputs `statusFor` needs so the
     // keyboard handler can read them at action time without bloating
     // the useEffect dep list.
@@ -428,6 +437,26 @@ export function Checklist() {
         jointFailed,
     ]);
 
+    const playerColumnKeys = useStablePlayerColumnKeys(setup.players);
+
+    // When `popoverCell` becomes (or changes to) a non-null cell,
+    // move focus onto its trigger `<td>` if it isn't already there.
+    // The hover-intent path opens the popover from a mouse hover,
+    // which doesn't naturally move focus; without this effect the
+    // popover would float without a visible cell anchor (the popover
+    // content is portaled into `document.body`, so the visual link
+    // back to the trigger comes entirely from the cell's `:focus`
+    // ring). `preventScroll: true` keeps the page from jumping —
+    // the user is already looking at the cell.
+    useEffect(() => {
+        if (popoverCell === null) return;
+        const key = `${ownerKey(popoverCell.owner, playerColumnKeys)}-${String(popoverCell.card)}`;
+        const node = cellNodesByKeyRef.current.get(key);
+        if (node && document.activeElement !== node) {
+            node.focus({ preventScroll: true });
+        }
+    }, [popoverCell, playerColumnKeys]);
+
     const owners: ReadonlyArray<Owner> = allOwners(setup);
 
     // Flat (card → row) index used for arrow-key grid navigation.
@@ -454,7 +483,6 @@ export function Checklist() {
         maxCol: totalCols - 1,
     };
 
-    const playerColumnKeys = useStablePlayerColumnKeys(setup.players);
     const tableEntryTransition = useReducedTransition(TABLE_ENTRY_TRANSITION);
     const tableRowEntryTransition = useReducedTransition(
         TABLE_ROW_ENTRY_TRANSITION,
@@ -1665,6 +1693,18 @@ export function Checklist() {
                                                     popoverZone="checklist"
                                                 >
                                                     <motion.td
+                                                        ref={(el: HTMLElement | null) => {
+                                                            if (el) {
+                                                                cellNodesByKeyRef.current.set(
+                                                                    ownerCellKey,
+                                                                    el,
+                                                                );
+                                                            } else {
+                                                                cellNodesByKeyRef.current.delete(
+                                                                    ownerCellKey,
+                                                                );
+                                                            }
+                                                        }}
                                                         className={tdClassName}
                                                         exit={columnCellExit}
                                                         style={STYLE_COLUMN_CELL_VISIBLE}
@@ -2702,7 +2742,7 @@ const STICKY_FIRST_COL_HEADER =
 
 // Z-index ladder for the checklist:
 //   - body cell hover ring      : --z-checklist-cell-hover
-//   - body cell focus-visible   : --z-checklist-cell-focus
+//   - body cell focus           : --z-checklist-cell-focus
 //   - sticky first column       : --z-checklist-sticky-column
 //   - sticky <thead>            : --z-checklist-sticky-header
 // The body-cell z-index escape keeps rings from being painted under
@@ -2719,10 +2759,18 @@ const STICKY_FIRST_COL_HEADER =
 // stacking context and respects z-index escape, so the ring renders
 // on all four sides regardless of which cell its neighbour is.
 //
-// 3px ring matches the global `*:focus-visible` outline width set
-// in `app/globals.css` so checklist cells read at the same weight
-// as every other focusable element on the page (inputs, buttons,
-// etc.).
+// 3px ring width matches the global `*:focus-visible` outline width
+// set in `app/globals.css` so checklist cells read at the same weight
+// as every other focusable element on the page (inputs, buttons, etc.).
+//
+// `:focus` (NOT `:focus-visible`): when a touch user taps a cell to
+// open its popover, we want the ring to make the trigger cell visible
+// — the popover is portaled into `document.body`, so without the ring
+// the user can't tell which cell anchors it. `:focus-visible` skips
+// touch and mouse focus, which would leave the popover floating
+// without a visible source. The slight cost is a ring after every
+// mouse click on a cell; that's acceptable here because the popover
+// it pairs with is the primary feedback anyway.
 //
 // The ring-offset color is set per-cell to match the cell's own
 // background (`ring-offset-yes-bg`, `ring-offset-no-bg`, or
@@ -2730,8 +2778,15 @@ const STICKY_FIRST_COL_HEADER =
 // visually equivalent to the transparent offset CSS outlines have.
 // Without that match the offset would render as a solid panel band
 // and the focus indicator would look like a thick double-ring.
+// `hover:` modifiers are gated by `not-focus:` so the soft hover
+// ring (2px, accent/30) yields to the focus ring (3px, accent)
+// whenever the cell is focused. Without that gate, both rules
+// write `--tw-ring-shadow` and the hover-pseudo wins while the
+// pointer is still over the focused cell — so opening the popover
+// via hover would show a faint hint until the cursor moved away,
+// at which point the strong focus ring would finally appear.
 const CELL_INTERACTIVE =
-    " cursor-pointer hover:z-[var(--z-checklist-cell-hover)] hover:rounded-[2px] hover:ring-2 hover:ring-accent/30 focus-visible:z-[var(--z-checklist-cell-focus)] focus-visible:ring-[3px] focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:rounded-[2px] focus-visible:outline-none";
+    " cursor-pointer hover:not-focus:z-[var(--z-checklist-cell-hover)] hover:not-focus:rounded-[2px] hover:not-focus:ring-2 hover:not-focus:ring-accent/30 focus:z-[var(--z-checklist-cell-focus)] focus:ring-[3px] focus:ring-accent focus:ring-offset-2 focus:rounded-[2px] focus:outline-none";
 
 const CELL_HIGHLIGHTED =
     " z-[var(--z-checklist-cell-hover)] ring-2 ring-accent ring-offset-1 ring-offset-panel";
@@ -2761,10 +2816,10 @@ const cellClass = (
                 ? display.value
                 : undefined;
     if (tone === Y) {
-        return `${base} bg-yes-bg text-yes focus-visible:ring-offset-yes-bg`;
+        return `${base} bg-yes-bg text-yes focus:ring-offset-yes-bg`;
     }
     if (tone === N) {
-        return `${base} bg-no-bg text-no focus-visible:ring-offset-no-bg`;
+        return `${base} bg-no-bg text-no focus:ring-offset-no-bg`;
     }
-    return `${base} bg-white focus-visible:ring-offset-white`;
+    return `${base} bg-white focus:ring-offset-white`;
 };

--- a/src/ui/components/InfoPopover.test.tsx
+++ b/src/ui/components/InfoPopover.test.tsx
@@ -7,7 +7,7 @@ vi.mock("next-intl", () => ({
 }));
 
 describe("InfoPopover — content pointer-event hooks", () => {
-    test("onContentPointerEnter fires when pointer enters the popover content", () => {
+    test("onContentPointerEnter fires for mouse pointer entering the popover content", () => {
         const onEnter = vi.fn();
         render(
             <InfoPopover
@@ -19,11 +19,11 @@ describe("InfoPopover — content pointer-event hooks", () => {
             </InfoPopover>,
         );
         const content = screen.getByRole("dialog");
-        fireEvent.pointerEnter(content);
+        fireEvent.pointerEnter(content, { pointerType: "mouse" });
         expect(onEnter).toHaveBeenCalledTimes(1);
     });
 
-    test("onContentPointerLeave fires when pointer leaves the popover content", () => {
+    test("onContentPointerLeave fires for mouse pointer leaving the popover content", () => {
         const onLeave = vi.fn();
         render(
             <InfoPopover
@@ -35,8 +35,54 @@ describe("InfoPopover — content pointer-event hooks", () => {
             </InfoPopover>,
         );
         const content = screen.getByRole("dialog");
-        fireEvent.pointerLeave(content);
+        fireEvent.pointerLeave(content, { pointerType: "mouse" });
         expect(onLeave).toHaveBeenCalledTimes(1);
+    });
+
+    // The hover-intent contract is mouse-only. On touch, the W3C spec
+    // fires a synthetic `pointerleave` after `pointerup` because the
+    // touch pointer ceases to exist. Forwarding that to the parent's
+    // exit timer would close the popover the user just tapped a
+    // control inside (regression covered: tapping Y/N inside a
+    // checklist popover on mobile dismissed it ~900 ms later).
+    test("does NOT forward touch pointer enter/leave to the parent", () => {
+        const onEnter = vi.fn();
+        const onLeave = vi.fn();
+        render(
+            <InfoPopover
+                content="why"
+                open
+                onContentPointerEnter={onEnter}
+                onContentPointerLeave={onLeave}
+            >
+                <button type="button">trigger</button>
+            </InfoPopover>,
+        );
+        const content = screen.getByRole("dialog");
+        fireEvent.pointerEnter(content, { pointerType: "touch" });
+        fireEvent.pointerLeave(content, { pointerType: "touch" });
+        expect(onEnter).not.toHaveBeenCalled();
+        expect(onLeave).not.toHaveBeenCalled();
+    });
+
+    test("does NOT forward pen pointer enter/leave to the parent", () => {
+        const onEnter = vi.fn();
+        const onLeave = vi.fn();
+        render(
+            <InfoPopover
+                content="why"
+                open
+                onContentPointerEnter={onEnter}
+                onContentPointerLeave={onLeave}
+            >
+                <button type="button">trigger</button>
+            </InfoPopover>,
+        );
+        const content = screen.getByRole("dialog");
+        fireEvent.pointerEnter(content, { pointerType: "pen" });
+        fireEvent.pointerLeave(content, { pointerType: "pen" });
+        expect(onEnter).not.toHaveBeenCalled();
+        expect(onLeave).not.toHaveBeenCalled();
     });
 
     test("absent handlers don't crash on pointer events", () => {
@@ -47,8 +93,10 @@ describe("InfoPopover — content pointer-event hooks", () => {
         );
         const content = screen.getByRole("dialog");
         expect(() => {
-            fireEvent.pointerEnter(content);
-            fireEvent.pointerLeave(content);
+            fireEvent.pointerEnter(content, { pointerType: "mouse" });
+            fireEvent.pointerLeave(content, { pointerType: "mouse" });
+            fireEvent.pointerEnter(content, { pointerType: "touch" });
+            fireEvent.pointerLeave(content, { pointerType: "touch" });
         }).not.toThrow();
     });
 });

--- a/src/ui/components/InfoPopover.tsx
+++ b/src/ui/components/InfoPopover.tsx
@@ -42,6 +42,13 @@ interface InfoPopoverProps {
      * parent driving the open state via hover-intent (e.g. the
      * Checklist) treat the portaled content as part of its hover zone:
      * entering it cancels the parent's exit timer, leaving it re-arms.
+     *
+     * Mouse-only by design: hover-intent is a mouse pattern. On touch,
+     * the W3C spec fires a synthetic `pointerleave` after `pointerup`
+     * (the touch pointer ceases to exist), which would re-arm a parent's
+     * exit timer and close the popover the user just tapped a control
+     * inside. We filter to `pointerType === "mouse"` before forwarding
+     * — touch and pen users dismiss via tap-outside / Esc / re-tap-trigger.
      */
     readonly onContentPointerEnter?: () => void;
     readonly onContentPointerLeave?: () => void;
@@ -119,8 +126,12 @@ export function InfoPopover({
                     sideOffset={6}
                     collisionPadding={8}
                     onOpenAutoFocus={e => e.preventDefault()}
-                    onPointerEnter={onContentPointerEnter}
-                    onPointerLeave={onContentPointerLeave}
+                    onPointerEnter={e => {
+                        if (e.pointerType === "mouse") onContentPointerEnter?.();
+                    }}
+                    onPointerLeave={e => {
+                        if (e.pointerType === "mouse") onContentPointerLeave?.();
+                    }}
                     data-popover-zone={popoverZone}
                     // The `before:` rules render an invisible 10px hover
                     // bridge in the gap between the popover and its


### PR DESCRIPTION
## Summary

Three related fixes to the checklist's per-cell why-popover, all surfaced by the new per-cell hypothesis controls:

- **Popover no longer closes after tapping Y/N on mobile.** On touch, the W3C-spec \`pointerleave\` that fires after \`pointerup\` was arming the 900ms hover-intent exit timer. Filtered the popover Content's pointer handlers to \`pointerType === \"mouse\"\` so the hover-intent path is mouse-only by construction.
- **On touch, the first tap on a different cell dismisses the open popover instead of swapping.** Tapping a neighbor used to silently move the popover; now the user has to tap a second time to see the new cell's popover. Mouse hover-intent still swaps as before. Implemented via a pointerdown gate that's consumed by the next cell's \`onOpenChange\`.
- **Focus ring is visible on whichever cell anchors the open popover.** Switched the cell focus indicator from \`:focus-visible\` to \`:focus\` so it shows on touch and mouse activation; programmatically focus the trigger cell when \`popoverCell\` changes (so the mouse hover-intent path's 300 ms-deferred open also lights up the cell); gated the soft hover ring with \`not-focus:\` so the strong focus ring wins when both states are active.

## Test plan

- [x] All five pre-commit checks green: \`pnpm typecheck\`, \`pnpm lint\`, \`pnpm test\` (1084 / 1084), \`pnpm knip\`, \`pnpm i18n:check\`
- [x] InfoPopover unit tests pin pointerType filtering (mouse fires handlers; touch and pen do not)
- [x] Verified mobile bug fix in \`next-dev\` preview: tap cell → tap Y → popover stays open
- [x] Verified mobile dismiss-not-swap: tap A → tap B → A dismisses, B doesn't open; tap B again → opens
- [x] Verified desktop hover-intent preserved: mouse hover → swap; mouse leave → 900ms exit timer fires
- [ ] Walk both viewports on a real device to confirm the focus ring appears on hover-open (preview's \`document.hasFocus()\` is false, so \`:focus\` doesn't paint in the headless screenshot — CSS rules and React focus call are wired correctly)

## Commits

- \`e59c0a7\` Fix mobile \"why\" popover closing after Y/N tap (\`InfoPopover.tsx\` filters touch \`pointerleave\`)
- \`44f8e05\` On touch, first tap outside dismisses popover instead of swapping (\`Checklist.tsx\` pointerdown gate + onOpenChange consumer)
- \`f098957\` Show focus ring on the cell whose popover is open (\`:focus-visible\` → \`:focus\`, programmatic focus on \`popoverCell\` change, hover ring gated by \`not-focus:\`)

## Observability

No new events. \`hypothesisSet\` / \`hypothesisCleared\` and \`why_tooltip_opened\` already cover the user-meaningful signals; popover dismissal mechanism isn't a funnel step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)