### PR TITLE
Sync card packs across devices and warn on offline logout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -255,13 +255,27 @@ Use these four icons consistently — picking the wrong glyph mis-signals what t
 
 If you need a glyph that doesn't fit one of these, add it to `src/ui/components/Icons.tsx` (or `ShareIcon.tsx` for share variants) — don't reach for an emoji or a literal character (`×`, `→`, etc.) that might be misread.
 
-## Sharing
+## Sharing and sync docs
 
-If you touch anything in `src/ui/share/`, `src/server/actions/shares.ts`, `src/logic/ShareCodec.ts`, or any `shares` DB column, walk through [docs/shares.md](docs/shares.md) first. Three rules drive the design and shouldn't be loosened without a deliberate change to the doc:
+Two docs in `docs/` cover how user data leaves the device:
 
-- **Universal sign-in.** Every share requires a real, non-anonymous user. The check lives at the top of `createShare` and the DB enforces it via `owner_id NOT NULL`. Don't reintroduce per-flow auth conditionals.
+- [docs/shares-and-sync.md](docs/shares-and-sync.md) — the sharing UX, the kind-discriminated wire contract, and the seven Effect-Schema-validated wire fields (cardPack / players / handSizes / knownCards / suggestions / accusations / hypotheses). Hypotheses are `transfer`-only.
+- [docs/card-pack-sync.md](docs/card-pack-sync.md) — the deep dive on how localStorage and the server stay in sync once the user is signed in: per-pack metadata (`unsyncedSince`, `lastSyncedSnapshot`), tombstones, the `<CardPacksSync />` reconcile loop, the `flushPendingChanges` logout chokepoint, and four "life of a card pack" timelines.
+
+**Whenever you touch sync-or-share code, update the corresponding doc as part of the same change.** This is non-negotiable — these systems have enough subtlety (auth gating, conflict resolution, in-flight registry, tombstones, the four-quadrant pack-state matrix) that drift between the code and the doc will burn the next person to come in.
+
+The triggering paths:
+
+- **Sharing**: anything in `src/ui/share/`, `src/server/actions/shares.ts`, `src/logic/ShareCodec.ts`, the `shares` DB columns. Touches → update `docs/shares-and-sync.md`.
+- **Card-pack sync**: `src/data/cardPacksSync.tsx`, `src/data/customCardPacks.ts`, `src/data/cardPacksInFlight.ts`, `src/data/serverPackCodec.ts`, `src/logic/CustomCardSets.ts`, `src/logic/CardPackTombstones.ts`, `src/server/actions/packs.ts`, `src/ui/account/AccountProvider.tsx`, `src/ui/account/LogoutWarningModal.tsx`, `src/ui/components/cardPackActions.ts`. Touches → update `docs/card-pack-sync.md` (and `docs/shares-and-sync.md` if the change crosses into the sharing wire format).
+
+The three rules from `docs/shares-and-sync.md` that govern sharing and shouldn't be loosened without a deliberate change to the doc:
+
+- **Universal sign-in.** Every share requires a real, non-anonymous user. The check lives at the top of `createShare` and the DB enforces it via `owner_id NOT NULL`. Don't reintroduce per-flow auth conditionals. The same gate (`useSignedInUserId` / `requireSignedInUser`) governs server-side card-pack mirroring.
 - **Kind-based wire contract.** `createShare`'s input is a discriminated union by `kind`. The server whitelists fields per kind and rejects anything extraneous. Don't expose the column structure to the client; add new flows by adding new kinds.
-- **Effect-Schema-validated wire format.** All six wire fields go through codecs in `src/logic/ShareCodec.ts`. Don't add a new wire field with a raw `JSON.stringify` / `JSON.parse` — write a codec, route both sender and receiver through it.
+- **Effect-Schema-validated wire format.** All seven wire fields go through codecs in `src/logic/ShareCodec.ts`. Don't add a new wire field with a raw `JSON.stringify` / `JSON.parse` — write a codec, route both sender and receiver through it.
+
+The card-pack sync architecture has its own load-bearing invariants that `docs/card-pack-sync.md` covers in depth — the four-quadrant pack-state matrix (`unsyncedSince` × `lastSyncedSnapshot`), the conflict-resolution rules (local-wins when `unsyncedSince` is set, otherwise server-wins), the always-tombstone-when-signed-in delete policy, and the `clearAccountTiedLocalState` keys list. Read the doc before changing those.
 
 ## Tests
 
