### PR TITLE
Quiet setup mode and surface rejected hypotheses

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -313,7 +313,13 @@
         "knownCardFix": "Known card: <strong>{player}</strong> has <strong>{card}</strong>",
         "knownCardUnset": "Unset",
         "handSizeFix": "Hand size: <strong>{player}</strong> = {size}",
-        "handSizeReset": "Reset"
+        "handSizeReset": "Reset",
+        "directBannerTitle": "{count, plural, one {Hypothesis conflicts with a known fact} other {Hypotheses conflict with known facts}}",
+        "directBannerHelp": "{count, plural, one {This hypothesis disagrees with what the deducer has already proven. Turn it off to keep exploring.} other {Each of these hypotheses disagrees with what the deducer has already proven. Turn them off to keep exploring.}}",
+        "jointBannerTitle": "{count, plural, one {Conflicting hypothesis} other {Conflicting hypotheses}}",
+        "jointBannerHelp": "These hypotheses can't all be true together. Turn one off to keep exploring — until you do, the checklist hides everything that would have followed from them.",
+        "jointHypothesisRow": "<strong>{owner}</strong> / <strong>{card}</strong> = <strong>{value}</strong>",
+        "jointHypothesisTurnOff": "Turn off"
     },
     "share": {
         "entryInvitePlayer": "Invite a player",

--- a/src/ui/components/CellGlyph.test.tsx
+++ b/src/ui/components/CellGlyph.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "vitest";
+import { N, Y } from "../../logic/Knowledge";
+import type {
+    CellDisplay,
+    HypothesisStatus,
+} from "../../logic/Hypothesis";
+import { glyphKindFor, renderGlyphNode } from "./CellGlyph";
+
+describe("glyphKindFor", () => {
+    test("real Y → 'yes'", () => {
+        const display: CellDisplay = { tag: "real", value: Y };
+        expect(glyphKindFor(display, { kind: "off" })).toBe("yes");
+    });
+
+    test("real N → 'no'", () => {
+        const display: CellDisplay = { tag: "real", value: N };
+        expect(glyphKindFor(display, { kind: "off" })).toBe("no");
+    });
+
+    test("hypothesis → 'question'", () => {
+        const display: CellDisplay = { tag: "hypothesis", value: Y };
+        expect(glyphKindFor(display, { kind: "active", value: Y })).toBe(
+            "question",
+        );
+    });
+
+    test("derived → 'question'", () => {
+        const display: CellDisplay = { tag: "derived", value: N };
+        expect(glyphKindFor(display, { kind: "derived", value: N })).toBe(
+            "question",
+        );
+    });
+
+    test("blank → 'blank'", () => {
+        expect(glyphKindFor({ tag: "blank" }, { kind: "off" })).toBe("blank");
+    });
+
+    test("directlyContradicted shows the deduced (real) Y, NOT an alert", () => {
+        // The hypothesis is N but the real-only deduction proved Y. Center
+        // glyph should show the real Y; the conflict signal lives in the
+        // top-right `HypothesisBadge`, which renders X + bounce.
+        const display: CellDisplay = { tag: "real", value: Y };
+        const status: HypothesisStatus = {
+            kind: "directlyContradicted",
+            hypothesis: N,
+            real: Y,
+        };
+        expect(glyphKindFor(display, status)).toBe("yes");
+    });
+
+    test("jointlyConflicts on a still-blank cell falls through to 'blank'", () => {
+        // Joint deduction failed, so the checklist falls back to real-only
+        // and this cell has no value yet. Center glyph stays blank; the
+        // hypothesis badge carries the X + bounce.
+        const display: CellDisplay = { tag: "blank" };
+        const status: HypothesisStatus = {
+            kind: "jointlyConflicts",
+            value: Y,
+        };
+        expect(glyphKindFor(display, status)).toBe("blank");
+    });
+});
+
+describe("renderGlyphNode", () => {
+    test("yes renders as ✓", () => {
+        expect(renderGlyphNode("yes")).toBe("✓");
+    });
+
+    test("no renders as ·", () => {
+        expect(renderGlyphNode("no")).toBe("·");
+    });
+
+    test("question renders as ?", () => {
+        expect(renderGlyphNode("question")).toBe("?");
+    });
+
+    test("blank renders as null", () => {
+        expect(renderGlyphNode("blank")).toBeNull();
+    });
+});

--- a/src/ui/components/CellGlyph.tsx
+++ b/src/ui/components/CellGlyph.tsx
@@ -4,7 +4,6 @@ import {
     type HypothesisStatus,
 } from "../../logic/Hypothesis";
 import { N, Y } from "../../logic/Knowledge";
-import { AlertIcon } from "./Icons";
 
 // Discriminator constants for the cell's primary glyph slot. Module-
 // scope so the `no-literal-string` lint rule reads them as code, not
@@ -20,28 +19,21 @@ import { AlertIcon } from "./Icons";
 const GLYPH_YES = "yes" as const;
 const GLYPH_NO = "no" as const;
 const GLYPH_QUESTION = "question" as const;
-const GLYPH_ALERT = "alert" as const;
 export const GLYPH_BLANK = "blank" as const;
 type GlyphKind =
     | typeof GLYPH_YES
     | typeof GLYPH_NO
     | typeof GLYPH_QUESTION
-    | typeof GLYPH_ALERT
     | typeof GLYPH_BLANK;
 
+// Rejected hypotheses (directly contradicted or jointly conflicting)
+// no longer override the center glyph — the cell keeps showing its
+// real-only deduced value, and the corner `HypothesisBadge` carries
+// the X icon + bounce animation that flags the conflict.
 export const glyphKindFor = (
     display: CellDisplay,
-    status: HypothesisStatus,
+    _status: HypothesisStatus,
 ): GlyphKind => {
-    // Contradicted hypotheses (directly or jointly) replace whatever
-    // glyph would have rendered with the alert icon, so the conflict
-    // reads at a glance.
-    if (
-        status.kind === "directlyContradicted" ||
-        status.kind === "jointlyConflicts"
-    ) {
-        return GLYPH_ALERT;
-    }
     switch (display.tag) {
         case "real":
             if (display.value === Y) return GLYPH_YES;
@@ -63,8 +55,6 @@ export const renderGlyphNode = (kind: GlyphKind): ReactNode => {
             return "·";
         case GLYPH_QUESTION:
             return "?";
-        case GLYPH_ALERT:
-            return <AlertIcon size={14} className="text-danger" />;
         case GLYPH_BLANK:
             return null;
     }

--- a/src/ui/components/CellWhyPopover.test.tsx
+++ b/src/ui/components/CellWhyPopover.test.tsx
@@ -250,8 +250,8 @@ describe("CellWhyPopover - Hypothesis section help text", () => {
         expect(screen.getByText("statusConfirmed")).toBeInTheDocument();
     });
 
-    test("directly contradicted: short selectedHelpContradicted + long statusDirectlyContradicted box", () => {
-        render(
+    test("directly contradicted: short selectedHelpContradicted + long statusDirectlyContradicted box with animated X badge", () => {
+        const { container } = render(
             <CellWhyPopover
                 {...baseProps}
                 hypothesisValue="N"
@@ -265,6 +265,19 @@ describe("CellWhyPopover - Hypothesis section help text", () => {
         );
         expect(screen.getByText(/^selectedHelpContradicted:/)).toBeInTheDocument();
         expect(screen.getByText("statusDirectlyContradicted")).toBeInTheDocument();
+
+        // The status box embeds an `<HypothesisBadge animated>` so the
+        // pulse moves into the popover when it opens. Two badges total
+        // in the popover (the short help row and the status box); the
+        // status-box one should carry the ping class.
+        const xBadges = container.querySelectorAll('svg[data-glyph="x"]');
+        expect(xBadges.length).toBe(2);
+        const animatedXBadges = Array.from(xBadges).filter(svg =>
+            (svg.getAttribute("class") ?? "").includes(
+                "motion-safe:animate-pulse",
+            ),
+        );
+        expect(animatedXBadges.length).toBe(1);
     });
 
     test("jointly conflicts: short selectedHelpJointlyConflicts + long statusJointlyConflicts box with bullets", () => {

--- a/src/ui/components/CellWhyPopover.tsx
+++ b/src/ui/components/CellWhyPopover.tsx
@@ -12,7 +12,7 @@ import {
     type HypothesisValue,
 } from "../../logic/Hypothesis";
 import { HashMap } from "effect";
-import { AlertIcon, CheckIcon, LightbulbIcon } from "./Icons";
+import { CheckIcon, LightbulbIcon } from "./Icons";
 import { HypothesisControl } from "./HypothesisControl";
 import { HypothesisBadge } from "./HypothesisBadge";
 import {
@@ -132,9 +132,20 @@ export function CellWhyPopover({
         }
     })();
 
-    const statusBox = longStatusMessage === undefined ? null : isContradicted ? (
+    const statusBox = longStatusMessage === undefined ? null : isContradicted &&
+      hypothesisValue !== undefined ? (
         <div className="flex items-start gap-2 rounded-[var(--radius)] border border-danger-border bg-danger-bg p-2 text-[12px] text-danger">
-            <AlertIcon size={14} className="mt-[1px] flex-shrink-0" />
+            <span className="mt-[1px] flex-shrink-0">
+                {/* `animated` is true here so the pulse moves into the
+                    popover whenever it's open — the matching cell
+                    badge stops animating while the popover is
+                    visible (see Checklist's `isPopoverOnThisCell`). */}
+                <HypothesisBadge
+                    value={hypothesisValue}
+                    status={status}
+                    animated
+                />
+            </span>
             <div className="flex flex-col gap-1">
                 <span>{longStatusMessage}</span>
                 {isJointConflict && activeHypothesisLabels.length > 0 && (
@@ -146,7 +157,7 @@ export function CellWhyPopover({
                 )}
             </div>
         </div>
-    ) : (
+    ) : isContradicted ? null : (
         // Confirmed — mirror the contradiction panel in success palette.
         <div className="flex items-start gap-2 rounded-[var(--radius)] border border-yes/40 bg-yes-bg p-2 text-[12px] text-yes">
             <CheckIcon size={14} className="mt-[1px] flex-shrink-0" />

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -1296,9 +1296,22 @@ export function Checklist() {
                                             hypotheses,
                                             jointFailed,
                                         );
+                                        // Setup mode is for entering known
+                                        // facts — hypotheses shouldn't tint
+                                        // cells, drive corner badges, or show
+                                        // lightbulb leads. Forcing the
+                                        // status to "off" makes `displayFor`
+                                        // return the real value (or blank),
+                                        // and the topLeft / topRight slots
+                                        // below skip the chip + badge in
+                                        // setup outright.
+                                        const effectiveStatus: HypothesisStatus =
+                                            inSetup
+                                                ? { kind: "off" }
+                                                : hypothesisStatus;
                                         const display = displayFor(
                                             value,
-                                            hypothesisStatus,
+                                            effectiveStatus,
                                         );
                                         const footnoteNumbers = footnotesForCell(
                                             footnotes,
@@ -1351,7 +1364,8 @@ export function Checklist() {
                                             tReasons,
                                         });
                                         const showChip =
-                                            footnoteNumbers.length > 0
+                                            !inSetup
+                                            && footnoteNumbers.length > 0
                                             && value === undefined;
                                         const topLeft = showChip ? (
                                             <span
@@ -1371,11 +1385,20 @@ export function Checklist() {
                                         // hypothesised N shows a red badge
                                         // against a green cell, making the
                                         // disagreement visible at a glance.
+                                        // The cell's rejected-badge pulse
+                                        // stays on whether or not the popover
+                                        // is open — the matching popover
+                                        // status-box badge also pulses, so the
+                                        // cell and popover read together when
+                                        // the user is looking at one or the
+                                        // other.
                                         const topRight =
+                                            !inSetup &&
                                             hypothesisValue !== undefined ? (
                                                 <HypothesisBadge
                                                     value={hypothesisValue}
                                                     status={hypothesisStatus}
+                                                    animated
                                                 />
                                             ) : null;
                                         const center = setupCheckbox ? (
@@ -2770,11 +2793,11 @@ const cellClass = (
 ): string => {
     let base = interactive ? `${CELL_BASE}${CELL_INTERACTIVE}` : CELL_BASE;
     if (highlighted) base += CELL_HIGHLIGHTED;
-    // Contradiction states are conveyed by the AlertIcon that
-    // replaces the central glyph (`directlyContradicted` and
-    // `jointlyConflicts` both render `<AlertIcon>`) and by the
-    // boxed status panel inside the popover, so no extra cell ring
-    // is needed here.
+    // Contradiction states are conveyed by the X glyph + bounce on
+    // the corner `HypothesisBadge` (`directlyContradicted` and
+    // `jointlyConflicts` both flip the badge into rejected mode) and
+    // by the boxed status panel inside the popover, so no extra
+    // cell ring is needed here.
     void status;
     // Pick the color tone from the displayed value (real wins; otherwise
     // the hypothesis or derived-from-hypothesis value).

--- a/src/ui/components/ContradictionBanner.test.tsx
+++ b/src/ui/components/ContradictionBanner.test.tsx
@@ -14,6 +14,11 @@ import type { DraftAccusation, DraftSuggestion } from "../../logic/ClueState";
 import { SuggestionId } from "../../logic/Suggestion";
 import type { ContradictionTrace } from "../../logic/Deducer";
 import type { ContradictionKind } from "../../logic/ContradictionKind";
+import {
+    emptyHypotheses,
+    type HypothesisMap,
+    type HypothesisValue,
+} from "../../logic/Hypothesis";
 
 // next-intl mock that handles both `t(key, …)` and `t.rich(key, …)`.
 // Both echo the template key so tests can assert which template the
@@ -58,13 +63,22 @@ const accusationDraft = (
     ...overrides,
 });
 
-const mockClueState = {
+const mockClueState: {
+    setup: typeof setup;
+    suggestions: ReadonlyArray<DraftSuggestion>;
+    accusations: ReadonlyArray<DraftAccusation>;
+    knownCards: ReadonlyArray<unknown>;
+    handSizes: ReadonlyArray<unknown>;
+    uiMode: "suggest";
+    hypotheses: HypothesisMap;
+} = {
     setup,
-    suggestions: [draft()] as ReadonlyArray<DraftSuggestion>,
-    accusations: [] as ReadonlyArray<DraftAccusation>,
+    suggestions: [draft()],
+    accusations: [],
     knownCards: [],
     handSizes: [],
-    uiMode: "suggest" as const,
+    uiMode: "suggest",
+    hypotheses: emptyHypotheses,
 };
 
 const mockDispatch = vi.fn();
@@ -338,5 +352,137 @@ describe("ContradictionBanner — FailedAccusation rows", () => {
         expect(
             screen.queryByRole("button", { name: "removeAccusation" }),
         ).toBeNull();
+    });
+});
+
+describe("JointHypothesisContradictionBanner", () => {
+    const importJointBanner = async () => {
+        const mod = await import("./ContradictionBanner");
+        return mod.JointHypothesisContradictionBanner;
+    };
+
+    type ConflictKind = "directly-contradicted" | "jointly-conflicting";
+    const conflict = (
+        kind: ConflictKind,
+        entries: ReadonlyArray<{
+            readonly cell: ReturnType<typeof Cell>;
+            readonly value: HypothesisValue;
+        }>,
+    ) => ({ kind, entries });
+
+    test("jointly-conflicting variant renders the joint title/help and one row per entry", async () => {
+        const cellA = Cell(PlayerOwner(A), MS_WHITE);
+        const cellB = Cell(PlayerOwner(B), KNIFE);
+        mockDispatch.mockReset();
+
+        const JointBanner = await importJointBanner();
+        const { container } = render(
+            <JointBanner
+                conflict={conflict("jointly-conflicting", [
+                    { cell: cellA, value: "Y" },
+                    { cell: cellB, value: "N" },
+                ])}
+            />,
+        );
+
+        expect(screen.getByText("jointBannerTitle")).toBeInTheDocument();
+        expect(screen.getByText("jointBannerHelp")).toBeInTheDocument();
+        // Joint variant should NOT render the direct copy.
+        expect(screen.queryByText("directBannerTitle")).toBeNull();
+        // One li per entry.
+        const items = container.querySelectorAll("ul > li");
+        expect(items.length).toBe(2);
+        const buttons = screen.getAllByRole("button", {
+            name: "jointHypothesisTurnOff",
+        });
+        expect(buttons.length).toBe(2);
+    });
+
+    test("directly-contradicted variant renders the direct title/help", async () => {
+        const cellA = Cell(PlayerOwner(A), MS_WHITE);
+        mockDispatch.mockReset();
+
+        const JointBanner = await importJointBanner();
+        const { container } = render(
+            <JointBanner
+                conflict={conflict("directly-contradicted", [
+                    { cell: cellA, value: "Y" },
+                ])}
+            />,
+        );
+
+        expect(screen.getByText("directBannerTitle")).toBeInTheDocument();
+        expect(screen.getByText("directBannerHelp")).toBeInTheDocument();
+        // Direct variant should NOT render the joint copy.
+        expect(screen.queryByText("jointBannerTitle")).toBeNull();
+        // Single row → single button.
+        const items = container.querySelectorAll("ul > li");
+        expect(items.length).toBe(1);
+    });
+
+    test("Turn off dispatches clearHypothesis for the row's cell", async () => {
+        const cellA = Cell(PlayerOwner(A), MS_WHITE);
+        mockDispatch.mockReset();
+
+        const JointBanner = await importJointBanner();
+        render(
+            <JointBanner
+                conflict={conflict("jointly-conflicting", [
+                    { cell: cellA, value: "Y" },
+                ])}
+            />,
+        );
+
+        const button = screen.getByRole("button", {
+            name: "jointHypothesisTurnOff",
+        });
+        fireEvent.click(button);
+        expect(mockDispatch).toHaveBeenCalledWith({
+            type: "clearHypothesis",
+            cell: cellA,
+        });
+    });
+
+    test("rows render in stable (owner, card) sort order", async () => {
+        // A is "Anisha", B is "Bob"; alphabetic owner order is A, A, B.
+        // Within A, cards sort: Knife < Mrs. White.
+        const cellBMsWhite = Cell(PlayerOwner(B), MS_WHITE);
+        const cellAKnife = Cell(PlayerOwner(A), KNIFE);
+        const cellAMsWhite = Cell(PlayerOwner(A), MS_WHITE);
+        mockDispatch.mockReset();
+
+        const JointBanner = await importJointBanner();
+        // Pass in reverse-of-expected order; banner sorts internally.
+        render(
+            <JointBanner
+                conflict={conflict("jointly-conflicting", [
+                    { cell: cellBMsWhite, value: "Y" },
+                    { cell: cellAMsWhite, value: "Y" },
+                    { cell: cellAKnife, value: "N" },
+                ])}
+            />,
+        );
+
+        const buttons = screen.getAllByRole("button", {
+            name: "jointHypothesisTurnOff",
+        });
+        expect(buttons.length).toBe(3);
+        // Click each button in DOM order; the dispatched `cell` arg
+        // proves the row order: A/Knife → A/Mrs.White → B/Mrs.White.
+        fireEvent.click(buttons[0]!);
+        fireEvent.click(buttons[1]!);
+        fireEvent.click(buttons[2]!);
+        expect(mockDispatch).toHaveBeenNthCalledWith(1, {
+            type: "clearHypothesis",
+            cell: cellAKnife,
+        });
+        expect(mockDispatch).toHaveBeenNthCalledWith(2, {
+            type: "clearHypothesis",
+            cell: cellAMsWhite,
+        });
+        expect(mockDispatch).toHaveBeenNthCalledWith(3, {
+            type: "clearHypothesis",
+            cell: cellBMsWhite,
+        });
     });
 });

--- a/src/ui/components/ContradictionBanner.tsx
+++ b/src/ui/components/ContradictionBanner.tsx
@@ -2,12 +2,20 @@
 
 import { useTranslations } from "next-intl";
 import type { ReactNode } from "react";
-import { Card, Player } from "../../logic/GameObjects";
+import { Card, Player, ownerLabel } from "../../logic/GameObjects";
 import { GameSetup, cardName, categoryName } from "../../logic/GameSetup";
 import { ContradictionTrace } from "../../logic/Deducer";
 import { DraftAccusation, DraftSuggestion } from "../../logic/ClueState";
-import { useClue } from "../state";
+import type { Cell } from "../../logic/Knowledge";
+import { useClue, type HypothesisConflict } from "../state";
 import { useSelection } from "../SelectionContext";
+
+// i18n key tags hoisted to module scope so the `no-literal-string`
+// lint rule reads them as code identifiers, not UI text.
+const KEY_DIRECT_TITLE = "directBannerTitle" as const;
+const KEY_DIRECT_HELP = "directBannerHelp" as const;
+const KEY_JOINT_TITLE = "jointBannerTitle" as const;
+const KEY_JOINT_HELP = "jointBannerHelp" as const;
 
 /**
  * Structured contradiction display + one-click quick-fix buttons. Reads
@@ -558,3 +566,107 @@ function OffendingAccusationRow({
         </li>
     );
 }
+
+/**
+ * Contradiction banner variant for any rejected-hypothesis state.
+ * Two flavours, distinguished by `conflict.kind`:
+ *
+ *   - `directly-contradicted`: at least one hypothesis disagrees with
+ *     a real fact. The banner lists ONLY the contradicted hypotheses
+ *     (other still-plausible ones don't belong here) and asks the user
+ *     to turn the rejected hypothesis off.
+ *   - `jointly-conflicting`: every hypothesis is individually
+ *     plausible against the real-only knowledge but their union is
+ *     unsatisfiable. The banner lists ALL active hypotheses since the
+ *     conflict is in their interaction.
+ *
+ * Both share the row layout (sorted by `(ownerLabel, cardName)` for
+ * stable order) and the per-row "Turn off" CTA dispatching
+ * `clearHypothesis`. Only the title + help text change.
+ */
+export function JointHypothesisContradictionBanner({
+    conflict,
+}: {
+    readonly conflict: HypothesisConflict;
+}) {
+    const t = useTranslations("contradictions");
+    const { state, dispatch } = useClue();
+    const setup = state.setup;
+    const isDirect = conflict.kind === "directly-contradicted";
+
+    interface Row {
+        readonly cell: Cell;
+        readonly ownerName: string;
+        readonly cardLabel: string;
+        readonly value: string;
+    }
+
+    const rows: ReadonlyArray<Row> = (() => {
+        const collected: Array<Row> = conflict.entries.map(entry => ({
+            cell: entry.cell,
+            ownerName: ownerLabel(entry.cell.owner),
+            cardLabel: cardName(setup, entry.cell.card),
+            value: entry.value,
+        }));
+        collected.sort((a, b) => {
+            const byOwner = a.ownerName.localeCompare(b.ownerName);
+            return byOwner !== 0
+                ? byOwner
+                : a.cardLabel.localeCompare(b.cardLabel);
+        });
+        return collected;
+    })();
+
+    const titleKey = isDirect ? KEY_DIRECT_TITLE : KEY_JOINT_TITLE;
+    const helpKey = isDirect ? KEY_DIRECT_HELP : KEY_JOINT_HELP;
+
+    return (
+        <div className="mb-3 rounded-[var(--radius)] border border-danger-border bg-danger-bg p-3 text-[13px] text-danger">
+            <div className="mb-2">
+                <div className="font-semibold">
+                    {t(titleKey, { count: rows.length })}
+                </div>
+                <div className="text-[12px] opacity-80">
+                    {t(helpKey, { count: rows.length })}
+                </div>
+            </div>
+            {rows.length > 0 && (
+                <ul className="m-0 flex list-none flex-col gap-2 pl-0">
+                    {rows.map(row => {
+                        const key = `${row.ownerName}/${row.cardLabel}/${row.value}`;
+                        return (
+                            <li
+                                key={key}
+                                className="flex items-center justify-between gap-2 rounded border border-danger-border bg-white/40 p-2"
+                            >
+                                <span>
+                                    {t.rich("jointHypothesisRow", {
+                                        owner: row.ownerName,
+                                        card: row.cardLabel,
+                                        value: row.value,
+                                        strong: chunks => (
+                                            <strong>{chunks}</strong>
+                                        ),
+                                    })}
+                                </span>
+                                <button
+                                    type="button"
+                                    className="cursor-pointer rounded border border-danger-border bg-white px-2 py-0.5 text-[12px] text-danger hover:bg-danger-bg"
+                                    onClick={() =>
+                                        dispatch({
+                                            type: "clearHypothesis",
+                                            cell: row.cell,
+                                        })
+                                    }
+                                >
+                                    {t("jointHypothesisTurnOff")}
+                                </button>
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
+        </div>
+    );
+}
+

--- a/src/ui/components/GlobalContradictionBanner.tsx
+++ b/src/ui/components/GlobalContradictionBanner.tsx
@@ -2,10 +2,18 @@
 
 import { Result } from "effect";
 import { AnimatePresence, motion } from "motion/react";
-import { useLayoutEffect, useRef } from "react";
+import { useLayoutEffect, useRef, type ReactNode, type RefObject } from "react";
 import { T_STANDARD, useReducedTransition } from "../motion";
 import { useClue } from "../state";
-import { ContradictionBanner } from "./ContradictionBanner";
+import {
+    ContradictionBanner,
+    JointHypothesisContradictionBanner,
+} from "./ContradictionBanner";
+
+// AnimatePresence keys hoisted to module scope so `no-literal-string`
+// reads them as code, not UI text.
+const KEY_REAL = "real" as const;
+const KEY_JOINT = "joint" as const;
 
 /**
  * Global contradiction banner pinned to the top of the viewport whenever
@@ -18,12 +26,25 @@ import { ContradictionBanner } from "./ContradictionBanner";
  * `AnimatePresence` drives slide-down enter + slide-up exit; the
  * offset variable is cleared on exit *complete* so `<main>`'s top
  * padding doesn't collapse while the banner is still on-screen.
+ *
+ * Two failure modes share this chrome:
+ *   1. Real-deduction failure (the canonical fact set is inconsistent)
+ *      — wins precedence. Once real is broken there's no point reasoning
+ *      about hypotheses on top of it.
+ *   2. Hypothesis conflict (real is fine, but at least one hypothesis
+ *      is rejected). The body distinguishes "conflicts with a known
+ *      fact" from "can't all be true together" via the
+ *      `hypothesisConflict.kind` discriminator and offers per-row
+ *      "Turn off" CTAs.
  */
 export function GlobalContradictionBanner() {
     const { derived } = useClue();
     const result = derived.deductionResult;
-    const trace = Result.isFailure(result) ? result.failure : undefined;
+    const realTrace = Result.isFailure(result) ? result.failure : undefined;
+    const conflict = derived.hypothesisConflict;
     const transition = useReducedTransition(T_STANDARD, { fadeMs: 120 });
+
+    const bodyKey = realTrace ? KEY_REAL : conflict ? KEY_JOINT : undefined;
 
     return (
         <AnimatePresence
@@ -34,22 +55,45 @@ export function GlobalContradictionBanner() {
                 );
             }}
         >
-            {trace ? (
-                <ContradictionBody key="banner" trace={trace} transition={transition} />
+            {bodyKey === KEY_REAL && realTrace ? (
+                <BannerShell key={KEY_REAL} transition={transition}>
+                    <ContradictionBanner trace={realTrace} />
+                </BannerShell>
+            ) : bodyKey === KEY_JOINT && conflict ? (
+                <BannerShell key={KEY_JOINT} transition={transition}>
+                    <JointHypothesisContradictionBanner conflict={conflict} />
+                </BannerShell>
             ) : null}
         </AnimatePresence>
     );
 }
 
-function ContradictionBody({
-    trace,
+function BannerShell({
+    children,
     transition,
 }: {
-    readonly trace: Parameters<typeof ContradictionBanner>[0]["trace"];
+    readonly children: ReactNode;
     readonly transition: ReturnType<typeof useReducedTransition>;
 }) {
     const ref = useRef<HTMLDivElement>(null);
+    useBannerOffset(ref);
 
+    return (
+        <motion.div
+            ref={ref}
+            role="alert"
+            initial={{ y: -16, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            exit={{ y: -16, opacity: 0 }}
+            transition={transition}
+            className="fixed inset-x-0 top-0 z-[var(--z-contradiction-banner)] border-b border-danger-border bg-panel/95 shadow-lg backdrop-blur-sm"
+        >
+            <div className="mx-auto max-w-[1400px] px-5 pt-3">{children}</div>
+        </motion.div>
+    );
+}
+
+function useBannerOffset(ref: RefObject<HTMLDivElement | null>) {
     useLayoutEffect(() => {
         const el = ref.current;
         if (!el) return;
@@ -63,21 +107,5 @@ function ContradictionBody({
         const ro = new ResizeObserver(write);
         ro.observe(el);
         return () => ro.disconnect();
-    }, []);
-
-    return (
-        <motion.div
-            ref={ref}
-            role="alert"
-            initial={{ y: -16, opacity: 0 }}
-            animate={{ y: 0, opacity: 1 }}
-            exit={{ y: -16, opacity: 0 }}
-            transition={transition}
-            className="fixed inset-x-0 top-0 z-[var(--z-contradiction-banner)] border-b border-danger-border bg-panel/95 shadow-lg backdrop-blur-sm"
-        >
-            <div className="mx-auto max-w-[1400px] px-5 pt-3">
-                <ContradictionBanner trace={trace} />
-            </div>
-        </motion.div>
-    );
+    }, [ref]);
 }

--- a/src/ui/components/HypothesisBadge.test.tsx
+++ b/src/ui/components/HypothesisBadge.test.tsx
@@ -30,7 +30,7 @@ describe("HypothesisBadge", () => {
         );
     });
 
-    test("renders the question glyph when directly contradicted", () => {
+    test("renders the X glyph when directly contradicted", () => {
         const { container } = render(
             <HypothesisBadge
                 value={Y}
@@ -41,20 +41,121 @@ describe("HypothesisBadge", () => {
                 }}
             />,
         );
-        expect(findBadge(container).getAttribute("data-glyph")).toBe(
-            "question",
-        );
+        expect(findBadge(container).getAttribute("data-glyph")).toBe("x");
     });
 
-    test("renders the question glyph when jointly conflicting", () => {
+    test("renders the X glyph when jointly conflicting", () => {
         const { container } = render(
             <HypothesisBadge
                 value={Y}
                 status={{ kind: "jointlyConflicts", value: Y }}
             />,
         );
-        expect(findBadge(container).getAttribute("data-glyph")).toBe(
-            "question",
+        expect(findBadge(container).getAttribute("data-glyph")).toBe("x");
+    });
+
+    test("rejected badges tone to text-danger", () => {
+        const { container: directly } = render(
+            <HypothesisBadge
+                value={Y}
+                status={{
+                    kind: "directlyContradicted",
+                    hypothesis: Y,
+                    real: N,
+                }}
+            />,
+        );
+        expect(findBadge(directly).getAttribute("class") ?? "").toContain(
+            "text-danger",
+        );
+
+        const { container: joint } = render(
+            <HypothesisBadge
+                value={N}
+                status={{ kind: "jointlyConflicts", value: N }}
+            />,
+        );
+        expect(findBadge(joint).getAttribute("class") ?? "").toContain(
+            "text-danger",
+        );
+    });
+
+    test("rejected badges with `animated` include motion-safe:animate-pulse", () => {
+        const { container: directly } = render(
+            <HypothesisBadge
+                value={Y}
+                status={{
+                    kind: "directlyContradicted",
+                    hypothesis: Y,
+                    real: N,
+                }}
+                animated
+            />,
+        );
+        expect(findBadge(directly).getAttribute("class") ?? "").toContain(
+            "motion-safe:animate-pulse",
+        );
+
+        const { container: joint } = render(
+            <HypothesisBadge
+                value={N}
+                status={{ kind: "jointlyConflicts", value: N }}
+                animated
+            />,
+        );
+        expect(findBadge(joint).getAttribute("class") ?? "").toContain(
+            "motion-safe:animate-pulse",
+        );
+    });
+
+    test("rejected badges WITHOUT `animated` are static (no animation class)", () => {
+        const { container: directly } = render(
+            <HypothesisBadge
+                value={Y}
+                status={{
+                    kind: "directlyContradicted",
+                    hypothesis: Y,
+                    real: N,
+                }}
+            />,
+        );
+        expect(findBadge(directly).getAttribute("class") ?? "").not.toContain(
+            "animate-",
+        );
+
+        const { container: joint } = render(
+            <HypothesisBadge
+                value={N}
+                status={{ kind: "jointlyConflicts", value: N }}
+                animated={false}
+            />,
+        );
+        expect(findBadge(joint).getAttribute("class") ?? "").not.toContain(
+            "animate-",
+        );
+    });
+
+    test("non-rejected badges never animate, even with `animated` true", () => {
+        const { container: active } = render(
+            <HypothesisBadge
+                value={Y}
+                status={{ kind: "active", value: Y }}
+                animated
+            />,
+        );
+        expect(findBadge(active).getAttribute("class") ?? "").not.toContain(
+            "animate-",
+        );
+
+        const { container: confirmed } = render(
+            <HypothesisBadge
+                value={Y}
+                status={{ kind: "confirmed", value: Y }}
+                animated
+            />,
+        );
+        expect(findBadge(confirmed).getAttribute("class") ?? "").not.toContain(
+            "animate-",
         );
     });
 

--- a/src/ui/components/HypothesisBadge.tsx
+++ b/src/ui/components/HypothesisBadge.tsx
@@ -4,24 +4,61 @@ import type {
     HypothesisValue,
 } from "../../logic/Hypothesis";
 
+// `data-glyph` discriminator constants hoisted to module scope so the
+// `no-literal-string` lint rule reads them as code, not UI text. Tests
+// assert on these too — keep them in sync.
+const GLYPH_X = "x" as const;
+const GLYPH_CHECK = "check" as const;
+const GLYPH_QUESTION = "question" as const;
+
 interface HypothesisBadgeProps {
     value: HypothesisValue;
     status: HypothesisStatus;
+    /**
+     * When `true`, a rejected badge (directlyContradicted /
+     * jointlyConflicts) gets a `motion-safe:animate-pulse` to draw the
+     * user's eye. Defaults to `false` so the badge is static
+     * everywhere except where it's specifically meant to call for
+     * attention (the cell, and the open popover — both can pulse at
+     * the same time). The contradiction banner doesn't render the
+     * badge at all today; the prop's `false` default is the future-
+     * proof guard if that changes.
+     */
+    animated?: boolean;
 }
 
-// Tone reflects the HYPOTHESIS value, not the cell's displayed value:
-// a cell that's been deduced Y but hypothesised N shows a red badge
-// against a green cell, making the disagreement visible at a glance.
-// Glyph reflects the resolved status — a check mark when the
-// hypothesis has been confirmed by real facts, a question mark while
-// it's still active, jointly conflicting, or directly contradicted.
+// Tone and glyph reflect the resolved status:
+//   - confirmed: tone = the (Y/N) hypothesis value's color, glyph = ✓.
+//   - rejected (directlyContradicted / jointlyConflicts): tone = danger
+//     red, glyph = X. Pulses with `motion-safe:animate-pulse` when
+//     `animated` is true; static otherwise.
+//   - active / off / derived: tone = the hypothesis value's color,
+//     glyph = ?.
 //
 // Positioning is the caller's responsibility. The badge sits in the
 // `topRight` slot of `CellLayout`, which handles corner placement and
 // the `auto`-column mirror trick that keeps the central glyph centered.
-export function HypothesisBadge({ value, status }: HypothesisBadgeProps) {
-    const tone = value === Y ? "text-yes" : "text-no";
+export function HypothesisBadge({
+    value,
+    status,
+    animated = false,
+}: HypothesisBadgeProps) {
+    const rejected =
+        status.kind === "directlyContradicted" ||
+        status.kind === "jointlyConflicts";
     const confirmed = status.kind === "confirmed";
+    const tone = rejected ? "text-danger" : value === Y ? "text-yes" : "text-no";
+    const glyphAttr = rejected
+        ? GLYPH_X
+        : confirmed
+          ? GLYPH_CHECK
+          : GLYPH_QUESTION;
+    // `motion-safe:` so users with `prefers-reduced-motion: reduce`
+    // see a static badge — same accessibility contract as the rest of
+    // the app's `useReducedTransition` wrappers. Animation only applies
+    // to rejected badges that are explicitly `animated`.
+    const className =
+        rejected && animated ? `${tone} motion-safe:animate-pulse` : tone;
     // ViewBox is "3 3 18 18" so the visible rounded square fills the
     // SVG's bounding box edge-to-edge. Without this, the rect at
     // (3,3) inside a "0 0 24 24" viewBox renders ~2px inside the SVG
@@ -39,8 +76,8 @@ export function HypothesisBadge({ value, status }: HypothesisBadgeProps) {
             viewBox="3 3 18 18"
             aria-hidden="true"
             focusable="false"
-            data-glyph={confirmed ? "check" : "question"}
-            className={tone}
+            data-glyph={glyphAttr}
+            className={className}
         >
             <rect
                 x="3"
@@ -50,7 +87,28 @@ export function HypothesisBadge({ value, status }: HypothesisBadgeProps) {
                 rx="3"
                 fill="currentColor"
             />
-            {confirmed ? (
+            {rejected ? (
+                <>
+                    <line
+                        x1="8"
+                        y1="8"
+                        x2="16"
+                        y2="16"
+                        stroke="white"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                    />
+                    <line
+                        x1="16"
+                        y1="8"
+                        x2="8"
+                        y2="16"
+                        stroke="white"
+                        strokeWidth="2"
+                        strokeLinecap="round"
+                    />
+                </>
+            ) : confirmed ? (
                 <polyline
                     points="7 12 11 16 17 8"
                     fill="none"

--- a/src/ui/components/Icons.tsx
+++ b/src/ui/components/Icons.tsx
@@ -231,35 +231,6 @@ export function UserIcon({ className, size = 18 }: IconProps) {
 
 
 /**
- * Filled triangle with an exclamation mark — used to flag a hypothesis
- * cell whose state is contradicted (either directly by a real fact, or
- * jointly by another hypothesis). `currentColor` lets the parent style
- * the tone (typically `text-danger`).
- */
-export function AlertIcon({ className, size = 14 }: IconProps) {
-    return (
-        <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width={size}
-            height={size}
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            aria-hidden="true"
-            focusable="false"
-            className={className}
-        >
-            <path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
-            <line x1="12" y1="9" x2="12" y2="13" />
-            <line x1="12" y1="17" x2="12.01" y2="17" />
-        </svg>
-    );
-}
-
-/**
  * Lightbulb — paired with the per-cell "candidate for suggestion N"
  * footnote affordance so the same glyph appears in the cell chip and
  * the why-popover explanation, tying them together visually.

--- a/src/ui/state.test.tsx
+++ b/src/ui/state.test.tsx
@@ -8,7 +8,7 @@ import { CLASSIC_SETUP_3P, DEFAULT_SETUP } from "../logic/GameSetup";
 import { emptyHypotheses } from "../logic/Hypothesis";
 import { KnownCard } from "../logic/InitialKnowledge";
 import type { GameSession } from "../logic/Persistence";
-import { CaseFileOwner } from "../logic/GameObjects";
+import { CaseFileOwner, PlayerOwner } from "../logic/GameObjects";
 import { Cell, getCell, N as N_VAL, Y as Y_VAL } from "../logic/Knowledge";
 import { Result } from "effect";
 import {
@@ -703,6 +703,204 @@ describe("derived values", () => {
         }));
         const after = HashMap.size(result.current.derived.initialKnowledge.checklist);
         expect(after).toBeGreaterThan(before);
+    });
+
+    test("derived.hypothesisConflict is `jointly-conflicting` when individually-plausible hypotheses jointly fail", () => {
+        // Scenario: A owns Knife (Y) AND B owns Knife (Y). Each
+        // hypothesis alone is fine — neither contradicts any real
+        // fact (knownCards is empty). Together they violate "every
+        // card has exactly one owner".
+        const { result } = renderClue();
+        const setup = CLASSIC_SETUP_3P;
+        const A = Player("Anisha");
+        const B = Player("Bob");
+        const KNIFE = cardByName(setup, "Knife");
+
+        act(() => {
+            result.current.dispatch({
+                type: "replaceSession",
+                session: {
+                    setup,
+                    hands: [],
+                    handSizes: [],
+                    suggestions: [],
+                    accusations: [],
+                    hypotheses: emptyHypotheses,
+                } satisfies GameSession,
+            });
+        });
+        expect(result.current.derived.hypothesisConflict).toBeUndefined();
+
+        // First hypothesis: A owns Knife. Plausible alone.
+        act(() => {
+            result.current.dispatch({
+                type: "setHypothesis",
+                cell: Cell(PlayerOwner(A), KNIFE),
+                value: Y_VAL,
+            });
+        });
+        expect(result.current.derived.hypothesisConflict).toBeUndefined();
+
+        // Second hypothesis: B also owns Knife. Now jointly conflicts.
+        act(() => {
+            result.current.dispatch({
+                type: "setHypothesis",
+                cell: Cell(PlayerOwner(B), KNIFE),
+                value: Y_VAL,
+            });
+        });
+        const conflict = result.current.derived.hypothesisConflict;
+        expect(conflict).toBeDefined();
+        expect(conflict?.kind).toBe("jointly-conflicting");
+        expect(conflict?.entries.length).toBe(2);
+        // Real-only deduction is still fine.
+        expect(
+            Result.isSuccess(result.current.derived.deductionResult),
+        ).toBe(true);
+
+        // Removing one hypothesis resolves the joint conflict.
+        act(() => {
+            result.current.dispatch({
+                type: "clearHypothesis",
+                cell: Cell(PlayerOwner(B), KNIFE),
+            });
+        });
+        expect(result.current.derived.hypothesisConflict).toBeUndefined();
+    });
+
+    test("derived.hypothesisConflict is `directly-contradicted` for a single hypothesis that conflicts with a known fact", () => {
+        // Single hypothesis that disagrees with a known card. The
+        // banner still fires (so the user has a one-click "Turn off"
+        // path), but with the directly-contradicted variant — copy is
+        // about the conflict with a known fact, not "these can't all
+        // be true together".
+        const { result } = renderClue();
+        const setup = CLASSIC_SETUP_3P;
+        const A = Player("Anisha");
+        const KNIFE = cardByName(setup, "Knife");
+
+        act(() => {
+            result.current.dispatch({
+                type: "replaceSession",
+                session: {
+                    setup,
+                    hands: [{ player: A, cards: [KNIFE] }],
+                    handSizes: [],
+                    suggestions: [],
+                    accusations: [],
+                    hypotheses: emptyHypotheses,
+                } satisfies GameSession,
+            });
+        });
+
+        // Hypothesis: Anisha does NOT own Knife — directly contradicts.
+        act(() => {
+            result.current.dispatch({
+                type: "setHypothesis",
+                cell: Cell(PlayerOwner(A), KNIFE),
+                value: N_VAL,
+            });
+        });
+
+        const conflict = result.current.derived.hypothesisConflict;
+        expect(conflict).toBeDefined();
+        expect(conflict?.kind).toBe("directly-contradicted");
+        expect(conflict?.entries.length).toBe(1);
+        expect(conflict?.entries[0]?.cell).toEqual(Cell(PlayerOwner(A), KNIFE));
+        expect(conflict?.entries[0]?.value).toBe(N_VAL);
+    });
+
+    test("derived.hypothesisConflict prefers `directly-contradicted` and lists ONLY contradicted hypotheses when both kinds coexist", () => {
+        // Two hypotheses: one directly contradicts a real fact, the
+        // other is plausible alone. The banner takes the
+        // directly-contradicted path (fix that first) and lists only
+        // the contradicted entry — the still-plausible hypothesis
+        // doesn't belong in this banner copy.
+        const { result } = renderClue();
+        const setup = CLASSIC_SETUP_3P;
+        const A = Player("Anisha");
+        const B = Player("Bob");
+        const KNIFE = cardByName(setup, "Knife");
+        const KITCHEN = cardByName(setup, "Kitchen");
+
+        act(() => {
+            result.current.dispatch({
+                type: "replaceSession",
+                session: {
+                    setup,
+                    hands: [{ player: A, cards: [KNIFE] }],
+                    handSizes: [],
+                    suggestions: [],
+                    accusations: [],
+                    hypotheses: emptyHypotheses,
+                } satisfies GameSession,
+            });
+        });
+
+        // First: Anisha doesn't own Knife — directly contradicts.
+        act(() => {
+            result.current.dispatch({
+                type: "setHypothesis",
+                cell: Cell(PlayerOwner(A), KNIFE),
+                value: N_VAL,
+            });
+        });
+        // Second: Bob owns Kitchen — plausible alone.
+        act(() => {
+            result.current.dispatch({
+                type: "setHypothesis",
+                cell: Cell(PlayerOwner(B), KITCHEN),
+                value: Y_VAL,
+            });
+        });
+
+        const conflict = result.current.derived.hypothesisConflict;
+        expect(conflict).toBeDefined();
+        expect(conflict?.kind).toBe("directly-contradicted");
+        // Only the directly-contradicted entry — not Bob's Kitchen.
+        expect(conflict?.entries.length).toBe(1);
+        expect(conflict?.entries[0]?.cell).toEqual(Cell(PlayerOwner(A), KNIFE));
+    });
+
+    test("derived.hypothesisConflict is undefined when individually-plausible hypotheses are also jointly consistent", () => {
+        // Sanity-check the success path: two hypotheses, individually
+        // and jointly fine. No banner.
+        const { result } = renderClue();
+        const setup = CLASSIC_SETUP_3P;
+        const A = Player("Anisha");
+        const B = Player("Bob");
+        const KNIFE = cardByName(setup, "Knife");
+        const KITCHEN = cardByName(setup, "Kitchen");
+
+        act(() => {
+            result.current.dispatch({
+                type: "replaceSession",
+                session: {
+                    setup,
+                    hands: [],
+                    handSizes: [],
+                    suggestions: [],
+                    accusations: [],
+                    hypotheses: emptyHypotheses,
+                } satisfies GameSession,
+            });
+        });
+        act(() => {
+            result.current.dispatch({
+                type: "setHypothesis",
+                cell: Cell(PlayerOwner(A), KNIFE),
+                value: Y_VAL,
+            });
+        });
+        act(() => {
+            result.current.dispatch({
+                type: "setHypothesis",
+                cell: Cell(PlayerOwner(B), KITCHEN),
+                value: Y_VAL,
+            });
+        });
+
+        expect(result.current.derived.hypothesisConflict).toBeUndefined();
     });
 });
 

--- a/src/ui/state.tsx
+++ b/src/ui/state.tsx
@@ -41,6 +41,7 @@ import {
     emptyHypotheses,
     foldHypothesesInto,
     type HypothesisMap,
+    type HypothesisValue,
 } from "../logic/Hypothesis";
 import { caseFileProgress } from "../logic/Recommender";
 import {
@@ -57,7 +58,7 @@ import {
     setupDurationMs,
     startSetup,
 } from "../analytics/gameSession";
-import type { Cell, CellValue, Knowledge } from "../logic/Knowledge";
+import { getCell, type Cell, type CellValue, type Knowledge } from "../logic/Knowledge";
 import { chainFor } from "../logic/Provenance";
 import {
     buildInitialKnowledge,
@@ -558,7 +559,41 @@ interface ClueDerived {
      * a runtime contradiction inside the deducer's fixed-point loop.
      */
     readonly jointDeductionResult: DeductionResult | undefined;
+    /**
+     * Categorised data for the hypothesis-conflict banner, set when
+     * the real-only deduction succeeds but at least one active
+     * hypothesis is rejected. `kind` distinguishes the two failure
+     * modes the banner copy distinguishes:
+     *
+     *   - `directly-contradicted`: at least one hypothesis disagrees
+     *     with a real fact. `entries` lists those hypotheses (only
+     *     the contradicted ones — other plausible hypotheses don't
+     *     belong in this banner).
+     *   - `jointly-conflicting`: every hypothesis is individually
+     *     plausible against the real-only knowledge, but their union
+     *     is unsatisfiable. `entries` lists ALL active hypotheses
+     *     since the conflict is in their interaction.
+     *
+     * Real-deduction failure still wins precedence — when
+     * `deductionResult` itself is a failure, this is `undefined`.
+     */
+    readonly hypothesisConflict: HypothesisConflict | undefined;
 }
+
+interface HypothesisConflictEntry {
+    readonly cell: Cell;
+    readonly value: HypothesisValue;
+}
+
+export type HypothesisConflict =
+    | {
+          readonly kind: "directly-contradicted";
+          readonly entries: ReadonlyArray<HypothesisConflictEntry>;
+      }
+    | {
+          readonly kind: "jointly-conflicting";
+          readonly entries: ReadonlyArray<HypothesisConflictEntry>;
+      };
 
 const deriveState = (
     suggestionsAsData: ReadonlyArray<Suggestion>,
@@ -1045,6 +1080,48 @@ export function ClueProvider({ children }: { children: ReactNode }) {
         [suggestionsAsData, initialKnowledge, deductionResult, deduceLayer],
     );
 
+    // Hypothesis-conflict banner: surfaces ANY rejected hypothesis the
+    // user needs to address. Categorises into two mutually-exclusive
+    // kinds so the banner copy can distinguish them:
+    //
+    //   - `directly-contradicted`: at least one hypothesis disagrees
+    //     with a real fact. The banner lists ONLY the contradicted
+    //     hypotheses; other (still-plausible) hypotheses don't belong
+    //     in this variant. We pick this kind whenever any hypothesis
+    //     is directly contradicted, even if a joint conflict could
+    //     also be argued — fixing the directly-contradicted ones
+    //     comes first, and the user can re-evaluate after.
+    //   - `jointly-conflicting`: every hypothesis is individually
+    //     plausible, but the joint deduction over their union fails.
+    //     The banner lists ALL active hypotheses since the conflict
+    //     is in their interaction.
+    //
+    // Real-deduction failure still wins precedence; this returns
+    // `undefined` when `deductionResult` itself is a failure.
+    const hypothesisConflict: HypothesisConflict | undefined = useMemo(() => {
+        if (jointDeductionResult === undefined) return undefined;
+        if (Result.isSuccess(jointDeductionResult)) return undefined;
+        if (Result.isFailure(deductionResult)) return undefined;
+        const realKnowledge = deductionResult.success;
+        const directlyContradicted: Array<HypothesisConflictEntry> = [];
+        const allEntries: Array<HypothesisConflictEntry> = [];
+        for (const [cell, value] of state.hypotheses) {
+            allEntries.push({ cell, value });
+            const real = getCell(realKnowledge, cell);
+            if (real !== undefined && real !== value) {
+                directlyContradicted.push({ cell, value });
+            }
+        }
+        if (directlyContradicted.length > 0) {
+            return {
+                kind: "directly-contradicted",
+                entries: directlyContradicted,
+            };
+        }
+        if (allEntries.length === 0) return undefined;
+        return { kind: "jointly-conflicting", entries: allEntries };
+    }, [deductionResult, jointDeductionResult, state.hypotheses]);
+
     const derived: ClueDerived = useMemo(
         () => ({
             suggestionsAsData,
@@ -1055,6 +1132,7 @@ export function ClueProvider({ children }: { children: ReactNode }) {
             footnotes,
             hypotheses: state.hypotheses,
             jointDeductionResult,
+            hypothesisConflict,
         }),
         [
             suggestionsAsData,
@@ -1065,6 +1143,7 @@ export function ClueProvider({ children }: { children: ReactNode }) {
             footnotes,
             state.hypotheses,
             jointDeductionResult,
+            hypothesisConflict,
         ],
     );
 


### PR DESCRIPTION
## Summary

Three related improvements to how the solver handles hypotheses.

### Setup mode is quieter

The Checklist's Setup tab is for entering known facts, so it now ignores hypothesis state entirely:

- No top-right hypothesis badge.
- No lightbulb "leads" chip in the top-left.
- Cell colors come only from real (entered) facts — no green/red tinting from hypotheses.

Hypotheses you set in Play mode stay in state and reappear when you switch back; they just don't bleed through into the Setup view.

### Rejected-hypothesis iconography

The center glyph now keeps showing the deduced value (`✓` / `·` / blank) regardless of whether the cell's hypothesis is rejected. The rejection signal moves to the top-right corner badge, which:

- Switches from `?` to a red `X`.
- Pulses with `motion-safe:animate-pulse` to draw the user's attention. (Static when the user has `prefers-reduced-motion: reduce`.)
- The popover's status panel mirrors the cell exactly — it embeds the same pulsing X badge instead of a separate alert icon.

### Contradiction banner for rejected hypotheses

The global contradiction banner now appears whenever any hypothesis is rejected, with one "Turn off" button per row. Two copy variants distinguish the case:

- **"Hypothesis conflicts with a known fact"** — when at least one hypothesis disagrees with what the deducer has already proven. The banner lists only the contradicted hypotheses.
- **"Conflicting hypotheses" / "These hypotheses can't all be true together"** — when every hypothesis is individually plausible but their union is unsatisfiable. The banner lists all active hypotheses, since the conflict is in their interaction.

When both kinds could apply, the directly-contradicted variant wins precedence (fix that first). Real-deduction failure still wins precedence over either hypothesis-conflict variant.

## Test plan

- [ ] **Setup mode cleanliness.** Set a hypothesis in Play mode, switch to Setup. Confirm no hypothesis badge, no lightbulb chip, and cells reflect only known cards. Switch back to Play — both reappear.
- [ ] **Direct contradiction.** In Play, mark a known card. Hypothesize the opposite on the same cell. Cell center reads the real `✓` / `·`; corner shows a pulsing red X. Open the popover — Deductions section shows the same real glyph; Hypothesis section's status panel shows the pulsing X.
- [ ] **Direct-contradiction banner.** Same as above — confirm the global banner appears with "Hypothesis conflicts with a known fact" copy and a "Turn off" button. Click "Turn off" — banner disappears and the hypothesis is cleared.
- [ ] **Joint contradiction.** Set up two hypotheses that are individually plausible but jointly unsatisfiable (e.g. two players each "owning" the same card). Confirm the banner appears with "Conflicting hypotheses" copy and a "Turn off" button per row. Click one — banner disappears.
- [ ] **Banner precedence.** Force a real-deduction contradiction with hypotheses still active. Confirm the existing real-deduction banner shows, not the hypothesis banner.
- [ ] **Reduced motion.** Toggle OS reduced-motion. Confirm the X badge stops pulsing.
- [ ] **Layout invariants.** Sticky `<thead>` sits below the banner; the page horizontal-scroll behavior on Setup mode is unchanged. (See `CLAUDE.md` "Layout, scroll, and animation behaviors".)
- [ ] CI green: `pnpm typecheck && pnpm lint && pnpm test && pnpm knip && pnpm i18n:check` (all 1129 tests passing locally).

## Commits

- **Quiet setup mode and surface hypothesis conflicts** — Removes hypothesis badge / leads chip / hypothesis tinting from Setup mode (passes synthetic `{ kind: "off" }` status into `displayFor`). Drops `GLYPH_ALERT` from `glyphKindFor` and removes `AlertIcon` (no callers left). Adds an `x` glyph variant + `animated` prop to `HypothesisBadge` with `motion-safe:animate-pulse`; the popover's contradicted status panel embeds the same badge. Adds `hypothesisConflict: HypothesisConflict | undefined` to `ClueDerived` with a discriminated `kind: "directly-contradicted" | "jointly-conflicting"` and a sorted `entries` list (directly-contradicted wins precedence; entries are filtered to only the contradicted hypotheses in that case). Updates `GlobalContradictionBanner` + `ContradictionBanner` to render kind-specific copy and per-row "Turn off" CTAs dispatching `clearHypothesis`. New i18n keys: `directBannerTitle`, `directBannerHelp` (both plural-aware), `jointBannerTitle` (plural-aware), `jointBannerHelp`, `jointHypothesisRow`, `jointHypothesisTurnOff`. Tests cover the new badge variants, the popover's pulse handoff, both banner kinds, and the `hypothesisConflict` derivation across `jointly-conflicting`, `directly-contradicted`, mixed-kinds-precedence, and jointly-consistent scenarios.

https://claude.ai/code/session_01StHVsj2PGqajq8NehfsX1Y