### PR TITLE
Refine checklist cell layout and sticky-cell z-index hierarchy

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -123,9 +123,18 @@
      * Ordering constraints:
      * - Checklist hover/focus rings sit above neighboring body cells,
      *   but below sticky first-column cells and sticky headers.
-     * - Sticky first-column cells sit above scrolled body cells, while
-     *   sticky table headers sit above both so column labels remain
-     *   readable during vertical scroll.
+     * - Sticky body first-column cells (row headers — card category
+     *   and card names) sit highest so they render over any content
+     *   cells they pass during horizontal scroll.
+     * - Sticky table headers (column headers — player names and hand
+     *   sizes) sit in the middle so non-corner header cells render
+     *   over the top-left cell as they slide left during horizontal
+     *   scroll. Non-corner header cells need explicit `relative
+     *   z-[var(--z-checklist-sticky-header)]` to escape document-order
+     *   layering and stack above the top-left within the thead's
+     *   stacking context.
+     * - The top-left corner cell sits lowest of the three sticky tiers
+     *   so column-header cells overlap it cleanly.
      * - App chrome (page header / bottom nav) sits above the checklist
      *   table, and dropdowns/tooltips sit above app chrome.
      * - The contradiction banner sits above app chrome because headers
@@ -137,8 +146,9 @@
     --z-local-raised: 10;
     --z-checklist-cell-hover: 20;
     --z-checklist-cell-focus: 25;
-    --z-checklist-sticky-column: 30;
-    --z-checklist-sticky-header: 35;
+    --z-checklist-sticky-top-left: 30;
+    --z-checklist-sticky-header: 33;
+    --z-checklist-sticky-column: 36;
     --z-app-chrome: 40;
     --z-popover: 50;
     --z-contradiction-banner: 55;