@@ -365,6 +379,27 @@ When I ask you to "rebase on/against latest origin/main" (or "latest remote main
 7. Verify in the `next-dev` preview if anything we changed is observable in the browser.
 8. Amend the rebased commit only if your fixes belong to it (style cleanup, conflict resolution). Otherwise stack a new commit.
 9. If the rebase required substantial reworking, **tell me before pushing or merging** so I can re-test before it ships.
+10. **Always report the rebase status when you're done.** Don't push or merge without it — I read this report to decide whether the rebase is safe to ship. The report goes in your reply to me and covers, in order:
+    - **Conflicts encountered.** List every file that conflicted and one sentence on what kind of conflict it was (overlapping function rename, divergent imports, semantic clash between two new features that both modify the same hook, etc.).
+    - **How each was resolved.** What you kept from upstream, what you kept from our branch, and any structural change you had to make beyond a mechanical merge (e.g. "renamed our internal `decodeServerPack` to `decodeForReconcile` so upstream's exported `decodeServerPack` could keep its name").
+    - **Major code changes upstream that might affect us.** Skim the 10ish upstream commits and call out anything that touches code paths we rely on, even if it didn't conflict — new hooks we should now route through, removed patterns we should follow, schema changes, new infra. Three sentences max per item, but don't omit anything that a human reviewer should know about.
+    - **Tests that changed.** Tests added by upstream that we modified (and why), tests of ours that needed updating (and why).
+    - **Pre-commit results.** typecheck / lint / test / knip / i18n:check status. List the test count if it shifted.
+    - **Manual verification status.** Whether you ran the `next-dev` preview, what scenarios you walked, what worked, what didn't, and whether the in-tool browser was available. If you couldn't verify, say so explicitly — don't gloss over it.
+    - **Commit list after the rebase.** The output of `git log --oneline -<N>` covering at least our new commits + the upstream HEAD they sit on.
+    - **Safety estimate.** A one-line confidence call on whether the rebase introduced no functional regressions, on a rough "low / medium / high" scale, with one sentence explaining what would shift the estimate. This is the line I read first when deciding whether to push.
+
+    Sample shape (paraphrase, don't copy verbatim):
+
+    > **Rebase report**
+    > - Conflicts: 3 files. `messages/en.json` (additive, both sides added new sibling keys), `src/data/customCardPacks.ts` (we restructured the file; upstream added two new hooks at the bottom), `src/data/cardPacksSync.tsx` (upstream exported a function we'd internally renamed).
+    > - Resolutions: kept our shape and slotted upstream's two hooks at the bottom; renamed our internal helper from `decodeServerPack` to `decodeForReconcile` so upstream's exported `decodeServerPack` keeps its name; merged the two i18n key sets.
+    > - Major upstream changes that might affect us: …
+    > - Tests: …
+    > - Pre-commit: typecheck ✓ / lint ✓ / test ✓ (1180 passed, +XX from previous) / knip ✓ / i18n:check ✓.
+    > - Manual verification: …
+    > - Commits: <`git log --oneline -5` snippet>.
+    > - Safety: **medium** — pre-commit is green but the unified-vs-split mutation-hook architectural call needs a real-browser walkthrough before push.
 
 ## Commit message format
 

--- a/docs/card-pack-sync.md
+++ b/docs/card-pack-sync.md
@@ -1,0 +1,583 @@
+# Card-pack sync — architecture deep dive
+
+> **Read this first** if you're touching anything in:
+>
+> - `src/data/cardPacksSync.tsx` — reconcile, flush, sign-in/out
+> - `src/data/customCardPacks.ts` — mutation hooks
+> - `src/data/cardPacksInFlight.ts` — in-flight Promise registry
+> - `src/data/serverPackCodec.ts` — wire decode helper
+> - `src/logic/CustomCardSets.ts` — localStorage layer + metadata
+> - `src/logic/CardPackTombstones.ts` — soft-delete tracking
+> - `src/server/actions/packs.ts` — server actions
+> - `src/ui/account/AccountProvider.tsx` — sign-out chokepoint
+> - `src/ui/account/LogoutWarningModal.tsx` — unsynced-changes UI
+> - `src/ui/components/cardPackActions.ts` — share/rename/delete
+>
+> The companion doc [shares-and-sync.md](./shares-and-sync.md)
+> covers the sharing UX and where sync intersects with it. Read that
+> first if your change is share-shaped; come here for the sync
+> internals.
+
+## TL;DR — the mental model
+
+> *"Once I'm logged into a device, those card packs are tied to my
+> account. They should stay synced to localStorage so that offline
+> access still works, and all the synchronization of card packs can
+> happen once I log on again."*
+>
+> — the user's words, [docs/shares-and-sync.md](./shares-and-sync.md)
+> rule
+
+Card-pack sync is **local-first with the server as source of truth
+once signed in**:
+
+1. localStorage is the live store the UI reads from. It works offline.
+2. When the user is signed in, every save / delete also mirrors to
+   the server. The mirror is best-effort — UI never blocks on it.
+3. Every signed-in mount, focus, or reconnect pulls the server's
+   view back and reconciles. Local-only packs (unsynced) survive
+   the merge; offline edits to synced packs win locally.
+4. Logout is a chokepoint: if everything's clean, the device's
+   localStorage is wiped (packs are tied to the account, not the
+   device) and the user is signed out. If anything is unsynced
+   (offline edits, failed pushes), the user gets a structured
+   warning describing what would be lost, with a "Stay logged in",
+   "Try again", or "Sign out anyway" choice.
+
+## The components, top-down
+
+```
+            ┌─────────────────────────────────────────────────────┐
+            │  AccountProvider                                    │
+            │  ─ provides `requestSignOut()` via context          │
+            │  ─ mounts <CardPacksSync /> + <LogoutWarningModal />│
+            └─────────────────────┬───────────────────────────────┘
+                                  │
+              ┌───────────────────┴────────────────┐
+              │                                    │
+   ┌──────────▼──────────┐         ┌───────────────▼──────────┐
+   │  CardPacksSync      │         │  LogoutWarningModal      │
+   │  (renders nothing)  │         │  (Radix AlertDialog)     │
+   │                     │         │                          │
+   │  ─ React Query for  │         │  ─ Lists created /       │
+   │    getMyCardPacks   │         │    modified / deleted    │
+   │  ─ sign-in push     │         │    sections from         │
+   │  ─ applyServerSnapshot│       │    UnsyncedSummary       │
+   └──────────┬──────────┘         └──────────────────────────┘
+              │
+     ┌────────┴──────────┐
+     │  reconcile + flush│
+     │  (cardPacksSync)  │
+     └────────┬──────────┘
+              │
+   ┌──────────▼──────────────────────────┐
+   │  in-flight registry                 │
+   │  cardPacksInFlight.ts               │
+   │  ─ trackInFlight, drainInFlight     │
+   └──────────┬──────────────────────────┘
+              │
+   ┌──────────▼──────────────┐    ┌──────────────────────────┐
+   │  Mutation hooks         │    │  Server actions          │
+   │  customCardPacks.ts     │───▶│  packs.ts                │
+   │  ─ useSaveCardPack      │    │  ─ getMyCardPacks        │
+   │  ─ useDeleteCardPack    │    │  ─ saveCardPack          │
+   │  ─ useSaveCardPackOnServer  │  ─ deleteCardPack         │
+   │  ─ useDeleteCardPackOnServer│  ─ pushLocalPacksOnSignIn │
+   └──────────┬──────────────┘    └──────────────────────────┘
+              │
+   ┌──────────▼──────────────┐    ┌──────────────────────────┐
+   │  localStorage layer     │    │  Tombstones              │
+   │  CustomCardSets.ts      │    │  CardPackTombstones.ts   │
+   │  ─ load / save / delete │    │  ─ effect-clue.deleted-  │
+   │  ─ markPackUnsynced     │    │    packs.v1              │
+   │  ─ markPackSynced       │    │  ─ load / add / clear    │
+   │  ─ replaceCustomCardSets│    │                          │
+   │  ─ clearAccountTied…    │    │                          │
+   └─────────────────────────┘    └──────────────────────────┘
+```
+
+## Per-pack metadata (the core data shape)
+
+Each `CustomCardSet` in `effect-clue.custom-presets.v1` carries
+three optional sync-related fields. They're **additive** to the
+schema — old payloads decode unchanged — and they're the foundation
+for every state machine in this doc.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `unsyncedSince` | `DateTime.Utc \| undefined` | Set on every local mutation while signed in. Cleared by a successful server roundtrip. Absent ⇒ pack is in sync (or pre-dates sync entirely). |
+| `lastSyncedSnapshot` | `{ label, cardSet } \| undefined` | The server's last-known view of this pack. Set by pulls and successful pushes. **Never mutated by local edits**, so it stays a stable diff baseline across multiple offline edits. Absent ⇒ the server has never acknowledged this pack. |
+| `id` | `string` | The canonical identifier the UI keys on. Equals the server's cuid2 once the pack has been pushed (or pulled); a `custom-…` ephemeral id otherwise. |
+
+The discriminator that drives most decisions:
+
+```ts
+isSynced(p) := p.unsyncedSince === undefined
+            && p.lastSyncedSnapshot !== undefined
+```
+
+Anything else needs to flush. The four cases:
+
+|   | `unsyncedSince` set | `unsyncedSince` unset |
+|---|---|---|
+| **`lastSyncedSnapshot` set** | offline edit to a previously-synced pack | synced |
+| **`lastSyncedSnapshot` unset** | local create, server hasn't acknowledged | local-only (anonymous-era OR new + push pending) |
+
+## Tombstones (`effect-clue.deleted-packs.v1`)
+
+When a signed-in user deletes a pack, the local entry is removed
+immediately *and* a tombstone is written:
+
+```ts
+{ id: string; label: string; deletedAt: number /* epoch ms */ }
+```
+
+The server delete fires in parallel. On success, the tombstone is
+cleared. On failure (offline / 5xx), the tombstone survives and gets
+two follow-up jobs:
+
+1. **Reconcile filter.** `reconcileCardPacks` drops any server pack
+   whose `id` or `clientGeneratedId` is in the tombstone set. This
+   is what stops a still-unconfirmed delete from being undone by the
+   next pull.
+2. **Logout warning.** `LogoutWarningModal` reads tombstones into
+   the "Deleted" section so the user knows a pending delete would
+   be lost on sign-out-anyway.
+
+Tombstones for packs the server never had (e.g. a `create-then-
+delete-offline` cycle) are also written; the server delete is
+idempotent (DELETE WHERE owner_id AND (id OR client_generated_id))
+so a no-op succeeds and the tombstone clears immediately. The brief
+existence of the tombstone is acceptable.
+
+## The mutation hooks
+
+```
+src/data/customCardPacks.ts exports four hooks
+  ─ useSaveCardPack            ← unified: local + server-when-signed-in
+  ─ useDeleteCardPack          ← unified: local + tombstone + server-when-signed-in
+  ─ useSaveCardPackOnServer    ← server-only fallback (rare)
+  ─ useDeleteCardPackOnServer  ← server-only fallback (rare)
+```
+
+The two **unified hooks** are what `CardPackRow.tsx` (the Setup
+pane), `useCardPackActions` (rename / delete buttons), and any
+future pack-mutating UI use. They:
+
+- Always write to localStorage first (so the UI snaps).
+- Stamp `unsyncedSince` if signed in.
+- Fire the server action in parallel (idempotent on
+  `(owner_id, client_generated_id)`).
+- On success, swap the localStorage `id` for the server's cuid2
+  (when different), set `lastSyncedSnapshot`, clear `unsyncedSince`,
+  and remap usage entries via `remapCardPackUsageIds`.
+- On failure, log via `Effect.logError` and leave local state alone.
+  The next reconcile retries.
+
+The two **server-only hooks** exist for one corner case:
+`useCardPackActions` decides which to call by reading both query
+caches. When the user has just signed in and the modal is open
+*before* `applyServerSnapshot` has run, the pack might exist only in
+`myCardPacksQueryKey(userId)` (the server cache) without a matching
+entry in `customCardPacksQueryKey` (the local cache). Calling the
+unified hook in that case would create a duplicate localStorage
+entry with a fresh client id. The server-only hooks dodge that.
+
+## The reconcile loop
+
+`<CardPacksSync />` mounts a React Query for `getMyCardPacks` keyed
+by the signed-in user id, with `refetchOnMount`,
+`refetchOnWindowFocus`, and `refetchOnReconnect` all on. The
+`staleTime` is `Duration.toMillis(Duration.seconds(30))` — enough
+to debounce rapid focus oscillations, short enough that a real
+cross-device update lands quickly.
+
+Every successful settle triggers `applyServerSnapshot`:
+
+```
+1. await drainInFlight()           // let in-flight saves/deletes settle
+2. flush tombstones                 // retry pending deletes; clear on success
+3. re-read localStorage             // post-mutation source of truth
+4. reconcileCardPacks(local, server, tombstoneIds)
+5. replaceCustomCardSets(merged)    // write merged list back
+6. remapCardPackUsageIds(idMap)     // recency map points at new ids
+7. setQueryData(customCardPacksQueryKey, merged)
+8. invalidate(cardPackUsageQueryKey)
+```
+
+### `reconcileCardPacks` rules (in order)
+
+1. **Tombstones win.** Any server pack whose `id` or `clientGeneratedId`
+   is in `tombstoneIds` is dropped. Any local pack whose `id` is in
+   `tombstoneIds` is dropped (defensive — already gone from
+   localStorage, but belt-and-braces).
+2. **Pair match (clientGeneratedId).** When a local pack's `id`
+   equals a server pack's `clientGeneratedId`:
+   - If content matches, merge with server's `id`, clear
+     `unsyncedSince`, set `lastSyncedSnapshot` to the server view.
+   - If content differs and `unsyncedSince` is set on the local
+     pack: **local wins** (the user's offline edit is newer).
+     Preserve local label/cardSet, retain `unsyncedSince`, refresh
+     the snapshot to the latest server view.
+   - If content differs and `unsyncedSince` is *not* set: **server
+     wins** (rename-on-push, other-device update).
+3. **Exact-content duplicate.** Server pack with no
+   clientGeneratedId pair-match BUT same label + cardSet as a local
+   pack: server wins (already canonical), idMap remaps.
+4. **Server-only.** Pulled in. Increments `countPulled`.
+5. **Local-only.** Preserved with all metadata intact.
+
+## The sign-in transition
+
+When `useSession` flips a user from `isAnonymous: true` to a real
+account, `<CardPacksSync />`'s `useEffect` fires once per `userId`:
+
+```
+1. read all localStorage packs
+2. pushLocalPacksOnSignIn({ packs })   // server upserts; rename-on-collision
+3. invalidateQueries(myCardPacksQueryKey(userId))
+4. (the React Query refetch triggers applyServerSnapshot)
+```
+
+The push is idempotent — re-running it for the same packs (e.g.
+sign-out then sign-in again on the same device) is a no-op apart
+from a `updated_at` bump. Errors are logged and swallowed; the
+React Query refetch doesn't depend on the push succeeding.
+
+## The logout flow
+
+Both `Toolbar` and `BottomNav` route their "Sign out" buttons
+through `requestSignOut` (provided by `AccountProvider`'s context).
+This single chokepoint runs:
+
+```
+1. flushPendingChanges()
+   ─ drainInFlight
+   ─ if navigator.onLine === false: return { ok: false, reason: "offline", unsynced }
+   ─ retry every tombstone (deleteCardPack)
+   ─ retry every pack with unsyncedSince OR no lastSyncedSnapshot (saveCardPack)
+   ─ if anything still pending: return { ok: false, reason: "serverError", unsynced }
+   ─ else return { ok: true }
+
+2a. on { ok: true }: commitSignOut → clearAccountTiedLocalState → authClient.signOut
+2b. on { ok: false }: open <LogoutWarningModal /> with the summary
+```
+
+`clearAccountTiedLocalState` removes exactly three keys:
+`effect-clue.custom-presets.v1`, `effect-clue.deleted-packs.v1`,
+`effect-clue.card-pack-usage.v1`. Game state, splash state, tour
+state, and install-prompt state are deliberately **not** account-
+tied and survive sign-out.
+
+## Life of a card pack — four timelines
+
+These walk the full state machine for the four scenarios that drive
+the design. Read at least one to get a feel for how the pieces fit.
+
+### Timeline 1: Sign-in is followed by another device's sign-in
+
+> *Flow 1 in the original spec — "create on Device A while signed
+> in, then sign in to Device B → pack should appear."*
+
+```
+T=0    Device A, signed in
+       User: "+ Save as card pack" with label "Office".
+       useSaveCardPack runs:
+         1. saveCustomCardSet("Office", cardSet) → localStorage gets
+            { id: "custom-abc", label: "Office", cardSet, ... }
+         2. markPackUnsynced("custom-abc") → unsyncedSince stamped
+         3. saveCardPackServer({ clientGeneratedId: "custom-abc",
+            label: "Office", cardSet }) fires
+       Device A's localStorage state:
+         { id: "custom-abc", label: "Office",
+           unsyncedSince: T0, lastSyncedSnapshot: undefined }
+
+T+50ms Server returns row { id: "srv-xyz", clientGeneratedId:
+       "custom-abc", label: "Office", cardSetData: ... }
+       useSaveCardPack onSuccess:
+         1. markPackSynced("custom-abc", row) → swaps id to "srv-xyz",
+            sets lastSyncedSnapshot = { label: "Office", cardSet },
+            clears unsyncedSince
+         2. remapCardPackUsageIds("custom-abc" → "srv-xyz")
+         3. clearTombstones(["custom-abc", "srv-xyz"])
+       Device A's localStorage state:
+         { id: "srv-xyz", label: "Office",
+           unsyncedSince: undefined,
+           lastSyncedSnapshot: { label: "Office", cardSet } }
+
+T+5min User picks up Device B and signs in for the first time.
+       <CardPacksSync /> mounts.
+       Sign-in transition useEffect fires:
+         1. localBefore = loadCustomCardSets() → [] (Device B fresh)
+         2. pushLocalPacksOnSignIn({ packs: [] }) → no-op
+         3. invalidateQueries(myCardPacksQueryKey(userId))
+       React Query refetches getMyCardPacks → returns [{ id: "srv-xyz",
+       clientGeneratedId: "custom-abc", label: "Office", ... }]
+       applyServerSnapshot runs:
+         1. drainInFlight (nothing to drain)
+         2. tombstone flush (no tombstones)
+         3. reconcileCardPacks([], [server's "Office"]) →
+            countPulled=1, packs=[{ id: "srv-xyz", label: "Office",
+            lastSyncedSnapshot: { ... } }]
+         4. replaceCustomCardSets → Device B's localStorage now has it
+       Device B's UI renders the new pack.
+```
+
+### Timeline 2: Anonymous create → sign-in
+
+> *Flow 2 — "create while not logged in, then sign in. Then sign in
+> on Device B → pack should appear."*
+
+```
+T=0    Device A, anonymous (no user, or isAnonymous: true)
+       User: "+ Save as card pack" with label "Mansion".
+       useSaveCardPack runs. userId === undefined (anon) — skip the
+       server mirror.
+       Device A's localStorage state:
+         { id: "custom-abc", label: "Mansion",
+           unsyncedSince: undefined, lastSyncedSnapshot: undefined }
+
+T+10s  User clicks "Sign in with Google". Better Auth completes;
+       useSession flips to { isAnonymous: false, id: "alice" }.
+       <CardPacksSync />'s sign-in transition useEffect fires:
+         1. localBefore = [{ id: "custom-abc", label: "Mansion", ... }]
+         2. pushLocalPacksOnSignIn({ packs: [{
+              clientGeneratedId: "custom-abc", label: "Mansion",
+              cardSet }] })
+            → server creates row with id "srv-xyz",
+              clientGeneratedId "custom-abc", label "Mansion".
+         3. invalidateQueries(myCardPacksQueryKey("alice"))
+       React Query refetches → [{ id: "srv-xyz", clientGeneratedId:
+       "custom-abc", label: "Mansion", cardSetData: ... }]
+       applyServerSnapshot:
+         1. drainInFlight (nothing)
+         2. tombstone flush (none)
+         3. reconcileCardPacks([anon-era pack], [server's pack]) →
+            Phase 1 finds clientGeneratedId match. Content matches.
+            Merge with server's id; lastSyncedSnapshot = server view.
+         4. localStorage now: { id: "srv-xyz", label: "Mansion",
+            unsyncedSince: undefined,
+            lastSyncedSnapshot: { label: "Mansion", cardSet } }
+
+T+5min Device B signs in. (Same as Timeline 1's T+5min.) The pack
+       arrives via the standard pull → reconcile path.
+```
+
+**Robustness note.** If `pushLocalPacksOnSignIn` fails (offline,
+5xx), the localStorage entry stays as an anonymous-era pack with
+no metadata. The next `applyServerSnapshot` won't fix it (push
+isn't part of reconcile). But the next time the user does *anything*
+that triggers a save (rename, edit, etc.), the unified hook will
+push it. And `flushPendingChanges` (called from logout) treats any
+pack with `lastSyncedSnapshot === undefined` as needing a push, so
+even an idle user gets retry on logout.
+
+### Timeline 3: Two devices sign in around the same time
+
+> *Flow 3 — "save packs on both A and B (signed out), sign in to
+> both, all packs should sync."*
+
+```
+T=0    Device A signed-out. Local: pack "Hall" (custom-aaa).
+       Device B signed-out. Local: pack "Library" (custom-bbb).
+
+T+1s   Device A signs in. Sign-in push uploads "Hall".
+       Server now has:  [{srv-1, custom-aaa, "Hall"}]
+       Reconcile: localStorage = [{srv-1, "Hall", snapshot}]
+
+T+2s   Device B signs in (race — A's push has already landed).
+       Sign-in push uploads "Library".
+       Server now has: [{srv-1, custom-aaa, "Hall"},
+                        {srv-2, custom-bbb, "Library"}]
+       Device B reconcile: pull both, paired with custom-bbb,
+       new pull for "Hall". Device B's localStorage:
+       [{srv-1, "Hall"}, {srv-2, "Library"}]
+
+T+10s  Device A's window regains focus. React Query refetches:
+       refetchOnWindowFocus is on. Returns both packs from server.
+       Device A reconcile: pulls "Library". Device A's localStorage:
+       [{srv-1, "Hall"}, {srv-2, "Library"}]
+```
+
+If Device B signs in *before* Device A's push completes (faster
+race), Device B initially sees only its own pack. Device A's push
+lands shortly after. Device B's next refetch (on focus, on
+reconnect, or after staleTime expires) pulls both. The same end
+state — both devices have both packs — just on a slightly longer
+timeline.
+
+### Timeline 4: Offline edits → logout
+
+> *The "warn before discarding" logout flow.*
+
+```
+T=0    User signed in. localStorage: [{ id: "srv-1", label: "Office",
+       unsyncedSince: undefined, lastSyncedSnapshot: { ... } }]
+
+T+1m   User goes offline (DevTools throttle, plane mode).
+       User renames "Office" → "Office Edition" via the modal.
+       useCardPackActions.renamePack:
+         findLocal("srv-1") → found
+         saveLocal.mutate({ existingId: "srv-1", label: "Office Edition", cardSet })
+       useSaveCardPack:
+         1. saveCustomCardSet writes localStorage with new label.
+            Existing pack found, label updated, snapshot retained.
+         2. markPackUnsynced("srv-1") → stamps unsyncedSince
+         3. saveCardPackServer({ ... }) fires → fetch fails (offline)
+         4. Effect.logError → Honeycomb gets a record. mutationFn
+            returns the unsynced local pack (no rethrow).
+       localStorage: { id: "srv-1", label: "Office Edition",
+                       unsyncedSince: T+1m,
+                       lastSyncedSnapshot: { label: "Office", ... } }
+
+T+2m   User clicks Sign out.
+       requestSignOut → flushPendingChanges:
+         1. drainInFlight (nothing left in flight)
+         2. navigator.onLine === false → return { ok: false,
+            reason: "offline", unsynced: { modified: [{ id, label,
+            labelChanged: true, cardsChanged: false }], ... } }
+       AccountProvider opens <LogoutWarningModal />.
+       Modal renders:
+         "1 edited card pack — Office Edition [renamed]"
+         [Stay logged in] [Sign out anyway]
+
+T+2m+5s
+   User clicks "Stay logged in".
+       Modal closes. localStorage state unchanged. Pack still
+       `unsyncedSince`-stamped. User re-enables network.
+
+T+3m   The next React Query focus fires. applyServerSnapshot runs.
+       Inside it, the in-flight registry is empty AND the pack is
+       still in localStorage (unsynced). Reconcile sees the pack
+       paired with no server match (server still has the old
+       "Office") — actually it pairs by clientGeneratedId since the
+       server has it. Conflict resolution: unsyncedSince is set,
+       local wins. Merged pack keeps "Office Edition" with the
+       refreshed snapshot. unsyncedSince retained because content
+       differs from snapshot.
+
+       Actually we WANT the push to happen now so the server
+       catches up. The reconcile alone doesn't push. So:
+
+       At T+3m, the user's next save / delete OR the next logout
+       attempt's flushPendingChanges will push it. Since this is
+       the ambient background, the user typically triggers it by
+       clicking sign-out again — flushPendingChanges retries the
+       save, server accepts, lastSyncedSnapshot refreshes, flush
+       returns { ok: true }, sign-out commits.
+
+       (Future improvement: have applyServerSnapshot also push
+       any pack with `unsyncedSince` set OR no `lastSyncedSnapshot`,
+       not just retry tombstones. The flush already does this; the
+       reconcile loop could.)
+```
+
+## Edge cases worth knowing
+
+- **Race: save in flight at sign-out.** `flushPendingChanges` calls
+  `drainInFlight()` first. The in-flight save settles (either
+  clearing `unsyncedSince` on success or retaining it on failure),
+  *then* the flush evaluates state. No false negatives.
+- **Race: create-then-delete offline.** A pack with no
+  `lastSyncedSnapshot` is still tombstoned on delete. The server
+  delete is a no-op (server never had it). Tombstone clears
+  immediately. Briefly visible in the logout warning if the user
+  signs out between the delete and the tombstone clear, but
+  expected — they did just delete a pack.
+- **Race: concurrent edit on another device.** Device A edits a
+  pack while offline. Device B edits the same pack and pushes. When
+  A reconnects, the next pull's reconcile finds the
+  clientGeneratedId pair-match with differing content. A's local
+  has `unsyncedSince` set → **local wins**. The server's view
+  becomes the new `lastSyncedSnapshot`. A's next push (next save or
+  next flush) overwrites the server's version. B picks up the change
+  on its next refetch.
+- **First sign-in then immediate logout.** The sign-in push
+  populates `lastSyncedSnapshot` via the post-push reconcile. So a
+  brand-new sign-in followed by an immediate sign-out doesn't
+  trigger the warning. **However**, if the sign-in push *fails*,
+  packs stay metadata-less. `flushPendingChanges` treats those as
+  needing a push (the `lastSyncedSnapshot === undefined` path) and
+  retries. The warning fires only if the retry *also* fails.
+- **`navigator.onLine` lying.** Captive portals / DNS issues report
+  `online: true` but block requests. We try anyway and treat any
+  network failure as `reason: "serverError"`. The user sees the
+  same warning UI with a "Try again" button.
+- **Two browser tabs, same user.** No broadcast channel; each tab's
+  reconcile is independent and idempotent. Worst case both push;
+  the server upserts on `(owner_id, client_generated_id)` and
+  dedups.
+- **Anonymous → signed-in transition with already-existing
+  localStorage.** Those anonymous-era packs are pushed in the sign-in
+  transition. They become "synced" via the post-push reconcile. The
+  eventual sign-out clears them off the device (per the "packs are
+  tied to the account" rule).
+
+## Common change scenarios
+
+### Adding a new field to the persisted pack shape
+
+1. Add the field to `PersistedCustomCardSetSchema` in
+   `src/logic/CustomCardSets.ts`. Use `Schema.optional` so old
+   payloads still decode.
+2. Map it through `loadCustomCardSets` (decode) and `writeAll`
+   (encode). Wire in the `DateTime`/`Duration` conversions at the
+   storage edge.
+3. Surface it on the `CustomCardSet` interface with an explicit
+   `| undefined` (the project's `exactOptionalPropertyTypes` is on).
+4. If the field affects sync decisions, update the discriminator
+   logic in `summarizeUnsynced` and the flush's `needsPush` check.
+5. Add unit tests for the round-trip and any state-transition logic.
+
+### Adding a new mutation that should sync
+
+1. Decide whether to hang it off the existing unified hook or add a
+   new one. If it's a cardSet-shape mutation (rename, edit cards,
+   etc.), `useSaveCardPack` already handles it via `existingId`.
+2. If it's a different shape (e.g. archive a pack), follow the same
+   pattern: local-first, then server mirror via `Effect.fn` +
+   `trackInFlight`. On success use `markPackSynced` (or a new
+   marker). On failure log via `Effect.logError` and leave local
+   state alone.
+3. If the mutation introduces a new "unsynced" state, extend
+   `summarizeUnsynced` so the logout warning describes it.
+4. Update this doc with a new timeline if the state machine got
+   more complex.
+
+### Adding a new account-tied localStorage key
+
+1. Add the key constant.
+2. Add it to `clearAccountTiedLocalState` in
+   `src/logic/CustomCardSets.ts`.
+3. Update the `clearAccountTiedLocalState` test in
+   `src/logic/CustomCardSets.test.ts` so the assertion lists the
+   new key.
+4. Update the [Logout flow](#the-logout-flow) section above.
+
+## Storage keys (canonical list)
+
+| Key | Owner | Cleared on logout? | Notes |
+|---|---|---|---|
+| `effect-clue.custom-presets.v1` | `CustomCardSets.ts` | ✅ | The pack library, with sync metadata. |
+| `effect-clue.deleted-packs.v1` | `CardPackTombstones.ts` | ✅ | Soft-delete tracking for unconfirmed server deletes. |
+| `effect-clue.card-pack-usage.v1` | `CardPackUsage.ts` | ✅ | Per-pack last-used timestamps. |
+| `effect-clue.session.v7` | `state.tsx` | ❌ | In-progress game state. Not account-tied. |
+| `effect-clue.splash.v1` | `useSplashGate.tsx` | ❌ | Welcome modal dismissal. Not account-tied. |
+| `effect-clue.tour.*` | `tour/*` | ❌ | Per-screen tour gates. Not account-tied. |
+| `effect-clue.install-prompt.v1` | `useInstallPrompt.tsx` | ❌ | PWA install nag suppression. Not account-tied. |
+
+## Updating this doc
+
+This file is the authoritative source for the sync architecture.
+**Per [CLAUDE.md → Sharing and sync docs](../CLAUDE.md), any change
+that touches the files listed at the top of this doc must also
+update this file.** That includes:
+
+- Renaming a hook, splitting one into many, merging two.
+- Adding a new sync metadata field.
+- Changing the conflict-resolution rules in `reconcileCardPacks`.
+- Changing what `clearAccountTiedLocalState` clears.
+- Adding a new error path or wire shape.
+
+If you can't articulate the change in terms of one of the timelines
+above, the change probably warrants a new timeline.

--- a/docs/shares-and-sync.md
+++ b/docs/shares-and-sync.md
@@ -1,10 +1,26 @@
-# Sharing — UX, server, and DB end-to-end
+# Sharing and sync — UX, server, and DB end-to-end
 
 > **Read this first** if you're touching anything in `src/ui/share/`,
-> `src/server/actions/shares.ts`, `src/logic/ShareCodec.ts`, or any
-> `shares` DB column. Three load-bearing rules drive the whole
-> design — see *Universal sign-in*, *Kind-based wire contract*, and
-> *Effect-Schema-validated wire format* below.
+> `src/server/actions/shares.ts`, `src/logic/ShareCodec.ts`, any
+> `shares` DB column, or the card-pack sync pipeline
+> (`src/data/cardPacksSync.tsx`, `src/data/customCardPacks.ts`,
+> `src/server/actions/packs.ts`, `src/logic/CustomCardSets.ts`,
+> `src/logic/CardPackTombstones.ts`). Three load-bearing rules drive
+> the sharing design — see *Universal sign-in*, *Kind-based wire
+> contract*, and *Effect-Schema-validated wire format* below. The
+> card-pack sync architecture has its own deep-dive in
+> [card-pack-sync.md](./card-pack-sync.md) — start there if you're
+> touching mutation hooks, the reconcile loop, the logout flush,
+> tombstones, or the unsynced-changes warning.
+>
+> Sharing and sync share infrastructure: both are auth-gated, both
+> use `useSession` / `requireSignedInUser` plumbing, and both touch
+> the same `card_packs` server-side rows when a transferred game's
+> card pack happens to also be in the sender's synced library. Where
+> they differ is the wire shape and the lifecycle — sharing emits
+> ephemeral one-shot snapshots that the receiver imports; sync
+> maintains a continuously-reconciled mirror of the user's library
+> across every device they sign in on.
 
 ## What sharing is
 
@@ -27,8 +43,8 @@ just summarises what's in the link.
 | Variant | Entry points | What ships | Notes |
 |---|---|---|---|
 | `pack` | Card-pack row in Setup ("Share this pack" button), per-pack share icon in the "All card packs" picker | Card pack only | Picker entry passes `forcedCardPack` so the share contains the *picked* pack rather than the live setup pack |
-| `invite` | Setup pane near the Start playing CTA, overflow menu ("Invite a player") | Card pack + players + hand sizes; optional checkbox adds suggestions + accusations together when at least one of either has been logged | Checkbox is hidden when neither suggestions nor accusations exist. Label adapts to what's there: "Include all N prior suggestions and M failed accusations", "Include all N prior suggestions", or "Include all M prior failed accusations" |
-| `transfer` | Overflow menu only ("Continue on another device") | Everything: card pack + players + hand sizes + known cards + suggestions + accusations | Renders a prominent privacy warning above the CTA — this link discloses your hand |
+| `invite` | Setup pane near the Start playing CTA, overflow menu ("Invite a player") | Card pack + players + hand sizes; optional checkbox adds suggestions + accusations together when at least one of either has been logged | Checkbox is hidden when neither suggestions nor accusations exist. Label adapts to what's there: "Include all N prior suggestions and M failed accusations", "Include all N prior suggestions", or "Include all M prior failed accusations". **No hypotheses** — they're personal scratch notes; another player shouldn't see them. |
+| `transfer` | Overflow menu only ("Continue on another device") | Everything: card pack + players + hand sizes + known cards + suggestions + accusations + **hypotheses** | Renders a prominent privacy warning above the CTA — this link discloses your hand AND your in-progress hunches |
 
 The flow taxonomy intentionally hides the underlying column structure
 from the user. Earlier versions of the modal exposed four toggles
@@ -84,8 +100,13 @@ type CreateShareInput =
   | { kind: "invite"; cardPackData; playersData; handSizesData;
       suggestionsData?; accusationsData? }     // pair both or neither
   | { kind: "transfer"; cardPackData; playersData; handSizesData;
-      knownCardsData; suggestionsData; accusationsData };
+      knownCardsData; suggestionsData; accusationsData;
+      hypothesesData };                        // transfer-only
 ```
+
+The hypotheses field is `transfer`-only by design — hypotheses are
+the user's private scratch notes about who-might-own-what, and an
+`invite` share goes to *another* player who shouldn't see them.
 
 The server whitelists the fields each `kind` is allowed to carry.
 A `kind: "pack"` request with an extraneous `playersData` is
@@ -114,7 +135,7 @@ kind is a wire-and-server change, not a schema change.
 
 ## Effect-Schema-validated wire format
 
-All six wire fields round-trip through Effect `Schema` codecs in
+All seven wire fields round-trip through Effect `Schema` codecs in
 [src/logic/ShareCodec.ts](../src/logic/ShareCodec.ts):
 
 ```ts
@@ -124,6 +145,7 @@ export const handSizesCodec   = Schema.fromJsonString(...);
 export const knownCardsCodec  = Schema.fromJsonString(...);
 export const suggestionsCodec = Schema.fromJsonString(...);
 export const accusationsCodec = Schema.fromJsonString(...);
+export const hypothesesCodec  = Schema.fromJsonString(...);
 ```
 
 Each codec packages "JSON-string ↔ schema-validated object" into one
@@ -197,8 +219,10 @@ Migration history:
   index for the cron cleanup.
 - [0006_shares_owner_required.ts](../src/server/migrations/0006_shares_owner_required.ts)
   — tightens `owner_id` to `NOT NULL` (M22 universal sign-in).
+- [0007_shares_hypotheses.ts](../src/server/migrations/0007_shares_hypotheses.ts)
+  — adds `snapshot_hypotheses_data` for the `transfer` kind.
 
-Schema (post-0006):
+Schema (post-0007):
 
 ```sql
 shares (
@@ -210,6 +234,7 @@ shares (
   snapshot_known_cards_data   TEXT,
   snapshot_suggestions_data   TEXT,
   snapshot_accusations_data   TEXT,
+  snapshot_hypotheses_data    TEXT,         -- JSON-encoded Hypotheses; transfer-only
   created_at                  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   expires_at                  TIMESTAMPTZ,  -- NOW() + SHARE_TTL on insert
   -- index: shares_owner_id_idx, shares_expires_at_idx
@@ -262,3 +287,57 @@ Surfaced from `createShare` / `getShare`:
 | `ERR_SIGN_IN_REQUIRED` | `sign_in_required_to_share` | Caller is anonymous (no session OR isAnonymous=true). Modal catches and slides into the inline sign-in step. |
 | `ERR_MALFORMED_INPUT` | `share_malformed_input[:<detail>]` | Input shape didn't validate — wrong kind, missing required field, extraneous field, bad codec, or suggestion/accusation pairing violation. The optional `:<detail>` suffix names which check failed. |
 | `ERR_SHARE_NOT_FOUND` | `share_not_found` | `getShare` couldn't find a row for the id (or it has expired). Receive page renders a 404. |
+
+## Card-pack sync (separate from sharing)
+
+Sync is the other half of "the user's data follows them across
+devices." Whereas sharing is one-shot — a sender produces a snapshot
+URL, a receiver imports it once — sync is **continuous**: every
+mutation a signed-in user makes to their card-pack library propagates
+to the server, every device's React Query refetch pulls the latest
+view back, and a localStorage mirror keeps things working offline.
+
+The sync architecture is intentionally larger than sharing's because
+it has to handle:
+
+- A signed-in mutation that has to reach every other device the user
+  is logged in on.
+- An anonymous-era pack that gets attached to an account on sign-in.
+- Two devices each holding offline edits to the same pack at the
+  same time (last-flush wins on the server; local-wins during
+  reconcile when the local edit is newer than the last sync).
+- Logout: the packs are tied to the account, not the device, so the
+  device's localStorage is cleared. If there are unsynced edits, the
+  user is warned before discarding them.
+- Offline deletes (tombstones) so a deleted pack can't resurrect on
+  the next pull.
+
+**See [card-pack-sync.md](./card-pack-sync.md) for the full
+architecture, the conflict-resolution rules, and the four
+"life of a card pack" timelines that walk through the full state
+machine.**
+
+### Where sync and sharing intersect
+
+- **`pack`-kind shares vs. sync.** A `pack` share is a sender-driven
+  snapshot — it does not modify either user's `card_packs` rows. The
+  receiver imports it via the local-only `saveCustomCardSet` flow,
+  which then triggers their own sync push if they're signed in.
+- **`transfer`-kind shares vs. sync.** A transfer ships the sender's
+  card pack as part of the snapshot. On the receiver's side, the
+  `useApplyShareSnapshot` hook treats it the same as any other game
+  load — it doesn't go through the sync hooks. If the receiver wants
+  the pack saved permanently, they have to save it from the Setup
+  pane afterward.
+- **Auth.** Both systems share `requireSignedInUser` (server) and
+  `useSignedInUserId` (client) for the gate. A user signed in via
+  the anonymous plugin counts as **not** signed in for both — neither
+  share-create nor card-pack-server-mirror runs.
+
+### Updating the docs
+
+This file is the canonical reference for both systems. **Per
+[CLAUDE.md → Sharing and sync docs](../CLAUDE.md), any change that
+touches code in those areas should also update this doc and (for
+card-pack sync changes) [card-pack-sync.md](./card-pack-sync.md).**
+The list of triggering paths is at the top of this file.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -134,6 +134,13 @@ export default [
                             // tracing span — internal observability key,
                             // never user copy.
                             "Effect\\.fn",
+                            // `Effect.logError("module.operation failed", {cause})`
+                            // — same observability story as `Effect.fn`,
+                            // the leading string is an internal log key.
+                            "Effect\\.logError",
+                            "Effect\\.logWarning",
+                            "Effect\\.logInfo",
+                            "Effect\\.logDebug",
                             // `window.open(url, targetName, features)`
                             // takes the route, the named-tab target, and
                             // a features list — none of them user copy.

--- a/messages/en.json
+++ b/messages/en.json
@@ -94,7 +94,8 @@
         "renamePackInputLabel": "Card pack name",
         "saveAsCardPack": "+ Save as card pack",
         "saveAsCardPackTitle": "Save the current cards as a reusable card pack",
-        "saveAsCardPackPrompt": "Save this card pack. Name it:",
+        "saveAsCardPackDialogTitle": "Save card pack",
+        "saveAsCardPackInputLabel": "Card pack name",
         "updateCardPack": "Update {label}",
         "updateCardPackTitle": "Save your edits to {label} (in place)",
         "saveAsNewCardPack": "+ Save as new pack",
@@ -403,7 +404,21 @@
         "sharePackAria": "Share card pack {label}",
         "deletePackTitle": "Delete card pack \"{label}\"",
         "deletePackAria": "Delete card pack {label}",
-        "deletePackConfirm": "Delete card pack \"{label}\"?"
+        "deletePackConfirm": "Delete card pack \"{label}\"?",
+        "logoutWarning": {
+            "title": "Unsynced card pack changes",
+            "ledeOffline": "You’re offline, so these card pack changes haven’t been saved to your account yet. If you sign out now, they’ll be lost.",
+            "ledeServerError": "We couldn’t reach the server to save these card pack changes. If you sign out now, they’ll be lost.",
+            "createdHeading": "{count, plural, one {# new card pack} other {# new card packs}}",
+            "modifiedHeading": "{count, plural, one {# edited card pack} other {# edited card packs}}",
+            "deletedHeading": "{count, plural, one {# pending deletion} other {# pending deletions}}",
+            "tagRenamed": "renamed",
+            "tagCardsChanged": "cards changed",
+            "stayLoggedIn": "Stay logged in",
+            "tryAgain": "Try again",
+            "tryingAgain": "Trying…",
+            "signOutAnyway": "Sign out anyway"
+        }
     },
     "installPrompt": {
         "title": "Install Clue Solver",

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -676,7 +676,19 @@ export const signInFailed = (props: {
     reason: string;
 }): void => capture("sign_in_failed", props);
 
-export const signOut = (): void => capture("sign_out");
+export const signOut = (props?: {
+    /**
+     * True when the user clicked "Sign out anyway" in the unsynced-
+     * changes warning. Lets us alert on cases where local card-pack
+     * edits were intentionally discarded.
+     */
+    discardedUnsyncedChanges?: boolean;
+    unsyncedCounts?: {
+        created: number;
+        modified: number;
+        deleted: number;
+    };
+}): void => capture("sign_out", props);
 
 // ── Server-side card packs (M8) ───────────────────────────────────────────
 
@@ -688,6 +700,20 @@ export const localPacksPushedOnSignIn = (props: {
     countPulled: number;
     countFailed: number;
 }): void => capture("local_packs_pushed_on_sign_in", props);
+
+export const cardPackSaveSyncFailed = (props: {
+    reason: string;
+}): void => capture("card_pack_save_sync_failed", props);
+
+export const cardPackDeleteSyncFailed = (props: {
+    reason: string;
+}): void => capture("card_pack_delete_sync_failed", props);
+
+export const cardPackPullReconciled = (props: {
+    countPulled: number;
+    countTombstonesFlushed: number;
+    countConflicts: number;
+}): void => capture("card_pack_pull_reconciled", props);
 
 export const cardPackSaved = (props: {
     isFirstTime: boolean;

--- a/src/data/cardPacksFlush.test.tsx
+++ b/src/data/cardPacksFlush.test.tsx
@@ -1,0 +1,267 @@
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    test,
+    vi,
+} from "vitest";
+import { DateTime } from "effect";
+import { CardSet } from "../logic/CardSet";
+import { Card, CardCategory } from "../logic/GameObjects";
+import { CardEntry, Category } from "../logic/GameSetup";
+import {
+    addTombstone,
+    loadTombstones,
+} from "../logic/CardPackTombstones";
+import {
+    loadCustomCardSets,
+    replaceCustomCardSets,
+    type CustomCardSet,
+} from "../logic/CustomCardSets";
+
+// Mocks must be declared before imports of the module under test —
+// `vi.mock` is hoisted by Vitest.
+const saveCardPackMock = vi.fn();
+const deleteCardPackMock = vi.fn();
+
+vi.mock("../server/actions/packs", () => ({
+    saveCardPack: (...args: unknown[]) => saveCardPackMock(...args),
+    deleteCardPack: (...args: unknown[]) => deleteCardPackMock(...args),
+    // Other exports left as stubs — flush only uses these two.
+    getMyCardPacks: vi.fn(),
+    pushLocalPacksOnSignIn: vi.fn(),
+}));
+
+import { flushPendingChanges } from "./cardPacksSync";
+
+const makeCardSet = (cardName: string): CardSet =>
+    CardSet({
+        categories: [
+            Category({
+                id: CardCategory(`category-${cardName}`),
+                name: "Suspect",
+                cards: [
+                    CardEntry({
+                        id: Card(`card-${cardName}`),
+                        name: cardName,
+                    }),
+                ],
+            }),
+        ],
+    });
+
+const localPack = (
+    id: string,
+    label: string,
+    cardName: string,
+    overrides: Partial<CustomCardSet> = {},
+): CustomCardSet => ({
+    id,
+    label,
+    cardSet: makeCardSet(cardName),
+    ...overrides,
+});
+
+const persistedServerRow = (
+    id: string,
+    clientGeneratedId: string,
+    label: string,
+    cardName: string,
+) => ({
+    id,
+    clientGeneratedId,
+    label,
+    cardSetData: JSON.stringify(makeCardSet(cardName)),
+});
+
+const setOnline = (online: boolean) => {
+    Object.defineProperty(navigator, "onLine", {
+        configurable: true,
+        get: () => online,
+    });
+};
+
+describe("flushPendingChanges", () => {
+    beforeEach(() => {
+        window.localStorage.clear();
+        saveCardPackMock.mockReset();
+        deleteCardPackMock.mockReset();
+        setOnline(true);
+    });
+    afterEach(() => {
+        window.localStorage.clear();
+    });
+
+    test("returns ok when nothing is pending", async () => {
+        replaceCustomCardSets([
+            {
+                ...localPack("server-1", "Office", "Rope"),
+                lastSyncedSnapshot: {
+                    label: "Office",
+                    cardSet: makeCardSet("Rope"),
+                },
+            },
+        ]);
+        const result = await flushPendingChanges();
+        expect(result.ok).toBe(true);
+    });
+
+    test("offline + unsynced → returns offline summary without calling network", async () => {
+        setOnline(false);
+        replaceCustomCardSets([
+            {
+                ...localPack("custom-1", "Office", "Rope"),
+                unsyncedSince: DateTime.makeUnsafe("2026-04-22T12:00:00Z"),
+            },
+        ]);
+        const result = await flushPendingChanges();
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.reason).toBe("offline");
+            expect(result.unsynced.created).toEqual([
+                { id: "custom-1", label: "Office" },
+            ]);
+        }
+        expect(saveCardPackMock).not.toHaveBeenCalled();
+    });
+
+    test("offline + tombstone → reports as deleted", async () => {
+        setOnline(false);
+        addTombstone({
+            id: "server-1",
+            label: "Mansion",
+            deletedAt: DateTime.makeUnsafe("2026-04-22T12:00:00Z"),
+        });
+        const result = await flushPendingChanges();
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.reason).toBe("offline");
+            expect(result.unsynced.deleted).toEqual([
+                { id: "server-1", label: "Mansion" },
+            ]);
+        }
+    });
+
+    test("online + push succeeds → ok and localStorage marked synced", async () => {
+        replaceCustomCardSets([
+            {
+                ...localPack("custom-1", "Office", "Rope"),
+                unsyncedSince: DateTime.makeUnsafe("2026-04-22T12:00:00Z"),
+            },
+        ]);
+        saveCardPackMock.mockResolvedValueOnce(
+            persistedServerRow("server-1", "custom-1", "Office", "Rope"),
+        );
+        const result = await flushPendingChanges();
+        expect(result.ok).toBe(true);
+        expect(saveCardPackMock).toHaveBeenCalledTimes(1);
+        const persisted = loadCustomCardSets();
+        expect(persisted[0]?.id).toBe("server-1");
+        expect(persisted[0]?.unsyncedSince).toBeUndefined();
+        expect(persisted[0]?.lastSyncedSnapshot?.label).toBe("Office");
+    });
+
+    test("online + push fails → returns serverError summary", async () => {
+        replaceCustomCardSets([
+            {
+                ...localPack("custom-1", "Office", "Rope"),
+                unsyncedSince: DateTime.makeUnsafe("2026-04-22T12:00:00Z"),
+            },
+        ]);
+        saveCardPackMock.mockRejectedValueOnce(new Error("boom"));
+        const result = await flushPendingChanges();
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.reason).toBe("serverError");
+            expect(result.unsynced.created).toEqual([
+                { id: "custom-1", label: "Office" },
+            ]);
+        }
+    });
+
+    test("online + tombstone delete succeeds → tombstone cleared", async () => {
+        addTombstone({
+            id: "server-1",
+            label: "Mansion",
+            deletedAt: DateTime.makeUnsafe("2026-04-22T12:00:00Z"),
+        });
+        deleteCardPackMock.mockResolvedValueOnce(undefined);
+        const result = await flushPendingChanges();
+        expect(result.ok).toBe(true);
+        expect(deleteCardPackMock).toHaveBeenCalledTimes(1);
+        expect(loadTombstones()).toEqual([]);
+    });
+
+    test("online + tombstone delete fails → reported in deleted summary", async () => {
+        addTombstone({
+            id: "server-1",
+            label: "Mansion",
+            deletedAt: DateTime.makeUnsafe("2026-04-22T12:00:00Z"),
+        });
+        deleteCardPackMock.mockRejectedValueOnce(new Error("offline"));
+        const result = await flushPendingChanges();
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.unsynced.deleted).toEqual([
+                { id: "server-1", label: "Mansion" },
+            ]);
+        }
+    });
+
+    test("modified pack with diff against snapshot → reported with tags", async () => {
+        replaceCustomCardSets([
+            {
+                ...localPack("server-1", "Office Updated", "Pipe"),
+                unsyncedSince: DateTime.makeUnsafe("2026-04-22T12:00:00Z"),
+                lastSyncedSnapshot: {
+                    label: "Office",
+                    cardSet: makeCardSet("Rope"),
+                },
+            },
+        ]);
+        // Server save fails so the pack stays modified.
+        saveCardPackMock.mockRejectedValueOnce(new Error("offline"));
+        const result = await flushPendingChanges();
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.unsynced.modified).toHaveLength(1);
+            expect(result.unsynced.modified[0]).toMatchObject({
+                id: "server-1",
+                label: "Office Updated",
+                labelChanged: true,
+                cardsChanged: true,
+            });
+        }
+    });
+
+    test("anon-era pack with no metadata → flush pushes and clears", async () => {
+        // Mimics the post-sign-in case where push succeeded server-side
+        // but reconcile hasn't run yet, OR where push failed entirely.
+        replaceCustomCardSets([localPack("custom-1", "Office", "Rope")]);
+        saveCardPackMock.mockResolvedValueOnce(
+            persistedServerRow("server-1", "custom-1", "Office", "Rope"),
+        );
+        const result = await flushPendingChanges();
+        expect(result.ok).toBe(true);
+        expect(saveCardPackMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("modified pack pushed with same content as snapshot → ok", async () => {
+        replaceCustomCardSets([
+            {
+                ...localPack("server-1", "Office", "Rope"),
+                unsyncedSince: DateTime.makeUnsafe("2026-04-22T12:00:00Z"),
+                lastSyncedSnapshot: {
+                    label: "Office",
+                    cardSet: makeCardSet("Rope"),
+                },
+            },
+        ]);
+        saveCardPackMock.mockResolvedValueOnce(
+            persistedServerRow("server-1", "server-1", "Office", "Rope"),
+        );
+        const result = await flushPendingChanges();
+        expect(result.ok).toBe(true);
+    });
+});

--- a/src/data/cardPacksInFlight.test.ts
+++ b/src/data/cardPacksInFlight.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "vitest";
+import { drainInFlight, trackInFlight } from "./cardPacksInFlight";
+
+/**
+ * Build a "deferred" Promise — a Promise plus its resolve/reject
+ * callbacks so the test controls when it settles. The
+ * `flushPendingChanges` reconcile loop calls `drainInFlight()`
+ * before evaluating localStorage; the registry's contract is that
+ * once every tracked Promise has settled, `drainInFlight` resolves.
+ */
+const deferred = <T = void>(): {
+    readonly promise: Promise<T>;
+    readonly resolve: (value: T) => void;
+    readonly reject: (reason: unknown) => void;
+} => {
+    let resolve!: (value: T) => void;
+    let reject!: (reason: unknown) => void;
+    const promise = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return { promise, resolve, reject };
+};
+
+const tick = () => new Promise(r => setTimeout(r, 0));
+
+describe("trackInFlight + drainInFlight", () => {
+    test("drainInFlight resolves immediately when registry is empty", async () => {
+        await drainInFlight();
+        // No assertion needed — just that it doesn't hang.
+    });
+
+    test("drainInFlight waits for a tracked Promise to settle", async () => {
+        const d = deferred<string>();
+        trackInFlight(d.promise);
+
+        let drained = false;
+        const drainPromise = drainInFlight().then(() => {
+            drained = true;
+        });
+
+        // Yield once so any pending micro-tasks would settle if they
+        // could; drain should still be pending.
+        await tick();
+        expect(drained).toBe(false);
+
+        d.resolve("done");
+        await drainPromise;
+        expect(drained).toBe(true);
+    });
+
+    test("drainInFlight waits for ALL tracked Promises to settle", async () => {
+        const a = deferred<string>();
+        const b = deferred<string>();
+        const c = deferred<string>();
+        trackInFlight(a.promise);
+        trackInFlight(b.promise);
+        trackInFlight(c.promise);
+
+        let drained = false;
+        const drainPromise = drainInFlight().then(() => {
+            drained = true;
+        });
+
+        a.resolve("a");
+        await tick();
+        expect(drained).toBe(false);
+
+        b.resolve("b");
+        await tick();
+        expect(drained).toBe(false);
+
+        c.resolve("c");
+        await drainPromise;
+        expect(drained).toBe(true);
+    });
+
+    test("a rejected Promise still releases drainInFlight", async () => {
+        const d = deferred<string>();
+        // trackInFlight returns the original Promise; the registry's
+        // own `.catch` handler swallows the rejection internally so
+        // that `Promise.allSettled` inside `drainInFlight` doesn't
+        // see an unhandled rejection.
+        trackInFlight(d.promise).catch(() => undefined);
+
+        let drained = false;
+        const drainPromise = drainInFlight().then(() => {
+            drained = true;
+        });
+
+        await tick();
+        expect(drained).toBe(false);
+
+        d.reject(new Error("boom"));
+        await drainPromise;
+        expect(drained).toBe(true);
+    });
+
+    test("Promises tracked AFTER drainInFlight starts are also awaited", async () => {
+        // Real-world race: an in-flight save kicks off, then while
+        // it's settling another save fires (e.g. user mashes the
+        // Save button). drainInFlight should not resolve until both
+        // have settled.
+        const a = deferred<string>();
+        trackInFlight(a.promise);
+
+        let drained = false;
+        const drainPromise = drainInFlight().then(() => {
+            drained = true;
+        });
+
+        // Settle `a`, but synchronously add `b` before the drain
+        // gets a chance to observe an empty registry.
+        const b = deferred<string>();
+        a.resolve("a");
+        trackInFlight(b.promise);
+
+        await tick();
+        await tick();
+        expect(drained).toBe(false);
+
+        b.resolve("b");
+        await drainPromise;
+        expect(drained).toBe(true);
+    });
+
+    test("trackInFlight returns the original Promise (so callers can await it)", async () => {
+        const d = deferred<string>();
+        const tracked = trackInFlight(d.promise);
+        // Identity, not a wrapped Promise.
+        expect(tracked).toBe(d.promise);
+        d.resolve("ok");
+        await expect(tracked).resolves.toBe("ok");
+    });
+
+    test("settled Promises don't keep drain pending on a subsequent call", async () => {
+        const a = deferred<string>();
+        trackInFlight(a.promise);
+        a.resolve("a");
+        // Allow the registry's `.finally` handler to remove the
+        // entry.
+        await tick();
+        await tick();
+        // Drain should be a no-op now.
+        await drainInFlight();
+    });
+});

--- a/src/data/cardPacksInFlight.ts
+++ b/src/data/cardPacksInFlight.ts
@@ -1,0 +1,40 @@
+/**
+ * Module-scoped registry of in-flight server-mirror Promises for
+ * card-pack mutations.
+ *
+ * The reconcile loop (`applyServerSnapshot`) and the logout
+ * `flushPendingChanges` helper both `await drainInFlight()` before
+ * inspecting localStorage, so an in-progress save / delete is given
+ * a chance to settle (clearing or retaining `unsyncedSince`) before
+ * we decide whether to warn the user.
+ *
+ * Lives in its own file to avoid a circular import between
+ * `customCardPacks.ts` (which produces Promises) and
+ * `cardPacksSync.tsx` (which drains them).
+ */
+
+const inFlight = new Set<Promise<unknown>>();
+
+/**
+ * Add a Promise to the registry; auto-removes it on settle.
+ */
+export const trackInFlight = <T>(promise: Promise<T>): Promise<T> => {
+    inFlight.add(promise);
+    promise
+        .catch(() => undefined)
+        .finally(() => {
+            inFlight.delete(promise);
+        });
+    return promise;
+};
+
+/**
+ * Wait for every currently-tracked Promise to settle. Loops in case
+ * a settling Promise spawns another (defensive — typically one pass
+ * suffices).
+ */
+export const drainInFlight = async (): Promise<void> => {
+    while (inFlight.size > 0) {
+        await Promise.allSettled([...inFlight]);
+    }
+};

--- a/src/data/cardPacksSync.test.tsx
+++ b/src/data/cardPacksSync.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
-import { CardSet } from "../logic/CardSet";
+import { DateTime } from "effect";
+import { cardSetEquals, CardSet } from "../logic/CardSet";
 import { Card, CardCategory } from "../logic/GameObjects";
 import { CardEntry, Category } from "../logic/GameSetup";
 import type { CustomCardSet } from "../logic/CustomCardSets";
@@ -102,5 +103,107 @@ describe("reconcileCardPacks", () => {
             { id: "server-1", label: "Office (2)" },
         ]);
         expect(result.idMap.get("local-1")).toBe("server-1");
+    });
+
+    test("server-only packs land with lastSyncedSnapshot populated", () => {
+        const result = reconcileCardPacks(
+            [],
+            [serverPack("server-1", "other-client", "Office", "Rope")],
+        );
+        expect(result.packs[0]?.lastSyncedSnapshot).toBeDefined();
+        expect(result.packs[0]?.lastSyncedSnapshot?.label).toBe("Office");
+        expect(
+            cardSetEquals(
+                result.packs[0]!.lastSyncedSnapshot!.cardSet,
+                makeCardSet("Rope"),
+            ),
+        ).toBe(true);
+        expect(result.packs[0]?.unsyncedSince).toBeUndefined();
+    });
+
+    test("paired-and-matching content clears unsyncedSince and sets snapshot", () => {
+        const local: CustomCardSet = {
+            ...localPack("local-1", "Office", "Rope"),
+            unsyncedSince: DateTime.makeUnsafe("2026-04-22T12:00:00Z"),
+        };
+        const result = reconcileCardPacks(
+            [local],
+            [serverPack("server-1", "local-1", "Office", "Rope")],
+        );
+        expect(result.packs[0]?.id).toBe("server-1");
+        expect(result.packs[0]?.unsyncedSince).toBeUndefined();
+        expect(result.packs[0]?.lastSyncedSnapshot?.label).toBe("Office");
+    });
+
+    test("conflict with unsyncedSince — local wins on label/cardSet", () => {
+        const local: CustomCardSet = {
+            ...localPack("local-1", "Office Updated", "Rope"),
+            unsyncedSince: DateTime.makeUnsafe("2026-04-22T12:00:00Z"),
+            lastSyncedSnapshot: {
+                label: "Office",
+                cardSet: makeCardSet("Rope"),
+            },
+        };
+        const result = reconcileCardPacks(
+            [local],
+            // Server has a newer "Mansion" version (other device)
+            [serverPack("server-1", "local-1", "Mansion", "Pipe")],
+        );
+        expect(result.packs[0]?.id).toBe("server-1");
+        expect(result.packs[0]?.label).toBe("Office Updated");
+        expect(
+            cardSetEquals(
+                result.packs[0]!.cardSet,
+                makeCardSet("Rope"),
+            ),
+        ).toBe(true);
+        // unsyncedSince retained — user still has unflushed local edits.
+        expect(result.packs[0]?.unsyncedSince).toBeDefined();
+        // Baseline refreshed to the new server view.
+        expect(result.packs[0]?.lastSyncedSnapshot?.label).toBe("Mansion");
+    });
+
+    test("conflict without unsyncedSince — server wins (rename / other device)", () => {
+        const local = localPack("local-1", "Office", "Rope");
+        const result = reconcileCardPacks(
+            [local],
+            [serverPack("server-1", "local-1", "Office (renamed)", "Rope")],
+        );
+        expect(result.packs[0]?.label).toBe("Office (renamed)");
+        expect(result.packs[0]?.unsyncedSince).toBeUndefined();
+        expect(result.packs[0]?.lastSyncedSnapshot?.label).toBe(
+            "Office (renamed)",
+        );
+    });
+
+    test("tombstone filter drops server packs by id and clientGeneratedId", () => {
+        const result = reconcileCardPacks(
+            [],
+            [
+                serverPack("server-1", "other-client", "Office", "Rope"),
+                serverPack("server-2", "local-1", "Mansion", "Pipe"),
+            ],
+            new Set(["server-1", "local-1"]),
+        );
+        expect(result.packs).toEqual([]);
+    });
+
+    test("tombstone filter drops local packs by id", () => {
+        const result = reconcileCardPacks(
+            [localPack("local-1", "Office", "Rope")],
+            [],
+            new Set(["local-1"]),
+        );
+        expect(result.packs).toEqual([]);
+    });
+
+    test("local-only pack preserves its sync metadata across reconcile", () => {
+        const local: CustomCardSet = {
+            ...localPack("local-1", "Office", "Rope"),
+            unsyncedSince: DateTime.makeUnsafe("2026-04-22T12:00:00Z"),
+        };
+        const result = reconcileCardPacks([local], []);
+        expect(result.packs[0]?.unsyncedSince).toBeDefined();
+        expect(result.packs[0]?.id).toBe("local-1");
     });
 });

