### PR TITLE
Fix Checklist sticky-header z-index so the thead stacks above the first column

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -122,19 +122,25 @@
      *
      * Ordering constraints:
      * - Checklist hover/focus rings sit above neighboring body cells,
-     *   but below sticky first-column cells and sticky headers.
+     *   but below every sticky tier.
      * - Sticky body first-column cells (row headers — card category
-     *   and card names) sit highest so they render over any content
-     *   cells they pass during horizontal scroll.
-     * - Sticky table headers (column headers — player names and hand
-     *   sizes) sit in the middle so non-corner header cells render
-     *   over the top-left cell as they slide left during horizontal
-     *   scroll. Non-corner header cells need explicit `relative
-     *   z-[var(--z-checklist-sticky-header)]` to escape document-order
-     *   layering and stack above the top-left within the thead's
-     *   stacking context.
-     * - The top-left corner cell sits lowest of the three sticky tiers
-     *   so column-header cells overlap it cleanly.
+     *   and card names) sit lowest of the sticky tiers so the entire
+     *   thead (player names, hand-size label, hand-size inputs)
+     *   renders over them when their sticky-left and sticky-top
+     *   positions overlap during scroll.
+     * - Hand-size input cells (second header row) sit just above the
+     *   first column so they cover card names/categories during
+     *   vertical scroll, but below the top-left corner so they tuck
+     *   under the "Hand size" label when sliding left during
+     *   horizontal scroll. Non-corner header cells need explicit
+     *   `relative z-[…]` to escape document-order layering and stack
+     *   above the top-left within the thead's stacking context.
+     * - The top-left corner cell ("Hand size" label) sits above the
+     *   hand-size inputs so it covers them during horizontal scroll,
+     *   but below the player-name headers so they slide over it.
+     * - Player-name header cells (first header row) sit highest of
+     *   the sticky tiers so they cover the top-left corner cell and
+     *   the first-column cells during horizontal scroll.
      * - App chrome (page header / bottom nav) sits above the checklist
      *   table, and dropdowns/tooltips sit above app chrome.
      * - The contradiction banner sits above app chrome because headers
@@ -146,9 +152,10 @@
     --z-local-raised: 10;
     --z-checklist-cell-hover: 20;
     --z-checklist-cell-focus: 25;