--- a/src/ui/components/Checklist.setup.test.tsx
+++ b/src/ui/components/Checklist.setup.test.tsx
@@ -121,7 +121,7 @@ describe("Checklist — setup mode — top-level structure", () => {
         const firstHeader = thead?.querySelector("th");
         expect(firstHeader?.className).toContain("sticky left-0");
         expect(firstHeader?.className).toContain(
-            "z-[var(--z-checklist-sticky-header)]",
+            "z-[var(--z-checklist-sticky-top-left)]",
         );
         const firstBodyHeader = document.querySelector("tbody th");
         expect(firstBodyHeader?.className).toContain("sticky left-0");

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -682,7 +682,7 @@ export function Checklist() {
     const addPlayerHeaderCell = (
         <motion.th
             key={ADD_PLAYER_COLUMN_KEY}
-            className="w-px overflow-hidden whitespace-nowrap border-r border-b border-border bg-row-header p-0 text-center"
+            className={`${COLUMN_HEADER_STACK} w-px overflow-hidden whitespace-nowrap border-r border-b border-border bg-row-header p-0 text-center`}
             initial={TABLE_COLUMN_HIDDEN}
             animate={TABLE_COLUMN_VISIBLE}
             exit={columnCellExit}
@@ -717,7 +717,7 @@ export function Checklist() {
     const addPlayerEmptyCell = (
         <motion.td
             key={ADD_PLAYER_COLUMN_KEY}
-            className="overflow-hidden border-r border-b border-border"
+            className={`${COLUMN_HEADER_STACK} overflow-hidden border-r border-b border-border`}
             initial={TABLE_COLUMN_HIDDEN}
             animate={TABLE_COLUMN_VISIBLE}
             exit={columnCellExit}
@@ -960,7 +960,7 @@ export function Checklist() {
                             const cell = (
                                 <motion.th
                                     key={ownerKey(owner, playerColumnKeys)}
-                                    className="overflow-hidden border-r border-b border-border bg-row-header p-0 text-center align-top font-semibold"
+                                    className={`${COLUMN_HEADER_STACK} overflow-hidden border-r border-b border-border bg-row-header p-0 text-center align-top font-semibold`}
                                     initial={TABLE_COLUMN_HIDDEN}
                                     animate={TABLE_COLUMN_VISIBLE}
                                     exit={columnCellExit}
@@ -992,7 +992,7 @@ export function Checklist() {
                     {inSetup && (
                         <tr>
                             <th
-                                className={`${STICKY_FIRST_COL_HEADER} whitespace-nowrap border-r border-b border-border bg-row-header px-1.5 py-1 text-left font-semibold`}
+                                className={`${STICKY_FIRST_COL} whitespace-nowrap border-r border-b border-border bg-row-header px-1.5 py-1 text-left font-semibold`}
                                 data-tour-sticky-left=""
                                 // The setup tour's "Set hand sizes"
                                 // step highlights the row label cell
@@ -1009,7 +1009,7 @@ export function Checklist() {
                                     cell = (
                                         <motion.td
                                             key={ownerKey(owner, playerColumnKeys)}
-                                            className="overflow-hidden border-r border-b border-border"
+                                            className={`${COLUMN_HEADER_STACK} overflow-hidden border-r border-b border-border`}
                                             initial={TABLE_COLUMN_HIDDEN}
                                             animate={TABLE_COLUMN_VISIBLE}
                                             exit={columnCellExit}
@@ -1029,7 +1029,7 @@ export function Checklist() {
                                     cell = (
                                         <motion.td
                                             key={ownerKey(owner, playerColumnKeys)}
-                                            className="overflow-hidden border-r border-b border-border p-0 text-center"
+                                            className={`${COLUMN_HEADER_STACK} overflow-hidden border-r border-b border-border p-0 text-center`}
                                             initial={TABLE_COLUMN_HIDDEN}
                                             animate={TABLE_COLUMN_VISIBLE}
                                             exit={columnCellExit}
@@ -2731,7 +2731,12 @@ function AnimatedCellGlyph({
                     animate={{ scale: 1, opacity: 1 }}
                     exit={{ scale: 0.5, opacity: 0 }}
                     transition={transition}
-                    className="inline-flex items-center justify-center"
+                    // p-1 gives the glyph a 4px gutter so it doesn't
+                    // visually crash into the corner badges when the
+                    // cell is tight. The setup-mode checkbox renders
+                    // through a separate code path and intentionally
+                    // skips this padding.
+                    className="inline-flex items-center justify-center p-1"
                 >
                     {renderGlyphNode(kind)}
                 </motion.span>
@@ -2755,18 +2760,29 @@ const STICKY_FIRST_COL =
     "sticky left-0 z-[var(--z-checklist-sticky-column)]";
 
 const STICKY_FIRST_COL_HEADER =
-    "sticky left-0 z-[var(--z-checklist-sticky-header)]";
+    "sticky left-0 z-[var(--z-checklist-sticky-top-left)]";
+
+// `relative z-[sticky-header]` on every non-corner thead cell so they
+// escape document-order layering and stack above the top-left cell
+// within the thead's stacking context. Without this, the top-left's
+// own `z-[sticky-top-left]` (positive z, step 7 of the thead context)
+// would render over non-positioned siblings (step 3) — i.e. the
+// player-name cells would slide UNDER the top-left during horizontal
+// scroll, the opposite of the desired behavior.
+const COLUMN_HEADER_STACK =
+    "relative z-[var(--z-checklist-sticky-header)]";
 
 // Z-index ladder for the checklist:
 //   - body cell hover ring      : --z-checklist-cell-hover
 //   - body cell focus           : --z-checklist-cell-focus
+//   - sticky top-left cell      : --z-checklist-sticky-top-left
+//   - sticky <thead> + cols     : --z-checklist-sticky-header
 //   - sticky first column       : --z-checklist-sticky-column
-//   - sticky <thead>            : --z-checklist-sticky-header
-// The body-cell z-index escape keeps rings from being painted under
-// neighboring cells in document order. The sticky first column and
-// sticky header deliberately sit higher so horizontal / vertical
-// scroll never hides the card/category labels or column labels under
-// an active body cell.
+// Row headers (body's sticky first column) sit at the top of the
+// ladder so they render over content cells during horizontal scroll.
+// Column headers (thead column-name cells) sit in the middle so they
+// overlap the top-left corner cell during horizontal scroll. The
+// top-left corner sits at the bottom of the three sticky tiers.
 //
 // Focus indicator: `ring-[3px] ring-offset-2` (box-shadow) instead of
 // `outline-3 outline-offset-2`. Outlines on `<td>` cells in


### PR DESCRIPTION
The center glyph (question mark / check / dot / alert) in deduce-mode
checklist cells used to sit flush against the bottom edge of the
top-left/top-right corner badges in tight cells. Add `p-1` to the
glyph's flex span so it carries a 4px gutter into the corner zone;
the setup-mode checkbox keeps its existing sizing.

Reorder the sticky stacking ladder for the checklist into three tiers
so the relative layering during scroll is explicit:

  1. row headers (body sticky first column) — highest
  2. column headers (thead column-name cells) — middle
  3. top-left corner cell — lowest

Add a `--z-checklist-sticky-top-left` token for the corner, drop
`--z-checklist-sticky-header` to sit between top-left and the body
column, and raise `--z-checklist-sticky-column` so row headers sit at
the top of the ladder. Stamp `relative z-[sticky-header]` onto every
non-corner thead cell (player names, hand-size cells, the add-player
column) so they escape document-order stacking and visibly slide over
the top-left cell during horizontal scroll instead of disappearing
under it. Apply in both setup and deduce modes via the shared
constants.

https://claude.ai/code/session_01TFBrtFhC29rLwKPXL3nFog