--- a/src/data/cardPacksSync.tsx
+++ b/src/data/cardPacksSync.tsx
@@ -1,51 +1,77 @@
 /**
- * Sign-in side-effect: when an anonymous user signs in (or
- * upgrades their anonymous account into a real one), push every
- * localStorage-resident custom card pack up to the server so the
- * library syncs across devices going forward.
+ * Continuous reconcile between the server-side card-pack library and
+ * the localStorage cache, plus the logout flush helper.
  *
- * The push is idempotent — `pushLocalPacksOnSignIn` keys on
- * `(owner_id, client_generated_id)` so re-running with the same
- * payload after a re-sign-in is a no-op apart from refreshing the
- * `updated_at` timestamp.
+ * The mental model is local-first with the server as source of truth
+ * once signed in: every signed-in mount, focus, and reconnect is a
+ * chance to converge. Three mechanisms drive convergence:
  *
- * Mounts inside the same provider stack as `useSession`. The
- * effect fires exactly once per "anon→signedIn transition" per
- * session — we track the previous user id in a ref so re-renders
- * caused by other state changes don't spam the server.
+ *   1. Mutations (`useSaveCardPack` / `useDeleteCardPack`) mirror to
+ *      the server in parallel with the localStorage write.
+ *   2. A React Query for `getMyCardPacks` (in this file's
+ *      `<CardPacksSync />`) refetches on mount / focus / reconnect
+ *      and triggers `applyServerSnapshot` on every settle —
+ *      tombstone-flush, then reconcile, then write the merged list
+ *      back to localStorage.
+ *   3. The sign-in transition still calls `pushLocalPacksOnSignIn` to
+ *      bulk-upload localStorage packs that pre-date the sign-in, then
+ *      invalidates the React Query so the pull lands.
+ *
+ * Errors land in Honeycomb logs + Sentry breadcrumbs via
+ * `Effect.logError`; sign-in / sync UX is never blocked by a sync
+ * failure.
+ *
+ * The logout chokepoint `requestSignOut` runs `flushPendingChanges`
+ * first. If everything's synced, it clears account-tied
+ * localStorage and calls `authClient.signOut()`. If something is
+ * unsynced (offline or server error), the
+ * `LogoutWarningModal` opens with a per-pack diff and the user
+ * decides whether to stay logged in, retry, or sign out anyway.
  */
 "use client";
 
 import { useEffect, useRef } from "react";
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Duration, Effect } from "effect";
 import {
     localPacksPushedOnSignIn,
 } from "../analytics/events";
-import { cardSetEquals, CardSet } from "../logic/CardSet";
-import { CardEntry, Category } from "../logic/GameSetup";
-import { Card, CardCategory } from "../logic/GameObjects";
+import { cardSetEquals, type CardSet } from "../logic/CardSet";
 import {
+    clearAllTombstones,
+    clearTombstones,
+    loadTombstones,
+    type CardPackTombstone,
+} from "../logic/CardPackTombstones";
+import {
+    clearAccountTiedLocalState,
     loadCustomCardSets,
+    markPackSynced,
     replaceCustomCardSets,
+    type CardPackSnapshot,
     type CustomCardSet,
 } from "../logic/CustomCardSets";
+import { remapCardPackUsageIds } from "../logic/CardPackUsage";
 import {
-    remapCardPackUsageIds,
-} from "../logic/CardPackUsage";
-import {
-    cardPackUsageQueryKey,
-} from "./cardPackUsage";
-import {
-    customCardPacksQueryKey,
-} from "./customCardPacks";
-import {
+    deleteCardPack,
     getMyCardPacks,
     pushLocalPacksOnSignIn,
+    saveCardPack,
     type PersistedCardPack,
     type PushResult,
 } from "../server/actions/packs";
+import { TelemetryRuntime } from "../observability/runtime";
+import { authClient } from "../ui/account/authClient";
 import { useSession } from "../ui/hooks/useSession";
