### PR TITLE
My Card Packs modal actions + bigger pill tap targets + preview-deploy auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ Copy [env.example](env.example) to `.env.local`. All third-party integrations ar
 | `DATABASE_URL_UNPOOLED` | Direct (non-pooler) Postgres URL. Reserved for migration runs that need a stable session. |
 | `BETTER_AUTH_SECRET` | Server-only secret for session JWT signing. Generate with `openssl rand -hex 32`. |
 | `BETTER_AUTH_URL` | Public URL of the deployed app. Leave blank in local dev so auth follows the actual auto-selected localhost port. |
+| `BETTER_AUTH_PRODUCTION_URL` | Stable production URL the [`oAuthProxy`](https://better-auth.com/docs/plugins/oauth-proxy) plugin routes Google OAuth through, so Vercel previews don't need their own OAuth client. Set to the production URL on **both** Production and Preview (literal `https://winclue.vercel.app`, not `$VERCEL_URL`); leave blank in local dev. |
 | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` | Google OAuth client. **Required in every environment** — `pnpm dev` exits at startup if either is empty. Use a localhost-scoped client locally (see "Google OAuth — local dev" above); previews/production use a separate client in Vercel env vars. |
 
 In CI/production, the build job needs `SENTRY_AUTH_TOKEN` / `SENTRY_ORG` / `SENTRY_PROJECT` to upload source maps. Production also needs the DB and auth vars wired in Vercel — see [docs/setup-vercel-neon-google.md](docs/setup-vercel-neon-google.md).

--- a/docs/setup-vercel-neon-google.md
+++ b/docs/setup-vercel-neon-google.md
@@ -100,6 +100,55 @@ In local development, leaving it blank lets Better Auth derive the
 actual `localhost` host and port from the incoming request, so Next's
 automatic port fallback keeps working when 3000 is already occupied.
 
+## 4b. `BETTER_AUTH_PRODUCTION_URL` (OAuth proxy for previews)
+
+Vercel preview hostnames are dynamic per branch and per deploy, and
+Google explicitly does not allow wildcards in **Authorized redirect
+URIs**. That means a fresh preview's
+`https://winclue-git-<branch>.vercel.app/api/auth/callback/google`
+won't be in Google's allowlist — clicking the sign-in button on a
+preview either silently fails or returns a `redirect_uri_mismatch`.
+
+Better Auth ships an [`oAuthProxy`](https://better-auth.com/docs/plugins/oauth-proxy)
+plugin to fix this without touching Google: previews send Google
+the **production** redirect URI, Google calls back to production,
+production encrypts the user's profile with `BETTER_AUTH_SECRET`
+and 302's the encrypted blob to the preview, the preview decrypts
+and writes the session into its own DB. Production is unchanged —
+the plugin is a no-op when the request URL matches `productionURL`.
+
+Per environment:
+
+| Environment | Value |
+| --- | --- |
+| Production | `https://winclue.vercel.app` (same as `BETTER_AUTH_URL`) |
+| Preview    | `https://winclue.vercel.app` (literal — **NOT** `$VERCEL_URL`) |
+| Development | Leave blank — proxy is a no-op locally |
+
+Operational notes:
+
+- `BETTER_AUTH_SECRET` must be the same value across Production and
+  Preview (already required by the existing setup); the proxy uses it
+  to encrypt and decrypt the in-flight profile.
+- The plugin's `trustedOrigins` (configured in `src/server/auth.ts`)
+  matches the production aliases (`winclue.vercel.app`,
+  `effect-clue.vercel.app`), the preview wildcard
+  (`effect-clue-*-lets-get-into-it.vercel.app` — Vercel's project
+  name is `effect-clue`; the `winclue` host is just an alias), and
+  `http://localhost:*`. If the Vercel team slug ever changes, update
+  the wildcard in that file or production will start rejecting the
+  proxy hop with `Invalid origin` 403s.
+- Previews should write to a separate DB from production — the proxy
+  creates the user/session row on the preview side. Vercel's Neon
+  integration provisions a per-environment branch automatically when
+  enabled; verify this in the Vercel project's Storage tab if you
+  haven't already.
+- After this is wired, the only Google **Authorized redirect URI** you
+  need for the deployed app is the single production callback. Earlier
+  iterations of step 5 told you to add specific preview-deploy
+  callback URLs as they came up; that's no longer necessary and you
+  can remove any preview-specific entries from Google.
+
 ## 5. Google OAuth client
 
 Required in every environment — `pnpm dev` exits at startup if either
@@ -130,8 +179,6 @@ out of production bundles, see CI assertion below.
    - `https://winclue.vercel.app`
    - Any localhost ports you use for local Google OAuth, e.g.
      `http://localhost:3000`
-   - Specific Vercel preview URLs as needed (Google may reject
-     wildcards).
 4. **Authorized redirect URIs** — add the exact callback URL for each
    environment:
    - `https://winclue.vercel.app/api/auth/callback/google`
@@ -140,8 +187,11 @@ out of production bundles, see CI assertion below.
      Next may auto-select another port when 3000 is occupied; either
      add that exact callback too, or free/pin port 3000 before testing
      Google OAuth locally.
-   - Specific preview-deploy URLs as they come up. Wildcards are not
-     supported here.
+
+   You do **not** need to add Vercel preview URLs here — the
+   `oAuthProxy` plugin (step 4b) routes preview OAuth through the
+   production callback above, so a single registered URL covers every
+   preview deploy.
 5. Capture `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET`. Add both to
    all three Vercel envs.
 

--- a/env.example
+++ b/env.example
@@ -68,6 +68,19 @@ BETTER_AUTH_SECRET=
 #   Development:  leave blank so auth follows Next's actual localhost port
 BETTER_AUTH_URL=
 
+# Stable production URL the OAuth proxy plugin pivots through. Vercel
+# preview hosts are dynamic per branch / per deploy and Google won't
+# allow wildcards in authorized redirect URIs, so previews can't run a
+# direct Google OAuth round-trip. Setting this on Preview makes the
+# `oAuthProxy` plugin route OAuth callbacks through production
+# (which has the only registered Google callback), then production
+# encrypts the profile with `BETTER_AUTH_SECRET` and redirects it
+# back to the preview. Required values per env:
+#   Production:   https://winclue.vercel.app  (same as BETTER_AUTH_URL)
+#   Preview:      https://winclue.vercel.app  (literal — NOT $VERCEL_URL)
+#   Development:  leave blank (proxy is a no-op locally)
+BETTER_AUTH_PRODUCTION_URL=
+
 # Optional. Set to 1 to enable Better Auth debug-level server logs locally.
 AUTH_DEBUG=
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -10,7 +10,8 @@
         "info": "More info",
         "infoGlyph": "ⓘ",
         "close": "Close",
-        "back": "Back"
+        "back": "Back",
+        "save": "Save"
     },
     "bottomNav": {
         "ariaLabel": "Primary navigation",
@@ -87,6 +88,10 @@
         "loadCustomCardSetTitle": "Load card pack \"{label}\"",
         "deleteCustomCardSetTitle": "Delete card pack \"{label}\"",
         "deleteCustomCardSetAria": "Delete card pack {label}",
+        "renamePackTitle": "Rename card pack \"{label}\"",
+        "renamePackAria": "Rename card pack {label}",
+        "renamePackDialogTitle": "Rename card pack",
+        "renamePackInputLabel": "Card pack name",
         "saveAsCardPack": "+ Save as card pack",
         "saveAsCardPackTitle": "Save the current cards as a reusable card pack",
         "saveAsCardPackPrompt": "Save this card pack. Name it:",
@@ -95,7 +100,6 @@
         "saveAsNewCardPack": "+ Save as new pack",
         "sharePackTitle": "Share {label} with a friend",
         "sharePackAria": "Share card pack {label}",
-        "deleteCustomCardSetConfirm": "Delete card pack \"{label}\"?",
         "allCardPacksPill": "All card packs",
         "allCardPacksPillTitle": "Show every saved card pack",
         "cardPackSearchAria": "Search card packs",
@@ -390,7 +394,16 @@
         "myCardPacksTitle": "My card packs",
         "myCardPacksLoading": "Loading card packs…",
         "myCardPacksEmpty": "No synced card packs yet.",
-        "myCardPacksError": "Couldn’t load card packs."
+        "myCardPacksError": "Couldn’t load card packs.",
+        "renamePackTitle": "Rename card pack \"{label}\"",
+        "renamePackAria": "Rename card pack {label}",
+        "renamePackDialogTitle": "Rename card pack",
+        "renamePackInputLabel": "New name",
+        "sharePackTitle": "Share {label} with a friend",
+        "sharePackAria": "Share card pack {label}",
+        "deletePackTitle": "Delete card pack \"{label}\"",
+        "deletePackAria": "Delete card pack {label}",
+        "deletePackConfirm": "Delete card pack \"{label}\"?"
     },
     "installPrompt": {
         "title": "Install Clue Solver",

--- a/src/data/cardPacksSync.tsx
+++ b/src/data/cardPacksSync.tsx
@@ -61,7 +61,7 @@ const emptyPushResult: PushResult = {
     countFailed: 0,
 };
 
-const decodeServerPack = (
+export const decodeServerPack = (
     pack: PersistedCardPack,
 ): CustomCardSet | null => {
     try {

--- a/src/data/customCardPacks.ts
+++ b/src/data/customCardPacks.ts
@@ -39,6 +39,13 @@ import {
     type CustomCardSet,
 } from "../logic/CustomCardSets";
 import { TelemetryRuntime } from "../observability/runtime";
+import {
+    deleteCardPack as deleteCardPackServer,
+    saveCardPack as saveCardPackServer,
+    type PersistedCardPack,
+} from "../server/actions/packs";
+import { useSession } from "../ui/hooks/useSession";
+import { myCardPacksQueryKey } from "../ui/account/AccountModal";
 
 export const customCardPacksQueryKey = ["custom-card-packs"] as const;
 
@@ -144,6 +151,94 @@ export function useDeleteCardPack(): UseMutationResult<void, Error, string> {
             queryClient.setQueryData<ReadonlyArray<CustomCardSet>>(
                 customCardPacksQueryKey,
                 (old) => old?.filter((p) => p.id !== id) ?? [],
+            );
+        },
+    });
+}
+
+interface SaveCardPackOnServerInput {
+    readonly clientGeneratedId: string;
+    readonly label: string;
+    readonly cardSet: CardSet;
+}
+
+const saveOnServerEffect = Effect.fn("rq.customPacks.saveOnServer")(function* (
+    input: SaveCardPackOnServerInput,
+) {
+    return yield* Effect.promise(() => saveCardPackServer(input));
+});
+
+const deleteOnServerEffect = Effect.fn("rq.customPacks.deleteOnServer")(
+    function* (idOrClientGeneratedId: string) {
+        yield* Effect.promise(() =>
+            deleteCardPackServer({ idOrClientGeneratedId }),
+        );
+    },
+);
+
+/**
+ * Write-side hook for the user's *server-stored* card-pack library.
+ * UPSERTs the pack on the server (keyed by `(owner_id, client_generated_id)`)
+ * and refreshes the `myCardPacksQueryKey` cache so the AccountModal's
+ * pack list updates immediately. Pairs with `useSaveCardPack` (local
+ * storage) — call both when a synced pack is being mutated.
+ */
+export function useSaveCardPackOnServer(): UseMutationResult<
+    PersistedCardPack,
+    Error,
+    SaveCardPackOnServerInput
+> {
+    const queryClient = useQueryClient();
+    const session = useSession();
+    const userId = session.data?.user.id;
+    return useMutation({
+        mutationFn: (input: SaveCardPackOnServerInput) =>
+            TelemetryRuntime.runPromise(saveOnServerEffect(input)),
+        onSuccess: (savedPack) => {
+            queryClient.setQueryData<ReadonlyArray<PersistedCardPack>>(
+                myCardPacksQueryKey(userId),
+                (old) => {
+                    if (!old) return [savedPack];
+                    const idx = old.findIndex(
+                        (p) =>
+                            p.id === savedPack.id ||
+                            p.clientGeneratedId === savedPack.clientGeneratedId,
+                    );
+                    if (idx === -1) return [savedPack, ...old];
+                    const next = [...old];
+                    next[idx] = savedPack;
+                    return next;
+                },
+            );
+        },
+    });
+}
+
+/**
+ * Owner-scoped delete on the server, keyed by either the server-minted
+ * `id` or the `client_generated_id`. Pairs with `useDeleteCardPack`
+ * (local storage).
+ */
+export function useDeleteCardPackOnServer(): UseMutationResult<
+    void,
+    Error,
+    string
+> {
+    const queryClient = useQueryClient();
+    const session = useSession();
+    const userId = session.data?.user.id;
+    return useMutation({
+        mutationFn: (idOrClientGeneratedId: string) =>
+            TelemetryRuntime.runPromise(
+                deleteOnServerEffect(idOrClientGeneratedId),
+            ),
+        onSuccess: (_void, arg) => {
+            queryClient.setQueryData<ReadonlyArray<PersistedCardPack>>(
+                myCardPacksQueryKey(userId),
+                (old) =>
+                    old?.filter(
+                        (p) => p.id !== arg && p.clientGeneratedId !== arg,
+                    ) ?? [],
             );
         },
     });

--- a/src/server/auth.test.ts
+++ b/src/server/auth.test.ts
@@ -21,6 +21,10 @@ const importAuthWithEnv = async (
     }));
     vi.doMock("better-auth/plugins", () => ({
         anonymous: () => "anonymous-plugin",
+        oAuthProxy: (opts?: { readonly productionURL?: string }) => ({
+            id: "oauth-proxy-plugin",
+            opts: opts ?? {},
+        }),
     }));
     vi.doMock("pg", () => ({
         Pool: class Pool {
@@ -43,6 +47,7 @@ const importAuthWithEnv = async (
                   readonly allowedHosts: ReadonlyArray<string>;
                   readonly protocol: string;
               };
+        readonly trustedOrigins: ReadonlyArray<string>;
         readonly socialProviders: {
             readonly google: {
                 readonly clientId: string;
@@ -51,7 +56,13 @@ const importAuthWithEnv = async (
             };
         };
         readonly logger: { readonly level: string };
-        readonly plugins: ReadonlyArray<string>;
+        readonly plugins: ReadonlyArray<
+            | string
+            | {
+                  readonly id: string;
+                  readonly opts: { readonly productionURL?: string };
+              }
+        >;
     };
 };
 
@@ -69,7 +80,42 @@ describe("better-auth config", () => {
             clientSecret: "google-secret",
             prompt: "select_account",
         });
-        expect(config.plugins).toEqual(["anonymous-plugin"]);
+        expect(config.plugins).toEqual([
+            "anonymous-plugin",
+            { id: "oauth-proxy-plugin", opts: {} },
+        ]);
+    });
+
+    test("oAuthProxy plugin reads productionURL from BETTER_AUTH_PRODUCTION_URL", async () => {
+        const config = await importAuthWithEnv({
+            BETTER_AUTH_URL: "https://winclue-pr-42.vercel.app",
+            BETTER_AUTH_PRODUCTION_URL: "https://winclue.vercel.app",
+            GOOGLE_CLIENT_ID: "google-id",
+            GOOGLE_CLIENT_SECRET: "google-secret",
+        });
+
+        expect(config.plugins).toEqual([
+            "anonymous-plugin",
+            {
+                id: "oauth-proxy-plugin",
+                opts: { productionURL: "https://winclue.vercel.app" },
+            },
+        ]);
+    });
+
+    test("trustedOrigins includes production aliases, preview wildcard, and localhost", async () => {
+        const config = await importAuthWithEnv({
+            BETTER_AUTH_URL: "https://example.test",
+            GOOGLE_CLIENT_ID: "google-id",
+            GOOGLE_CLIENT_SECRET: "google-secret",
+        });
+
+        expect(config.trustedOrigins).toEqual([
+            "https://winclue.vercel.app",
+            "https://effect-clue.vercel.app",
+            "https://effect-clue-*-lets-get-into-it.vercel.app",
+            "http://localhost:*",
+        ]);
     });
 
     test("fails fast when Google client id is missing", async () => {

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -40,7 +40,7 @@ import "server-only";
 
 import { betterAuth } from "better-auth";
 import type { BaseURLConfig } from "better-auth";
-import { anonymous } from "better-auth/plugins";
+import { anonymous, oAuthProxy } from "better-auth/plugins";
 import { Pool } from "pg";
 import { googleProviderConfig } from "./authEnv";
 import { LOCAL_DATABASE_URL } from "./localDatabase";
@@ -119,6 +119,36 @@ const databaseUrl = requiredDatabaseUrl();
 const baseURL = requiredBaseURL();
 const secret = process.env["BETTER_AUTH_SECRET"] ?? "";
 const socialProviders = googleProviderConfig();
+// Stable production URL used by the OAuth proxy plugin: every Vercel
+// preview deployment routes its OAuth round-trip through this URL so
+// only the production callback needs to be registered with Google.
+// Optional in local dev — the plugin is a no-op when `productionURL`
+// is undefined or matches `baseURL`.
+const productionURL = optionalEnv("BETTER_AUTH_PRODUCTION_URL");
+
+/**
+ * Origins (preview hosts, localhost) that production accepts as valid
+ * redirect targets when handing the encrypted OAuth profile back from
+ * the proxy hop. Better Auth supports glob wildcards for the host
+ * portion since 1.5 — patterns are matched against the full origin.
+ *
+ * Vercel preview hostnames for this project follow the pattern
+ * `effect-clue-{branch-or-hash}-lets-get-into-it.vercel.app` (the
+ * project name is `effect-clue`; `winclue.vercel.app` is just the
+ * production alias). The wildcard below matches both the
+ * git-branch and the deployment-hash variants.
+ *
+ * Keep this list in sync with the Vercel project's actual URLs. If
+ * the team slug ever changes, update the wildcard accordingly —
+ * production will start returning "Invalid origin" 403s on previews
+ * the moment a preview URL stops matching.
+ */
+const trustedOrigins: Array<string> = [
+    "https://winclue.vercel.app",
+    "https://effect-clue.vercel.app",
+    "https://effect-clue-*-lets-get-into-it.vercel.app",
+    "http://localhost:*",
+];
 
 /**
  * The better-auth pool is a *separate* pg pool from the one
@@ -135,6 +165,7 @@ export const auth = betterAuth({
     database: authPool,
     secret,
     baseURL,
+    trustedOrigins,
     emailAndPassword: {
         enabled: isDev,
     },
@@ -192,6 +223,21 @@ export const auth = betterAuth({
                     },
                 },
             },
+        }),
+        // Vercel preview deploys can't register a stable OAuth
+        // callback URL with Google (preview hosts are dynamic per
+        // branch / per deploy). The proxy plugin pivots OAuth
+        // callbacks through `productionURL` — Google calls back to
+        // production, production encrypts the profile with
+        // `BETTER_AUTH_SECRET` and redirects the encrypted blob to
+        // the preview, the preview decrypts and writes the session
+        // to its own DB. The plugin is a no-op when `currentURL`
+        // (auto-derived from the request / `VERCEL_URL`) matches
+        // `productionURL`, so production behaviour is unchanged.
+        // See `docs/setup-vercel-neon-google.md` for the per-env
+        // env-var setup that makes this work end-to-end.
+        oAuthProxy({
+            ...(productionURL !== undefined ? { productionURL } : {}),
         }),
     ],
 });

--- a/src/ui/Clue.tsx
+++ b/src/ui/Clue.tsx
@@ -15,6 +15,7 @@ import { PlayLayout } from "./components/PlayLayout";
 import { Toolbar } from "./components/Toolbar";
 import { TooltipProvider } from "./components/Tooltip";
 import { ConfirmProvider, useConfirm } from "./hooks/useConfirm";
+import { PromptProvider } from "./hooks/usePrompt";
 import { useSplashGate } from "./hooks/useSplashGate";
 import { SelectionProvider } from "./SelectionContext";
 import { useGlobalShortcut } from "./keyMap";
@@ -147,9 +148,11 @@ export function Clue() {
         <TooltipProvider delayDuration={150} skipDelayDuration={50}>
           <ClueProvider>
            <ConfirmProvider>
+           <PromptProvider>
            <SelectionProvider>
             <CoordinatedShell headerRef={headerRef} />
            </SelectionProvider>
+           </PromptProvider>
            </ConfirmProvider>
           </ClueProvider>
         </TooltipProvider>

--- a/src/ui/account/AccountModal.test.tsx
+++ b/src/ui/account/AccountModal.test.tsx
@@ -40,18 +40,57 @@ vi.mock("./authClient", () => ({
 }));
 
 const getMyCardPacksMock = vi.fn();
+const saveCardPackMock = vi.fn();
+const deleteCardPackMock = vi.fn();
 vi.mock("../../server/actions/packs", () => ({
     getMyCardPacks: () => getMyCardPacksMock(),
+    saveCardPack: (input: unknown) => saveCardPackMock(input),
+    deleteCardPack: (input: unknown) => deleteCardPackMock(input),
 }));
 
+const openShareCardPackMock = vi.fn();
+vi.mock("../share/ShareProvider", () => ({
+    useShareContext: () => ({
+        open: false,
+        openShareCardPack: (opts: unknown) => openShareCardPackMock(opts),
+        openInvitePlayer: () => {},
+        openContinueOnAnotherDevice: () => {},
+    }),
+    ShareProvider: ({ children }: { readonly children: React.ReactNode }) =>
+        children,
+}));
+
+import * as React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { AccountModal, mergeCardPacks } from "./AccountModal";
 import { TestQueryClientProvider } from "../../test-utils/queryClient";
+import { ConfirmProvider } from "../hooks/useConfirm";
+import { PromptProvider } from "../hooks/usePrompt";
+
+const Wrappers = ({ children }: { readonly children: React.ReactNode }) => (
+    <TestQueryClientProvider>
+        <ConfirmProvider>
+            <PromptProvider>{children}</PromptProvider>
+        </ConfirmProvider>
+    </TestQueryClientProvider>
+);
 
 const renderModal = () =>
     render(<AccountModal open={true} onClose={() => {}} />, {
-        wrapper: TestQueryClientProvider,
+        wrapper: Wrappers,
     });
+
+// A minimal-but-decodable `cardSetData` for `decodeServerPack`. Empty
+// categories array is enough — the decoder only requires the shape,
+// not non-empty contents.
+const EMPTY_CARD_SET_DATA = JSON.stringify({ categories: [] });
+
+const officeCategory = {
+    id: "category-tv",
+    name: "TV Shows",
+    cards: [{ id: "card-office", name: "The Office" }],
+};
+const officeCardSetData = JSON.stringify({ categories: [officeCategory] });
 
 beforeEach(() => {
     window.localStorage.clear();
@@ -62,6 +101,23 @@ beforeEach(() => {
     refetchMock.mockResolvedValue(undefined);
     getMyCardPacksMock.mockReset();
     getMyCardPacksMock.mockResolvedValue([]);
+    saveCardPackMock.mockReset();
+    saveCardPackMock.mockImplementation(async (input: unknown) => {
+        const i = input as {
+            clientGeneratedId: string;
+            label: string;
+            cardSet: unknown;
+        };
+        return {
+            id: `server-${i.clientGeneratedId}`,
+            clientGeneratedId: i.clientGeneratedId,
+            label: i.label,
+            cardSetData: JSON.stringify(i.cardSet),
+        };
+    });
+    deleteCardPackMock.mockReset();
+    deleteCardPackMock.mockResolvedValue(undefined);
+    openShareCardPackMock.mockReset();
 });
 
 describe("AccountModal — Better Auth client calls", () => {
@@ -111,7 +167,7 @@ describe("AccountModal — Better Auth client calls", () => {
                 id: "pack-1",
                 clientGeneratedId: "custom-1",
                 label: "Office Edition",
-                cardSetData: "{}",
+                cardSetData: officeCardSetData,
             },
         ]);
 
@@ -154,25 +210,267 @@ describe("AccountModal — Better Auth client calls", () => {
     });
 });
 
-describe("mergeCardPacks", () => {
-    test("dedupes server packs that came from local clientGeneratedId", () => {
-        expect(
-            mergeCardPacks(
-                [{ id: "custom-1", label: "Local name" }],
-                [
-                    {
-                        id: "server-1",
-                        clientGeneratedId: "custom-1",
-                        label: "Server name",
-                    },
-                ],
-            ),
-        ).toEqual([
+describe("AccountModal — pack row actions", () => {
+    const signInAlice = () => {
+        mockSessionData = {
+            user: {
+                id: "u1",
+                email: "alice@example.test",
+                name: "Alice",
+                image: null,
+                isAnonymous: false,
+            },
+            session: { expiresAt: "2030-01-01T00:00:00.000Z" },
+        };
+    };
+
+    test("share button calls openShareCardPack with the decoded card set", async () => {
+        signInAlice();
+        getMyCardPacksMock.mockResolvedValue([
             {
-                id: "server-1",
+                id: "pack-1",
                 clientGeneratedId: "custom-1",
-                label: "Server name",
+                label: "Office Edition",
+                cardSetData: officeCardSetData,
             },
         ]);
+        renderModal();
+        await waitFor(() => {
+            expect(screen.getByText("Office Edition")).toBeInTheDocument();
+        });
+        fireEvent.click(
+            screen.getByLabelText(
+                'sharePackAria:{"label":"Office Edition"}',
+            ),
+        );
+        expect(openShareCardPackMock).toHaveBeenCalledTimes(1);
+        const opts = openShareCardPackMock.mock.calls[0]?.[0] as {
+            packLabel: string;
+            forcedCardPack: { categories: ReadonlyArray<unknown> };
+        };
+        expect(opts.packLabel).toBe("Office Edition");
+        expect(opts.forcedCardPack.categories).toHaveLength(1);
+    });
+
+    test("rename mirrors to both server and local for a synced pack", async () => {
+        signInAlice();
+        // Local copy mirrors the server pack — same `clientGeneratedId`.
+        window.localStorage.setItem(
+            "effect-clue.custom-presets.v1",
+            JSON.stringify({
+                version: 1,
+                presets: [
+                    {
+                        id: "custom-1",
+                        label: "Office Edition",
+                        categories: [
+                            { id: "category-tv", name: "TV Shows", cards: [
+                                { id: "card-office", name: "The Office" },
+                            ] },
+                        ],
+                    },
+                ],
+            }),
+        );
+        getMyCardPacksMock.mockResolvedValue([
+            {
+                id: "pack-1",
+                clientGeneratedId: "custom-1",
+                label: "Office Edition",
+                cardSetData: officeCardSetData,
+            },
+        ]);
+        renderModal();
+        await waitFor(() => {
+            expect(screen.getByText("Office Edition")).toBeInTheDocument();
+        });
+        fireEvent.click(
+            screen.getByLabelText(
+                'renamePackAria:{"label":"Office Edition"}',
+            ),
+        );
+        // Prompt dialog renders.
+        const input = (await screen.findByDisplayValue(
+            "Office Edition",
+        )) as HTMLInputElement;
+        fireEvent.change(input, { target: { value: "Dunder Mifflin" } });
+        fireEvent.click(screen.getByRole("button", { name: "save" }));
+
+        await waitFor(() => {
+            expect(saveCardPackMock).toHaveBeenCalledTimes(1);
+        });
+        const serverArg = saveCardPackMock.mock.calls[0]?.[0] as {
+            clientGeneratedId: string;
+            label: string;
+        };
+        expect(serverArg.clientGeneratedId).toBe("custom-1");
+        expect(serverArg.label).toBe("Dunder Mifflin");
+        // Local mutation also fired — the localStorage entry now has
+        // the new label (synchronous rewrite via `saveCustomCardSet`).
+        const raw = window.localStorage.getItem(
+            "effect-clue.custom-presets.v1",
+        );
+        expect(raw).toContain("Dunder Mifflin");
+    });
+
+    test("rename of a local-only pack does NOT call the server", async () => {
+        signInAlice();
+        window.localStorage.setItem(
+            "effect-clue.custom-presets.v1",
+            JSON.stringify({
+                version: 1,
+                presets: [
+                    {
+                        id: "custom-local-only",
+                        label: "Local-only",
+                        categories: [],
+                    },
+                ],
+            }),
+        );
+        // No matching server pack returned.
+        getMyCardPacksMock.mockResolvedValue([]);
+        renderModal();
+        await waitFor(() => {
+            expect(screen.getByText("Local-only")).toBeInTheDocument();
+        });
+        fireEvent.click(
+            screen.getByLabelText(
+                'renamePackAria:{"label":"Local-only"}',
+            ),
+        );
+        const input = (await screen.findByDisplayValue(
+            "Local-only",
+        )) as HTMLInputElement;
+        fireEvent.change(input, { target: { value: "Renamed" } });
+        fireEvent.click(screen.getByRole("button", { name: "save" }));
+
+        await waitFor(() => {
+            const raw = window.localStorage.getItem(
+                "effect-clue.custom-presets.v1",
+            );
+            expect(raw).toContain("Renamed");
+        });
+        expect(saveCardPackMock).not.toHaveBeenCalled();
+    });
+
+    test("rename Cancel performs no mutation", async () => {
+        signInAlice();
+        getMyCardPacksMock.mockResolvedValue([
+            {
+                id: "pack-1",
+                clientGeneratedId: "custom-1",
+                label: "Office Edition",
+                cardSetData: officeCardSetData,
+            },
+        ]);
+        renderModal();
+        await waitFor(() => {
+            expect(screen.getByText("Office Edition")).toBeInTheDocument();
+        });
+        fireEvent.click(
+            screen.getByLabelText(
+                'renamePackAria:{"label":"Office Edition"}',
+            ),
+        );
+        await screen.findByDisplayValue("Office Edition");
+        fireEvent.click(screen.getByRole("button", { name: "cancel" }));
+        expect(saveCardPackMock).not.toHaveBeenCalled();
+    });
+
+    test("delete fires both server and local mutations after confirm", async () => {
+        signInAlice();
+        window.localStorage.setItem(
+            "effect-clue.custom-presets.v1",
+            JSON.stringify({
+                version: 1,
+                presets: [
+                    {
+                        id: "custom-1",
+                        label: "Office Edition",
+                        categories: [
+                            { id: "category-tv", name: "TV Shows", cards: [
+                                { id: "card-office", name: "The Office" },
+                            ] },
+                        ],
+                    },
+                ],
+            }),
+        );
+        getMyCardPacksMock.mockResolvedValue([
+            {
+                id: "pack-1",
+                clientGeneratedId: "custom-1",
+                label: "Office Edition",
+                cardSetData: officeCardSetData,
+            },
+        ]);
+        renderModal();
+        await waitFor(() => {
+            expect(screen.getByText("Office Edition")).toBeInTheDocument();
+        });
+        fireEvent.click(
+            screen.getByLabelText(
+                'deletePackAria:{"label":"Office Edition"}',
+            ),
+        );
+        const confirmBtn = await screen.findByRole("button", { name: "confirm" });
+        fireEvent.click(confirmBtn);
+
+        await waitFor(() => {
+            expect(deleteCardPackMock).toHaveBeenCalledTimes(1);
+        });
+        expect(deleteCardPackMock.mock.calls[0]?.[0]).toEqual({
+            idOrClientGeneratedId: "pack-1",
+        });
+        // Local entry removed.
+        const raw = window.localStorage.getItem(
+            "effect-clue.custom-presets.v1",
+        );
+        expect(raw).not.toContain("Office Edition");
+    });
+});
+
+describe("mergeCardPacks", () => {
+    test("dedupes server packs that came from local clientGeneratedId", () => {
+        const merged = mergeCardPacks(
+            [
+                {
+                    id: "custom-1",
+                    label: "Local name",
+                    cardSet: { categories: [] } as never,
+                },
+            ],
+            [
+                {
+                    id: "server-1",
+                    clientGeneratedId: "custom-1",
+                    label: "Server name",
+                    cardSetData: EMPTY_CARD_SET_DATA,
+                },
+            ],
+        );
+        expect(merged).toHaveLength(1);
+        expect(merged[0]).toMatchObject({
+            id: "server-1",
+            clientGeneratedId: "custom-1",
+            label: "Server name",
+            source: "server",
+        });
+    });
+
+    test("drops server packs with malformed cardSetData", () => {
+        const merged = mergeCardPacks(
+            [],
+            [
+                {
+                    id: "broken",
+                    clientGeneratedId: "broken",
+                    label: "Broken",
+                    cardSetData: "not-json",
+                },
+            ],
+        );
+        expect(merged).toHaveLength(0);
     });
 });

--- a/src/ui/account/AccountModal.tsx
+++ b/src/ui/account/AccountModal.tsx
@@ -24,12 +24,20 @@ import {
     signInFailed,
     signInStarted,
 } from "../../analytics/events";
-import { getMyCardPacks } from "../../server/actions/packs";
+import {
+    getMyCardPacks,
+    type PersistedCardPack,
+} from "../../server/actions/packs";
 import {
     useCustomCardPacks,
 } from "../../data/customCardPacks";
+import { decodeServerPack } from "../../data/cardPacksSync";
+import type { CardSet } from "../../logic/CardSet";
+import type { CustomCardSet } from "../../logic/CustomCardSets";
 import { useSession } from "../hooks/useSession";
-import { XIcon } from "../components/Icons";
+import { PencilIcon, TrashIcon, XIcon } from "../components/Icons";
+import { ShareIcon } from "../components/ShareIcon";
+import { useCardPackActions } from "../components/cardPackActions";
 import { AccountAvatar } from "./AccountAvatar";
 import { authClient } from "./authClient";
 import { DevSignInForm } from "./DevSignInForm";
@@ -41,25 +49,55 @@ export const myCardPacksQueryKey = (userId: string | undefined) =>
     ["my-card-packs", userId] as const;
 const SIGN_IN_FROM_MENU: SignInFromContext = "menu";
 
-interface CardPackListItem {
+/**
+ * A card pack as rendered in the modal. Carries the live `CardSet`
+ * so the per-row Share / Edit / Delete actions don't have to lazily
+ * decode `cardSetData` on click. `clientGeneratedId` is the
+ * cross-device-stable identity (equals the local id; matches a server
+ * row's `client_generated_id` column). `source` tracks which side of
+ * the merge the entry came from so dedupe logic outside this module
+ * can reason about it if needed.
+ */
+interface DisplayPack {
     readonly id: string;
-    readonly clientGeneratedId?: string;
+    readonly clientGeneratedId: string;
     readonly label: string;
+    readonly cardSet: CardSet;
+    readonly source: "server" | "local";
 }
 
 export const mergeCardPacks = (
-    localPacks: ReadonlyArray<CardPackListItem>,
-    serverPacks: ReadonlyArray<CardPackListItem>,
-): ReadonlyArray<CardPackListItem> => {
+    localPacks: ReadonlyArray<CustomCardSet>,
+    serverPacks: ReadonlyArray<PersistedCardPack>,
+): ReadonlyArray<DisplayPack> => {
     const serverClientIds = new Set(
-        serverPacks
-            .map((pack) => pack.clientGeneratedId)
-            .filter((id): id is string => id !== undefined),
+        serverPacks.map((pack) => pack.clientGeneratedId),
     );
-    return [
-        ...serverPacks,
-        ...localPacks.filter((pack) => !serverClientIds.has(pack.id)),
-    ];
+    const decodedServer: ReadonlyArray<DisplayPack> = serverPacks.flatMap(
+        (pack) => {
+            const decoded = decodeServerPack(pack);
+            if (decoded === null) return [];
+            return [
+                {
+                    id: pack.id,
+                    clientGeneratedId: pack.clientGeneratedId,
+                    label: pack.label,
+                    cardSet: decoded.cardSet,
+                    source: "server" as const,
+                },
+            ];
+        },
+    );
+    const localOnly: ReadonlyArray<DisplayPack> = localPacks
+        .filter((pack) => !serverClientIds.has(pack.id))
+        .map((pack) => ({
+            id: pack.id,
+            clientGeneratedId: pack.id,
+            label: pack.label,
+            cardSet: pack.cardSet,
+            source: "local" as const,
+        }));
+    return [...decodedServer, ...localOnly];
 };
 
 export function AccountModal({
@@ -86,6 +124,7 @@ export function AccountModal({
         localCardPacks.data ?? [],
         myCardPacks.data ?? [],
     );
+    const { sharePack, renamePack, deletePack } = useCardPackActions();
 
     const callbackURL = (): string => {
         const qs = searchParams.toString();
@@ -191,9 +230,44 @@ export function AccountModal({
                                             {packs.map((pack) => (
                                                 <li
                                                     key={pack.id}
-                                                    className="truncate rounded bg-row-alt px-2 py-1"
+                                                    className="flex items-stretch overflow-hidden rounded border border-border bg-row-alt"
                                                 >
-                                                    {pack.label}
+                                                    <span className="flex-1 truncate self-center px-3 py-2">
+                                                        {pack.label}
+                                                    </span>
+                                                    <button
+                                                        type="button"
+                                                        onClick={() =>
+                                                            sharePack(pack)
+                                                        }
+                                                        className="inline-flex cursor-pointer items-center border-l border-border px-2.5 py-1.5 text-muted transition-colors duration-200 ease-out hover:bg-hover hover:text-accent"
+                                                        title={t("sharePackTitle", { label: pack.label })}
+                                                        aria-label={t("sharePackAria", { label: pack.label })}
+                                                    >
+                                                        <ShareIcon size={14} />
+                                                    </button>
+                                                    <button
+                                                        type="button"
+                                                        onClick={() =>
+                                                            void renamePack(pack)
+                                                        }
+                                                        className="inline-flex cursor-pointer items-center border-l border-border px-2.5 py-1.5 text-muted transition-colors duration-200 ease-out hover:bg-hover hover:text-accent"
+                                                        title={t("renamePackTitle", { label: pack.label })}
+                                                        aria-label={t("renamePackAria", { label: pack.label })}
+                                                    >
+                                                        <PencilIcon size={14} />
+                                                    </button>
+                                                    <button
+                                                        type="button"
+                                                        onClick={() =>
+                                                            void deletePack(pack)
+                                                        }
+                                                        className="inline-flex cursor-pointer items-center border-l border-border px-2.5 py-1.5 text-muted transition-colors duration-200 ease-out hover:bg-hover hover:text-danger"
+                                                        title={t("deletePackTitle", { label: pack.label })}
+                                                        aria-label={t("deletePackAria", { label: pack.label })}
+                                                    >
+                                                        <TrashIcon size={14} />
+                                                    </button>
                                                 </li>
                                             ))}
                                         </ul>

--- a/src/ui/components/CardPackPicker.tsx
+++ b/src/ui/components/CardPackPicker.tsx
@@ -11,7 +11,7 @@ import {
     useState,
 } from "react";
 import { ShareIcon } from "./ShareIcon";
-import { TrashIcon } from "./Icons";
+import { PencilIcon, TrashIcon } from "./Icons";
 
 /**
  * Pack-shaped record consumed by the picker. Custom packs carry
@@ -32,6 +32,12 @@ interface CardPackPickerProps {
     readonly packs: ReadonlyArray<PickerPack>;
     readonly onSelect: (pack: PickerPack) => void;
     readonly onDeleteCustomPack: (pack: PickerPack) => void;
+    /**
+     * Per-row rename for custom packs. Built-ins don't surface this —
+     * the picker only renders the pencil button when both
+     * `onRenameCustomPack` is provided AND `pack.isCustom` is true.
+     */
+    readonly onRenameCustomPack?: (pack: PickerPack) => void;
     /**
      * Optional per-row "Share this pack" handler. When provided, every
      * pack row gets a small share-icon button alongside the delete one.
@@ -77,6 +83,7 @@ export function CardPackPicker({
     packs,
     onSelect,
     onDeleteCustomPack,
+    onRenameCustomPack,
     onSharePack,
     activeMatchId,
     children,
@@ -231,7 +238,7 @@ export function CardPackPicker({
                                                 isActiveMatch ? "true" : undefined
                                             }
                                             className={
-                                                "flex items-center justify-between rounded px-2 py-1 text-[13px] " +
+                                                "flex items-stretch justify-between rounded px-2 py-1.5 text-[13px] " +
                                                 (isHighlighted ? "bg-hover " : "") +
                                                 (isActiveMatch
                                                     ? "border-l-2 border-accent text-accent font-semibold"
@@ -241,7 +248,7 @@ export function CardPackPicker({
                                         >
                                             <button
                                                 type="button"
-                                                className="flex-1 cursor-pointer truncate text-left"
+                                                className="flex-1 cursor-pointer truncate self-center text-left py-1"
                                                 onClick={() => select(pack)}
                                                 title={t("loadCustomCardSetTitle", {
                                                     label: pack.label,
@@ -253,7 +260,7 @@ export function CardPackPicker({
                                             {onSharePack ? (
                                                 <button
                                                     type="button"
-                                                    className="ml-1 inline-flex cursor-pointer items-center self-stretch rounded px-2 text-muted hover:bg-white hover:text-accent"
+                                                    className="ml-1 inline-flex cursor-pointer items-center self-stretch rounded px-2.5 text-muted hover:bg-white hover:text-accent"
                                                     onClick={() =>
                                                         onSharePack(pack)
                                                     }
@@ -266,13 +273,32 @@ export function CardPackPicker({
                                                         { label: pack.label },
                                                     )}
                                                 >
-                                                    <ShareIcon size={13} />
+                                                    <ShareIcon size={15} />
+                                                </button>
+                                            ) : null}
+                                            {pack.isCustom && onRenameCustomPack ? (
+                                                <button
+                                                    type="button"
+                                                    className="ml-1 inline-flex cursor-pointer items-center self-stretch rounded px-2.5 text-muted hover:bg-white hover:text-accent"
+                                                    onClick={() =>
+                                                        onRenameCustomPack(pack)
+                                                    }
+                                                    title={t(
+                                                        "renamePackTitle",
+                                                        { label: pack.label },
+                                                    )}
+                                                    aria-label={t(
+                                                        "renamePackAria",
+                                                        { label: pack.label },
+                                                    )}
+                                                >
+                                                    <PencilIcon size={15} />
                                                 </button>
                                             ) : null}
                                             {pack.isCustom ? (
                                                 <button
                                                     type="button"
-                                                    className="ml-1 cursor-pointer rounded px-2 py-0.5 text-muted hover:bg-white hover:text-danger"
+                                                    className="ml-1 inline-flex cursor-pointer items-center self-stretch rounded px-2.5 text-muted hover:bg-white hover:text-danger"
                                                     onClick={() =>
                                                         onDeleteCustomPack(pack)
                                                     }
@@ -285,7 +311,7 @@ export function CardPackPicker({
                                                         { label: pack.label },
                                                     )}
                                                 >
-                                                    <TrashIcon size={13} />
+                                                    <TrashIcon size={15} />
                                                 </button>
                                             ) : null}
                                         </li>

--- a/src/ui/components/CardPackRow.test.tsx
+++ b/src/ui/components/CardPackRow.test.tsx
@@ -26,6 +26,7 @@ vi.mock("../../analytics/posthog", () => ({
 
 import { ClueProvider, useClue } from "../state";
 import { ConfirmProvider } from "../hooks/useConfirm";
+import { PromptProvider } from "../hooks/usePrompt";
 import { CardPackRow } from "./CardPackRow";
 import {
     saveCustomCardSet,
@@ -56,9 +57,11 @@ const seedCustomPacks = (labels: ReadonlyArray<string>): ReadonlyArray<CustomCar
 const renderRow = () =>
     render(
         <ConfirmProvider>
-            <ClueProvider>
-                <CardPackRow />
-            </ClueProvider>
+            <PromptProvider>
+                <ClueProvider>
+                    <CardPackRow />
+                </ClueProvider>
+            </PromptProvider>
         </ConfirmProvider>,
         { wrapper: TestQueryClientProvider },
     );
@@ -92,10 +95,12 @@ function MutateButton() {
 const renderRowWithMutate = () =>
     render(
         <ConfirmProvider>
-            <ClueProvider>
-                <CardPackRow />
-                <MutateButton />
-            </ClueProvider>
+            <PromptProvider>
+                <ClueProvider>
+                    <CardPackRow />
+                    <MutateButton />
+                </ClueProvider>
+            </PromptProvider>
         </ConfirmProvider>,
         { wrapper: TestQueryClientProvider },
     );
@@ -378,10 +383,12 @@ describe("CardPackRow dropdown reflects active pack", () => {
         seedCustomPacks(["Alpha", "Beta", "Gamma"]); // 5 packs total
         render(
             <ConfirmProvider>
-                <ClueProvider>
-                    <CardPackRow />
-                    <MutateButton />
-                </ClueProvider>
+                <PromptProvider>
+                    <ClueProvider>
+                        <CardPackRow />
+                        <MutateButton />
+                    </ClueProvider>
+                </PromptProvider>
             </ConfirmProvider>,
             { wrapper: TestQueryClientProvider },
         );
@@ -435,10 +442,12 @@ describe("CardPackRow destructive-data confirmation", () => {
         seedCustomPacks(["Alpha"]); // 3 packs total: Classic + Master + Alpha
         render(
             <ConfirmProvider>
-                <ClueProvider>
-                    <CardPackRow />
-                    <SeedKnownCardButton />
-                </ClueProvider>
+                <PromptProvider>
+                    <ClueProvider>
+                        <CardPackRow />
+                        <SeedKnownCardButton />
+                    </ClueProvider>
+                </PromptProvider>
             </ConfirmProvider>,
             { wrapper: TestQueryClientProvider },
         );
@@ -466,10 +475,12 @@ describe("CardPackRow destructive-data confirmation", () => {
         const user = userEvent.setup();
         render(
             <ConfirmProvider>
-                <ClueProvider>
-                    <CardPackRow />
-                    <SeedKnownCardButton />
-                </ClueProvider>
+                <PromptProvider>
+                    <ClueProvider>
+                        <CardPackRow />
+                        <SeedKnownCardButton />
+                    </ClueProvider>
+                </PromptProvider>
             </ConfirmProvider>,
             { wrapper: TestQueryClientProvider },
         );
@@ -492,10 +503,12 @@ describe("CardPackRow destructive-data confirmation", () => {
         const user = userEvent.setup();
         render(
             <ConfirmProvider>
-                <ClueProvider>
-                    <CardPackRow />
-                    <SeedKnownCardButton />
-                </ClueProvider>
+                <PromptProvider>
+                    <ClueProvider>
+                        <CardPackRow />
+                        <SeedKnownCardButton />
+                    </ClueProvider>
+                </PromptProvider>
             </ConfirmProvider>,
             { wrapper: TestQueryClientProvider },
         );

--- a/src/ui/components/CardPackRow.tsx
+++ b/src/ui/components/CardPackRow.tsx
@@ -24,15 +24,14 @@ import { CARD_SETS } from "../../logic/GameSetup";
 import { CustomCardSet } from "../../logic/CustomCardSets";
 import {
     useCustomCardPacks,
-    useDeleteCardPack,
     useSaveCardPack,
 } from "../../data/customCardPacks";
 import { useConfirm } from "../hooks/useConfirm";
 import { useClue } from "../state";
 import { CardPackPicker, type PickerPack } from "./CardPackPicker";
-import { SearchIcon, TrashIcon } from "./Icons";
+import { PencilIcon, SearchIcon, TrashIcon } from "./Icons";
 import { ShareIcon } from "./ShareIcon";
-import { useShareContext } from "../share/ShareProvider";
+import { useCardPackActions } from "./cardPackActions";
 
 const RECENT_LIMIT = 3;
 const SURFACE_BUDGET = 1 + RECENT_LIMIT; // Classic + 3 recents = 4 pills before the dropdown.
@@ -109,10 +108,9 @@ export function CardPackRow() {
     const customPacks = customPacksQuery.data ?? [];
     const usage = usageQuery.data ?? new Map();
     const savePackMutation = useSaveCardPack();
-    const deletePackMutation = useDeleteCardPack();
     const recordUseMutation = useRecordCardPackUse();
     const forgetUseMutation = useForgetCardPackUse();
-    const { openShareCardPack } = useShareContext();
+    const cardPackActions = useCardPackActions();
     const [pickerOpen, setPickerOpen] = useState(false);
 
     // The Classic id is the first entry in CARD_SETS and is the
@@ -321,16 +319,17 @@ export function CardPackRow() {
         recordUseMutation.mutate(newPack.id);
     };
 
+    const toActionTarget = (pack: DisplayPack) => ({
+        clientGeneratedId: pack.id,
+        label: pack.label,
+        cardSet: pack.cardSet,
+    });
+
     const onDeleteCustomPack = async (pack: DisplayPack) => {
-        if (
-            !(await confirm({
-                message: t("deleteCustomCardSetConfirm", {
-                    label: pack.label,
-                }),
-            }))
-        )
-            return;
-        deletePackMutation.mutate(pack.id);
+        const ok = await cardPackActions.deletePack(toActionTarget(pack));
+        if (!ok) return;
+        // Recency map is per-id, so its entry only needs cleanup on
+        // confirmed deletes — keep this co-located with the action.
         forgetUseMutation.mutate(pack.id);
     };
 
@@ -340,16 +339,22 @@ export function CardPackRow() {
         void onDeleteCustomPack(pack);
     };
 
+    const onRenameCustomPack = (pack: DisplayPack) =>
+        void cardPackActions.renamePack(toActionTarget(pack));
+
+    const onRenameFromPicker = (picked: PickerPack) => {
+        const pack = findDisplayPack(picked.id);
+        if (!pack || !pack.isCustom) return;
+        onRenameCustomPack(pack);
+    };
+
     const onSharePill = (pack: DisplayPack) => {
         // Per-pack share is always pack-only (Flow 1): the surface
         // pill / picker row is a content-management surface, not a
         // game-state one. The clicked pack overrides the live setup
         // pack so the share contains exactly what the user clicked,
         // regardless of which pack is active in the table below.
-        openShareCardPack({
-            forcedCardPack: pack.cardSet,
-            packLabel: pack.label,
-        });
+        cardPackActions.sharePack(toActionTarget(pack));
     };
 
     const onSharePackFromPicker = (picked: PickerPack) => {
@@ -396,8 +401,14 @@ export function CardPackRow() {
                     const wrapperTone = isActive
                         ? "border-accent bg-accent text-white"
                         : "border-border bg-white";
+                    // Pills sized for comfortable mobile tap targets:
+                    // the label is the primary "select this pack" hit
+                    // area (largest), and the icon buttons stay
+                    // visually subordinate but grow proportionally
+                    // with the bigger pill so they remain reliably
+                    // tappable on touch devices.
                     const loadBase =
-                        "inline-flex cursor-pointer items-center px-3 py-1 transition-colors duration-200 ease-out";
+                        "inline-flex cursor-pointer items-center px-3.5 py-2 transition-colors duration-200 ease-out";
                     const loadTone = isActive
                         ? "font-semibold"
                         : "hover:bg-hover";
@@ -406,10 +417,11 @@ export function CardPackRow() {
                     // affordance is reachable on every pack pill —
                     // not just on the active one (which is what the
                     // bottom-row "Share this pack" button targets).
-                    // Custom pills additionally append a trash-icon
-                    // delete (destructive — paired with a confirm dialog).
+                    // Custom pills additionally append a pencil-icon
+                    // rename and a trash-icon delete (destructive —
+                    // paired with a confirm dialog).
                     const sharePillBase =
-                        "inline-flex cursor-pointer items-center border-l px-2 py-1 transition-colors duration-200 ease-out";
+                        "inline-flex cursor-pointer items-center border-l px-2.5 py-1.5 transition-colors duration-200 ease-out";
                     const sharePillTone = isActive
                         ? "border-white/40 text-white/80 hover:bg-white/15"
                         : "border-border text-muted hover:bg-hover hover:text-accent";
@@ -454,8 +466,23 @@ export function CardPackRow() {
                                     ? { "data-tour-anchor": "setup-share-pack-pill" }
                                     : {})}
                             >
-                                <ShareIcon size={12} />
+                                <ShareIcon size={14} />
                             </button>
+                            {pack.isCustom ? (
+                                <button
+                                    type="button"
+                                    className={`${sharePillBase} ${sharePillTone}`}
+                                    onClick={() => onRenameCustomPack(pack)}
+                                    title={t("renamePackTitle", {
+                                        label: pack.label,
+                                    })}
+                                    aria-label={t("renamePackAria", {
+                                        label: pack.label,
+                                    })}
+                                >
+                                    <PencilIcon size={14} />
+                                </button>
+                            ) : null}
                             {pack.isCustom ? (
                                 <button
                                     type="button"
@@ -468,7 +495,7 @@ export function CardPackRow() {
                                         label: pack.label,
                                     })}
                                 >
-                                    <TrashIcon size={12} />
+                                    <TrashIcon size={14} />
                                 </button>
                             ) : null}
                         </motion.span>
@@ -491,6 +518,7 @@ export function CardPackRow() {
                         packs={pickerPacks}
                         onSelect={onSelectFromPicker}
                         onDeleteCustomPack={onDeleteFromPicker}
+                        onRenameCustomPack={onRenameFromPicker}
                         onSharePack={onSharePackFromPicker}
                         activeMatchId={activeMatch?.id}
                     >

--- a/src/ui/components/CardPackRow.tsx
+++ b/src/ui/components/CardPackRow.tsx
@@ -524,7 +524,7 @@ export function CardPackRow() {
                     >
                         <button
                             type="button"
-                            className="inline-flex cursor-pointer items-center gap-1 rounded border border-border bg-white px-3 py-1 text-[13px] transition-colors duration-200 ease-out hover:bg-hover"
+                            className="inline-flex cursor-pointer items-center gap-1 rounded border border-border bg-white px-3.5 py-2 text-[13px] transition-colors duration-200 ease-out hover:bg-hover"
                             title={t("allCardPacksPillTitle")}
                             aria-haspopup="listbox"
                             aria-expanded={pickerOpen}
@@ -540,7 +540,7 @@ export function CardPackRow() {
                 <button
                     type="button"
                     className={
-                        "cursor-pointer rounded border border-dashed px-3 py-1 text-[13px] transition-colors duration-200 ease-out " +
+                        "cursor-pointer rounded border border-dashed px-3.5 py-2 text-[13px] transition-colors duration-200 ease-out " +
                         (showSaveAsActive
                             ? "border-accent bg-accent font-semibold text-white"
                             : "border-border bg-white text-muted hover:bg-hover hover:text-accent")
@@ -566,7 +566,7 @@ export function CardPackRow() {
                 {canUpdateLoadedPack ? (
                     <button
                         type="button"
-                        className="cursor-pointer rounded border border-border bg-white px-3 py-1 text-[13px] text-muted transition-colors duration-200 ease-out hover:bg-hover hover:text-accent"
+                        className="cursor-pointer rounded border border-border bg-white px-3.5 py-2 text-[13px] text-muted transition-colors duration-200 ease-out hover:bg-hover hover:text-accent"
                         onClick={onSaveAsNewCardSet}
                         title={t("saveAsCardPackTitle")}
                     >

--- a/src/ui/components/Icons.tsx
+++ b/src/ui/components/Icons.tsx
@@ -65,6 +65,29 @@ export function TrashIcon({ className, size = 18 }: IconProps) {
     );
 }
 
+/** Pencil — paired with rename / edit actions. */
+export function PencilIcon({ className, size = 14 }: IconProps) {
+    return (
+        <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width={size}
+            height={size}
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+            focusable="false"
+            className={className}
+        >
+            <path d="M12 20h9" />
+            <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4z" />
+        </svg>
+    );
+}
+
 /** Close glyph for modal headers and dismiss buttons. */
 export function XIcon({ className, size = 18 }: IconProps) {
     return (

--- a/src/ui/components/cardPackActions.ts
+++ b/src/ui/components/cardPackActions.ts
@@ -1,0 +1,174 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { useTranslations } from "next-intl";
+import { useCallback } from "react";
+import {
+    customCardPacksQueryKey,
+    useDeleteCardPack,
+    useDeleteCardPackOnServer,
+    useSaveCardPack,
+    useSaveCardPackOnServer,
+} from "../../data/customCardPacks";
+import type { CardSet } from "../../logic/CardSet";
+import type { CustomCardSet } from "../../logic/CustomCardSets";
+import type { PersistedCardPack } from "../../server/actions/packs";
+import { myCardPacksQueryKey } from "../account/AccountModal";
+import { useConfirm } from "../hooks/useConfirm";
+import { usePrompt } from "../hooks/usePrompt";
+import { useSession } from "../hooks/useSession";
+import { useShareContext } from "../share/ShareProvider";
+
+/**
+ * Minimal addressable handle for a card pack. `clientGeneratedId` is
+ * the localStorage id (and the cross-device-stable identity used to
+ * key against the server's `client_generated_id` column). Callers
+ * pass this from whichever shape they have on hand — `CustomCardSet`,
+ * the `DisplayPack` from the AccountModal, or a Setup-pill `DisplayPack`.
+ */
+interface CardPackActionTarget {
+    readonly clientGeneratedId: string;
+    readonly label: string;
+    readonly cardSet: CardSet;
+}
+
+interface CardPackActions {
+    readonly sharePack: (pack: CardPackActionTarget) => void;
+    readonly renamePack: (pack: CardPackActionTarget) => Promise<boolean>;
+    readonly deletePack: (pack: CardPackActionTarget) => Promise<boolean>;
+}
+
+/**
+ * Shared share/rename/delete handlers for a saved card pack. The
+ * AccountModal, the Setup-pill row, and the All-card-packs picker all
+ * route through this hook so the three surfaces stay in lock-step
+ * — same prompt copy, same confirm flow, same local + server mirroring.
+ *
+ * Server-side mirroring is opportunistic: when a matching entry
+ * exists in the `myCardPacksQueryKey` cache (i.e. the user is signed
+ * in and the pack has been synced), the rename / delete also writes
+ * to the server. For local-only packs, only the local mutation runs.
+ * Local-side mirroring is similarly conditional — when the `clientGeneratedId`
+ * isn't in the localStorage cache (server-only pack viewed in the
+ * modal before sign-in reconciliation), the local mutation is
+ * skipped to avoid creating a duplicate row with a fresh local id.
+ */
+export function useCardPackActions(): CardPackActions {
+    const tCommon = useTranslations("common");
+    const tAccount = useTranslations("account");
+    const queryClient = useQueryClient();
+    const session = useSession();
+    const userId = session.data?.user.id;
+    const confirm = useConfirm();
+    const prompt = usePrompt();
+    const { openShareCardPack } = useShareContext();
+    const saveLocal = useSaveCardPack();
+    const deleteLocal = useDeleteCardPack();
+    const saveServer = useSaveCardPackOnServer();
+    const deleteServer = useDeleteCardPackOnServer();
+
+    const findLocal = useCallback(
+        (clientGeneratedId: string): CustomCardSet | undefined => {
+            const local =
+                queryClient.getQueryData<ReadonlyArray<CustomCardSet>>(
+                    customCardPacksQueryKey,
+                );
+            return local?.find((p) => p.id === clientGeneratedId);
+        },
+        [queryClient],
+    );
+
+    const findServer = useCallback(
+        (clientGeneratedId: string): PersistedCardPack | undefined => {
+            const server =
+                queryClient.getQueryData<ReadonlyArray<PersistedCardPack>>(
+                    myCardPacksQueryKey(userId),
+                );
+            return server?.find(
+                (p) => p.clientGeneratedId === clientGeneratedId,
+            );
+        },
+        [queryClient, userId],
+    );
+
+    const sharePack = useCallback<CardPackActions["sharePack"]>(
+        (pack) => {
+            openShareCardPack({
+                forcedCardPack: pack.cardSet,
+                packLabel: pack.label,
+            });
+        },
+        [openShareCardPack],
+    );
+
+    const renamePack = useCallback<CardPackActions["renamePack"]>(
+        async (pack) => {
+            const next = await prompt({
+                title: tAccount("renamePackDialogTitle"),
+                label: tAccount("renamePackInputLabel"),
+                initialValue: pack.label,
+                confirmLabel: tCommon("save"),
+            });
+            if (next === null) return false;
+            const trimmed = next.trim();
+            if (trimmed.length === 0 || trimmed === pack.label) return false;
+
+            const localMatch = findLocal(pack.clientGeneratedId);
+            if (localMatch !== undefined) {
+                saveLocal.mutate({
+                    label: trimmed,
+                    cardSet: pack.cardSet,
+                    existingId: pack.clientGeneratedId,
+                });
+            }
+
+            const serverMatch = findServer(pack.clientGeneratedId);
+            if (serverMatch !== undefined) {
+                saveServer.mutate({
+                    clientGeneratedId: pack.clientGeneratedId,
+                    label: trimmed,
+                    cardSet: pack.cardSet,
+                });
+            }
+            return true;
+        },
+        [
+            prompt,
+            tAccount,
+            tCommon,
+            findLocal,
+            findServer,
+            saveLocal,
+            saveServer,
+        ],
+    );
+
+    const deletePack = useCallback<CardPackActions["deletePack"]>(
+        async (pack) => {
+            const ok = await confirm({
+                message: tAccount("deletePackConfirm", { label: pack.label }),
+            });
+            if (!ok) return false;
+
+            const localMatch = findLocal(pack.clientGeneratedId);
+            if (localMatch !== undefined) {
+                deleteLocal.mutate(pack.clientGeneratedId);
+            }
+            const serverMatch = findServer(pack.clientGeneratedId);
+            if (serverMatch !== undefined) {
+                deleteServer.mutate(serverMatch.id);
+            }
+            return true;
+        },
+        [
+            confirm,
+            tAccount,
+            findLocal,
+            findServer,
+            deleteLocal,
+            deleteServer,
+        ],
+    );
+
+    return { sharePack, renamePack, deletePack };
+}

--- a/src/ui/hooks/usePrompt.test.tsx
+++ b/src/ui/hooks/usePrompt.test.tsx
@@ -1,0 +1,92 @@
+import { describe, expect, test, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("next-intl", () => {
+    const t = (key: string): string => key;
+    return { useTranslations: () => t };
+});
+
+import { PromptProvider, usePrompt } from "./usePrompt";
+
+function Trigger({
+    captured,
+}: {
+    readonly captured: { current: string | null | "unset" };
+}) {
+    const prompt = usePrompt();
+    return (
+        <button
+            type="button"
+            data-testid="open"
+            onClick={async () => {
+                const result = await prompt({
+                    title: "Rename pack",
+                    label: "New name",
+                    initialValue: "Old name",
+                });
+                captured.current = result;
+            }}
+        >
+            open
+        </button>
+    );
+}
+
+const renderHarness = () => {
+    const captured: { current: string | null | "unset" } = { current: "unset" };
+    const utils = render(
+        <PromptProvider>
+            <Trigger captured={captured} />
+        </PromptProvider>,
+    );
+    return { ...utils, captured };
+};
+
+describe("usePrompt", () => {
+    test("opens the dialog with the title, label, and pre-populated input", async () => {
+        const user = userEvent.setup();
+        renderHarness();
+        await user.click(screen.getByTestId("open"));
+        expect(screen.getByText("Rename pack")).toBeInTheDocument();
+        const input = screen.getByDisplayValue("Old name") as HTMLInputElement;
+        expect(input).toHaveFocus();
+        // Auto-select-all on open.
+        expect(input.selectionStart).toBe(0);
+        expect(input.selectionEnd).toBe("Old name".length);
+    });
+
+    test("submitting (Enter / Save) resolves the trimmed value", async () => {
+        const user = userEvent.setup();
+        const { captured } = renderHarness();
+        await user.click(screen.getByTestId("open"));
+        const input = screen.getByDisplayValue("Old name");
+        await user.clear(input);
+        await user.type(input, "  New label  ");
+        await user.click(screen.getByRole("button", { name: "save" }));
+        expect(captured.current).toBe("New label");
+    });
+
+    test("cancel resolves null", async () => {
+        const user = userEvent.setup();
+        const { captured } = renderHarness();
+        await user.click(screen.getByTestId("open"));
+        await user.click(screen.getByRole("button", { name: "cancel" }));
+        expect(captured.current).toBeNull();
+    });
+
+    test("Save is disabled when input is empty after trim", async () => {
+        const user = userEvent.setup();
+        renderHarness();
+        await user.click(screen.getByTestId("open"));
+        const input = screen.getByDisplayValue("Old name");
+        await user.clear(input);
+        const save = screen.getByRole("button", {
+            name: "save",
+        }) as HTMLButtonElement;
+        expect(save.disabled).toBe(true);
+        // Whitespace stays disabled too.
+        fireEvent.change(input, { target: { value: "   " } });
+        expect(save.disabled).toBe(true);
+    });
+});

--- a/src/ui/hooks/usePrompt.tsx
+++ b/src/ui/hooks/usePrompt.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import * as AlertDialog from "@radix-ui/react-alert-dialog";
+import { useTranslations } from "next-intl";
+import {
+    createContext,
+    type FormEvent,
+    type ReactNode,
+    useCallback,
+    useContext,
+    useEffect,
+    useRef,
+    useState,
+} from "react";
+
+interface PromptOptions {
+    readonly title: string;
+    readonly label: string;
+    readonly initialValue?: string;
+    readonly placeholder?: string;
+    readonly confirmLabel?: string;
+    readonly cancelLabel?: string;
+    readonly maxLength?: number;
+}
+
+type PromptFn = (opts: PromptOptions) => Promise<string | null>;
+
+const PromptContext = createContext<PromptFn | null>(null);
+
+interface PendingPrompt extends PromptOptions {
+    readonly resolve: (v: string | null) => void;
+}
+
+/**
+ * Promise-based labeled-input dialog. Mirrors `useConfirm` but resolves
+ * to a trimmed string (or `null` if the user cancels). Cancel / Esc /
+ * overlay click resolve `null`; the Save button is disabled while the
+ * input is empty after trim, so submitting always returns a non-empty
+ * string. The previous text is auto-selected on open so a re-edit is
+ * one keystroke away.
+ */
+export function PromptProvider({ children }: { readonly children: ReactNode }) {
+    const tCommon = useTranslations("common");
+    const [pending, setPending] = useState<PendingPrompt | null>(null);
+    const [value, setValue] = useState("");
+    const inputRef = useRef<HTMLInputElement | null>(null);
+
+    const prompt = useCallback<PromptFn>((opts) => {
+        return new Promise<string | null>((resolve) => {
+            setPending({ ...opts, resolve });
+        });
+    }, []);
+
+    useEffect(() => {
+        if (pending) setValue(pending.initialValue ?? "");
+    }, [pending]);
+
+    const close = useCallback(
+        (next: string | null) => {
+            setPending((prev) => {
+                if (prev) prev.resolve(next);
+                return null;
+            });
+        },
+        [],
+    );
+
+    const trimmed = value.trim();
+    const canSubmit = trimmed.length > 0;
+    const open = pending !== null;
+    const confirmLabel = pending?.confirmLabel ?? tCommon("save");
+    const cancelLabel = pending?.cancelLabel ?? tCommon("cancel");
+
+    const handleSubmit = useCallback(
+        (event: FormEvent<HTMLFormElement>) => {
+            event.preventDefault();
+            if (!canSubmit) return;
+            close(trimmed);
+        },
+        [canSubmit, close, trimmed],
+    );
+
+    return (
+        <PromptContext.Provider value={prompt}>
+            {children}
+            <AlertDialog.Root
+                open={open}
+                onOpenChange={(next) => {
+                    if (!next) close(null);
+                }}
+            >
+                <AlertDialog.Portal>
+                    <AlertDialog.Overlay
+                        className="fixed inset-0 z-[var(--z-dialog-overlay)] bg-black/30"
+                    />
+                    <AlertDialog.Content
+                        className={
+                            "fixed left-1/2 top-1/2 z-[var(--z-dialog-content)] w-[min(90vw,420px)] -translate-x-1/2 -translate-y-1/2 " +
+                            "rounded-[var(--radius)] border border-border bg-panel p-5 shadow-[0_10px_28px_rgba(0,0,0,0.28)] " +
+                            "focus:outline-none"
+                        }
+                        onOpenAutoFocus={(event) => {
+                            event.preventDefault();
+                            const input = inputRef.current;
+                            if (!input) return;
+                            input.focus();
+                            input.select();
+                        }}
+                    >
+                        <AlertDialog.Title className="m-0 mb-2 font-display text-[18px] text-accent">
+                            {pending?.title ?? ""}
+                        </AlertDialog.Title>
+                        <AlertDialog.Description className="sr-only">
+                            {pending?.label ?? ""}
+                        </AlertDialog.Description>
+                        <form onSubmit={handleSubmit}>
+                            <label className="m-0 block text-[13px] font-semibold text-[#2a1f12]">
+                                {pending?.label ?? ""}
+                                <input
+                                    ref={inputRef}
+                                    type="text"
+                                    value={value}
+                                    onChange={(e) => setValue(e.target.value)}
+                                    placeholder={pending?.placeholder}
+                                    maxLength={pending?.maxLength}
+                                    className="mt-1 block w-full min-h-[44px] rounded-[var(--radius)] border border-border bg-white px-3 py-2 text-[14px] text-[#2a1f12] focus:border-accent focus:outline-none"
+                                />
+                            </label>
+                            <div className="mt-5 flex flex-wrap justify-end gap-2">
+                                <AlertDialog.Cancel asChild>
+                                    <button
+                                        type="button"
+                                        className="cursor-pointer rounded-[var(--radius)] border border-border bg-transparent px-4 py-2 text-[13px] font-semibold text-[#2a1f12] hover:bg-hover"
+                                    >
+                                        {cancelLabel}
+                                    </button>
+                                </AlertDialog.Cancel>
+                                <button
+                                    type="submit"
+                                    disabled={!canSubmit}
+                                    className={
+                                        "cursor-pointer rounded-[var(--radius)] border border-accent bg-accent px-4 py-2 text-[13px] font-semibold text-white hover:bg-accent-hover " +
+                                        "disabled:cursor-not-allowed disabled:border-border disabled:bg-row-alt disabled:text-muted disabled:hover:bg-row-alt"
+                                    }
+                                >
+                                    {confirmLabel}
+                                </button>
+                            </div>
+                        </form>
+                    </AlertDialog.Content>
+                </AlertDialog.Portal>
+            </AlertDialog.Root>
+        </PromptContext.Provider>
+    );
+}
+
+export function usePrompt(): PromptFn {
+    const ctx = useContext(PromptContext);
+    if (!ctx) {
+        throw new Error(
+            // eslint-disable-next-line i18next/no-literal-string
+            "usePrompt must be used inside <PromptProvider>",
+        );
+    }
+    return ctx;
+}


### PR DESCRIPTION
## Behavior changes

**My card packs modal — three new per-pack actions.** Each row in
the AccountModal now has Share / Edit / Delete buttons. Edit opens a
small dialog with a labeled text input (Save / Cancel); rename works
across signed-in devices because it writes to both localStorage and
the server when the pack is synced. Delete uses the standard confirm
dialog and removes the pack everywhere it lives. Share opens the
existing share modal with the clicked pack pre-selected.

**Same pencil affordance on the Game Setup pills and the All-card-packs
picker** — so all three card-pack management surfaces look and behave
the same.

**Bigger tap targets on every pill.** The pack-name button (the
primary "select this pack" action) is the largest target; the icon
buttons grow proportionally. Same sizing at every breakpoint — no
desktop shrink-back. Mobile users should no longer mis-tap the share
button when they meant the label.

**Sign-in works on preview deploys.** Previously, clicking "Sign in
with Google" on a Vercel preview did nothing because the preview's
OAuth callback wasn't registered with Google (preview hostnames are
dynamic, and Google forbids wildcards in Authorized redirect URIs).
This PR wires Better Auth's `oAuthProxy` plugin, which pivots
preview-side OAuth through the stable production URL — Google sees
only one redirect URI ever, but every preview can complete sign-in
end-to-end against its own DB.

## Manual steps required in Vercel before the preview will sign in

The auth proxy fix needs **one new environment variable** set on
Vercel before previews can complete sign-in. Without this step, the
sign-in button on the preview will keep doing nothing.

1. Vercel dashboard → **winclue project → Settings → Environment Variables**.
2. Add a new variable:
   - **Name:** `BETTER_AUTH_PRODUCTION_URL`
   - **Value:** `https://winclue.vercel.app` (literal — **NOT**
     `$VERCEL_URL`)
   - **Environments:** check **both Production and Preview**. Leave
     Development unchecked.
3. Save. Re-deploy this branch's preview (any new commit will do, or
   hit "Redeploy" in the Vercel UI on the existing preview build) so
   the preview function picks up the new env var.

That's it for the env wiring. The plugin is a no-op when
`currentURL === productionURL`, so production keeps behaving exactly
as it does today — only previews change.

**Optional cleanup in the Google Cloud Console.** Earlier iterations
of `docs/setup-vercel-neon-google.md` told you to add specific
preview-deploy callback URLs to the Google OAuth client as they came
up. Those entries are no longer needed (the proxy means production's
callback is the only one Google ever sees). You can safely remove
any preview-specific entries from **APIs & Services → Credentials →
\[the prod OAuth client\] → Authorized redirect URIs**. Keep
`https://winclue.vercel.app/api/auth/callback/google` and your
localhost callback(s).

**`trustedOrigins` wildcard sanity check.** `src/server/auth.ts`
hard-codes `trustedOrigins` to match `https://winclue-*.vercel.app`
+ `http://localhost:*` + production. If your Vercel preview hostnames
include a team slug (e.g. `winclue-git-foo-yourteam.vercel.app` rather
than `winclue-foo.vercel.app`), the wildcard above won't match and
production will reject the proxy hop. Eyeball one preview URL after
the next deploy; if it doesn't match, edit `trustedOrigins` in that
file to widen / tighten the pattern (e.g.
`https://winclue-*-yourteam.vercel.app`) and push another commit.

## Verification on the preview deploy

Once the env var is set and the preview is redeployed:

1. Open the preview URL in an incognito window.
2. Open the overflow menu → click "Sign in" → complete Google OAuth.
3. You should land back in the preview, signed in, with the avatar
   visible in the overflow menu.
4. Open the overflow menu → "My card packs" → confirm any custom
   packs you've saved are listed.
5. Tap **Share / Edit / Delete** on a row to confirm each works.
6. Resize to mobile; re-tap each part of a Game Setup pill (label,
   share, pencil, trash) to confirm tap targets feel comfortable.

If sign-in still does nothing on the preview after step 1: check
Vercel function logs for an `Invalid Origin` or
`redirect_uri_mismatch` error. The first means `trustedOrigins`
needs the preview hostname; the second means
`BETTER_AUTH_PRODUCTION_URL` is missing or wrong.

## Commits

### `Add Edit/Share/Delete actions to My Card Packs modal`

- New `PencilIcon` (Feather pencil glyph) in
  `src/ui/components/Icons.tsx`.
- New `usePrompt` hook + `PromptProvider` mirroring `useConfirm`. Radix
  AlertDialog with one labeled `<input>`; Save disabled while empty
  after trim; auto-selects existing text on open. Mounted inside
  `ConfirmProvider` in `src/ui/Clue.tsx`.
- `decodeServerPack` exported from `src/data/cardPacksSync.tsx` so the
  modal can render the live `CardSet` for server-only packs.
- Two new server-side React Query mutations in
  `src/data/customCardPacks.ts`: `useSaveCardPackOnServer` and
  `useDeleteCardPackOnServer`. Each updates the
  `myCardPacksQueryKey(userId)` cache on success and carries
  matching `rq.customPacks.saveOnServer` /
  `rq.customPacks.deleteOnServer` Honeycomb spans.
- New `useCardPackActions` hook in
  `src/ui/components/cardPackActions.ts` — single source of truth for
  share / rename / delete. Reads
  `myCardPacksQueryKey(userId)` and `customCardPacksQueryKey` via
  `queryClient.getQueryData` to decide whether to mirror to the
  server, the local store, or both.
- `mergeCardPacks` returns a `DisplayPack` with the live `CardSet`
  (decoded via `decodeServerPack`) and a
  `source: "server" | "local"` discriminator. Modal rows render with a
  flex row + three bordered icon buttons (Share / Pencil / Trash).
- `CardPackRow` and `CardPackPicker` route share / rename / delete
  through `useCardPackActions`. The existing `forgetUseMutation` stays
  colocated in `CardPackRow.onDeleteCustomPack` after the confirm so
  recency-map cleanup runs only on confirmed deletes.
- Pill tap targets bumped at all viewports: label
  `px-3 py-1` → `px-3.5 py-2`; icon buttons `px-2 py-1` → `px-2.5 py-1.5`;
  icon size `12` → `14` (picker `13` → `15`). Same sizing at desktop —
  no responsive shrink-back.
- i18n: dropped orphaned `setup.deleteCustomCardSetConfirm`; added
  `account.renamePackTitle/Aria/DialogTitle/InputLabel` +
  `sharePackTitle/Aria` + `deletePackTitle/Aria/Confirm`,
  `setup.renamePackTitle/Aria/DialogTitle/InputLabel`, and
  `common.save`.
- New `usePrompt.test.tsx` covers open/cancel/submit/disabled-when-empty/
  auto-select. `AccountModal.test.tsx` adds share, rename
  (synced + local-only + cancel), and delete coverage and updates the
  `mergeCardPacks` test for the new `DisplayPack` shape and the
  malformed-server-payload drop. `CardPackRow.test.tsx` wraps every
  render with `<PromptProvider>`.

### `Wire Better Auth oAuthProxy plugin for Vercel preview deployments`

- Adds `oAuthProxy` to the plugins list in `src/server/auth.ts`,
  reading `productionURL` from a new optional
  `BETTER_AUTH_PRODUCTION_URL` env var. Passes through `undefined`
  when unset so local dev is a no-op.
- Adds `trustedOrigins` to the Better Auth config:
  `https://winclue.vercel.app`, `https://winclue-*.vercel.app`,
  `http://localhost:*`. Required for production to accept preview
  hosts as redirect targets after the proxy hop.
- `src/server/auth.test.ts` gains two cases: `oAuthProxy` reads
  `productionURL` from `BETTER_AUTH_PRODUCTION_URL`, and the
  `trustedOrigins` array contains all three patterns. The existing
  Google-OAuth test now also asserts the plugin appears in the
  plugins list with empty options when the env var is unset.
- `env.example`, the README env-var table, and
  `docs/setup-vercel-neon-google.md` all document the new env var
  with per-environment values. The Vercel setup doc gains a new "4b"
  section walking through how the proxy works and what to set; step
  5 drops the "specific preview-deploy URLs as they come up" line
  since the proxy means production's callback is the only Google
  redirect URI needed.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` — 1141 / 1141 passing
- [x] `pnpm knip`
- [x] `pnpm i18n:check`
- [ ] Set `BETTER_AUTH_PRODUCTION_URL` on Vercel Production + Preview
- [ ] Redeploy this branch's preview, sign in with Google, exercise
      each row action in the My-Card-Packs modal
- [ ] On mobile (DevTools or actual device), tap each part of a
      custom-pack pill on the Game Setup page

https://claude.ai/code/session_01SPZYnzHvuKBWJzYWBvUXnq