-    --z-checklist-sticky-top-left: 30;
-    --z-checklist-sticky-header: 33;
-    --z-checklist-sticky-column: 36;
+    --z-checklist-sticky-column: 30;
+    --z-checklist-sticky-handsize-input: 33;
+    --z-checklist-sticky-top-left: 36;
+    --z-checklist-sticky-header: 39;
     --z-app-chrome: 40;
     --z-popover: 50;
     --z-contradiction-banner: 55;

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -997,7 +997,7 @@ export function Checklist() {
                     {inSetup && (
                         <tr>
                             <th
-                                className={`${STICKY_FIRST_COL} whitespace-nowrap border-r border-b border-border bg-row-header px-1.5 py-1 text-left font-semibold`}
+                                className={`${STICKY_FIRST_COL_HEADER} whitespace-nowrap border-r border-b border-border bg-row-header px-1.5 py-1 text-left font-semibold`}
                                 data-tour-sticky-left=""
                                 // The setup tour's "Set hand sizes"
                                 // step highlights the row label cell
@@ -1014,7 +1014,7 @@ export function Checklist() {
                                     cell = (
                                         <motion.td
                                             key={ownerKey(owner, playerColumnKeys)}
-                                            className={`${COLUMN_HEADER_STACK} overflow-hidden border-r border-b border-border`}
+                                            className={`${COLUMN_HEADER_STACK_HANDSIZE} overflow-hidden border-r border-b border-border`}
                                             initial={TABLE_COLUMN_HIDDEN}
                                             animate={TABLE_COLUMN_VISIBLE}
                                             exit={columnCellExit}
@@ -1034,7 +1034,7 @@ export function Checklist() {
                                     cell = (
                                         <motion.td
                                             key={ownerKey(owner, playerColumnKeys)}
-                                            className={`${COLUMN_HEADER_STACK} overflow-hidden border-r border-b border-border p-0 text-center`}
+                                            className={`${COLUMN_HEADER_STACK_HANDSIZE} overflow-hidden border-r border-b border-border p-0 text-center`}
                                             initial={TABLE_COLUMN_HIDDEN}
                                             animate={TABLE_COLUMN_VISIBLE}
                                             exit={columnCellExit}
@@ -2723,27 +2723,38 @@ const STICKY_FIRST_COL =
 const STICKY_FIRST_COL_HEADER =
     "sticky left-0 z-[var(--z-checklist-sticky-top-left)]";
 
-// `relative z-[sticky-header]` on every non-corner thead cell so they
-// escape document-order layering and stack above the top-left cell
-// within the thead's stacking context. Without this, the top-left's
-// own `z-[sticky-top-left]` (positive z, step 7 of the thead context)
-// would render over non-positioned siblings (step 3) — i.e. the
-// player-name cells would slide UNDER the top-left during horizontal
-// scroll, the opposite of the desired behavior.
+// `relative z-[…]` on every non-corner thead cell so they escape
+// document-order layering and stack within the thead's stacking
+// context above the sticky-left first-column cells. Without this,
+// the sticky-left cells' own positive z-index (step 7 of the thead
+// context) would render over non-positioned siblings (step 3) — i.e.
+// the player-name cells would slide UNDER the top-left and hand-size
+// label during horizontal scroll, the opposite of the desired
+// behavior. Player-name headers and hand-size inputs use different
+// values so the inputs tuck under the hand-size label while the
+// player names cover both.
 const COLUMN_HEADER_STACK =
     "relative z-[var(--z-checklist-sticky-header)]";
 
-// Z-index ladder for the checklist:
-//   - body cell hover ring      : --z-checklist-cell-hover
-//   - body cell focus           : --z-checklist-cell-focus
-//   - sticky top-left cell      : --z-checklist-sticky-top-left
-//   - sticky <thead> + cols     : --z-checklist-sticky-header
-//   - sticky first column       : --z-checklist-sticky-column
-// Row headers (body's sticky first column) sit at the top of the
-// ladder so they render over content cells during horizontal scroll.
-// Column headers (thead column-name cells) sit in the middle so they
-// overlap the top-left corner cell during horizontal scroll. The
-// top-left corner sits at the bottom of the three sticky tiers.
+const COLUMN_HEADER_STACK_HANDSIZE =
+    "relative z-[var(--z-checklist-sticky-handsize-input)]";
+
+// Z-index ladder for the checklist (bottom → top):
+//   - body cell hover ring       : --z-checklist-cell-hover
+//   - body cell focus            : --z-checklist-cell-focus
+//   - sticky body first column   : --z-checklist-sticky-column
+//     (card category + card name cells)
+//   - sticky hand-size inputs    : --z-checklist-sticky-handsize-input
+//   - sticky top-left cells      : --z-checklist-sticky-top-left
+//     (top-left corner + the hand-size label cell, which is also
+//     sticky-left in the thead)
+//   - sticky player-name headers : --z-checklist-sticky-header
+// The body's sticky first column sits at the bottom of the sticky
+// tiers so the entire thead — player names, hand-size label, and
+// hand-size inputs — covers it during scroll. Within the thead the
+// hand-size inputs tuck under the hand-size label, and the player
+// names cover both the hand-size label and the top-left corner as
+// they slide left during horizontal scroll.
 //
 // Focus indicator: `ring-[3px] ring-offset-2` (box-shadow) instead of
 // `outline-3 outline-offset-2`. Outlines on `<td>` cells in


### PR DESCRIPTION
Player-name headers, the "Hand size" label, and hand-size input cells now
render over the card category and card name cells when the user scrolls.
Previously the sticky-left first column sat at the top of the sticky
ladder and slid in front of the column-header row during scroll.

Reorder the ladder (bottom → top): card category + card name (30) →
hand-size input cells (33) → "Hand size" label / top-left corner (36) →
player-name headers (39). This keeps card category/name cells above
internal body cells (already true via the body's stacking context) while
ensuring the hand-size inputs tuck under the "Hand size" label and the
player-name headers cover the top-left corner during horizontal scroll.

Plumbing:
- Add `--z-checklist-sticky-handsize-input` and rebalance the existing
  three sticky variables in `app/globals.css`.
- Add a `COLUMN_HEADER_STACK_HANDSIZE` constant in `Checklist.tsx` and
  apply it to the second header row's input cells (and their non-player
  empty siblings).
- Switch the "Hand size" label cell from `STICKY_FIRST_COL` (now z 30)
  to `STICKY_FIRST_COL_HEADER` (z 36) so it shares the top-left tier
  rather than the body first-column tier.

https://claude.ai/code/session_01HnCRfyhFYqQoRezvFnDnX7