-import { myCardPacksQueryKey } from "../ui/account/AccountModal";
+import { cardPackUsageQueryKey } from "./cardPackUsage";
+import { drainInFlight, trackInFlight } from "./cardPacksInFlight";
+import {
+    customCardPacksQueryKey,
+    myCardPacksQueryKey,
+} from "./customCardPacks";
+import { decodeServerPack } from "./serverPackCodec";
+
+// ── Reconcile ────────────────────────────────────────────────────────────────
 
 interface ReconcileResult {
     readonly packs: ReadonlyArray<CustomCardSet>;
@@ -53,190 +79,560 @@ interface ReconcileResult {
     readonly countPulled: number;
 }
 
-const emptyPushResult: PushResult = {
-    countPushed: 0,
-    countAlreadySynced: 0,
-    countRenamed: 0,
-    countDeduped: 0,
-    countFailed: 0,
-};
-
-export const decodeServerPack = (
-    pack: PersistedCardPack,
-): CustomCardSet | null => {
-    try {
-        const parsed: unknown = JSON.parse(pack.cardSetData);
-        if (
-            typeof parsed !== "object" ||
-            parsed === null ||
-            !("categories" in parsed) ||
-            !Array.isArray(parsed.categories)
-        ) {
-            return null;
-        }
-        const categories = [];
-        for (const category of parsed.categories) {
-            if (
-                typeof category !== "object" ||
-                category === null ||
-                !("id" in category) ||
-                typeof category.id !== "string" ||
-                !("name" in category) ||
-                typeof category.name !== "string" ||
-                !("cards" in category) ||
-                !Array.isArray(category.cards)
-            ) {
-                return null;
-            }
-            const cards = [];
-            for (const card of category.cards) {
-                if (
-                    typeof card !== "object" ||
-                    card === null ||
-                    !("id" in card) ||
-                    typeof card.id !== "string" ||
-                    !("name" in card) ||
-                    typeof card.name !== "string"
-                ) {
-                    return null;
-                }
-                cards.push(
-                    CardEntry({
-                        id: Card(card.id),
-                        name: card.name,
-                    }),
-                );
-            }
-            categories.push(
-                Category({
-                    id: CardCategory(category.id),
-                    name: category.name,
-                    cards,
-                }),
-            );
-        }
-        return {
-            id: pack.id,
-            label: pack.label,
-            cardSet: CardSet({ categories }),
-        };
-    } catch {
-        return null;
-    }
-};
-
-const isExactDuplicate = (
+const isExactDuplicateContent = (
     a: CustomCardSet,
-    b: CustomCardSet,
+    b: { label: string; cardSet: CardSet },
 ): boolean => a.label === b.label && cardSetEquals(a.cardSet, b.cardSet);
 
+/**
+ * Merge the localStorage library with the server's view, returning a
+ * single canonical list. Discriminator rules:
+ *
+ *   1. **Tombstones win.** Any server pack whose `id` or
+ *      `clientGeneratedId` is in `tombstoneIds` is dropped (the
+ *      delete is still being retried). Any local pack in
+ *      `tombstoneIds` is dropped too (defensive — should already be
+ *      gone from localStorage).
+ *   2. **Pair match (clientGeneratedId).** When a local pack's `id`
+ *      equals a server pack's `clientGeneratedId`:
+ *        - If content matches: merge with server's id; clear
+ *          `unsyncedSince`; refresh `lastSyncedSnapshot` to server's
+ *          view.
+ *        - If content differs and the local pack has
+ *          `unsyncedSince`: **local wins** — preserve local label /
+ *          cardSet, retain `unsyncedSince`, baseline becomes the new
+ *          server snapshot. (B.3 in plan.)
+ *        - If content differs and there's no local
+ *          `unsyncedSince`: **server wins** — that's a rename or a
+ *          clean update from another device.
+ *   3. **Exact-content duplicate.** Server pack with no
+ *      clientGeneratedId pair-match BUT label + cardSet identical to
+ *      a local pack: server wins (already canonical), idMap remaps
+ *      the local id.
+ *   4. **Server-only.** Pulled in. Increments `countPulled`.
+ *   5. **Local-only.** Preserved with all metadata intact.
+ */
 export const reconcileCardPacks = (
     localPacks: ReadonlyArray<CustomCardSet>,
     serverPacks: ReadonlyArray<PersistedCardPack>,
+    tombstoneIds: ReadonlySet<string> = new Set(),
 ): ReconcileResult => {
-    const decodedServer = serverPacks.flatMap((pack) => {
-        const decoded = decodeServerPack(pack);
-        return decoded === null ? [] : [decoded];
+    const filteredServerRaw = serverPacks.filter(
+        s =>
+            !tombstoneIds.has(s.id) &&
+            !tombstoneIds.has(s.clientGeneratedId),
+    );
+    const filteredLocal = localPacks.filter(p => !tombstoneIds.has(p.id));
+
+    // Each `decoded` entry pairs the `CustomCardSet` shape with the
+    // server's `clientGeneratedId` (which `decodeServerPack` drops).
+    const decodedServer = filteredServerRaw.flatMap(p => {
+        const decoded = decodeServerPack(p);
+        return decoded === null
+            ? []
+            : [{ pack: decoded, clientGeneratedId: p.clientGeneratedId }];
     });
+
     const merged: Array<CustomCardSet> = [];
     const idMap = new Map<string, string>();
+    const handledServerIds = new Set<string>();
+    const handledLocalIds = new Set<string>();
     let countPulled = 0;
 
-    for (const serverPack of decodedServer) {
-        const existing = merged.find((pack) =>
-            isExactDuplicate(pack, serverPack),
+    // Phase 1: client-id pair matches.
+    for (const localPack of filteredLocal) {
+        const match = decodedServer.find(
+            s => s.clientGeneratedId === localPack.id,
         );
-        if (existing) {
-            idMap.set(serverPack.id, existing.id);
-            continue;
+        if (match === undefined) continue;
+        const matchingServer = match.pack;
+        const contentMatches =
+            localPack.label === matchingServer.label &&
+            cardSetEquals(localPack.cardSet, matchingServer.cardSet);
+        const serverSnapshot: CardPackSnapshot = {
+            label: matchingServer.label,
+            cardSet: matchingServer.cardSet,
+        };
+        if (contentMatches) {
+            merged.push({
+                id: matchingServer.id,
+                label: localPack.label,
+                cardSet: localPack.cardSet,
+                unsyncedSince: undefined,
+                lastSyncedSnapshot: serverSnapshot,
+            });
+        } else if (localPack.unsyncedSince !== undefined) {
+            // Local edit, conflict — local wins.
+            merged.push({
+                id: matchingServer.id,
+                label: localPack.label,
+                cardSet: localPack.cardSet,
+                unsyncedSince: localPack.unsyncedSince,
+                lastSyncedSnapshot: serverSnapshot,
+            });
+        } else {
+            // No local edit — server wins (rename, other-device update).
+            merged.push({
+                id: matchingServer.id,
+                label: matchingServer.label,
+                cardSet: matchingServer.cardSet,
+                unsyncedSince: undefined,
+                lastSyncedSnapshot: serverSnapshot,
+            });
         }
-        const hadLocalEquivalent = localPacks.some((pack) =>
-            isExactDuplicate(pack, serverPack),
-        );
-        const hadLocalClientId = serverPacks.some(
-            (pack) =>
-                pack.id === serverPack.id &&
-                localPacks.some((local) => local.id === pack.clientGeneratedId),
-        );
-        if (!hadLocalEquivalent && !hadLocalClientId) {
-            countPulled += 1;
+        if (localPack.id !== matchingServer.id) {
+            idMap.set(localPack.id, matchingServer.id);
         }
-        merged.push(serverPack);
+        handledServerIds.add(matchingServer.id);
+        handledLocalIds.add(localPack.id);
     }
 
-    for (const localPack of localPacks) {
-        const sameClientServer = serverPacks.find(
-            (pack) => pack.clientGeneratedId === localPack.id,
+    // Phase 2: remaining server packs — exact-content duplicate or fresh pull.
+    for (const { pack: serverPack } of decodedServer) {
+        if (handledServerIds.has(serverPack.id)) continue;
+        const exactDup = filteredLocal.find(
+            local =>
+                !handledLocalIds.has(local.id) &&
+                isExactDuplicateContent(local, serverPack),
         );
-        if (sameClientServer !== undefined) {
-            idMap.set(localPack.id, sameClientServer.id);
-            continue;
+        const serverSnapshot: CardPackSnapshot = {
+            label: serverPack.label,
+            cardSet: serverPack.cardSet,
+        };
+        merged.push({
+            id: serverPack.id,
+            label: serverPack.label,
+            cardSet: serverPack.cardSet,
+            unsyncedSince: undefined,
+            lastSyncedSnapshot: serverSnapshot,
+        });
+        if (exactDup !== undefined) {
+            idMap.set(exactDup.id, serverPack.id);
+            handledLocalIds.add(exactDup.id);
+        } else {
+            countPulled += 1;
         }
-        const exactDuplicate = merged.find((pack) =>
-            isExactDuplicate(pack, localPack),
-        );
-        if (exactDuplicate) {
-            idMap.set(localPack.id, exactDuplicate.id);
-            continue;
-        }
+        handledServerIds.add(serverPack.id);
+    }
+
+    // Phase 3: remaining local-only packs.
+    for (const localPack of filteredLocal) {
+        if (handledLocalIds.has(localPack.id)) continue;
         merged.push(localPack);
     }
 
     return { packs: merged, idMap, countPulled };
 };
 
-export function CardPacksSyncOnSignIn() {
+// ── Server-snapshot application ─────────────────────────────────────────────
+
+const applyServerSnapshotEffect = Effect.fn(
+    "data.cardPacks.applyServerSnapshot",
+)(function* (serverPacks: ReadonlyArray<PersistedCardPack>) {
+    yield* Effect.promise(() => drainInFlight());
+
+    // Tombstone flush — retry every pending delete; clear successes.
+    const tombstones = loadTombstones();
+    const survivors: Array<CardPackTombstone> = [];
+    for (const tombstone of tombstones) {
+        try {
+            const promise = deleteCardPack({
+                idOrClientGeneratedId: tombstone.id,
+            });
+            trackInFlight(promise);
+            yield* Effect.promise(() => promise);
+        } catch (cause) {
+            yield* Effect.logError(
+                "data.cardPacks.tombstoneFlush failed",
+                { cause },
+            );
+            survivors.push(tombstone);
+        }
+    }
+    if (survivors.length === 0) {
+        clearAllTombstones();
+    } else {
+        clearTombstones(
+            tombstones
+                .filter(
+                    t => !survivors.some(s => s.id === t.id),
+                )
+                .map(t => t.id),
+        );
+    }
+
+    const tombstoneIds = new Set<string>(survivors.map(t => t.id));
+
+    // Reconcile against latest localStorage state.
+    const local = loadCustomCardSets();
+    const reconciled = reconcileCardPacks(local, serverPacks, tombstoneIds);
+    replaceCustomCardSets(reconciled.packs);
+    if (reconciled.idMap.size > 0) {
+        remapCardPackUsageIds(reconciled.idMap);
+    }
+    return reconciled;
+});
+
+// ── Sign-in transition: bulk push ───────────────────────────────────────────
+
+const signInPushEffect = Effect.fn("data.cardPacks.signInPush")(function* (
+    packs: ReadonlyArray<CustomCardSet>,
+) {
+    if (packs.length === 0) {
+        return {
+            countPushed: 0,
+            countAlreadySynced: 0,
+            countRenamed: 0,
+            countDeduped: 0,
+            countFailed: 0,
+        } satisfies PushResult;
+    }
+    const promise = pushLocalPacksOnSignIn({
+        packs: packs.map(p => ({
+            clientGeneratedId: p.id,
+            label: p.label,
+            cardSet: p.cardSet,
+        })),
+    });
+    trackInFlight(promise);
+    return yield* Effect.tryPromise({
+        try: () => promise,
+        catch: cause => new Error(String(cause)),
+    });
+});
+
+// ── CardPacksSync component ─────────────────────────────────────────────────
+
+/**
+ * Mounted inside `AccountProvider`. Owns:
+ *   - The per-user React Query for `getMyCardPacks` (refetch on
+ *     mount / focus / reconnect).
+ *   - The sign-in transition effect (bulk push on anon → real).
+ *   - The `applyServerSnapshot` effect that runs every time the
+ *     query produces fresh data.
+ *
+ * Renders nothing.
+ */
+export function CardPacksSync(): null {
     const session = useSession();
     const queryClient = useQueryClient();
-    const lastSyncedUserIdRef = useRef<string | null>(null);
+    const user = session.data?.user;
+    const userId =
+        user && !user.isAnonymous ? user.id : undefined;
+    const lastPushedUserIdRef = useRef<string | null>(null);
+    const lastAppliedDataUpdatedAtRef = useRef<number | null>(null);
 
+    const myCardPacks = useQuery({
+        queryKey: myCardPacksQueryKey(userId),
+        queryFn: getMyCardPacks,
+        enabled: userId !== undefined,
+        staleTime: Duration.toMillis(Duration.seconds(30)),
+        refetchOnWindowFocus: true,
+        refetchOnReconnect: true,
+        refetchOnMount: true,
+    });
+
+    // Sign-in transition: push localStorage packs on the
+    // anon → real transition. Idempotent on (owner_id,
+    // client_generated_id) so accidental re-runs are no-ops.
     useEffect(() => {
-        const user = session.data?.user;
-        if (!user || user.isAnonymous) return;
-        if (lastSyncedUserIdRef.current === user.id) return;
-        lastSyncedUserIdRef.current = user.id;
+        if (userId === undefined) return;
+        if (lastPushedUserIdRef.current === userId) return;
+        lastPushedUserIdRef.current = userId;
+        const localBefore = loadCustomCardSets();
+        void TelemetryRuntime.runPromise(
+            signInPushEffect(localBefore).pipe(
+                Effect.tap(result =>
+                    Effect.sync(() => {
+                        localPacksPushedOnSignIn({
+                            countPushed: result.countPushed,
+                            countAlreadySynced: result.countAlreadySynced,
+                            countRenamed: result.countRenamed,
+                            countDeduped: result.countDeduped,
+                            countPulled: 0,
+                            countFailed: result.countFailed,
+                        });
+                    }),
+                ),
+                Effect.tapError(cause =>
+                    Effect.logError(
+                        "data.cardPacks.signInPush failed",
+                        { cause },
+                    ),
+                ),
+                Effect.ignore,
+                Effect.tap(() =>
+                    Effect.sync(() => {
+                        // Force the React Query to pull now that the
+                        // push is settled, so reconcile picks up the
+                        // freshly-stamped server rows.
+                        void queryClient.invalidateQueries({
+                            queryKey: myCardPacksQueryKey(userId),
+                        });
+                    }),
+                ),
+            ),
+        );
+    }, [queryClient, userId]);
 
-        const packs = loadCustomCardSets();
+    // Apply server snapshot whenever the React Query produces fresh
+    // data. `dataUpdatedAt` increments on every successful fetch
+    // (including refetches), so a once-per-update guard is enough.
+    useEffect(() => {
+        if (userId === undefined) return;
+        const serverPacks = myCardPacks.data;
+        if (serverPacks === undefined) return;
+        if (
+            lastAppliedDataUpdatedAtRef.current === myCardPacks.dataUpdatedAt
+        ) {
+            return;
+        }
+        lastAppliedDataUpdatedAtRef.current = myCardPacks.dataUpdatedAt;
 
-        void (async () => {
-            try {
-                const result = packs.length > 0
-                    ? await pushLocalPacksOnSignIn({
-                          packs: packs.map((p) => ({
-                              clientGeneratedId: p.id,
-                              label: p.label,
-                              cardSet: p.cardSet,
-                          })),
-                      })
-                    : emptyPushResult;
-                const serverPacks = await getMyCardPacks();
-                const reconciled = reconcileCardPacks(packs, serverPacks);
-                replaceCustomCardSets(reconciled.packs);
-                const usage = remapCardPackUsageIds(reconciled.idMap);
-                queryClient.setQueryData(
-                    customCardPacksQueryKey,
-                    reconciled.packs,
-                );
-                queryClient.setQueryData(cardPackUsageQueryKey, usage);
-                queryClient.setQueryData(
-                    myCardPacksQueryKey(user.id),
-                    serverPacks,
-                );
-                localPacksPushedOnSignIn({
-                    countPushed: result.countPushed,
-                    countAlreadySynced: result.countAlreadySynced,
-                    countRenamed: result.countRenamed,
-                    countDeduped: result.countDeduped,
-                    countPulled: reconciled.countPulled,
-                    countFailed: result.countFailed,
-                });
-            } catch {
-                // Sign-in itself succeeded — the push is best-effort
-                // and Sentry catches any thrown error from the
-                // server-action wrapper. Don't block the UI on it.
-            }
-        })();
-    }, [queryClient, session.data]);
+        void TelemetryRuntime.runPromise(
+            applyServerSnapshotEffect(serverPacks).pipe(
+                Effect.tap(reconciled =>
+                    Effect.sync(() => {
+                        queryClient.setQueryData<ReadonlyArray<CustomCardSet>>(
+                            customCardPacksQueryKey,
+                            reconciled.packs,
+                        );
+                        if (reconciled.idMap.size > 0) {
+                            void queryClient.invalidateQueries({
+                                queryKey: cardPackUsageQueryKey,
+                            });
+                        }
+                    }),
+                ),
+                Effect.tapError(cause =>
+                    Effect.logError(
+                        "data.cardPacks.applyServerSnapshot failed",
+                        { cause },
+                    ),
+                ),
+                Effect.ignore,
+            ),
+        );
+    }, [
+        userId,
+        queryClient,
+        myCardPacks.data,
+        myCardPacks.dataUpdatedAt,
+    ]);
 
     return null;
 }
+
+// ── Flush helper ────────────────────────────────────────────────────────────
+
+export interface UnsyncedSummary {
+    readonly created: ReadonlyArray<{
+        readonly id: string;
+        readonly label: string;
+    }>;
+    readonly modified: ReadonlyArray<{
+        readonly id: string;
+        readonly label: string;
+        readonly labelChanged: boolean;
+        readonly cardsChanged: boolean;
+    }>;
+    readonly deleted: ReadonlyArray<{
+        readonly id: string;
+        readonly label: string;
+    }>;
+}
+
+export type FlushReason = "offline" | "serverError";
+
+type FlushResult =
+    | { readonly ok: true }
+    | {
+          readonly ok: false;
+          readonly unsynced: UnsyncedSummary;
+          readonly reason: FlushReason;
+      };
+
+const summarizeUnsynced = (
+    packs: ReadonlyArray<CustomCardSet>,
+    tombstones: ReadonlyArray<CardPackTombstone>,
+): UnsyncedSummary => {
+    const created: Array<{ id: string; label: string }> = [];
+    const modified: Array<{
+        id: string;
+        label: string;
+        labelChanged: boolean;
+        cardsChanged: boolean;
+    }> = [];
+    for (const p of packs) {
+        // A pack is in sync iff it has a server snapshot AND no
+        // pending local edit. Anything else needs to flush.
+        const isSynced =
+            p.unsyncedSince === undefined &&
+            p.lastSyncedSnapshot !== undefined;
+        if (isSynced) continue;
+        if (p.lastSyncedSnapshot === undefined) {
+            // Never been on the server — covers a fresh local
+            // creation AND an anonymous-era pack whose sign-in push
+            // failed before `lastSyncedSnapshot` was populated.
+            created.push({ id: p.id, label: p.label });
+            continue;
+        }
+        const labelChanged = p.label !== p.lastSyncedSnapshot.label;
+        const cardsChanged = !cardSetEquals(
+            p.cardSet,
+            p.lastSyncedSnapshot.cardSet,
+        );
+        if (!labelChanged && !cardsChanged) continue;
+        modified.push({
+            id: p.id,
+            label: p.label,
+            labelChanged,
+            cardsChanged,
+        });
+    }
+    return {
+        created,
+        modified,
+        deleted: tombstones.map(t => ({ id: t.id, label: t.label })),
+    };
+};
+
+const isOfflineHeuristic = (): boolean =>
+    typeof navigator !== "undefined" && navigator.onLine === false;
+
+/**
+ * Drain in-flight, retry tombstones, push every pack with
+ * `unsyncedSince`, then synthesize a summary if anything's still
+ * pending. Treats `navigator.onLine === false` as a fast skip
+ * (returns `reason: "offline"` without touching the network); any
+ * post-precheck network failure is reported as `reason:
+ * "serverError"`.
+ */
+export const flushPendingChanges = async (): Promise<FlushResult> => {
+    await drainInFlight();
+
+    if (isOfflineHeuristic()) {
+        const summary = summarizeUnsynced(
+            loadCustomCardSets(),
+            loadTombstones(),
+        );
+        if (
+            summary.created.length === 0 &&
+            summary.modified.length === 0 &&
+            summary.deleted.length === 0
+        ) {
+            return { ok: true };
+        }
+        // eslint-disable-next-line i18next/no-literal-string -- FlushReason discriminator.
+        return { ok: false, unsynced: summary, reason: "offline" };
+    }
+
+    // Tombstone flush.
+    const tombstones = loadTombstones();
+    for (const tombstone of tombstones) {
+        try {
+            const promise = deleteCardPack({
+                idOrClientGeneratedId: tombstone.id,
+            });
+            trackInFlight(promise);
+            await promise;
+            clearTombstones([tombstone.id]);
+        } catch (cause) {
+            await TelemetryRuntime.runPromise(
+                Effect.logError(
+                    "data.cardPacks.flush.deleteFailed",
+                    { cause },
+                ),
+            );
+        }
+    }
+
+    // Pack-save flush. Push anything we don't know is in sync —
+    // that includes packs with `unsyncedSince` (a local edit) AND
+    // packs with no `lastSyncedSnapshot` (anonymous-era packs whose
+    // sign-in push failed before the snapshot was populated).
+    const packs = loadCustomCardSets();
+    for (const pack of packs) {
+        const needsPush =
+            pack.unsyncedSince !== undefined ||
+            pack.lastSyncedSnapshot === undefined;
+        if (!needsPush) continue;
+        try {
+            const promise = saveCardPack({
+                clientGeneratedId: pack.id,
+                label: pack.label,
+                cardSet: pack.cardSet,
+            });
+            trackInFlight(promise);
+            const serverRow = await promise;
+            const decoded = decodeServerPack(serverRow);
+            if (decoded !== null) {
+                const synced = markPackSynced(pack.id, {
+                    id: serverRow.id,
+                    label: serverRow.label,
+                    cardSet: decoded.cardSet,
+                });
+                if (synced && synced.id !== pack.id) {
+                    remapCardPackUsageIds(new Map([[pack.id, synced.id]]));
+                }
+            }
+        } catch (cause) {
+            await TelemetryRuntime.runPromise(
+                Effect.logError(
+                    "data.cardPacks.flush.saveFailed",
+                    { cause },
+                ),
+            );
+        }
+    }
+
+    const summary = summarizeUnsynced(
+        loadCustomCardSets(),
+        loadTombstones(),
+    );
+    const stillUnsynced =
+        summary.created.length > 0 ||
+        summary.modified.length > 0 ||
+        summary.deleted.length > 0;
+    if (!stillUnsynced) {
+        return { ok: true };
+    }
+    return {
+        ok: false,
+        unsynced: summary,
+        // We got past the `navigator.onLine` precheck but still have
+        // pending changes — either an explicit network failure
+        // (sawNetworkError) or an unprocessable server response
+        // (decode failure, etc.). Either way the user-facing
+        // "couldn't reach the server" framing fits.
+        // eslint-disable-next-line i18next/no-literal-string -- FlushReason discriminator.
+        reason: "serverError",
+    };
+};
+
+// ── Sign-out chokepoint ─────────────────────────────────────────────────────
+
+/**
+ * Commit a sign-out: clear account-tied localStorage, drop affected
+ * React Query caches, then call `authClient.signOut()`. Caller emits
+ * the `signOut` analytics event with whatever metadata is
+ * appropriate for the path that got us here.
+ */
+export const commitSignOut = async (
+    queryClientArg: import("@tanstack/react-query").QueryClient,
+    userId: string | undefined,
+): Promise<void> => {
+    clearAccountTiedLocalState();
+    queryClientArg.removeQueries({
+        queryKey: customCardPacksQueryKey,
+    });
+    queryClientArg.removeQueries({
+        queryKey: cardPackUsageQueryKey,
+    });
+    if (userId !== undefined) {
+        queryClientArg.removeQueries({
+            queryKey: myCardPacksQueryKey(userId),
+        });
+    }
+    await authClient.signOut();
+};

--- a/src/data/customCardPacks.ts
+++ b/src/data/customCardPacks.ts
@@ -1,14 +1,22 @@
 /**
  * React Query hooks for the user's saved custom card packs.
  *
- * Wraps the localStorage-backed `loadCustomCardSets` /
- * `saveCustomCardSet` / `deleteCustomCardSet` functions so callers
- * use the same imperative API as React Query elsewhere in the app
- * (`useQuery`, `useMutation`). The actual encoding / decoding logic
- * stays in [`src/logic/CustomCardSets.ts`](../logic/CustomCardSets.ts);
- * these hooks add caching, automatic UI updates after mutations, and
- * the Honeycomb spans defined in the plan's analytics inventory
- * (`rq.customPacks.load`, `rq.customPacks.save`, `rq.customPacks.delete`).
+ * The hooks split along the local-vs-server axis:
+ *
+ *   - `useCustomCardPacks` reads from localStorage.
+ *   - `useSaveCardPack` / `useDeleteCardPack` write to localStorage.
+ *     `useSaveCardPack` additionally stamps `unsyncedSince` when the
+ *     user is signed in so the logout flush / next reconcile knows to
+ *     push.
+ *   - `useSaveCardPackOnServer` / `useDeleteCardPackOnServer` operate
+ *     on the server-stored library. On success they reach back into
+ *     localStorage to call `markPackSynced` / clear tombstones, and
+ *     they update the React Query caches so the modal refreshes.
+ *
+ * The `useCardPackActions` orchestrator in
+ * [`src/ui/components/cardPackActions.ts`](../ui/components/cardPackActions.ts)
+ * is the canonical entry point for share / rename / delete / save
+ * flows — it decides which hooks to fire based on cache state.
  *
  * SSR note: `loadCustomCardSets()` reads `window.localStorage`, so
  * we gate it with `typeof window === "undefined"` and return `[]` on
@@ -32,9 +40,13 @@ import {
 } from "@tanstack/react-query";
 import { Effect } from "effect";
 import type { CardSet } from "../logic/CardSet";
+import { clearTombstones } from "../logic/CardPackTombstones";
+import { remapCardPackUsageIds } from "../logic/CardPackUsage";
 import {
     deleteCustomCardSet,
     loadCustomCardSets,
+    markPackSynced,
+    markPackUnsynced,
     saveCustomCardSet,
     type CustomCardSet,
 } from "../logic/CustomCardSets";
@@ -45,9 +57,12 @@ import {
     type PersistedCardPack,
 } from "../server/actions/packs";
 import { useSession } from "../ui/hooks/useSession";
-import { myCardPacksQueryKey } from "../ui/account/AccountModal";
+import { trackInFlight } from "./cardPacksInFlight";
+import { decodeServerPack } from "./serverPackCodec";
 
 export const customCardPacksQueryKey = ["custom-card-packs"] as const;
+export const myCardPacksQueryKey = (userId: string | undefined) =>
+    ["my-card-packs", userId] as const;
 
 /** SSR-safe gate: localStorage queries only run on the client. */
 const isClient = (): boolean => typeof window !== "undefined";
@@ -56,20 +71,21 @@ const loadEffect = Effect.fn("rq.customPacks.load")(function* () {
     return loadCustomCardSets();
 });
 
-const saveEffect = Effect.fn("rq.customPacks.save")(function* (
-    label: string,
-    cardSet: CardSet,
-    existingId: string | undefined,
-) {
-    return saveCustomCardSet(label, cardSet, existingId);
-});
-
-const deleteEffect = Effect.fn("rq.customPacks.delete")(function* (id: string) {
-    deleteCustomCardSet(id);
-});
-
 const readPacks = (): ReadonlyArray<CustomCardSet> =>
     isClient() ? TelemetryRuntime.runSync(loadEffect()) : [];
+
+/**
+ * Returns the signed-in non-anonymous user id, or `undefined` for
+ * anonymous / signed-out sessions. Anonymous sessions are real DB
+ * rows but treated as "not yet attached to an account" — server
+ * mirroring is gated on this returning a real id.
+ */
+export const useSignedInUserId = (): string | undefined => {
+    const session = useSession();
+    const user = session.data?.user;
+    if (!user || user.isAnonymous) return undefined;
+    return user.id;
+};
 
 /**
  * Read-side hook: returns every saved custom card pack as a stable,
@@ -104,13 +120,42 @@ interface SaveCardPackInput {
     readonly existingId?: string;
 }
 
+const saveLocalEffect = Effect.fn("rq.customPacks.save")(function* (
+    label: string,
+    cardSet: CardSet,
+    existingId: string | undefined,
+    stampUnsynced: boolean,
+) {
+    const saved = saveCustomCardSet(label, cardSet, existingId);
+    if (stampUnsynced) {
+        markPackUnsynced(saved.id);
+        // Re-read so the returned value carries the freshly-stamped
+        // metadata (caller may pass it through to the React Query
+        // cache or the orchestrator).
+        const refreshed = loadCustomCardSets().find(
+            p => p.id === saved.id,
+        );
+        return refreshed ?? saved;
+    }
+    return saved;
+});
+
+const deleteLocalEffect = Effect.fn("rq.customPacks.delete")(function* (
+    id: string,
+) {
+    deleteCustomCardSet(id);
+});
+
 /**
- * Write-side hook: snapshot the current `CardSet` as a custom card
- * pack. Defaults to inserting a new pack; pass `existingId` to update
- * an existing pack in place. Returns the persisted pack so callers
- * can immediately reference it (e.g. record-as-recently-used).
+ * Local-side write hook: snapshot the current `CardSet` as a custom
+ * card pack in localStorage. Defaults to inserting a new pack;
+ * pass `existingId` to update an existing pack in place. When the
+ * user is signed in, also stamps `unsyncedSince` so the next
+ * reconcile / logout flush knows to push.
  *
- * On success the query cache is updated optimistically — no refetch.
+ * Server-side mirroring is the orchestrator's job — see
+ * `useCardPackActions.savePack` / `renamePack` for the call sites
+ * that fire `useSaveCardPackOnServer` after this resolves.
  */
 export function useSaveCardPack(): UseMutationResult<
     CustomCardSet,
@@ -118,9 +163,17 @@ export function useSaveCardPack(): UseMutationResult<
     SaveCardPackInput
 > {
     const queryClient = useQueryClient();
+    const userId = useSignedInUserId();
     return useMutation({
         mutationFn: ({ label, cardSet, existingId }: SaveCardPackInput) =>
-            TelemetryRuntime.runPromise(saveEffect(label, cardSet, existingId)),
+            TelemetryRuntime.runPromise(
+                saveLocalEffect(
+                    label,
+                    cardSet,
+                    existingId,
+                    userId !== undefined,
+                ),
+            ),
         onSuccess: (savedPack) => {
             queryClient.setQueryData<ReadonlyArray<CustomCardSet>>(
                 customCardPacksQueryKey,
@@ -138,15 +191,18 @@ export function useSaveCardPack(): UseMutationResult<
 }
 
 /**
- * Delete a saved custom card pack by id. Built-in pack ids that
- * don't match any saved pack are silently ignored — `deleteCustomCardSet`
- * itself is a no-op on misses.
+ * Local-side delete hook: removes a saved custom card pack by id.
+ * Built-in pack ids that don't match any saved pack are silently
+ * ignored — `deleteCustomCardSet` itself is a no-op on misses.
+ *
+ * Tombstone bookkeeping + server-side mirror live in
+ * `useCardPackActions.deletePack`.
  */
 export function useDeleteCardPack(): UseMutationResult<void, Error, string> {
     const queryClient = useQueryClient();
     return useMutation({
         mutationFn: (id: string) =>
-            TelemetryRuntime.runPromise(deleteEffect(id)),
+            TelemetryRuntime.runPromise(deleteLocalEffect(id)),
         onSuccess: (_void, id) => {
             queryClient.setQueryData<ReadonlyArray<CustomCardSet>>(
                 customCardPacksQueryKey,
@@ -165,23 +221,62 @@ interface SaveCardPackOnServerInput {
 const saveOnServerEffect = Effect.fn("rq.customPacks.saveOnServer")(function* (
     input: SaveCardPackOnServerInput,
 ) {
-    return yield* Effect.promise(() => saveCardPackServer(input));
+    const promise = saveCardPackServer(input);
+    trackInFlight(promise);
+    return yield* Effect.promise(() => promise);
 });
 
 const deleteOnServerEffect = Effect.fn("rq.customPacks.deleteOnServer")(
     function* (idOrClientGeneratedId: string) {
-        yield* Effect.promise(() =>
-            deleteCardPackServer({ idOrClientGeneratedId }),
-        );
+        const promise = deleteCardPackServer({ idOrClientGeneratedId });
+        trackInFlight(promise);
+        yield* Effect.promise(() => promise);
     },
 );
 
 /**
- * Write-side hook for the user's *server-stored* card-pack library.
- * UPSERTs the pack on the server (keyed by `(owner_id, client_generated_id)`)
- * and refreshes the `myCardPacksQueryKey` cache so the AccountModal's
- * pack list updates immediately. Pairs with `useSaveCardPack` (local
- * storage) — call both when a synced pack is being mutated.
+ * Apply a successful server save back into local state. Finds the
+ * local pack by either its current `id` (post-reconcile, equals
+ * server id) or its original `clientGeneratedId` (pre-swap), calls
+ * `markPackSynced` to swap the id (when needed), refreshes
+ * `lastSyncedSnapshot`, and clears `unsyncedSince`. Remaps any
+ * usage entries from the old id to the new one. Clears any
+ * tombstones that match either id (covers the rare fast
+ * delete-then-save resurrection).
+ */
+const applyServerSave = (serverRow: PersistedCardPack): void => {
+    const decoded = decodeServerPack(serverRow);
+    if (decoded === null) return;
+    const local = loadCustomCardSets().find(
+        p =>
+            p.id === serverRow.id ||
+            p.id === serverRow.clientGeneratedId,
+    );
+    if (local === undefined) return;
+    const synced = markPackSynced(local.id, {
+        id: serverRow.id,
+        label: serverRow.label,
+        cardSet: decoded.cardSet,
+    });
+    if (synced !== undefined && synced.id !== local.id) {
+        remapCardPackUsageIds(new Map([[local.id, synced.id]]));
+    }
+    clearTombstones([local.id, serverRow.id, serverRow.clientGeneratedId]);
+};
+
+/**
+ * Server-side write hook for the user's card-pack library. UPSERTs
+ * the row keyed by `(owner_id, client_generated_id)` and updates
+ * the `myCardPacksQueryKey` cache so the AccountModal's pack list
+ * refreshes immediately.
+ *
+ * On success it also reaches back into localStorage to apply
+ * `markPackSynced` (which swaps the local id for the server's
+ * canonical id when they differ) and updates
+ * `customCardPacksQueryKey` so the rest of the UI sees the new id.
+ * That coupling lives here so every server-write call site —
+ * orchestrator-driven or not — gets the same id-swap + snapshot
+ * bookkeeping.
  */
 export function useSaveCardPackOnServer(): UseMutationResult<
     PersistedCardPack,
@@ -189,8 +284,7 @@ export function useSaveCardPackOnServer(): UseMutationResult<
     SaveCardPackOnServerInput
 > {
     const queryClient = useQueryClient();
-    const session = useSession();
-    const userId = session.data?.user.id;
+    const userId = useSignedInUserId();
     return useMutation({
         mutationFn: (input: SaveCardPackOnServerInput) =>
             TelemetryRuntime.runPromise(saveOnServerEffect(input)),
@@ -210,14 +304,20 @@ export function useSaveCardPackOnServer(): UseMutationResult<
                     return next;
                 },
             );
+            applyServerSave(savedPack);
+            queryClient.setQueryData<ReadonlyArray<CustomCardSet>>(
+                customCardPacksQueryKey,
+                loadCustomCardSets(),
+            );
         },
     });
 }
 
 /**
- * Owner-scoped delete on the server, keyed by either the server-minted
- * `id` or the `client_generated_id`. Pairs with `useDeleteCardPack`
- * (local storage).
+ * Server-side delete hook, owner-scoped, keyed by either the server-
+ * minted `id` or the `client_generated_id`. On success clears the
+ * matching tombstone (so the next pull doesn't filter the pack
+ * back out by mistake).
  */
 export function useDeleteCardPackOnServer(): UseMutationResult<
     void,
@@ -225,8 +325,7 @@ export function useDeleteCardPackOnServer(): UseMutationResult<
     string
 > {
     const queryClient = useQueryClient();
-    const session = useSession();
-    const userId = session.data?.user.id;
+    const userId = useSignedInUserId();
     return useMutation({
         mutationFn: (idOrClientGeneratedId: string) =>
             TelemetryRuntime.runPromise(
@@ -240,6 +339,7 @@ export function useDeleteCardPackOnServer(): UseMutationResult<
                         (p) => p.id !== arg && p.clientGeneratedId !== arg,
                     ) ?? [],
             );
+            clearTombstones([arg]);
         },
     });
 }

--- a/src/data/serverPackCodec.ts
+++ b/src/data/serverPackCodec.ts
@@ -1,0 +1,96 @@
+/**
+ * Decoder for the server's `PersistedCardPack` wire format. The
+ * `cardSetData` column is a JSON-encoded `CardSet` produced by
+ * `JSON.stringify` inside `saveCardPack`; this module deserialises
+ * the whole row into the domain `CustomCardSet` shape used
+ * throughout the UI.
+ *
+ * Lives in its own file so the reconcile pipeline
+ * ([`cardPacksSync.tsx`]), the mutation hooks
+ * ([`customCardPacks.ts`]), and the AccountModal preview can all
+ * decode without duplicating the defensive shape-checking. Returns
+ * `null` on a malformed payload — the calling site falls back to
+ * whatever it already has (e.g. the input cardSet for a save)
+ * rather than throwing.
+ */
+import { CardSet } from "../logic/CardSet";
+import type { CustomCardSet } from "../logic/CustomCardSets";
+import { Card, CardCategory } from "../logic/GameObjects";
+import { CardEntry, Category } from "../logic/GameSetup";
+import type { PersistedCardPack } from "../server/actions/packs";
+
+const decodeCardSet = (raw: string): CardSet | null => {
+    try {
+        const parsed: unknown = JSON.parse(raw);
+        if (
+            typeof parsed !== "object" ||
+            parsed === null ||
+            !("categories" in parsed) ||
+            !Array.isArray(parsed.categories)
+        ) {
+            return null;
+        }
+        const categories: Array<Category> = [];
+        for (const category of parsed.categories) {
+            if (
+                typeof category !== "object" ||
+                category === null ||
+                !("id" in category) ||
+                typeof category.id !== "string" ||
+                !("name" in category) ||
+                typeof category.name !== "string" ||
+                !("cards" in category) ||
+                !Array.isArray(category.cards)
+            ) {
+                return null;
+            }
+            const cards: Array<CardEntry> = [];
+            for (const card of category.cards) {
+                if (
+                    typeof card !== "object" ||
+                    card === null ||
+                    !("id" in card) ||
+                    typeof card.id !== "string" ||
+                    !("name" in card) ||
+                    typeof card.name !== "string"
+                ) {
+                    return null;
+                }
+                cards.push(
+                    CardEntry({
+                        id: Card(card.id),
+                        name: card.name,
+                    }),
+                );
+            }
+            categories.push(
+                Category({
+                    id: CardCategory(category.id),
+                    name: category.name,
+                    cards,
+                }),
+            );
+        }
+        return CardSet({ categories });
+    } catch {
+        return null;
+    }
+};
+
+/**
+ * Decode a server-side `PersistedCardPack` into a domain
+ * `CustomCardSet`. Drops the wire-format-only `clientGeneratedId` —
+ * callers that need it pluck it from the original `PersistedCardPack`
+ * they already had access to.
+ */
+export const decodeServerPack = (
+    pack: PersistedCardPack,
+): CustomCardSet | null => {
+    const cardSet = decodeCardSet(pack.cardSetData);
+    if (cardSet === null) return null;
+    return {
+        id: pack.id,
+        label: pack.label,
+        cardSet,
+    };
+};

--- a/src/logic/CardPackTombstones.test.ts
+++ b/src/logic/CardPackTombstones.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { DateTime } from "effect";
+import {
+    addTombstone,
+    clearAllTombstones,
+    clearTombstones,
+    loadTombstones,
+} from "./CardPackTombstones";
+
+const at = (iso: string): DateTime.Utc => DateTime.makeUnsafe(iso);
+
+const STORAGE_KEY = "effect-clue.deleted-packs.v1";
+
+describe("CardPackTombstones", () => {
+    beforeEach(() => {
+        window.localStorage.clear();
+    });
+    afterEach(() => {
+        window.localStorage.clear();
+    });
+
+    test("loadTombstones returns empty when key absent", () => {
+        expect(loadTombstones()).toEqual([]);
+    });
+
+    test("addTombstone persists and loadTombstones reads it back", () => {
+        addTombstone({
+            id: "pack-1",
+            label: "Office",
+            deletedAt: at("2026-04-22T12:00:00Z"),
+        });
+        const loaded = loadTombstones();
+        expect(loaded).toHaveLength(1);
+        expect(loaded[0]?.id).toBe("pack-1");
+        expect(loaded[0]?.label).toBe("Office");
+        expect(DateTime.toEpochMillis(loaded[0]!.deletedAt)).toBe(
+            DateTime.toEpochMillis(at("2026-04-22T12:00:00Z")),
+        );
+    });
+
+    test("addTombstone with duplicate id replaces rather than appends", () => {
+        addTombstone({
+            id: "pack-1",
+            label: "Office",
+            deletedAt: at("2026-04-22T12:00:00Z"),
+        });
+        addTombstone({
+            id: "pack-1",
+            label: "Office (renamed)",
+            deletedAt: at("2026-04-22T13:00:00Z"),
+        });
+        const loaded = loadTombstones();
+        expect(loaded).toHaveLength(1);
+        expect(loaded[0]?.label).toBe("Office (renamed)");
+    });
+
+    test("clearTombstones removes only the given ids", () => {
+        addTombstone({
+            id: "pack-1",
+            label: "Office",
+            deletedAt: at("2026-04-22T12:00:00Z"),
+        });
+        addTombstone({
+            id: "pack-2",
+            label: "Mansion",
+            deletedAt: at("2026-04-22T12:01:00Z"),
+        });
+        addTombstone({
+            id: "pack-3",
+            label: "Library",
+            deletedAt: at("2026-04-22T12:02:00Z"),
+        });
+        clearTombstones(["pack-2"]);
+        const loaded = loadTombstones();
+        expect(loaded.map(t => t.id)).toEqual(["pack-1", "pack-3"]);
+    });
+
+    test("clearTombstones with empty list is a no-op", () => {
+        addTombstone({
+            id: "pack-1",
+            label: "Office",
+            deletedAt: at("2026-04-22T12:00:00Z"),
+        });
+        clearTombstones([]);
+        expect(loadTombstones()).toHaveLength(1);
+    });
+
+    test("clearTombstones with non-matching ids leaves storage untouched", () => {
+        addTombstone({
+            id: "pack-1",
+            label: "Office",
+            deletedAt: at("2026-04-22T12:00:00Z"),
+        });
+        const before = window.localStorage.getItem(STORAGE_KEY);
+        clearTombstones(["pack-99"]);
+        const after = window.localStorage.getItem(STORAGE_KEY);
+        expect(after).toBe(before);
+    });
+
+    test("clearAllTombstones drops the storage key entirely", () => {
+        addTombstone({
+            id: "pack-1",
+            label: "Office",
+            deletedAt: at("2026-04-22T12:00:00Z"),
+        });
+        clearAllTombstones();
+        expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+        expect(loadTombstones()).toEqual([]);
+    });
+
+    test("loadTombstones tolerates a malformed payload by returning empty", () => {
+        window.localStorage.setItem(STORAGE_KEY, "not-json");
+        expect(loadTombstones()).toEqual([]);
+    });
+
+    test("loadTombstones rejects a wrong-shape payload (Schema fails)", () => {
+        window.localStorage.setItem(
+            STORAGE_KEY,
+            JSON.stringify({ version: 999, entries: [] }),
+        );
+        expect(loadTombstones()).toEqual([]);
+    });
+});

--- a/src/logic/CardPackTombstones.ts
+++ b/src/logic/CardPackTombstones.ts
@@ -1,0 +1,130 @@
+/**
+ * Tombstones for card packs the user has deleted while signed in.
+ *
+ * When a delete fails to reach the server (offline, 5xx, etc.), the
+ * pack is removed from `effect-clue.custom-presets.v1` immediately
+ * for snappy UI but a tombstone records the intent so:
+ *
+ *   - The next continuous-reconcile pull can retry `deleteCardPack`
+ *     for each tombstone, then `clearTombstones` on success.
+ *   - `reconcileCardPacks` filters tombstoned ids out of the pulled
+ *     server list, so a pack the user deleted offline doesn't
+ *     resurrect on the next pull.
+ *   - `LogoutWarningModal` can name the deleted packs in the
+ *     "won't be saved" list so the user knows what's at stake.
+ *
+ * Stored under `effect-clue.deleted-packs.v1` — separate keyspace
+ * from packs themselves so a forward-only schema decision here can
+ * never break the v1 pack reader. The `id` field is whatever id the
+ * pack carried at delete time (could be a `custom-…` localStorage
+ * id OR a server cuid2); `deleteCardPack` accepts either via
+ * `idOrClientGeneratedId` so retry doesn't need to discriminate.
+ *
+ * Per CLAUDE.md, dates flow as `DateTime.Utc` in memory; the on-disk
+ * shape stores epoch millis as a plain number and converts only at
+ * the storage edge.
+ */
+import { DateTime, Result, Schema } from "effect";
+
+const PersistedTombstoneSchema = Schema.Struct({
+    id: Schema.String,
+    label: Schema.String,
+    deletedAt: Schema.Number,
+});
+
+const PersistedTombstonesSchema = Schema.Struct({
+    version: Schema.Literal(1),
+    entries: Schema.Array(PersistedTombstoneSchema),
+});
+
+const decodeUnknown = Schema.decodeUnknownResult(PersistedTombstonesSchema);
+const encode = Schema.encodeSync(PersistedTombstonesSchema);
+
+const STORAGE_KEY = "effect-clue.deleted-packs.v1";
+
+export interface CardPackTombstone {
+    /**
+     * Whatever id the pack carried at delete time. The server's
+     * `deleteCardPack` action looks up by either `id` OR
+     * `client_generated_id`, so a tombstone created from a
+     * never-synced local pack and one from a previously-synced pack
+     * both flush identically.
+     */
+    readonly id: string;
+    readonly label: string;
+    readonly deletedAt: DateTime.Utc;
+}
+
+const empty: ReadonlyArray<CardPackTombstone> = [];
+
+export const loadTombstones = (): ReadonlyArray<CardPackTombstone> => {
+    if (typeof window === "undefined") return empty;
+    try {
+        const raw = window.localStorage.getItem(STORAGE_KEY);
+        if (!raw) return empty;
+        const decoded = decodeUnknown(JSON.parse(raw));
+        if (Result.isFailure(decoded)) return empty;
+        return decoded.success.entries.map(entry => ({
+            id: entry.id,
+            label: entry.label,
+            deletedAt: DateTime.makeUnsafe(entry.deletedAt),
+        }));
+    } catch {
+        return empty;
+    }
+};
+
+const writeAll = (tombstones: ReadonlyArray<CardPackTombstone>): void => {
+    if (typeof window === "undefined") return;
+    try {
+        const encoded = encode({
+            version: 1,
+            entries: tombstones.map(t => ({
+                id: t.id,
+                label: t.label,
+                deletedAt: DateTime.toEpochMillis(t.deletedAt),
+            })),
+        });
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(encoded));
+    } catch {
+        // Quota exceeded, private mode, etc. — non-fatal.
+    }
+};
+
+/**
+ * Add or replace a tombstone for the given id. Idempotent: a repeat
+ * call with the same id refreshes `deletedAt` and `label` rather
+ * than appending a duplicate.
+ */
+export const addTombstone = (entry: CardPackTombstone): void => {
+    const current = loadTombstones();
+    const next = current.filter(t => t.id !== entry.id);
+    next.push(entry);
+    writeAll(next);
+};
+
+/**
+ * Drop tombstones whose ids appear in `ids`. Called after a
+ * successful `deleteCardPack` retry, or eagerly from
+ * `useSaveCardPack` when a fast delete-then-save resurrects a pack.
+ */
+export const clearTombstones = (ids: ReadonlyArray<string>): void => {
+    if (ids.length === 0) return;
+    const drop = new Set(ids);
+    const current = loadTombstones();
+    const next = current.filter(t => !drop.has(t.id));
+    if (next.length === current.length) return;
+    writeAll(next);
+};
+
+/**
+ * Wholesale clear — used by `clearAccountTiedLocalState` on logout.
+ */
+export const clearAllTombstones = (): void => {
+    if (typeof window === "undefined") return;
+    try {
+        window.localStorage.removeItem(STORAGE_KEY);
+    } catch {
+        // Private mode, quota — non-fatal.
+    }
+};

--- a/src/logic/CustomCardSets.test.ts
+++ b/src/logic/CustomCardSets.test.ts
@@ -1,8 +1,17 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
+import { DateTime } from "effect";
 import { CardSet, CardEntry, Category } from "./CardSet";
 import {
+    addTombstone,
+    loadTombstones,
+} from "./CardPackTombstones";
+import {
+    clearAccountTiedLocalState,
     deleteCustomCardSet,
     loadCustomCardSets,
+    markPackSynced,
+    markPackUnsynced,
+    replaceCustomCardSets,
     saveCustomCardSet,
 } from "./CustomCardSets";
 import { Card, CardCategory } from "./GameObjects";
@@ -164,5 +173,140 @@ describe("deleteCustomCardSet", () => {
     test("on an empty store is a no-op", () => {
         deleteCustomCardSet("anything");
         expect(loadCustomCardSets()).toEqual([]);
+    });
+});
+
+describe("markPackUnsynced", () => {
+    beforeEach(() => window.localStorage.clear());
+
+    test("stamps unsyncedSince on a pack that exists", () => {
+        const saved = saveCustomCardSet("A", makePack());
+        markPackUnsynced(saved.id);
+        const loaded = loadCustomCardSets();
+        expect(loaded[0]?.unsyncedSince).toBeDefined();
+    });
+
+    test("is a no-op when the id doesn't match", () => {
+        saveCustomCardSet("A", makePack());
+        markPackUnsynced("nonexistent");
+        const loaded = loadCustomCardSets();
+        expect(loaded[0]?.unsyncedSince).toBeUndefined();
+    });
+
+    test("does NOT mutate other packs", () => {
+        const a = saveCustomCardSet("A", makePack());
+        const b = saveCustomCardSet("B", makePack());
+        markPackUnsynced(a.id);
+        const loaded = loadCustomCardSets();
+        expect(loaded.find(p => p.id === a.id)?.unsyncedSince).toBeDefined();
+        expect(loaded.find(p => p.id === b.id)?.unsyncedSince).toBeUndefined();
+    });
+});
+
+describe("markPackSynced", () => {
+    beforeEach(() => window.localStorage.clear());
+
+    test("swaps id, sets snapshot, clears unsyncedSince", () => {
+        const saved = saveCustomCardSet("Office", makePack());
+        markPackUnsynced(saved.id);
+        const result = markPackSynced(saved.id, {
+            id: "server-1",
+            label: "Office",
+            cardSet: makePack(),
+        });
+        expect(result?.id).toBe("server-1");
+        expect(result?.unsyncedSince).toBeUndefined();
+        expect(result?.lastSyncedSnapshot?.label).toBe("Office");
+        const loaded = loadCustomCardSets();
+        expect(loaded[0]?.id).toBe("server-1");
+    });
+
+    test("returns undefined when the local id doesn't match", () => {
+        saveCustomCardSet("A", makePack());
+        const result = markPackSynced("nonexistent", {
+            id: "server-1",
+            label: "A",
+            cardSet: makePack(),
+        });
+        expect(result).toBeUndefined();
+    });
+
+    test("preserves the local label / cardSet (server snapshot is separate)", () => {
+        const saved = saveCustomCardSet("My Office", makePack());
+        const result = markPackSynced(saved.id, {
+            id: "server-1",
+            label: "Server Office",
+            cardSet: makePack(),
+        });
+        expect(result?.label).toBe("My Office");
+        expect(result?.lastSyncedSnapshot?.label).toBe("Server Office");
+    });
+});
+
+describe("replaceCustomCardSets metadata round-trip", () => {
+    beforeEach(() => window.localStorage.clear());
+
+    test("preserves unsyncedSince and lastSyncedSnapshot", () => {
+        replaceCustomCardSets([
+            {
+                id: "server-1",
+                label: "Office",
+                cardSet: makePack(),
+                unsyncedSince: DateTime.makeUnsafe("2026-04-22T12:00:00Z"),
+                lastSyncedSnapshot: {
+                    label: "Office",
+                    cardSet: makePack(),
+                },
+            },
+        ]);
+        const loaded = loadCustomCardSets();
+        expect(loaded).toHaveLength(1);
+        expect(DateTime.toEpochMillis(loaded[0]!.unsyncedSince!)).toBe(
+            DateTime.toEpochMillis(
+                DateTime.makeUnsafe("2026-04-22T12:00:00Z"),
+            ),
+        );
+        expect(loaded[0]?.lastSyncedSnapshot?.label).toBe("Office");
+    });
+});
+
+describe("clearAccountTiedLocalState", () => {
+    beforeEach(() => window.localStorage.clear());
+
+    test("clears card-pack, tombstones, and usage keys", () => {
+        saveCustomCardSet("Office", makePack());
+        addTombstone({
+            id: "server-1",
+            label: "Mansion",
+            deletedAt: DateTime.makeUnsafe("2026-04-22T12:00:00Z"),
+        });
+        window.localStorage.setItem(
+            "effect-clue.card-pack-usage.v1",
+            JSON.stringify({ version: 1, entries: [] }),
+        );
+        clearAccountTiedLocalState();
+        expect(loadCustomCardSets()).toEqual([]);
+        expect(loadTombstones()).toEqual([]);
+        expect(
+            window.localStorage.getItem("effect-clue.card-pack-usage.v1"),
+        ).toBeNull();
+    });
+
+    test("does NOT clear non-account-tied keys", () => {
+        // Game state, splash, tour, install — all kept.
+        const survivors = [
+            "effect-clue.session.v7",
+            "effect-clue.splash.v1",
+            "effect-clue.tour.setup.v1",
+            "effect-clue.install-prompt.v1",
+        ];
+        for (const key of survivors) {
+            window.localStorage.setItem(key, "x");
+        }
+        saveCustomCardSet("Office", makePack());
+        clearAccountTiedLocalState();
+        for (const key of survivors) {
+            expect(window.localStorage.getItem(key)).toBe("x");
+        }
     });
 });

--- a/src/logic/CustomCardSets.ts
+++ b/src/logic/CustomCardSets.ts
@@ -13,8 +13,13 @@
  * The on-disk payload goes through `Schema`: malformed blobs are
  * rejected with a structured error rather than silently ignored, and
  * branded ids (Card, CardCategory) flow through the decoder directly.
+ *
+ * Sync metadata: each pack carries optional `unsyncedSince` and
+ * `lastSyncedSnapshot` fields used by the sign-in / continuous
+ * reconcile pipeline (see [`src/data/cardPacksSync.tsx`]). They are
+ * additive — old payloads without them still decode.
  */
-import { Result, Schema } from "effect";
+import { DateTime, Result, Schema } from "effect";
 import { CardSet } from "./CardSet";
 import { Card, CardCategory } from "./GameObjects";
 import { CardEntry, Category } from "./GameSetup";
@@ -35,10 +40,24 @@ const PersistedCategorySchema = Schema.Struct({
     cards: Schema.Array(PersistedCardEntrySchema),
 });
 
+/**
+ * Last-known server-side view of a pack. Set when a pull arrives or
+ * a push confirms; never mutated by local edits, so it remains a
+ * stable diff baseline across multiple offline edits and powers the
+ * "what changed" copy in `LogoutWarningModal`.
+ */
+const PersistedSnapshotSchema = Schema.Struct({
+    label: Schema.String,
+    categories: Schema.Array(PersistedCategorySchema),
+});
+
 const PersistedCustomCardSetSchema = Schema.Struct({
     id: Schema.String,
     label: Schema.String,
     categories: Schema.Array(PersistedCategorySchema),
+    /** Epoch millis at the storage edge; `DateTime.Utc` in memory. */
+    unsyncedSince: Schema.optional(Schema.Number),
+    lastSyncedSnapshot: Schema.optional(PersistedSnapshotSchema),
 });
 
 /**
@@ -58,6 +77,15 @@ const decodeUnknown = Schema.decodeUnknownResult(
 const encode = Schema.encodeSync(PersistedCustomCardSetsSchema);
 
 /**
+ * Snapshot of the server's last-known view of a pack. Drives the
+ * "what changed" diff in the logout warning UI.
+ */
+export interface CardPackSnapshot {
+    readonly label: string;
+    readonly cardSet: CardSet;
+}
+
+/**
  * Runtime-shape card pack as consumed by the UI. Stores a `CardSet`
  * — the deck half of a game — so callers can compose a fresh
  * `GameSetup` with whatever `PlayerSet` the current game already
@@ -67,6 +95,17 @@ export interface CustomCardSet {
     readonly id: string;
     readonly label: string;
     readonly cardSet: CardSet;
+    /**
+     * Set on every local mutation while signed in; cleared by a
+     * server roundtrip confirmation. Absent ⇒ pack is in sync.
+     */
+    readonly unsyncedSince?: DateTime.Utc | undefined;
+    /**
+     * Server's last-known view of this pack — set by pulls and by
+     * successful pushes. Absent ⇒ the server has never acknowledged
+     * this pack (a local-only creation).
+     */
+    readonly lastSyncedSnapshot?: CardPackSnapshot | undefined;
 }
 
 // Historical key — retains the `custom-presets` path so users who
@@ -74,11 +113,50 @@ export interface CustomCardSet {
 // code-level names changed.
 const STORAGE_KEY = "effect-clue.custom-presets.v1";
 
+const TOMBSTONES_KEY = "effect-clue.deleted-packs.v1";
+const USAGE_KEY = "effect-clue.card-pack-usage.v1";
+
+interface PersistedCategoryShape {
+    readonly id: CardCategory;
+    readonly name: string;
+    readonly cards: ReadonlyArray<{
+        readonly id: Card;
+        readonly name: string;
+    }>;
+}
+
+const decodePersistedCategories = (
+    cats: ReadonlyArray<PersistedCategoryShape>,
+): CardSet =>
+    CardSet({
+        categories: cats.map(c => Category({
+            id: c.id,
+            name: c.name,
+            cards: c.cards.map(card => CardEntry({
+                id: card.id,
+                name: card.name,
+            })),
+        })),
+    });
+
+const encodePersistedCategories = (
+    cardSet: CardSet,
+): ReadonlyArray<PersistedCategoryShape> =>
+    cardSet.categories.map(c => ({
+        id: c.id,
+        name: c.name,
+        cards: c.cards.map(card => ({
+            id: card.id,
+            name: card.name,
+        })),
+    }));
+
 /**
  * Read all user-saved card packs from localStorage. Returns an
  * empty array if the key is missing or the payload doesn't decode.
  */
 export const loadCustomCardSets = (): ReadonlyArray<CustomCardSet> => {
+    if (typeof window === "undefined") return [];
     try {
         const raw = window.localStorage.getItem(STORAGE_KEY);
         if (!raw) return [];
@@ -87,16 +165,18 @@ export const loadCustomCardSets = (): ReadonlyArray<CustomCardSet> => {
         return decoded.success.presets.map(p => ({
             id: p.id,
             label: p.label,
-            cardSet: CardSet({
-                categories: p.categories.map(c => Category({
-                    id: c.id,
-                    name: c.name,
-                    cards: c.cards.map(card => CardEntry({
-                        id: card.id,
-                        name: card.name,
-                    })),
-                })),
-            }),
+            cardSet: decodePersistedCategories(p.categories),
+            unsyncedSince: p.unsyncedSince !== undefined
+                ? DateTime.makeUnsafe(p.unsyncedSince)
+                : undefined,
+            lastSyncedSnapshot: p.lastSyncedSnapshot !== undefined
+                ? {
+                    label: p.lastSyncedSnapshot.label,
+                    cardSet: decodePersistedCategories(
+                        p.lastSyncedSnapshot.categories,
+                    ),
+                }
+                : undefined,
         }));
     } catch {
         return [];
@@ -104,20 +184,25 @@ export const loadCustomCardSets = (): ReadonlyArray<CustomCardSet> => {
 };
 
 const writeAll = (packs: ReadonlyArray<CustomCardSet>): void => {
+    if (typeof window === "undefined") return;
     try {
         const encoded = encode({
             version: 1,
             presets: packs.map(p => ({
                 id: p.id,
                 label: p.label,
-                categories: p.cardSet.categories.map(c => ({
-                    id: c.id,
-                    name: c.name,
-                    cards: c.cards.map(card => ({
-                        id: card.id,
-                        name: card.name,
-                    })),
-                })),
+                categories: encodePersistedCategories(p.cardSet),
+                unsyncedSince: p.unsyncedSince !== undefined
+                    ? DateTime.toEpochMillis(p.unsyncedSince)
+                    : undefined,
+                lastSyncedSnapshot: p.lastSyncedSnapshot !== undefined
+                    ? {
+                        label: p.lastSyncedSnapshot.label,
+                        categories: encodePersistedCategories(
+                            p.lastSyncedSnapshot.cardSet,
+                        ),
+                    }
+                    : undefined,
             })),
         });
         window.localStorage.setItem(STORAGE_KEY, JSON.stringify(encoded));
@@ -134,6 +219,10 @@ const writeAll = (packs: ReadonlyArray<CustomCardSet>): void => {
  * recency map and any other id-based references stay valid. If
  * `existingId` doesn't match any saved pack, falls back to insert
  * (so a stale id from an evicted pack still produces a save).
+ *
+ * Returns the persisted pack with sync metadata preserved when
+ * updating in place — caller decides whether to mark it unsynced via
+ * [`markPackUnsynced`] after the fact.
  */
 export const saveCustomCardSet = (
     label: string,
@@ -144,7 +233,14 @@ export const saveCustomCardSet = (
     if (existingId !== undefined) {
         const matchIdx = packs.findIndex(p => p.id === existingId);
         if (matchIdx !== -1) {
-            const updated: CustomCardSet = { id: existingId, label, cardSet };
+            const previous = packs[matchIdx]!;
+            const updated: CustomCardSet = {
+                id: existingId,
+                label,
+                cardSet,
+                unsyncedSince: previous.unsyncedSince,
+                lastSyncedSnapshot: previous.lastSyncedSnapshot,
+            };
             const next = [...packs];
             next[matchIdx] = updated;
             writeAll(next);
@@ -173,4 +269,78 @@ export const replaceCustomCardSets = (
     packs: ReadonlyArray<CustomCardSet>,
 ): void => {
     writeAll(packs);
+};
+
+/**
+ * Mark a pack as having local changes the server hasn't seen yet.
+ * Stamps `unsyncedSince` with the current `DateTime.now`. No-op if
+ * the pack id isn't found.
+ */
+export const markPackUnsynced = (id: string): void => {
+    const packs = loadCustomCardSets();
+    const idx = packs.findIndex(p => p.id === id);
+    if (idx === -1) return;
+    const next = [...packs];
+    next[idx] = {
+        ...packs[idx]!,
+        unsyncedSince: DateTime.nowUnsafe(),
+    };
+    writeAll(next);
+};
+
+/**
+ * Confirm a server roundtrip for a pack. Swaps the local id for the
+ * server's canonical id (if different), refreshes the
+ * `lastSyncedSnapshot` to the server's view, and clears
+ * `unsyncedSince`. Returns the updated pack, or `undefined` if no
+ * pack matched `localId`.
+ *
+ * Caller is responsible for `remapCardPackUsageIds` when the id
+ * changes.
+ */
+export const markPackSynced = (
+    localId: string,
+    serverRow: {
+        readonly id: string;
+        readonly label: string;
+        readonly cardSet: CardSet;
+    },
+): CustomCardSet | undefined => {
+    const packs = loadCustomCardSets();
+    const idx = packs.findIndex(p => p.id === localId);
+    if (idx === -1) return undefined;
+    const previous = packs[idx]!;
+    const updated: CustomCardSet = {
+        id: serverRow.id,
+        label: previous.label,
+        cardSet: previous.cardSet,
+        unsyncedSince: undefined,
+        lastSyncedSnapshot: {
+            label: serverRow.label,
+            cardSet: serverRow.cardSet,
+        },
+    };
+    const next = [...packs];
+    next[idx] = updated;
+    writeAll(next);
+    return updated;
+};
+
+/**
+ * Clear every account-tied localStorage key. Called as part of
+ * [`requestSignOut`] once a sign-out is committed (either because
+ * sync confirmed everything or because the user chose
+ * "sign out anyway"). Deliberately scoped: tour state, splash state,
+ * install-prompt state, in-progress game state are NOT account-tied
+ * and remain untouched.
+ */
+export const clearAccountTiedLocalState = (): void => {
+    if (typeof window === "undefined") return;
+    try {
+        window.localStorage.removeItem(STORAGE_KEY);
+        window.localStorage.removeItem(TOMBSTONES_KEY);
+        window.localStorage.removeItem(USAGE_KEY);
+    } catch {
+        // Private mode, quota — non-fatal.
+    }
 };

--- a/src/logic/ShareCodec.ts
+++ b/src/logic/ShareCodec.ts
@@ -40,7 +40,7 @@ export const accusationsCodec = Schema.fromJsonString(AccusationsArraySchema);
  * Hypotheses codec — only used by the `transfer` share kind ("move my
  * game to another device"). `pack` and `invite` shares deliberately
  * omit hypotheses since those flows go to other people; hypotheses are
- * personal scratchwork. See `docs/shares.md` for the kind-discriminated
- * wire-format rule.
+ * personal scratchwork. See `docs/shares-and-sync.md` for the
+ * kind-discriminated wire-format rule.
  */
 export const hypothesesCodec = Schema.fromJsonString(HypothesesArraySchema);

--- a/src/ui/account/AccountModal.test.tsx
+++ b/src/ui/account/AccountModal.test.tsx
@@ -313,7 +313,15 @@ describe("AccountModal — pack row actions", () => {
         expect(raw).toContain("Dunder Mifflin");
     });
 
-    test("rename of a local-only pack does NOT call the server", async () => {
+    test("rename of a local-only pack while signed in mirrors to server", async () => {
+        // The pack is in localStorage but `getMyCardPacks` doesn't
+        // return it yet — that's the "anon-era pack waiting for
+        // first reconcile" case OR a brand-new pack created while
+        // signed in but offline. Per the Flow 1 invariant in
+        // `docs/shares-and-sync.md`, a signed-in mutation pushes to
+        // the server even for a pack the server hasn't seen yet —
+        // the unified `useSaveCardPack` handles the upsert and the
+        // localStorage `lastSyncedSnapshot` stamp.
         signInAlice();
         window.localStorage.setItem(
             "effect-clue.custom-presets.v1",
@@ -328,7 +336,6 @@ describe("AccountModal — pack row actions", () => {
                 ],
             }),
         );
-        // No matching server pack returned.
         getMyCardPacksMock.mockResolvedValue([]);
         renderModal();
         await waitFor(() => {
@@ -351,7 +358,15 @@ describe("AccountModal — pack row actions", () => {
             );
             expect(raw).toContain("Renamed");
         });
-        expect(saveCardPackMock).not.toHaveBeenCalled();
+        await waitFor(() => {
+            expect(saveCardPackMock).toHaveBeenCalledTimes(1);
+        });
+        const serverArg = saveCardPackMock.mock.calls[0]?.[0] as {
+            clientGeneratedId: string;
+            label: string;
+        };
+        expect(serverArg.clientGeneratedId).toBe("custom-local-only");
+        expect(serverArg.label).toBe("Renamed");
     });
 
     test("rename Cancel performs no mutation", async () => {
@@ -420,6 +435,10 @@ describe("AccountModal — pack row actions", () => {
         await waitFor(() => {
             expect(deleteCardPackMock).toHaveBeenCalledTimes(1);
         });
+        // The orchestrator passes the server's canonical `id` to
+        // `deleteCardPackOnServer`. Server action's `WHERE id = $1
+        // OR client_generated_id = $1` would accept either, but the
+        // server id is the more direct key.
         expect(deleteCardPackMock.mock.calls[0]?.[0]).toEqual({
             idOrClientGeneratedId: "pack-1",
         });
@@ -472,5 +491,38 @@ describe("mergeCardPacks", () => {
             ],
         );
         expect(merged).toHaveLength(0);
+    });
+
+    test("dedupes when local id has been swapped to server id by reconcile", () => {
+        // Post-reconcile state: the local pack's `id` is the server's
+        // `id` (the swap happens in `markPackSynced` after a
+        // successful push or pull). The server pack's
+        // `clientGeneratedId` is the original `custom-…` id. If
+        // `mergeCardPacks` only checked against
+        // `clientGeneratedId`, the same pack would render twice —
+        // once from `decodedServer` and once from `localOnly`.
+        const merged = mergeCardPacks(
+            [
+                {
+                    id: "server-1",
+                    label: "Mansion",
+                    cardSet: { categories: [] } as never,
+                },
+            ],
+            [
+                {
+                    id: "server-1",
+                    clientGeneratedId: "custom-mansion",
+                    label: "Mansion",
+                    cardSetData: EMPTY_CARD_SET_DATA,
+                },
+            ],
+        );
+        expect(merged).toHaveLength(1);
+        expect(merged[0]).toMatchObject({
+            id: "server-1",
+            clientGeneratedId: "custom-mansion",
+            source: "server",
+        });
     });
 });

--- a/src/ui/account/AccountModal.tsx
+++ b/src/ui/account/AccountModal.tsx
@@ -29,9 +29,10 @@ import {
     type PersistedCardPack,
 } from "../../server/actions/packs";
 import {
+    myCardPacksQueryKey,
     useCustomCardPacks,
 } from "../../data/customCardPacks";
-import { decodeServerPack } from "../../data/cardPacksSync";
+import { decodeServerPack } from "../../data/serverPackCodec";
 import type { CardSet } from "../../logic/CardSet";
 import type { CustomCardSet } from "../../logic/CustomCardSets";
 import { useSession } from "../hooks/useSession";
@@ -45,8 +46,6 @@ import { DevSignInForm } from "./DevSignInForm";
 const isDev = process.env.NODE_ENV === "development";
 
 const PROVIDER_GOOGLE = "google" as const;
-export const myCardPacksQueryKey = (userId: string | undefined) =>
-    ["my-card-packs", userId] as const;
 const SIGN_IN_FROM_MENU: SignInFromContext = "menu";
 
 /**
@@ -70,9 +69,15 @@ export const mergeCardPacks = (
     localPacks: ReadonlyArray<CustomCardSet>,
     serverPacks: ReadonlyArray<PersistedCardPack>,
 ): ReadonlyArray<DisplayPack> => {
-    const serverClientIds = new Set(
-        serverPacks.map((pack) => pack.clientGeneratedId),
-    );
+    // The continuous reconcile in `CardPacksSync` swaps local ids
+    // for server ids once a pack has been pulled, so the local
+    // `id` may equal EITHER a server `id` OR a server
+    // `clientGeneratedId`. Track both to catch every pair-match.
+    const serverIdentities = new Set<string>();
+    for (const pack of serverPacks) {
+        serverIdentities.add(pack.id);
+        serverIdentities.add(pack.clientGeneratedId);
+    }
     const decodedServer: ReadonlyArray<DisplayPack> = serverPacks.flatMap(
         (pack) => {
             const decoded = decodeServerPack(pack);
@@ -89,7 +94,7 @@ export const mergeCardPacks = (
         },
     );
     const localOnly: ReadonlyArray<DisplayPack> = localPacks
-        .filter((pack) => !serverClientIds.has(pack.id))
+        .filter((pack) => !serverIdentities.has(pack.id))
         .map((pack) => ({
             id: pack.id,
             clientGeneratedId: pack.id,

--- a/src/ui/account/AccountProvider.test.tsx
+++ b/src/ui/account/AccountProvider.test.tsx
@@ -1,0 +1,340 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+vi.mock("next-intl", () => {
+    const make = (ns: string) =>
+        (key: string, values?: Record<string, unknown>): string => {
+            const fq = ns.length > 0 ? `${ns}.${key}` : key;
+            return values ? `${fq}:${JSON.stringify(values)}` : fq;
+        };
+    return {
+        useTranslations: (ns?: string) => make(ns ?? ""),
+    };
+});
+
+vi.mock("next/navigation", () => ({
+    usePathname: () => "/play",
+    useSearchParams: () => new URLSearchParams(),
+}));
+
+const refetchMock = vi.fn();
+let mockSessionData: {
+    user: { id: string; isAnonymous?: boolean };
+} | null = null;
+
+vi.mock("../hooks/useSession", () => ({
+    useSession: () => ({
+        data: mockSessionData,
+        isPending: false,
+        isRefetching: false,
+        error: null,
+        refetch: refetchMock,
+    }),
+}));
+
+vi.mock("./authClient", () => ({
+    authClient: { useSession: () => ({ data: null }), signIn: { social: vi.fn() } },
+}));
+
+// Mock the AccountModal — we don't render it; we only care about the
+// LogoutWarningModal that AccountProvider opens via `requestSignOut`.
+vi.mock("./AccountModal", () => ({
+    AccountModal: () => null,
+}));
+
+const flushPendingChangesMock = vi.fn();
+const commitSignOutMock = vi.fn();
+
+// Mock the whole `cardPacksSync` module so AccountProvider's
+// `<CardPacksSync />` mount doesn't try to spin up a React Query
+// against `getMyCardPacks`. The orchestration we want to exercise
+// is `requestSignOut` → `flushPendingChanges` → modal → user choice
+// → `commitSignOut`.
+vi.mock("../../data/cardPacksSync", () => ({
+    CardPacksSync: () => null,
+    commitSignOut: (...args: unknown[]) => commitSignOutMock(...args),
+    flushPendingChanges: () => flushPendingChangesMock(),
+}));
+
+const signOutEventMock = vi.fn();
+vi.mock("../../analytics/events", () => ({
+    signOut: (...args: unknown[]) => signOutEventMock(...args),
+    signInStarted: vi.fn(),
+    signInFailed: vi.fn(),
+    signInCompleted: vi.fn(),
+}));
+
+import {
+    AccountProvider,
+    useAccountContext,
+} from "./AccountProvider";
+import { TestQueryClientProvider } from "../../test-utils/queryClient";
+
+const SignOutButton = () => {
+    const { requestSignOut } = useAccountContext();
+    return (
+        <button
+            type="button"
+            data-testid="sign-out"
+            onClick={() => void requestSignOut()}
+        >
+            sign out
+        </button>
+    );
+};
+
+const renderProvider = () =>
+    render(
+        <AccountProvider>
+            <SignOutButton />
+        </AccountProvider>,
+        { wrapper: TestQueryClientProvider },
+    );
+
+beforeEach(() => {
+    refetchMock.mockReset();
+    refetchMock.mockResolvedValue(undefined);
+    flushPendingChangesMock.mockReset();
+    commitSignOutMock.mockReset();
+    commitSignOutMock.mockResolvedValue(undefined);
+    signOutEventMock.mockReset();
+    mockSessionData = {
+        user: { id: "alice-id", isAnonymous: false },
+    };
+});
+
+afterEach(() => {
+    mockSessionData = null;
+});
+
+describe("AccountProvider — requestSignOut orchestration", () => {
+    test("flush ok → no modal, commitSignOut + signOut event fire immediately", async () => {
+        flushPendingChangesMock.mockResolvedValue({ ok: true });
+        renderProvider();
+        fireEvent.click(screen.getByTestId("sign-out"));
+
+        await waitFor(() => {
+            expect(commitSignOutMock).toHaveBeenCalledTimes(1);
+        });
+        // Provider passes (queryClient, userId) to commitSignOut.
+        const args = commitSignOutMock.mock.calls[0];
+        expect(args?.[1]).toBe("alice-id");
+        expect(signOutEventMock).toHaveBeenCalledTimes(1);
+        // No `discardedUnsyncedChanges` flag on the clean path.
+        expect(signOutEventMock.mock.calls[0]?.[0]).toBeUndefined();
+        expect(refetchMock).toHaveBeenCalledTimes(1);
+        // No warning modal.
+        expect(
+            screen.queryByText(/logoutWarning\.title/),
+        ).not.toBeInTheDocument();
+    });
+
+    test("flush !ok → warning modal opens with summary; commitSignOut NOT called", async () => {
+        flushPendingChangesMock.mockResolvedValue({
+            ok: false,
+            reason: "offline",
+            unsynced: {
+                created: [{ id: "a", label: "Office" }],
+                modified: [],
+                deleted: [],
+            },
+        });
+        renderProvider();
+        fireEvent.click(screen.getByTestId("sign-out"));
+
+        await waitFor(() => {
+            expect(
+                screen.getByText("account.logoutWarning.title"),
+            ).toBeInTheDocument();
+        });
+        expect(commitSignOutMock).not.toHaveBeenCalled();
+        // Per-pack item renders inside the created section.
+        expect(screen.getByText("Office")).toBeInTheDocument();
+    });
+
+    test("Stay logged in → modal closes, commitSignOut NOT called", async () => {
+        flushPendingChangesMock.mockResolvedValue({
+            ok: false,
+            reason: "offline",
+            unsynced: {
+                created: [{ id: "a", label: "Office" }],
+                modified: [],
+                deleted: [],
+            },
+        });
+        renderProvider();
+        fireEvent.click(screen.getByTestId("sign-out"));
+        await screen.findByText("account.logoutWarning.title");
+
+        fireEvent.click(
+            screen.getByRole("button", { name: "account.logoutWarning.stayLoggedIn" }),
+        );
+        await waitFor(() => {
+            expect(
+                screen.queryByText("account.logoutWarning.title"),
+            ).not.toBeInTheDocument();
+        });
+        expect(commitSignOutMock).not.toHaveBeenCalled();
+        expect(signOutEventMock).not.toHaveBeenCalled();
+    });
+
+    test("Try again succeeds on retry → modal closes, commitSignOut fires", async () => {
+        flushPendingChangesMock
+            .mockResolvedValueOnce({
+                ok: false,
+                reason: "serverError",
+                unsynced: {
+                    created: [{ id: "a", label: "Office" }],
+                    modified: [],
+                    deleted: [],
+                },
+            })
+            .mockResolvedValueOnce({ ok: true });
+        renderProvider();
+        fireEvent.click(screen.getByTestId("sign-out"));
+        await screen.findByText("account.logoutWarning.title");
+        // Try again button only renders for `serverError` reason.
+        fireEvent.click(
+            screen.getByRole("button", { name: "account.logoutWarning.tryAgain" }),
+        );
+        await waitFor(() => {
+            expect(commitSignOutMock).toHaveBeenCalledTimes(1);
+        });
+        await waitFor(() => {
+            expect(
+                screen.queryByText("account.logoutWarning.title"),
+            ).not.toBeInTheDocument();
+        });
+        expect(signOutEventMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("Try again still fails → modal stays open with refreshed summary", async () => {
+        flushPendingChangesMock
+            .mockResolvedValueOnce({
+                ok: false,
+                reason: "serverError",
+                unsynced: {
+                    created: [{ id: "a", label: "First" }],
+                    modified: [],
+                    deleted: [],
+                },
+            })
+            .mockResolvedValueOnce({
+                ok: false,
+                reason: "offline",
+                unsynced: {
+                    created: [],
+                    modified: [{ id: "b", label: "Second", labelChanged: true, cardsChanged: false }],
+                    deleted: [],
+                },
+            });
+        renderProvider();
+        fireEvent.click(screen.getByTestId("sign-out"));
+        await screen.findByText("First");
+
+        fireEvent.click(
+            screen.getByRole("button", { name: "account.logoutWarning.tryAgain" }),
+        );
+        // After retry the modal still open, but reflects the new
+        // summary + new reason.
+        await screen.findByText("Second");
+        // Lede swapped from serverError to offline.
+        expect(
+            screen.getByText("account.logoutWarning.ledeOffline"),
+        ).toBeInTheDocument();
+        // No `Try again` button this time — reason is now offline.
+        expect(
+            screen.queryByRole("button", { name: "account.logoutWarning.tryAgain" }),
+        ).not.toBeInTheDocument();
+        expect(commitSignOutMock).not.toHaveBeenCalled();
+    });
+
+    test("Sign out anyway → commitSignOut with discardedUnsyncedChanges + counts", async () => {
+        flushPendingChangesMock.mockResolvedValue({
+            ok: false,
+            reason: "offline",
+            unsynced: {
+                created: [
+                    { id: "a", label: "Office" },
+                    { id: "b", label: "Library" },
+                ],
+                modified: [
+                    { id: "c", label: "Mansion", labelChanged: true, cardsChanged: false },
+                ],
+                deleted: [{ id: "d", label: "Cellar" }],
+            },
+        });
+        renderProvider();
+        fireEvent.click(screen.getByTestId("sign-out"));
+        await screen.findByText("account.logoutWarning.title");
+
+        fireEvent.click(
+            screen.getByRole("button", { name: "account.logoutWarning.signOutAnyway" }),
+        );
+        await waitFor(() => {
+            expect(commitSignOutMock).toHaveBeenCalledTimes(1);
+        });
+        await waitFor(() => {
+            expect(signOutEventMock).toHaveBeenCalledTimes(1);
+        });
+        const props = signOutEventMock.mock.calls[0]?.[0] as {
+            discardedUnsyncedChanges: boolean;
+            unsyncedCounts: { created: number; modified: number; deleted: number };
+        };
+        expect(props.discardedUnsyncedChanges).toBe(true);
+        expect(props.unsyncedCounts).toEqual({
+            created: 2,
+            modified: 1,
+            deleted: 1,
+        });
+    });
+
+    test("requestSignOut Promise resolves only after the user makes a choice", async () => {
+        flushPendingChangesMock.mockResolvedValue({
+            ok: false,
+            reason: "offline",
+            unsynced: {
+                created: [{ id: "a", label: "Office" }],
+                modified: [],
+                deleted: [],
+            },
+        });
+
+        let resolved = false;
+        const Caller = () => {
+            const { requestSignOut } = useAccountContext();
+            return (
+                <button
+                    type="button"
+                    data-testid="sign-out"
+                    onClick={() => {
+                        void requestSignOut().then(() => {
+                            resolved = true;
+                        });
+                    }}
+                >
+                    sign out
+                </button>
+            );
+        };
+        render(
+            <AccountProvider>
+                <Caller />
+            </AccountProvider>,
+            { wrapper: TestQueryClientProvider },
+        );
+        fireEvent.click(screen.getByTestId("sign-out"));
+        await screen.findByText("account.logoutWarning.title");
+
+        // Modal is open; the Promise has NOT resolved.
+        await new Promise(r => setTimeout(r, 0));
+        expect(resolved).toBe(false);
+
+        fireEvent.click(
+            screen.getByRole("button", { name: "account.logoutWarning.stayLoggedIn" }),
+        );
+        await waitFor(() => {
+            expect(resolved).toBe(true);
+        });
+    });
+});

--- a/src/ui/account/AccountProvider.tsx
+++ b/src/ui/account/AccountProvider.tsx
@@ -4,27 +4,51 @@
  * step, future M8 card-pack management) can call
  * `openAccountModal()` without threading state through props.
  *
+ * Also owns the sign-out chokepoint `requestSignOut`. Both Toolbar
+ * and BottomNav call it instead of `authClient.signOut()` directly,
+ * so the unsynced-changes flush + warning modal sits in one place.
+ *
  * Mirrors the `InstallPromptProvider` pattern — single state,
  * exposed via context, modal rendered at the provider root.
  */
 "use client";
 
+import { useQueryClient } from "@tanstack/react-query";
 import {
     createContext,
     useCallback,
     useContext,
     useMemo,
+    useRef,
     useState,
     type ReactNode,
 } from "react";
-import { CardPacksSyncOnSignIn } from "../../data/cardPacksSync";
+import { signOut as signOutEvent } from "../../analytics/events";
+import {
+    CardPacksSync,
+    commitSignOut,
+    flushPendingChanges,
+    type FlushReason,
+    type UnsyncedSummary,
+} from "../../data/cardPacksSync";
+import { useSession } from "../hooks/useSession";
 import { AccountModal } from "./AccountModal";
+import { LogoutWarningModal } from "./LogoutWarningModal";
 
 interface AccountContextValue {
     /** True when the account modal is currently open. */
     readonly open: boolean;
     /** Open the modal. Idempotent; calling while open is a no-op. */
     readonly openModal: () => void;
+    /**
+     * Single chokepoint for signing the user out. Flushes any pending
+     * card-pack changes first. If everything's synced, clears
+     * account-tied localStorage and calls `authClient.signOut()`. If
+     * something is unsynced, opens `LogoutWarningModal` and lets the
+     * user decide. Returns when sign-out is committed OR the user
+     * elected to stay (or after retries).
+     */
+    readonly requestSignOut: () => Promise<void>;
 }
 
 const AccountContext = createContext<AccountContextValue | undefined>(
@@ -40,30 +64,156 @@ export const useAccountContext = (): AccountContextValue => {
     return ctx;
 };
 
+interface LogoutModalState {
+    readonly open: boolean;
+    readonly summary: UnsyncedSummary | null;
+    readonly reason: FlushReason | null;
+    readonly retrying: boolean;
+}
+
+const initialLogoutModalState: LogoutModalState = {
+    open: false,
+    summary: null,
+    reason: null,
+    retrying: false,
+};
+
 export function AccountProvider({
     children,
 }: {
     readonly children: ReactNode;
 }) {
+    const session = useSession();
+    const queryClient = useQueryClient();
     const [open, setOpen] = useState(false);
+    const [logoutModal, setLogoutModal] = useState<LogoutModalState>(
+        initialLogoutModalState,
+    );
+    /**
+     * Resolver registry for in-flight `requestSignOut` calls. The
+     * promise resolves once the user has either committed sign-out
+     * or chosen to stay. Multiple concurrent callers (unlikely) all
+     * await the same outcome.
+     */
+    const pendingResolvesRef = useRef<Array<() => void>>([]);
+
     const openModal = useCallback(() => setOpen(true), []);
     const closeModal = useCallback(() => setOpen(false), []);
+
+    const resolvePending = useCallback(() => {
+        const resolvers = pendingResolvesRef.current;
+        pendingResolvesRef.current = [];
+        for (const resolve of resolvers) {
+            resolve();
+        }
+    }, []);
+
+    const userId =
+        session.data?.user && !session.data.user.isAnonymous
+            ? session.data.user.id
+            : undefined;
+
+    const performCommitSignOut = useCallback(
+        async (props?: {
+            discardedUnsyncedChanges?: boolean;
+            unsyncedCounts?: {
+                created: number;
+                modified: number;
+                deleted: number;
+            };
+        }) => {
+            await commitSignOut(queryClient, userId);
+            signOutEvent(props);
+            await session.refetch();
+        },
+        [queryClient, session, userId],
+    );
+
+    const requestSignOut = useCallback(async (): Promise<void> => {
+        const flush = await flushPendingChanges();
+        if (flush.ok) {
+            await performCommitSignOut();
+            return;
+        }
+        return new Promise<void>((resolve) => {
+            pendingResolvesRef.current.push(resolve);
+            setLogoutModal({
+                open: true,
+                summary: flush.unsynced,
+                reason: flush.reason,
+                retrying: false,
+            });
+        });
+    }, [performCommitSignOut]);
+
+    const onStay = useCallback(() => {
+        setLogoutModal(initialLogoutModalState);
+        resolvePending();
+        // Close the account modal too — staying logged in shouldn't
+        // leave a stale warning hanging.
+        setOpen(false);
+    }, [resolvePending]);
+
+    const onRetry = useCallback(async () => {
+        setLogoutModal((prev) => ({ ...prev, retrying: true }));
+        const flush = await flushPendingChanges();
+        if (flush.ok) {
+            await performCommitSignOut();
+            setLogoutModal(initialLogoutModalState);
+            resolvePending();
+            setOpen(false);
+            return;
+        }
+        setLogoutModal({
+            open: true,
+            summary: flush.unsynced,
+            reason: flush.reason,
+            retrying: false,
+        });
+    }, [performCommitSignOut, resolvePending]);
+
+    const onSignOutAnyway = useCallback(async () => {
+        const summary = logoutModal.summary;
+        await performCommitSignOut({
+            discardedUnsyncedChanges: true,
+            unsyncedCounts: summary
+                ? {
+                      created: summary.created.length,
+                      modified: summary.modified.length,
+                      deleted: summary.deleted.length,
+                  }
+                : { created: 0, modified: 0, deleted: 0 },
+        });
+        setLogoutModal(initialLogoutModalState);
+        resolvePending();
+        setOpen(false);
+    }, [logoutModal.summary, performCommitSignOut, resolvePending]);
+
     const value = useMemo<AccountContextValue>(
-        () => ({ open, openModal }),
-        [open, openModal],
+        () => ({ open, openModal, requestSignOut }),
+        [open, openModal, requestSignOut],
     );
     return (
         <AccountContext.Provider value={value}>
             {children}
             <AccountModal open={open} onClose={closeModal} />
             {/*
-              Sign-in side-effect: the moment the user transitions
-              from anon to signed-in, push their localStorage card
-              packs to the server (M8). The component renders
-              nothing; it's a behaviour mounted inside the
-              provider stack so it has the session in scope.
+              Sign-in side-effect + continuous reconcile (M8). The
+              component renders nothing; it owns the
+              `getMyCardPacks` React Query and the post-pull
+              reconcile that keeps localStorage and the server in
+              sync.
             */}
-            <CardPacksSyncOnSignIn />
+            <CardPacksSync />
+            <LogoutWarningModal
+                open={logoutModal.open}
+                summary={logoutModal.summary}
+                reason={logoutModal.reason}
+                retrying={logoutModal.retrying}
+                onStay={onStay}
+                onRetry={() => void onRetry()}
+                onSignOutAnyway={() => void onSignOutAnyway()}
+            />
         </AccountContext.Provider>
     );
 }

--- a/src/ui/account/LogoutWarningModal.tsx
+++ b/src/ui/account/LogoutWarningModal.tsx
@@ -1,0 +1,192 @@
+/**
+ * Modal that opens when [`requestSignOut`] detects unsynced card-pack
+ * changes (offline or server error). Lists each affected pack under
+ * `Created`, `Modified`, or `Deleted`, with inline tags on
+ * `Modified` rows describing whether the label, the cards, or both
+ * changed. Three actions:
+ *
+ *   - **Stay logged in** (cancel — default focused, safe option).
+ *   - **Try again** (only when `reason === "serverError"`) — re-runs
+ *     the flush and either closes the modal on success or refreshes
+ *     the list with whatever's still pending.
+ *   - **Sign out anyway** (destructive) — clears account-tied
+ *     localStorage and signs out. The just-discarded changes are
+ *     lost.
+ *
+ * Stays close to the existing `useConfirm` modal styling but uses
+ * its own structured body rather than a single description line.
+ */
+"use client";
+
+import * as AlertDialog from "@radix-ui/react-alert-dialog";
+import { useTranslations } from "next-intl";
+import { type ReactNode } from "react";
+import type {
+    FlushReason,
+    UnsyncedSummary,
+} from "../../data/cardPacksSync";
+
+interface LogoutWarningModalProps {
+    readonly open: boolean;
+    readonly summary: UnsyncedSummary | null;
+    readonly reason: FlushReason | null;
+    readonly retrying: boolean;
+    readonly onStay: () => void;
+    readonly onRetry: () => void;
+    readonly onSignOutAnyway: () => void;
+}
+
+interface SectionProps {
+    readonly heading: string;
+    readonly children: ReactNode;
+}
+
+const Section = ({ heading, children }: SectionProps) => (
+    <section className="mt-4">
+        <h3 className="m-0 text-[13px] font-semibold text-accent">
+            {heading}
+        </h3>
+        <ul className="m-0 mt-2 flex list-none flex-col gap-1 p-0 text-[13px]">
+            {children}
+        </ul>
+    </section>
+);
+
+const Tag = ({ children }: { readonly children: ReactNode }) => (
+    <span className="ml-2 inline-block rounded-[var(--radius-pill,999px)] border border-border px-2 py-px text-[11px] font-semibold text-muted">
+        {children}
+    </span>
+);
+
+export function LogoutWarningModal({
+    open,
+    summary,
+    reason,
+    retrying,
+    onStay,
+    onRetry,
+    onSignOutAnyway,
+}: LogoutWarningModalProps) {
+    const t = useTranslations("account.logoutWarning");
+    const created = summary?.created ?? [];
+    const modified = summary?.modified ?? [];
+    const deleted = summary?.deleted ?? [];
+
+    return (
+        <AlertDialog.Root
+            open={open}
+            onOpenChange={(next) => {
+                if (!next) onStay();
+            }}
+        >
+            <AlertDialog.Portal>
+                <AlertDialog.Overlay className="fixed inset-0 z-[var(--z-dialog-overlay)] bg-black/30" />
+                <AlertDialog.Content
+                    className={
+                        "fixed left-1/2 top-1/2 z-[var(--z-dialog-content)] flex max-h-[85vh] w-[min(92vw,460px)] flex-col " +
+                        "-translate-x-1/2 -translate-y-1/2 overflow-hidden " +
+                        "rounded-[var(--radius)] border border-border bg-panel shadow-[0_10px_28px_rgba(0,0,0,0.28)] " +
+                        "focus:outline-none"
+                    }
+                >
+                    <div className="px-5 pt-5">
+                        <AlertDialog.Title className="m-0 mb-2 font-display text-[18px] text-accent">
+                            {t("title")}
+                        </AlertDialog.Title>
+                        <AlertDialog.Description className="m-0 text-[14px] leading-snug text-[#2a1f12]">
+                            {reason === "offline"
+                                ? t("ledeOffline")
+                                : t("ledeServerError")}
+                        </AlertDialog.Description>
+                    </div>
+                    <div className="flex-1 overflow-y-auto px-5">
+                        {created.length > 0 ? (
+                            <Section
+                                heading={t("createdHeading", {
+                                    count: created.length,
+                                })}
+                            >
+                                {created.map((p) => (
+                                    <li
+                                        key={p.id}
+                                        className="truncate rounded bg-row-alt px-2 py-1"
+                                    >
+                                        {p.label}
+                                    </li>
+                                ))}
+                            </Section>
+                        ) : null}
+                        {modified.length > 0 ? (
+                            <Section
+                                heading={t("modifiedHeading", {
+                                    count: modified.length,
+                                })}
+                            >
+                                {modified.map((p) => (
+                                    <li
+                                        key={p.id}
+                                        className="truncate rounded bg-row-alt px-2 py-1"
+                                    >
+                                        {p.label}
+                                        {p.labelChanged ? (
+                                            <Tag>{t("tagRenamed")}</Tag>
+                                        ) : null}
+                                        {p.cardsChanged ? (
+                                            <Tag>{t("tagCardsChanged")}</Tag>
+                                        ) : null}
+                                    </li>
+                                ))}
+                            </Section>
+                        ) : null}
+                        {deleted.length > 0 ? (
+                            <Section
+                                heading={t("deletedHeading", {
+                                    count: deleted.length,
+                                })}
+                            >
+                                {deleted.map((p) => (
+                                    <li
+                                        key={p.id}
+                                        className="truncate rounded bg-row-alt px-2 py-1"
+                                    >
+                                        {p.label}
+                                    </li>
+                                ))}
+                            </Section>
+                        ) : null}
+                    </div>
+                    <div className="flex flex-wrap justify-end gap-2 px-5 pb-5 pt-4">
+                        <AlertDialog.Cancel asChild>
+                            <button
+                                type="button"
+                                onClick={onStay}
+                                className="cursor-pointer rounded-[var(--radius)] border border-border bg-transparent px-4 py-2 text-[13px] font-semibold text-[#2a1f12] hover:bg-hover"
+                            >
+                                {t("stayLoggedIn")}
+                            </button>
+                        </AlertDialog.Cancel>
+                        {reason === "serverError" ? (
+                            <button
+                                type="button"
+                                onClick={onRetry}
+                                disabled={retrying}
+                                className="cursor-pointer rounded-[var(--radius)] border border-border bg-panel px-4 py-2 text-[13px] font-semibold text-[#2a1f12] hover:bg-hover disabled:opacity-60"
+                            >
+                                {retrying ? t("tryingAgain") : t("tryAgain")}
+                            </button>
+                        ) : null}
+                        <AlertDialog.Action asChild>
+                            <button
+                                type="button"
+                                onClick={onSignOutAnyway}
+                                className="cursor-pointer rounded-[var(--radius)] border border-accent bg-accent px-4 py-2 text-[13px] font-semibold text-white hover:bg-accent-hover"
+                            >
+                                {t("signOutAnyway")}
+                            </button>
+                        </AlertDialog.Action>
+                    </div>
+                </AlertDialog.Content>
+            </AlertDialog.Portal>
+        </AlertDialog.Root>
+    );
+}

--- a/src/ui/components/BottomNav.tsx
+++ b/src/ui/components/BottomNav.tsx
@@ -6,7 +6,6 @@ import { useTranslations } from "next-intl";
 import { ReactNode, useState } from "react";
 import {
     aboutLinkClicked,
-    signOut as signOutEvent,
 } from "../../analytics/events";
 import { describeAction } from "../../logic/describeAction";
 import { routes } from "../../routes";
@@ -19,7 +18,6 @@ import { useTour } from "../tour/TourProvider";
 import { screenKeyForUiMode } from "../tour/screenKey";
 import { AccountAvatar } from "../account/AccountAvatar";
 import { useAccountContext } from "../account/AccountProvider";
-import { authClient } from "../account/authClient";
 import { useShareContext } from "../share/ShareProvider";
 import { useSession } from "../hooks/useSession";
 import { ExternalLinkIcon, RedoIcon, UndoIcon } from "./Icons";
@@ -276,7 +274,7 @@ function BottomOverflowMenu({
     const tourForcesMenuOpen = currentStep?.anchor === "overflow-menu";
     const { installable, openModal: openInstallModal } =
         useInstallPromptContext();
-    const { openModal: openAccountModal } = useAccountContext();
+    const { openModal: openAccountModal, requestSignOut } = useAccountContext();
     const { openInvitePlayer, openContinueOnAnotherDevice } =
         useShareContext();
     const session = useSession();
@@ -290,9 +288,9 @@ function BottomOverflowMenu({
             openAccountModal();
             return;
         }
-        await authClient.signOut();
-        signOutEvent();
-        await session.refetch();
+        // Provider owns the flush-then-warn-then-commit dance, the
+        // `sign_out` event emission, and the session refetch.
+        await requestSignOut();
     };
     return (
         <li>

--- a/src/ui/components/CardPackRow.test.tsx
+++ b/src/ui/components/CardPackRow.test.tsx
@@ -54,6 +54,30 @@ const makeCardSet = (id: string) =>
 const seedCustomPacks = (labels: ReadonlyArray<string>): ReadonlyArray<CustomCardSet> =>
     labels.map(label => saveCustomCardSet(label, makeCardSet(label)));
 
+/**
+ * Type a value into the open `usePrompt` Radix dialog and submit
+ * (or pass `null` to cancel). The "+ Save as card pack" / "+ Save
+ * as new pack" flows used to call `window.prompt`; they now open
+ * the same dialog primitive the rename action does.
+ */
+const submitPromptWith = async (
+    user: ReturnType<typeof userEvent.setup>,
+    value: string | null,
+) => {
+    if (value === null) {
+        const cancelBtn = await screen.findByRole("button", { name: "cancel" });
+        await user.click(cancelBtn);
+        return;
+    }
+    const input = await screen.findByRole("textbox");
+    await user.clear(input);
+    if (value.length > 0) {
+        await user.type(input, value);
+    }
+    const saveBtn = screen.getByRole("button", { name: "save" });
+    await user.click(saveBtn);
+};
+
 const renderRow = () =>
     render(
         <ConfirmProvider>
@@ -625,13 +649,10 @@ describe("CardPackRow save-as-pack activates the new pack", () => {
             document.querySelectorAll("[data-card-pack-active='true']"),
         ).toHaveLength(0);
         // Save the current configuration.
-        const promptSpy = vi
-            .spyOn(window, "prompt")
-            .mockReturnValue("My New Pack");
         await user.click(
             screen.getByRole("button", { name: "saveAsNewCardPack" }),
         );
-        promptSpy.mockRestore();
+        await submitPromptWith(user, "My New Pack");
         // Save should no longer be active.
         expect(
             document.querySelector("[data-card-pack-save-active='true']"),
@@ -647,13 +668,10 @@ describe("CardPackRow save-as-pack activates the new pack", () => {
     test("the saved pack appears on the surface row immediately", async () => {
         const user = userEvent.setup();
         renderRow(); // 2 packs to start (Classic + Master)
-        const promptSpy = vi
-            .spyOn(window, "prompt")
-            .mockReturnValue("Brand New");
         await user.click(
             screen.getByRole("button", { name: "saveAsCardPack" }),
         );
-        promptSpy.mockRestore();
+        await submitPromptWith(user, "Brand New");
         const labels = surfaceLabels();
         expect(labels).toContain("Brand New");
     });
@@ -661,13 +679,10 @@ describe("CardPackRow save-as-pack activates the new pack", () => {
     test("saving records a usage entry for the new pack", async () => {
         const user = userEvent.setup();
         renderRow();
-        const promptSpy = vi
-            .spyOn(window, "prompt")
-            .mockReturnValue("Recorded");
         await user.click(
             screen.getByRole("button", { name: "saveAsCardPack" }),
         );
-        promptSpy.mockRestore();
+        await submitPromptWith(user, "Recorded");
         const usage = JSON.parse(
             window.localStorage.getItem(
                 "effect-clue.card-pack-usage.v1",
@@ -708,13 +723,10 @@ describe("CardPackRow save-as-pack activates the new pack", () => {
             screen.getAllByRole("button", { name: "saveAsNewCardPack" }),
         ).toHaveLength(1);
 
-        const promptSpy = vi
-            .spyOn(window, "prompt")
-            .mockReturnValue("Master Fork");
         await user.click(
             screen.getByRole("button", { name: "saveAsNewCardPack" }),
         );
-        promptSpy.mockRestore();
+        await submitPromptWith(user, "Master Fork");
 
         const presets = JSON.parse(
             window.localStorage.getItem(
@@ -763,13 +775,10 @@ describe("CardPackRow save-as-pack activates the new pack", () => {
         // so it shouldn't pollute the deck-swap analytics funnel.
         const user = userEvent.setup();
         renderRow();
-        const promptSpy = vi
-            .spyOn(window, "prompt")
-            .mockReturnValue("No Analytics");
         await user.click(
             screen.getByRole("button", { name: "saveAsCardPack" }),
         );
-        promptSpy.mockRestore();
+        await submitPromptWith(user, "No Analytics");
         const events = captureCalls.map(c => c.event);
         expect(events).not.toContain("cards_dealt");
         expect(events).not.toContain("card_pack_selected");
@@ -779,11 +788,10 @@ describe("CardPackRow save-as-pack activates the new pack", () => {
         const user = userEvent.setup();
         renderRowWithMutate();
         await user.click(screen.getByTestId("mutate")); // Save now active
-        const promptSpy = vi.spyOn(window, "prompt").mockReturnValue(null);
         await user.click(
             screen.getByRole("button", { name: "saveAsNewCardPack" }),
         );
-        promptSpy.mockRestore();
+        await submitPromptWith(user, null);
         // Save still active; no pack-pill activation.
         expect(
             document.querySelector("[data-card-pack-save-active='true']"),
@@ -794,14 +802,21 @@ describe("CardPackRow save-as-pack activates the new pack", () => {
     });
 
     test("an empty / whitespace-only label is treated as cancel", async () => {
+        // The Save button in `usePrompt` is disabled when the
+        // trimmed input is empty, so cancelling is the only path
+        // out — exactly the behavior this test pins.
         const user = userEvent.setup();
         renderRowWithMutate();
         await user.click(screen.getByTestId("mutate"));
-        const promptSpy = vi.spyOn(window, "prompt").mockReturnValue("   ");
         await user.click(
             screen.getByRole("button", { name: "saveAsNewCardPack" }),
         );
-        promptSpy.mockRestore();
+        const input = await screen.findByRole("textbox");
+        await user.clear(input);
+        await user.type(input, "   ");
+        const saveBtn = screen.getByRole("button", { name: "save" });
+        expect(saveBtn).toBeDisabled();
+        await user.click(screen.getByRole("button", { name: "cancel" }));
         // Nothing was saved; Save pill stays active.
         const presets = JSON.parse(
             window.localStorage.getItem(

--- a/src/ui/components/CardPackRow.tsx
+++ b/src/ui/components/CardPackRow.tsx
@@ -22,11 +22,9 @@ import {
 } from "../../data/cardPackUsage";
 import { CARD_SETS } from "../../logic/GameSetup";
 import { CustomCardSet } from "../../logic/CustomCardSets";
-import {
-    useCustomCardPacks,
-    useSaveCardPack,
-} from "../../data/customCardPacks";
+import { useCustomCardPacks } from "../../data/customCardPacks";
 import { useConfirm } from "../hooks/useConfirm";
+import { usePrompt } from "../hooks/usePrompt";
 import { useClue } from "../state";
 import { CardPackPicker, type PickerPack } from "./CardPackPicker";
 import { PencilIcon, SearchIcon, TrashIcon } from "./Icons";
@@ -107,10 +105,11 @@ export function CardPackRow() {
     const usageQuery = useCardPackUsage();
     const customPacks = customPacksQuery.data ?? [];
     const usage = usageQuery.data ?? new Map();
-    const savePackMutation = useSaveCardPack();
     const recordUseMutation = useRecordCardPackUse();
     const forgetUseMutation = useForgetCardPackUse();
     const cardPackActions = useCardPackActions();
+    const prompt = usePrompt();
+    const tCommon = useTranslations("common");
     const [pickerOpen, setPickerOpen] = useState(false);
 
     // The Classic id is the first entry in CARD_SETS and is the
@@ -281,7 +280,7 @@ export function CardPackRow() {
         // same as the loaded pack (no prompt) so "Update MyDeck"
         // doesn't surprise the user with a label-rename dialog.
         if (canUpdateLoadedPack && loadedCustomPack !== undefined) {
-            const updated = await savePackMutation.mutateAsync({
+            const updated = await cardPackActions.savePack({
                 label: loadedCustomPack.label,
                 cardSet: setup.cardSet,
                 existingId: loadedCustomPack.id,
@@ -289,9 +288,14 @@ export function CardPackRow() {
             recordUseMutation.mutate(updated.id);
             return;
         }
-        const label = window.prompt(t("saveAsCardPackPrompt"));
-        if (!label || !label.trim()) return;
-        const newPack = await savePackMutation.mutateAsync({
+        const label = await prompt({
+            title: t("saveAsCardPackDialogTitle"),
+            label: t("saveAsCardPackInputLabel"),
+            initialValue: "",
+            confirmLabel: tCommon("save"),
+        });
+        if (label === null || label.trim().length === 0) return;
+        const newPack = await cardPackActions.savePack({
             label: label.trim(),
             cardSet: setup.cardSet,
         });
@@ -310,9 +314,14 @@ export function CardPackRow() {
      * `existingId`).
      */
     const onSaveAsNewCardSet = async () => {
-        const label = window.prompt(t("saveAsCardPackPrompt"));
-        if (!label || !label.trim()) return;
-        const newPack = await savePackMutation.mutateAsync({
+        const label = await prompt({
+            title: t("saveAsCardPackDialogTitle"),
+            label: t("saveAsCardPackInputLabel"),
+            initialValue: "",
+            confirmLabel: tCommon("save"),
+        });
+        if (label === null || label.trim().length === 0) return;
+        const newPack = await cardPackActions.savePack({
             label: label.trim(),
             cardSet: setup.cardSet,
         });

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -4,7 +4,6 @@ import { useTranslations } from "next-intl";
 import {
     aboutLinkClicked,
     gameSetupStarted,
-    signOut as signOutEvent,
 } from "../../analytics/events";
 import { startSetup } from "../../analytics/gameSession";
 import { describeAction } from "../../logic/describeAction";
@@ -17,7 +16,6 @@ import { useTour } from "../tour/TourProvider";
 import { screenKeyForUiMode } from "../tour/screenKey";
 import { AccountAvatar } from "../account/AccountAvatar";
 import { useAccountContext } from "../account/AccountProvider";
-import { authClient } from "../account/authClient";
 import { useShareContext } from "../share/ShareProvider";
 import { useSession } from "../hooks/useSession";
 import { ExternalLinkIcon, RedoIcon, UndoIcon } from "./Icons";
@@ -96,7 +94,7 @@ export function Toolbar() {
     const tourForcesMenuOpen = currentStep?.anchor === "overflow-menu";
     const { installable, openModal: openInstallModal } =
         useInstallPromptContext();
-    const { openModal: openAccountModal } = useAccountContext();
+    const { openModal: openAccountModal, requestSignOut } = useAccountContext();
     const { openInvitePlayer, openContinueOnAnotherDevice } =
         useShareContext();
     const session = useSession();
@@ -110,9 +108,9 @@ export function Toolbar() {
             openAccountModal();
             return;
         }
-        await authClient.signOut();
-        signOutEvent();
-        await session.refetch();
+        // Provider owns the flush-then-warn-then-commit dance, the
+        // `sign_out` event emission, and the session refetch.
+        await requestSignOut();
     };
 
     const undoTooltip = nextUndo

--- a/src/ui/components/cardPackActions.test.tsx
+++ b/src/ui/components/cardPackActions.test.tsx
@@ -1,0 +1,406 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+    QueryClient,
+    QueryClientProvider,
+} from "@tanstack/react-query";
+import { render } from "@testing-library/react";
+
+vi.mock("next-intl", () => {
+    const make = (ns: string) =>
+        (key: string, values?: Record<string, unknown>): string => {
+            const fq = ns.length > 0 ? `${ns}.${key}` : key;
+            return values ? `${fq}:${JSON.stringify(values)}` : fq;
+        };
+    return {
+        useTranslations: (ns?: string) => make(ns ?? ""),
+    };
+});
+
+// Mocks for the four mutation hooks. Each returns an object with
+// `mutate`, `mutateAsync` so the orchestrator can drive them. We
+// set the function bodies per-test.
+const saveLocalMutate = vi.fn();
+const saveLocalMutateAsync = vi.fn();
+const deleteLocalMutate = vi.fn();
+const saveServerMutate = vi.fn();
+const deleteServerMutate = vi.fn();
+let signedInUserId: string | undefined = undefined;
+
+vi.mock("../../data/customCardPacks", async () => {
+    const actual = await vi.importActual<
+        typeof import("../../data/customCardPacks")
+    >("../../data/customCardPacks");
+    return {
+        ...actual,
+        useSaveCardPack: () => ({
+            mutate: saveLocalMutate,
+            mutateAsync: saveLocalMutateAsync,
+        }),
+        useDeleteCardPack: () => ({
+            mutate: deleteLocalMutate,
+        }),
+        useSaveCardPackOnServer: () => ({
+            mutate: saveServerMutate,
+        }),
+        useDeleteCardPackOnServer: () => ({
+            mutate: deleteServerMutate,
+        }),
+        useSignedInUserId: () => signedInUserId,
+    };
+});
+
+let confirmAnswer: boolean | (() => boolean) = true;
+vi.mock("../hooks/useConfirm", () => ({
+    useConfirm: () => async () =>
+        typeof confirmAnswer === "function" ? confirmAnswer() : confirmAnswer,
+}));
+
+let promptAnswer: string | null = "New Label";
+vi.mock("../hooks/usePrompt", () => ({
+    usePrompt: () => async () => promptAnswer,
+}));
+
+const openShareCardPackMock = vi.fn();
+vi.mock("../share/ShareProvider", () => ({
+    useShareContext: () => ({
+        openShareCardPack: (opts: unknown) => openShareCardPackMock(opts),
+        openInvitePlayer: vi.fn(),
+        openContinueOnAnotherDevice: vi.fn(),
+        open: false,
+    }),
+}));
+
+const addTombstoneMock = vi.fn();
+vi.mock("../../logic/CardPackTombstones", () => ({
+    addTombstone: (entry: unknown) => addTombstoneMock(entry),
+    loadTombstones: () => [],
+    clearTombstones: vi.fn(),
+    clearAllTombstones: vi.fn(),
+}));
+
+import {
+    customCardPacksQueryKey,
+    myCardPacksQueryKey,
+} from "../../data/customCardPacks";
+import { CardSet } from "../../logic/CardSet";
+import { Card, CardCategory } from "../../logic/GameObjects";
+import { CardEntry, Category } from "../../logic/GameSetup";
+import type { CustomCardSet } from "../../logic/CustomCardSets";
+import type { PersistedCardPack } from "../../server/actions/packs";
+import { useCardPackActions } from "./cardPackActions";
+
+const makeCardSet = (cardName: string): CardSet =>
+    CardSet({
+        categories: [
+            Category({
+                id: CardCategory(`cat-${cardName}`),
+                name: "Stuff",
+                cards: [
+                    CardEntry({ id: Card(`card-${cardName}`), name: cardName }),
+                ],
+            }),
+        ],
+    });
+
+const localPackOf = (
+    id: string,
+    label: string,
+    overrides: Partial<CustomCardSet> = {},
+): CustomCardSet => ({
+    id,
+    label,
+    cardSet: makeCardSet(label),
+    ...overrides,
+});
+
+const serverPackOf = (
+    id: string,
+    clientGeneratedId: string,
+    label: string,
+): PersistedCardPack => ({
+    id,
+    clientGeneratedId,
+    label,
+    cardSetData: JSON.stringify(makeCardSet(label)),
+});
+
+let actionsRef: ReturnType<typeof useCardPackActions> | undefined;
+
+const Capture = () => {
+    actionsRef = useCardPackActions();
+    return null;
+};
+
+const renderWithSeed = (
+    locals: ReadonlyArray<CustomCardSet>,
+    serverPacks: ReadonlyArray<PersistedCardPack>,
+) => {
+    const client = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false, staleTime: Infinity, gcTime: Infinity },
+            mutations: { retry: false },
+        },
+    });
+    client.setQueryData(customCardPacksQueryKey, locals);
+    client.setQueryData(myCardPacksQueryKey(signedInUserId), serverPacks);
+    return render(
+        <QueryClientProvider client={client}>
+            <Capture />
+        </QueryClientProvider>,
+    );
+};
+
+const flush = () => new Promise(r => setTimeout(r, 0));
+
+beforeEach(() => {
+    saveLocalMutate.mockReset();
+    saveLocalMutateAsync.mockReset();
+    deleteLocalMutate.mockReset();
+    saveServerMutate.mockReset();
+    deleteServerMutate.mockReset();
+    addTombstoneMock.mockReset();
+    openShareCardPackMock.mockReset();
+    confirmAnswer = true;
+    promptAnswer = "New Label";
+    signedInUserId = undefined;
+    actionsRef = undefined;
+});
+
+afterEach(() => {
+    actionsRef = undefined;
+});
+
+describe("useCardPackActions.savePack", () => {
+    test("signed out → only saveLocal fires", async () => {
+        signedInUserId = undefined;
+        const localPack = localPackOf("custom-1", "Office");
+        saveLocalMutateAsync.mockResolvedValue(localPack);
+        renderWithSeed([], []);
+        await actionsRef!.savePack({
+            label: "Office",
+            cardSet: makeCardSet("Office"),
+        });
+        expect(saveLocalMutateAsync).toHaveBeenCalledTimes(1);
+        expect(saveServerMutate).not.toHaveBeenCalled();
+    });
+
+    test("signed in → saveLocal AND saveServer fire", async () => {
+        signedInUserId = "alice";
+        const localPack = localPackOf("custom-1", "Office");
+        saveLocalMutateAsync.mockResolvedValue(localPack);
+        renderWithSeed([], []);
+        const result = await actionsRef!.savePack({
+            label: "Office",
+            cardSet: makeCardSet("Office"),
+        });
+        expect(saveLocalMutateAsync).toHaveBeenCalledTimes(1);
+        expect(saveServerMutate).toHaveBeenCalledTimes(1);
+        // saveServer receives the LOCAL pack's id as clientGeneratedId.
+        expect(saveServerMutate.mock.calls[0]?.[0]).toMatchObject({
+            clientGeneratedId: "custom-1",
+            label: "Office",
+        });
+        expect(result.id).toBe("custom-1");
+    });
+});
+
+describe("useCardPackActions.renamePack", () => {
+    const target = {
+        clientGeneratedId: "custom-1",
+        label: "Office",
+        cardSet: makeCardSet("Office"),
+    };
+
+    test("user cancels prompt → no mutations", async () => {
+        promptAnswer = null;
+        renderWithSeed(
+            [localPackOf("custom-1", "Office")],
+            [],
+        );
+        const result = await actionsRef!.renamePack(target);
+        expect(result).toBe(false);
+        expect(saveLocalMutate).not.toHaveBeenCalled();
+        expect(saveServerMutate).not.toHaveBeenCalled();
+    });
+
+    test("user submits same label → no mutations", async () => {
+        promptAnswer = "Office";
+        renderWithSeed(
+            [localPackOf("custom-1", "Office")],
+            [],
+        );
+        const result = await actionsRef!.renamePack(target);
+        expect(result).toBe(false);
+        expect(saveLocalMutate).not.toHaveBeenCalled();
+    });
+
+    test("local match + signed out → only saveLocal fires", async () => {
+        signedInUserId = undefined;
+        promptAnswer = "Office Edition";
+        renderWithSeed(
+            [localPackOf("custom-1", "Office")],
+            [],
+        );
+        await actionsRef!.renamePack(target);
+        expect(saveLocalMutate).toHaveBeenCalledTimes(1);
+        expect(saveLocalMutate.mock.calls[0]?.[0]).toMatchObject({
+            label: "Office Edition",
+            existingId: "custom-1",
+        });
+        expect(saveServerMutate).not.toHaveBeenCalled();
+    });
+
+    test("local match + signed in → saveLocal AND saveServer fire", async () => {
+        signedInUserId = "alice";
+        promptAnswer = "Office Edition";
+        renderWithSeed(
+            [localPackOf("custom-1", "Office")],
+            [],
+        );
+        await actionsRef!.renamePack(target);
+        expect(saveLocalMutate).toHaveBeenCalledTimes(1);
+        expect(saveServerMutate).toHaveBeenCalledTimes(1);
+        expect(saveServerMutate.mock.calls[0]?.[0]).toMatchObject({
+            clientGeneratedId: "custom-1",
+            label: "Office Edition",
+        });
+    });
+
+    test("server-only (no local match) + signed in → only saveServer fires", async () => {
+        signedInUserId = "alice";
+        promptAnswer = "Office Edition";
+        renderWithSeed(
+            [],
+            [serverPackOf("srv-1", "custom-1", "Office")],
+        );
+        await actionsRef!.renamePack(target);
+        expect(saveLocalMutate).not.toHaveBeenCalled();
+        expect(saveServerMutate).toHaveBeenCalledTimes(1);
+    });
+
+    test("post-reconcile findLocal walks via server cache to find local pack", async () => {
+        // Local pack's `id` was swapped to the server's id by
+        // `markPackSynced`, so direct cgid match against local fails.
+        // The orchestrator should fall back to the server cache lookup
+        // and use that to find the local entry by server id.
+        signedInUserId = "alice";
+        promptAnswer = "Office Edition";
+        renderWithSeed(
+            [localPackOf("srv-1", "Office")], // post-swap: local id = server id
+            [serverPackOf("srv-1", "custom-1", "Office")],
+        );
+        await actionsRef!.renamePack(target);
+        // saveLocal called with existingId = the local pack's id (post-swap).
+        expect(saveLocalMutate).toHaveBeenCalledTimes(1);
+        expect(saveLocalMutate.mock.calls[0]?.[0]).toMatchObject({
+            existingId: "srv-1",
+        });
+        // saveServer called with the cgid (the wire-format-stable id).
+        expect(saveServerMutate.mock.calls[0]?.[0]).toMatchObject({
+            clientGeneratedId: "custom-1",
+        });
+    });
+});
+
+describe("useCardPackActions.deletePack", () => {
+    const target = {
+        clientGeneratedId: "custom-1",
+        label: "Office",
+        cardSet: makeCardSet("Office"),
+    };
+
+    test("user cancels confirm → no mutations", async () => {
+        confirmAnswer = false;
+        renderWithSeed(
+            [localPackOf("custom-1", "Office")],
+            [],
+        );
+        const result = await actionsRef!.deletePack(target);
+        expect(result).toBe(false);
+        expect(deleteLocalMutate).not.toHaveBeenCalled();
+        expect(deleteServerMutate).not.toHaveBeenCalled();
+        expect(addTombstoneMock).not.toHaveBeenCalled();
+    });
+
+    test("local match + signed out → only deleteLocal fires; no tombstone", async () => {
+        signedInUserId = undefined;
+        renderWithSeed(
+            [localPackOf("custom-1", "Office")],
+            [],
+        );
+        await actionsRef!.deletePack(target);
+        expect(deleteLocalMutate).toHaveBeenCalledWith("custom-1");
+        expect(deleteServerMutate).not.toHaveBeenCalled();
+        expect(addTombstoneMock).not.toHaveBeenCalled();
+    });
+
+    test("synced pack + signed in → tombstone + deleteLocal + deleteServer (with server id)", async () => {
+        signedInUserId = "alice";
+        renderWithSeed(
+            [
+                localPackOf("srv-1", "Office", {
+                    lastSyncedSnapshot: {
+                        label: "Office",
+                        cardSet: makeCardSet("Office"),
+                    },
+                }),
+            ],
+            [serverPackOf("srv-1", "custom-1", "Office")],
+        );
+        await actionsRef!.deletePack(target);
+        expect(addTombstoneMock).toHaveBeenCalledTimes(1);
+        expect(addTombstoneMock.mock.calls[0]?.[0]).toMatchObject({
+            id: "srv-1",
+            label: "Office",
+        });
+        expect(deleteLocalMutate).toHaveBeenCalledWith("srv-1");
+        // Server delete keys by the server's id (not the cgid).
+        expect(deleteServerMutate).toHaveBeenCalledWith("srv-1");
+    });
+
+    test("local-only-no-server-presence + signed in + no serverMatch → no tombstone, no server call", async () => {
+        signedInUserId = "alice";
+        renderWithSeed(
+            [localPackOf("custom-1", "Office")], // no lastSyncedSnapshot
+            [], // server doesn't have it
+        );
+        await actionsRef!.deletePack(target);
+        expect(addTombstoneMock).not.toHaveBeenCalled();
+        expect(deleteLocalMutate).toHaveBeenCalledWith("custom-1");
+        expect(deleteServerMutate).not.toHaveBeenCalled();
+    });
+
+    test("server-only + signed in → no local delete; deleteServer fires with serverMatch.id", async () => {
+        signedInUserId = "alice";
+        renderWithSeed(
+            [],
+            [serverPackOf("srv-1", "custom-1", "Office")],
+        );
+        await actionsRef!.deletePack(target);
+        // No local entry to remove, so no localDelete.
+        expect(deleteLocalMutate).not.toHaveBeenCalled();
+        expect(deleteServerMutate).toHaveBeenCalledWith("srv-1");
+        // Tombstone fires (signed in + server presence) — covers
+        // the race where a refetch could resurrect the deleted pack.
+        expect(addTombstoneMock).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("useCardPackActions.sharePack", () => {
+    test("calls openShareCardPack with the pack's cardSet and label", async () => {
+        renderWithSeed([], []);
+        actionsRef!.sharePack({
+            clientGeneratedId: "custom-1",
+            label: "Office",
+            cardSet: makeCardSet("Office"),
+        });
+        await flush();
+        expect(openShareCardPackMock).toHaveBeenCalledTimes(1);
+        const opts = openShareCardPackMock.mock.calls[0]?.[0] as {
+            packLabel: string;
+            forcedCardPack: { categories: ReadonlyArray<unknown> };
+        };
+        expect(opts.packLabel).toBe("Office");
+        expect(opts.forcedCardPack.categories).toHaveLength(1);
+    });
+});

--- a/src/ui/components/cardPackActions.ts
+++ b/src/ui/components/cardPackActions.ts
@@ -1,30 +1,33 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
+import { DateTime } from "effect";
 import { useTranslations } from "next-intl";
 import { useCallback } from "react";
 import {
     customCardPacksQueryKey,
+    myCardPacksQueryKey,
     useDeleteCardPack,
     useDeleteCardPackOnServer,
     useSaveCardPack,
     useSaveCardPackOnServer,
+    useSignedInUserId,
 } from "../../data/customCardPacks";
+import { addTombstone } from "../../logic/CardPackTombstones";
 import type { CardSet } from "../../logic/CardSet";
 import type { CustomCardSet } from "../../logic/CustomCardSets";
 import type { PersistedCardPack } from "../../server/actions/packs";
-import { myCardPacksQueryKey } from "../account/AccountModal";
 import { useConfirm } from "../hooks/useConfirm";
 import { usePrompt } from "../hooks/usePrompt";
-import { useSession } from "../hooks/useSession";
 import { useShareContext } from "../share/ShareProvider";
 
 /**
  * Minimal addressable handle for a card pack. `clientGeneratedId` is
- * the localStorage id (and the cross-device-stable identity used to
- * key against the server's `client_generated_id` column). Callers
- * pass this from whichever shape they have on hand — `CustomCardSet`,
- * the `DisplayPack` from the AccountModal, or a Setup-pill `DisplayPack`.
+ * the cross-device-stable identity (the server's
+ * `client_generated_id` column). The local pack's `id` may differ
+ * post-reconcile (it gets swapped to the server's id), so the
+ * orchestrator looks up the local entry by EITHER its `id` or
+ * `clientGeneratedId` to find a match.
  */
 interface CardPackActionTarget {
     readonly clientGeneratedId: string;
@@ -32,33 +35,51 @@ interface CardPackActionTarget {
     readonly cardSet: CardSet;
 }
 
+interface SavePackInput {
+    readonly label: string;
+    readonly cardSet: CardSet;
+    /**
+     * When provided and matches an existing pack's id, updates that
+     * pack in place. When absent, creates a new pack.
+     */
+    readonly existingId?: string;
+}
+
 interface CardPackActions {
+    /**
+     * Single-call entry point for both "+ Save as card pack" (no
+     * `existingId`) and "Update {label}" (with `existingId`). Writes
+     * to localStorage first; when signed in, also fires the server
+     * UPSERT. Returns the freshly-saved local pack.
+     */
+    readonly savePack: (input: SavePackInput) => Promise<CustomCardSet>;
     readonly sharePack: (pack: CardPackActionTarget) => void;
     readonly renamePack: (pack: CardPackActionTarget) => Promise<boolean>;
     readonly deletePack: (pack: CardPackActionTarget) => Promise<boolean>;
 }
 
 /**
- * Shared share/rename/delete handlers for a saved card pack. The
- * AccountModal, the Setup-pill row, and the All-card-packs picker all
- * route through this hook so the three surfaces stay in lock-step
- * — same prompt copy, same confirm flow, same local + server mirroring.
+ * Shared share / rename / delete / save handlers for a saved card
+ * pack. The AccountModal, the Setup-pill row, and the All-card-packs
+ * picker all route through this hook so the three surfaces stay in
+ * lock-step — same prompt copy, same confirm flow, same local +
+ * server mirroring.
  *
- * Server-side mirroring is opportunistic: when a matching entry
- * exists in the `myCardPacksQueryKey` cache (i.e. the user is signed
- * in and the pack has been synced), the rename / delete also writes
- * to the server. For local-only packs, only the local mutation runs.
- * Local-side mirroring is similarly conditional — when the `clientGeneratedId`
- * isn't in the localStorage cache (server-only pack viewed in the
- * modal before sign-in reconciliation), the local mutation is
- * skipped to avoid creating a duplicate row with a fresh local id.
+ * Local hooks (`useSaveCardPack` / `useDeleteCardPack`) handle
+ * localStorage; server hooks (`useSaveCardPackOnServer` /
+ * `useDeleteCardPackOnServer`) handle the server row, and on success
+ * reach back to update the local pack's `lastSyncedSnapshot` /
+ * tombstone state. This orchestrator wires them together based on
+ * cache state — call local when there's a local match, call server
+ * when the user is signed in. The server-write hook's `onSuccess`
+ * carries all of the metadata bookkeeping (id swap, snapshot
+ * refresh, tombstone clear) so callers don't have to think about it.
  */
 export function useCardPackActions(): CardPackActions {
     const tCommon = useTranslations("common");
     const tAccount = useTranslations("account");
     const queryClient = useQueryClient();
-    const session = useSession();
-    const userId = session.data?.user.id;
+    const userId = useSignedInUserId();
     const confirm = useConfirm();
     const prompt = usePrompt();
     const { openShareCardPack } = useShareContext();
@@ -67,28 +88,50 @@ export function useCardPackActions(): CardPackActions {
     const saveServer = useSaveCardPackOnServer();
     const deleteServer = useDeleteCardPackOnServer();
 
-    const findLocal = useCallback(
-        (clientGeneratedId: string): CustomCardSet | undefined => {
-            const local =
-                queryClient.getQueryData<ReadonlyArray<CustomCardSet>>(
-                    customCardPacksQueryKey,
-                );
-            return local?.find((p) => p.id === clientGeneratedId);
-        },
-        [queryClient],
-    );
-
     const findServer = useCallback(
-        (clientGeneratedId: string): PersistedCardPack | undefined => {
+        (target: CardPackActionTarget): PersistedCardPack | undefined => {
             const server =
                 queryClient.getQueryData<ReadonlyArray<PersistedCardPack>>(
                     myCardPacksQueryKey(userId),
                 );
             return server?.find(
-                (p) => p.clientGeneratedId === clientGeneratedId,
+                (p) =>
+                    p.clientGeneratedId === target.clientGeneratedId ||
+                    p.id === target.clientGeneratedId,
             );
         },
         [queryClient, userId],
+    );
+
+    /**
+     * Find a local pack by its `clientGeneratedId`. Two cases to
+     * cover:
+     *
+     *   1. Pre-reconcile: the local pack's `id` equals its cgid
+     *      (that's how `saveCustomCardSet` mints them). Direct match.
+     *   2. Post-reconcile: `markPackSynced` swapped the local `id`
+     *      to the server's cuid2. The cgid lives on the server row;
+     *      we look it up via the `myCardPacksQueryKey` cache and
+     *      then find the local pack by the corresponding server id.
+     */
+    const findLocal = useCallback(
+        (target: CardPackActionTarget): CustomCardSet | undefined => {
+            const local =
+                queryClient.getQueryData<ReadonlyArray<CustomCardSet>>(
+                    customCardPacksQueryKey,
+                );
+            if (local === undefined) return undefined;
+            const directMatch = local.find(
+                (p) => p.id === target.clientGeneratedId,
+            );
+            if (directMatch !== undefined) return directMatch;
+            const serverMatch = findServer(target);
+            if (serverMatch !== undefined) {
+                return local.find((p) => p.id === serverMatch.id);
+            }
+            return undefined;
+        },
+        [queryClient, findServer],
     );
 
     const sharePack = useCallback<CardPackActions["sharePack"]>(
@@ -99,6 +142,21 @@ export function useCardPackActions(): CardPackActions {
             });
         },
         [openShareCardPack],
+    );
+
+    const savePack = useCallback<CardPackActions["savePack"]>(
+        async (input) => {
+            const localPack = await saveLocal.mutateAsync(input);
+            if (userId !== undefined) {
+                saveServer.mutate({
+                    clientGeneratedId: localPack.id,
+                    label: localPack.label,
+                    cardSet: localPack.cardSet,
+                });
+            }
+            return localPack;
+        },
+        [saveLocal, saveServer, userId],
     );
 
     const renamePack = useCallback<CardPackActions["renamePack"]>(
@@ -113,17 +171,21 @@ export function useCardPackActions(): CardPackActions {
             const trimmed = next.trim();
             if (trimmed.length === 0 || trimmed === pack.label) return false;
 
-            const localMatch = findLocal(pack.clientGeneratedId);
+            const localMatch = findLocal(pack);
             if (localMatch !== undefined) {
                 saveLocal.mutate({
                     label: trimmed,
                     cardSet: pack.cardSet,
-                    existingId: pack.clientGeneratedId,
+                    existingId: localMatch.id,
                 });
             }
-
-            const serverMatch = findServer(pack.clientGeneratedId);
-            if (serverMatch !== undefined) {
+            // Always push to the server when signed in. The server
+            // action is idempotent on `(owner_id,
+            // client_generated_id)` — if the row already exists,
+            // it's an UPDATE; if not, an INSERT. Covers both the
+            // "synced pack rename" and "server-only pack rename"
+            // cases without a separate fallback branch.
+            if (userId !== undefined) {
                 saveServer.mutate({
                     clientGeneratedId: pack.clientGeneratedId,
                     label: trimmed,
@@ -137,9 +199,9 @@ export function useCardPackActions(): CardPackActions {
             tAccount,
             tCommon,
             findLocal,
-            findServer,
             saveLocal,
             saveServer,
+            userId,
         ],
     );
 
@@ -150,12 +212,30 @@ export function useCardPackActions(): CardPackActions {
             });
             if (!ok) return false;
 
-            const localMatch = findLocal(pack.clientGeneratedId);
-            if (localMatch !== undefined) {
-                deleteLocal.mutate(pack.clientGeneratedId);
+            const localMatch = findLocal(pack);
+            const serverMatch = findServer(pack);
+
+            // Tombstone first (when there's any chance the server
+            // has the pack) so a refetch racing the delete doesn't
+            // resurrect it. The server-side delete's `onSuccess`
+            // clears the tombstone.
+            if (
+                userId !== undefined &&
+                (serverMatch !== undefined || localMatch?.lastSyncedSnapshot !== undefined)
+            ) {
+                addTombstone({
+                    id: localMatch?.id ?? pack.clientGeneratedId,
+                    label: pack.label,
+                    deletedAt: DateTime.nowUnsafe(),
+                });
             }
-            const serverMatch = findServer(pack.clientGeneratedId);
-            if (serverMatch !== undefined) {
+
+            if (localMatch !== undefined) {
+                deleteLocal.mutate(localMatch.id);
+            }
+            if (userId !== undefined && serverMatch !== undefined) {
+                // Use the server's `id` so the delete keys cleanly
+                // even when the local pack's id has been swapped.
                 deleteServer.mutate(serverMatch.id);
             }
             return true;
@@ -167,8 +247,9 @@ export function useCardPackActions(): CardPackActions {
             findServer,
             deleteLocal,
             deleteServer,
+            userId,
         ],
     );
 
-    return { sharePack, renamePack, deletePack };
+    return { savePack, sharePack, renamePack, deletePack };
 }


### PR DESCRIPTION
## Summary

Three previously-broken card-pack sync flows now work for signed-in users:

- **Create on Device A → Device B sees it.** Packs created or edited while signed in sync to the account immediately. Device B picks them up on its next mount or window-focus, not just sign-in.
- **Anonymous create → sign in → Device B.** Anonymous-era packs upload on the sign-in transition, then propagate to other devices the same way.
- **Two devices each holding offline packs → both sign in → union.** Both devices end up with the union of their libraries after the focus refetches converge.

Plus a new logout invariant: once signed in, packs are tied to your account, not the device. Sign out clears them from the device. **If you have unsynced edits the server hasn't seen yet, a warning modal lists what would be lost** — created packs, modified packs (with `renamed` / `cards changed` tags), and packs whose deletion hasn't been confirmed. Pick `Stay logged in`, `Try again`, or `Sign out anyway`.

Game state, splash dismissal, tour gates, and the install-prompt state are deliberately preserved across sign-out — they aren't account-tied.

## Architecture

- **Per-pack metadata** (additive to `effect-clue.custom-presets.v1`): `unsyncedSince: DateTime` on every signed-in mutation, cleared by a server roundtrip; `lastSyncedSnapshot: { label, cardSet }` is the server's last-known view, never mutated by local edits, used as a stable diff baseline.
- **Tombstones** (`effect-clue.deleted-packs.v1`) record unsynced deletes so a refetch racing the delete can't resurrect the pack.
- **Continuous reconcile**: `<CardPacksSync />` owns a React Query for `getMyCardPacks` (refetch on mount / focus / reconnect, 30s `staleTime`). Every settle drains in-flight, flushes tombstones, runs `reconcileCardPacks`, writes the merged result back. Conflict resolution: local-wins when `unsyncedSince` is set (preserve offline edit), server-wins otherwise (rename-on-push, other-device update).
- **Hook architecture** splits along the local-vs-server axis. `useSaveCardPack` / `useDeleteCardPack` are pure-local. `useSaveCardPackOnServer.onSuccess` does all the post-server-write bookkeeping (id swap, snapshot refresh, tombstone clear, both query caches refresh). `useCardPackActions` is the single decision point for share / rename / delete / save flows.
- **Logout chokepoint** `requestSignOut` (in `AccountProvider`) calls `flushPendingChanges()` first. On `ok`: clear three account-tied localStorage keys, sign out, emit analytics. On not-ok: open `LogoutWarningModal` with per-pack created / modified / deleted sections.

## Documentation

Two docs cover how user data leaves the device:

- **[`docs/shares-and-sync.md`](docs/shares-and-sync.md)** (renamed from `docs/shares.md`) — sharing UX, the kind-discriminated wire contract, the seven Effect-Schema-validated wire fields including the new transfer-only hypotheses field. Plus a "Card-pack sync (separate from sharing)" section cross-referencing the deep-dive doc.
- **[`docs/card-pack-sync.md`](docs/card-pack-sync.md)** (new) — architecture deep dive: the four-quadrant `unsyncedSince` × `lastSyncedSnapshot` matrix, tombstones, hook architecture, continuous reconcile, sign-in transition push, logout flow, edge cases, canonical storage-keys table, and **four "life of a card pack" timelines** walking the full state machine for each broken sync flow + the offline-edits-then-logout warning flow.
- **[`AGENTS.md` / `CLAUDE.md`](AGENTS.md)** — new "Sharing and sync docs" section makes updating both docs a hard requirement when touching the listed code paths. The "Rebasing" workflow gets a step 10 requiring a structured post-rebase status report.

## Test plan

Pre-commit (all green):
- [ ] `pnpm typecheck`
- [ ] `pnpm lint`
- [ ] `pnpm test` — 1209 passed (+78 from the start of this work; **99 card-pack-sync-related tests**: schema/persistence 24, tombstones 9, reconcile 12, flush 10, modal 12, prompt 4, requestSignOut orchestration 7, useCardPackActions decisions 14, drainInFlight registry 7).
- [ ] `pnpm knip`
- [ ] `pnpm i18n:check`

Manual verification in the Vercel preview build (please walk these — they were partially blocked locally by a pre-existing Effect SQL + Next.js dev-mode `saveCardPack` 500 that the preview build won't hit):

- [ ] **Flow 1**: sign in on Device A. Save a pack. Sign in on Device B. Open Account modal — pack appears.
- [ ] **Flow 2**: sign out everywhere. On A: save a pack. Sign in on A. Sign in on B. Pack appears.
- [ ] **Flow 3**: sign out on both. A: save "Hall". B: save "Library". Sign in on A first; immediately on B. Focus each tab — both packs visible everywhere after the focus refetches converge.
- [ ] **Logout, online, all synced**: save a pack → wait for sync → sign out → no warning.
- [ ] **Logout, offline, unsynced creates**: sign in → DevTools Offline → save a pack → sign out → modal shows it under "Created". Stay logged in → modal closes, pack still in localStorage.
- [ ] **Logout, offline, modified pack**: edit a synced pack offline → sign out → modal shows it under "Modified" with `renamed` and/or `cards changed` tags.
- [ ] **Sign out anyway**: trigger any unsynced state → click Sign out anyway → `effect-clue.custom-presets.v1` / `effect-clue.deleted-packs.v1` / `effect-clue.card-pack-usage.v1` cleared; session / splash / tour / install-prompt keys intact.
- [ ] **Modal pack-actions**: AccountModal's per-pack Edit (rename) / Share / Delete buttons round-trip end-to-end. Setup-pane pill rename and delete go through the same orchestrator.
- [ ] **`+ Save as card pack`**: opens the new Radix dialog (replacing `window.prompt`), accepts a label, persists, shows up as the active pill.
- [ ] **Both Toolbar AND BottomNav sign-out paths** trigger the same chokepoint (resize between desktop ≥800px and mobile <800px to test both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)