### PR TITLE
Polish share-receive flow: pack name, pill activation, save prompt, sign-in gate

### DIFF
--- a/docs/card-pack-sync.md
+++ b/docs/card-pack-sync.md
@@ -478,11 +478,15 @@ T+3m   The next React Query focus fires. applyServerSnapshot runs.
   invite/transfer share (or "Start new game with this pack" from a
   pack-only share), `useApplyShareSnapshot.applyShareSnapshotToLocalStorage`
   calls `saveOrRecognisePack` after writing the GameSession. Built-in
-  packs are recognised (just `recordCardPackUse(builtIn.id)`); custom
-  packs are appended to `customCardSets` and stamped MRU. Sign-in is
-  required to receive any share, so the user is signed in by the time
-  the pack lands locally — `CardPacksSync`'s post-`/play` mount picks
-  it up and pushes to the server like any other local create.
+  packs are recognised (just `recordCardPackUse(builtIn.id)`);
+  existing custom packs whose contents structurally match (per
+  `cardSetEquals`) are also recognised — receiving the same shared
+  deck twice doesn't accumulate duplicates in the library; only
+  genuinely new decks are appended to `customCardSets` and stamped
+  MRU. Sign-in is required to receive any share, so the user is
+  signed in by the time the pack lands locally — `CardPacksSync`'s
+  post-`/play` mount picks it up and pushes to the server like any
+  other local create.
 - **Race: save in flight at sign-out.** `flushPendingChanges` calls
   `drainInFlight()` first. The in-flight save settles (either
   clearing `unsyncedSince` on success or retaining it on failure),

--- a/docs/card-pack-sync.md
+++ b/docs/card-pack-sync.md
@@ -474,6 +474,15 @@ T+3m   The next React Query focus fires. applyServerSnapshot runs.
 
 ## Edge cases worth knowing
 
+- **Share-receive feeds the local registry.** When a user accepts an
+  invite/transfer share (or "Start new game with this pack" from a
+  pack-only share), `useApplyShareSnapshot.applyShareSnapshotToLocalStorage`
+  calls `saveOrRecognisePack` after writing the GameSession. Built-in
+  packs are recognised (just `recordCardPackUse(builtIn.id)`); custom
+  packs are appended to `customCardSets` and stamped MRU. Sign-in is
+  required to receive any share, so the user is signed in by the time
+  the pack lands locally — `CardPacksSync`'s post-`/play` mount picks
+  it up and pushes to the server like any other local create.
 - **Race: save in flight at sign-out.** `flushPendingChanges` calls
   `drainInFlight()` first. The in-flight save settles (either
   clearing `unsyncedSince` on success or retaining it on failure),

--- a/docs/shares-and-sync.md
+++ b/docs/shares-and-sync.md
@@ -195,25 +195,27 @@ to detect built-ins — the `name` is informational, not authoritative.
      side)* below.
 5. Click:
    - Pack-only → decodes `cardPackData` and routes through
-     `saveOrRecognisePack`. Built-in packs (matched by structural
-     equality against `CARD_SETS`) just stamp the built-in id as
-     most-recently-used; custom packs are added to the local
-     `customCardSets` registry and stamped as MRU. The pack is NOT
-     auto-loaded into the live setup; instead a follow-up confirm
-     dialog asks "Card pack {label} saved. Would you like to start a
-     new game with this pack?" with cancel "Not now" (default focus)
-     and confirm "Start new game with this pack". When the receiver
-     has a game in progress, the standard overwrite warning is
-     appended to the message. "Start new game" calls
-     `applyShareSnapshotToLocalStorage` with the same pack-only
+     `saveOrRecognisePack`. Built-in packs (matched by `cardSetEquals`
+     against `CARD_SETS`) just stamp the built-in id as
+     most-recently-used; existing custom packs whose contents match
+     are likewise recognised (no duplicate library entry); only
+     genuinely new decks are appended to the local `customCardSets`
+     registry. The pack is NOT auto-loaded into the live setup;
+     instead a follow-up confirm dialog asks "Card pack {label} saved.
+     Would you like to start a new game with this pack?" with cancel
+     "Not now" (default focus) and confirm "Start new game with this
+     pack". When the receiver has a game in progress, the standard
+     overwrite warning is appended to the message. "Start new game"
+     calls `applyShareSnapshotToLocalStorage` with the same pack-only
      snapshot, which clears game state and uses the imported deck.
    - Invite / transfer → standard "Start a new game?" confirm fires
      first when there's persisted game data; on accept,
      `useApplyShareSnapshot()` decodes each wire field via the codec,
      builds a `GameSession`, writes the new state to `localStorage`,
      AND also routes through `saveOrRecognisePack` so the imported
-     deck appears in `customCardSets` and lights up the active pill
-     in `CardPackRow` once the user lands on `/play`.
+     deck appears in the local registry (or recognises an existing
+     match) and lights up the active pill in `CardPackRow` once the
+     user lands on `/play`.
 6. Router pushes to `/play`.
 
 **Hydration semantics:** the share is the new game. Sections present

--- a/docs/shares-and-sync.md
+++ b/docs/shares-and-sync.md
@@ -190,24 +190,63 @@ to detect built-ins — the `name` is informational, not authoritative.
      `Players (4): Alice, Bob, Carol, Dana`,
      `Hand sizes`,
      `Known cards (12)`, etc.
-   - One CTA matched to the inferred receive flow.
+   - One CTA matched to the inferred receive flow. **Anonymous users
+     get "Sign in to import" instead** — see *Universal sign-in (receive
+     side)* below.
 5. Click:
-   - Pack-only → decodes `cardPackData`, writes a new custom card pack,
-     records the pack as most-recently-used, invalidates the card-pack
-     queries, and routes to `/play`. It does not call the game-session
-     hydration path or overwrite the current game.
-   - Invite / transfer → `useApplyShareSnapshot()` decodes each wire
-     field via the codec, builds a `GameSession`, and writes the new
-     state to `localStorage`.
+   - Pack-only → decodes `cardPackData` and routes through
+     `saveOrRecognisePack`. Built-in packs (matched by structural
+     equality against `CARD_SETS`) just stamp the built-in id as
+     most-recently-used; custom packs are added to the local
+     `customCardSets` registry and stamped as MRU. The pack is NOT
+     auto-loaded into the live setup; instead a follow-up confirm
+     dialog asks "Card pack {label} saved. Would you like to start a
+     new game with this pack?" with cancel "Not now" (default focus)
+     and confirm "Start new game with this pack". When the receiver
+     has a game in progress, the standard overwrite warning is
+     appended to the message. "Start new game" calls
+     `applyShareSnapshotToLocalStorage` with the same pack-only
+     snapshot, which clears game state and uses the imported deck.
+   - Invite / transfer → standard "Start a new game?" confirm fires
+     first when there's persisted game data; on accept,
+     `useApplyShareSnapshot()` decodes each wire field via the codec,
+     builds a `GameSession`, writes the new state to `localStorage`,
+     AND also routes through `saveOrRecognisePack` so the imported
+     deck appears in `customCardSets` and lights up the active pill
+     in `CardPackRow` once the user lands on `/play`.
 6. Router pushes to `/play`.
 
 **Hydration semantics:** the share is the new game. Sections present
 in the snapshot replace the matching slice; sections absent are
 blanked (because they may reference cards from the receiver's old
-pack). Pack-only shares bypass hydration entirely and add only the
-card pack. Defensive empty-share branch (no card pack — unreachable
-from the new sender flows but possible for legacy / direct API calls)
-renders an empty-state message and disables Import.
+pack). Pack-only shares stash the pack in the local registry and ask
+before swapping it into the live setup. Defensive empty-share branch
+(no card pack — unreachable from the new sender flows but possible
+for legacy / direct API calls) renders an empty-state message and
+disables Import.
+
+## Universal sign-in (receive side)
+
+Just like creating a share, **receiving a share requires a non-
+anonymous account**. The CTA on the receive modal reads
+"Sign in to import" for anonymous users; click → save a sessionStorage
+intent (`effect-clue.pending-import.v1`, see
+[src/ui/share/pendingImport.ts](../src/ui/share/pendingImport.ts))
+keyed by the current `shareId` and a fresh epoch-millis timestamp,
+then call `authClient.signIn.social({ provider, callbackURL:
+window.location.pathname })`. After OAuth lands the user back on
+`/share/{id}`, `ShareImportPage`'s `useEffect` consumes the intent and
+auto-fires the same `performImport` path that the button would have.
+
+The malicious-URL safety property is what justifies the auto-import:
+a third party who sends a `/share/{id}` URL has no way to populate
+sessionStorage on the recipient's tab, so an idle visit never
+auto-imports — the modal renders normally and waits for explicit
+user action. The `consumePendingImportIntent` helper enforces three
+checks: (1) the stored shareId matches the current page's, (2) the
+saved timestamp is within `Duration.minutes(10)` of now, and (3)
+single-use — `consume` always clears the entry, so a successful
+import can't be replayed by a follow-up share's auto-import path.
 
 ## DB representation
 
@@ -284,7 +323,7 @@ Surfaced from `createShare` / `getShare`:
 
 | Constant | Wire string | Cause |
 |---|---|---|
-| `ERR_SIGN_IN_REQUIRED` | `sign_in_required_to_share` | Caller is anonymous (no session OR isAnonymous=true). Modal catches and slides into the inline sign-in step. |
+| `ERR_SIGN_IN_REQUIRED` | `sign_in_required_to_share` | Caller is anonymous (no session OR isAnonymous=true). The create-side modal catches this and slides into the inline sign-in step; the receive side gates the import button entirely (CTA reads "Sign in to import") so this server error doesn't surface. |
 | `ERR_MALFORMED_INPUT` | `share_malformed_input[:<detail>]` | Input shape didn't validate — wrong kind, missing required field, extraneous field, bad codec, or suggestion/accusation pairing violation. The optional `:<detail>` suffix names which check failed. |
 | `ERR_SHARE_NOT_FOUND` | `share_not_found` | `getShare` couldn't find a row for the id (or it has expired). Receive page renders a 404. |
 
@@ -322,13 +361,17 @@ machine.**
 - **`pack`-kind shares vs. sync.** A `pack` share is a sender-driven
   snapshot — it does not modify either user's `card_packs` rows. The
   receiver imports it via the local-only `saveCustomCardSet` flow,
-  which then triggers their own sync push if they're signed in.
-- **`transfer`-kind shares vs. sync.** A transfer ships the sender's
-  card pack as part of the snapshot. On the receiver's side, the
-  `useApplyShareSnapshot` hook treats it the same as any other game
-  load — it doesn't go through the sync hooks. If the receiver wants
-  the pack saved permanently, they have to save it from the Setup
-  pane afterward.
+  which then triggers their own sync push (via `CardPacksSync`) once
+  the user is back on `/play` — sign-in is required to receive any
+  share, so the user is always signed in by the time the pack lands
+  in the local registry.
+- **`invite` and `transfer`-kind shares vs. sync.** Both of these
+  ship the sender's card pack as part of the snapshot.
+  `useApplyShareSnapshot` hydrates the GameSession AND routes the
+  pack through `saveOrRecognisePack`, which writes it to
+  `customCardSets` (or recognises it as a built-in and skips the
+  duplicate write). The same `CardPacksSync` mirror picks it up
+  post-`/play` mount.
 - **Auth.** Both systems share `requireSignedInUser` (server) and
   `useSignedInUserId` (client) for the gate. A user signed in via
   the anonymous plugin counts as **not** signed in for both — neither

--- a/messages/en.json
+++ b/messages/en.json
@@ -11,7 +11,8 @@
         "infoGlyph": "ⓘ",
         "close": "Close",
         "back": "Back",
-        "save": "Save"
+        "save": "Save",
+        "notNow": "Not now"
     },
     "bottomNav": {
         "ariaLabel": "Primary navigation",
@@ -379,7 +380,13 @@
         "importActionPack": "Import this pack",
         "importActionInvite": "Start this game",
         "importActionTransfer": "Continue this game",
-        "importing": "Importing…"
+        "importing": "Importing…",
+        "signInToImport": "Sign in to import",
+        "packSavedTitle": "Card pack \"{label}\" saved",
+        "packSavedTitleUnnamed": "Card pack saved",
+        "packSavedPrompt": "Would you like to start a new game with \"{label}\"?",
+        "packSavedPromptUnnamed": "Would you like to start a new game with this pack?",
+        "startNewGameWithPack": "Start new game with this pack"
     },
     "account": {
         "titleSignedOut": "Sign in to Clue Solver",

--- a/src/ui/share/ShareCreateModal.test.tsx
+++ b/src/ui/share/ShareCreateModal.test.tsx
@@ -309,6 +309,86 @@ describe("ShareCreateModal — wire payload by variant", () => {
         expect(payload.suggestionsData).toBeTypeOf("string");
         expect(payload.accusationsData).toBeTypeOf("string");
     });
+
+    test("invite variant embeds the loaded custom pack's name on the wire", async () => {
+        // Pre-seed localStorage with a session whose live deck matches
+        // a saved custom pack (with structurally distinct contents
+        // from any built-in, so the built-in branch in
+        // resolvePackLabel doesn't short-circuit). The modal's label
+        // backfill should then embed "Pack X" in cardPack.name so the
+        // receive modal renders "Card pack: Pack X (custom)" instead
+        // of the unnamed branch.
+        const { saveCustomCardSet } = await import(
+            "../../logic/CustomCardSets"
+        );
+        const { recordCardPackUse } = await import(
+            "../../logic/CardPackUsage"
+        );
+        const { saveToLocalStorage } = await import(
+            "../../logic/Persistence"
+        );
+        const { GameSetup } = await import("../../logic/GameSetup");
+        const { PlayerSet } = await import("../../logic/PlayerSet");
+        const { CardSet, Category, CardEntry } = await import(
+            "../../logic/CardSet"
+        );
+        const { Player, Card, CardCategory } = await import(
+            "../../logic/GameObjects"
+        );
+        const { emptyHypotheses } = await import("../../logic/Hypothesis");
+
+        const distinctDeck = CardSet({
+            categories: [
+                Category({
+                    id: CardCategory("category-distinct"),
+                    name: "Distinct",
+                    cards: [
+                        CardEntry({
+                            id: Card("card-distinct-1"),
+                            name: "Distinct 1",
+                        }),
+                        CardEntry({
+                            id: Card("card-distinct-2"),
+                            name: "Distinct 2",
+                        }),
+                    ],
+                }),
+            ],
+        });
+        const saved = saveCustomCardSet("Pack X", distinctDeck);
+        recordCardPackUse(saved.id);
+        saveToLocalStorage({
+            setup: GameSetup({
+                cardSet: distinctDeck,
+                playerSet: PlayerSet({
+                    players: [Player("Alice"), Player("Bob")],
+                }),
+            }),
+            hands: [],
+            handSizes: [
+                { player: Player("Alice"), size: 1 },
+                { player: Player("Bob"), size: 1 },
+            ],
+            suggestions: [],
+            accusations: [],
+            hypotheses: emptyHypotheses,
+        });
+
+        mockSession = {
+            data: { user: { id: "u1", isAnonymous: false } },
+        };
+        mountModal("invite");
+        await act(async () => {
+            fireEvent.click(findCta());
+        });
+        await waitFor(() => {
+            expect(createShareMock).toHaveBeenCalled();
+        });
+        const payload = createShareMock.mock.calls[0]?.[0];
+        expect(payload.kind).toBe("invite");
+        const decoded = JSON.parse(payload.cardPackData);
+        expect(decoded.name).toBe("Pack X");
+    });
 });
 
 describe("ShareCreateModal — copy existing share URL", () => {

--- a/src/ui/share/ShareCreateModal.tsx
+++ b/src/ui/share/ShareCreateModal.tsx
@@ -29,7 +29,7 @@
 "use client";
 
 import * as Dialog from "@radix-ui/react-dialog";
-import { Schema } from "effect";
+import { DateTime, Schema } from "effect";
 import { AnimatePresence, motion } from "motion/react";
 import { useTranslations } from "next-intl";
 import { usePathname, useSearchParams } from "next/navigation";
@@ -75,10 +75,13 @@ import { authClient } from "../account/authClient";
 import { DevSignInForm } from "../account/DevSignInForm";
 import { T_STANDARD, useReducedTransition } from "../motion";
 import { CheckIcon, XIcon } from "../components/Icons";
+import { useCardPackUsage } from "../../data/cardPackUsage";
+import { useCustomCardPacks } from "../../data/customCardPacks";
 import {
     savePendingShareIntent,
     type PendingShareIntent,
 } from "./pendingShare";
+import { resolveActivePackLabel } from "./resolveActivePackLabel";
 
 const isDev = process.env.NODE_ENV === "development";
 
@@ -370,6 +373,10 @@ export function ShareCreateModal({
     const pathname = usePathname();
     const searchParams = useSearchParams();
     const session = useSession();
+    const customPacksQuery = useCustomCardPacks();
+    const usageQuery = useCardPackUsage();
+    const customPacks = customPacksQuery.data ?? [];
+    const usage = usageQuery.data ?? new Map<string, DateTime.Utc>();
     const transition = useReducedTransition(T_STANDARD);
     const [step, setStep] = useState<Step>(STEP_TOGGLES);
     const [direction, setDirection] = useState<1 | -1>(1);
@@ -395,8 +402,18 @@ export function ShareCreateModal({
     // The pack the share will contain. Picker entry overrides; setup
     // and overflow-menu entries use the live setup's pack.
     const activeCardSet = forcedCardPack ?? state.setup.cardSet;
+    // Invite/transfer openers don't pass a label (they don't know which
+    // saved pack the live deck came from). Backfill from the
+    // most-recently-used custom pack whose contents still match — same
+    // resolution `CardPackRow` uses to pick the active pill.
+    const resolvedCustomLabel = resolveActivePackLabel(
+        activeCardSet,
+        customPacks,
+        usage,
+        forcedCardPackLabel,
+    );
     const { label: activeCardSetLabel, isCustom: cardSetIsCustom } =
-        resolvePackLabel(activeCardSet, forcedCardPackLabel);
+        resolvePackLabel(activeCardSet, resolvedCustomLabel);
 
     const suggestionsCount = derived.suggestionsAsData.length;
     const accusationsCount = derived.accusationsAsData.length;
@@ -419,12 +436,17 @@ export function ShareCreateModal({
         v === VARIANT_INVITE ? includeProgress : v === VARIANT_TRANSFER;
 
     const buildPayload = useCallback((): CreateShareInput => {
+        // `wirePackName` is what lands in the wire's optional
+        // cardPack `name` field. For pack variants opened from the
+        // picker, the caller's label wins. For invite/transfer (no
+        // explicit label), `resolvedCustomLabel` recovers the loaded
+        // custom pack's name so the receive modal can render it.
+        // Built-in packs don't need it (the receiver auto-detects
+        // built-ins by structural equality), but it's harmless to
+        // pass either way; `projectCardSet` drops empty strings.
+        const wirePackName = activeCardSetLabel;
         if (variant === VARIANT_PACK) {
-            // Pack variant: only the pack ships. The forcedCardPack
-            // path (per-pack share from picker) overrides the live
-            // setup pack — the share contains the picked pack, not
-            // whatever's currently loaded.
-            return buildPackInput(activeCardSet, forcedCardPackLabel);
+            return buildPackInput(activeCardSet, wirePackName);
         }
 
         // Invite + transfer variants ship the live game's data.
@@ -458,16 +480,16 @@ export function ShareCreateModal({
         if (variant === VARIANT_INVITE) {
             return buildInviteInput(
                 gameSession,
-                forcedCardPackLabel,
+                wirePackName,
                 includeProgress,
             );
         }
-        return buildTransferInput(gameSession, forcedCardPackLabel);
+        return buildTransferInput(gameSession, wirePackName);
     }, [
         activeCardSet,
+        activeCardSetLabel,
         derived.accusationsAsData,
         derived.suggestionsAsData,
-        forcedCardPackLabel,
         includeProgress,
         state.handSizes,
         state.knownCards,

--- a/src/ui/share/ShareImportPage.test.tsx
+++ b/src/ui/share/ShareImportPage.test.tsx
@@ -1,18 +1,23 @@
 /**
- * Tests for the M22 receive-page redesign. The previous version only
- * had analytics-fire smoke checks (the actual import was a TODO).
- * Now the page renders a sender + bullet-list summary and actually
- * hydrates on Import, so the test covers:
+ * Tests for the M22 receive-page redesign + the post-M22 share-receive
+ * polish (sign-in gate, "Use it now?" prompt for pack-only saves,
+ * pack pill activation after invite/transfer). The page renders a
+ * sender + bullet-list summary, requires sign-in to import, hydrates
+ * on Import, and surfaces a confirm dialog for the pack-save branch.
  *
+ * Coverage:
  *   - Sender line — present for non-anonymous senders, absent for
  *     anonymous senders (server-side `ownerName === null`).
- *   - Bullet list reflects exactly which slices the snapshot carries:
- *     pack name + custom flag, players + count, hand sizes, known
- *     cards / suggestions / accusations counts.
+ *   - Bullet list reflects exactly which slices the snapshot carries.
  *   - Empty-share defensive branch shows the empty-state copy and
  *     disables the Import CTA.
- *   - Import click invokes the hydration hook with the snapshot and
- *     routes to /play.
+ *   - Import click behaviour — branches by receive flow (pack-only
+ *     → save + confirm; invite/transfer → confirm-then-hydrate when
+ *     the receiver has a game in progress).
+ *   - Sign-in gate — anonymous users see "Sign in to import" and the
+ *     CTA kicks off social sign-in; auto-import only fires when a
+ *     matching sessionStorage intent is present (malicious-URL
+ *     defence).
  */
 import { Schema } from "effect";
 import { beforeEach, describe, expect, test, vi } from "vitest";
@@ -42,6 +47,30 @@ vi.mock("./useApplyShareSnapshot", () => ({
         saveCardPackFromSnapshotMock(snapshot),
 }));
 
+const consumePendingImportIntentMock = vi.fn();
+const savePendingImportIntentMock = vi.fn();
+vi.mock("./pendingImport", () => ({
+    consumePendingImportIntent: (id: string) =>
+        consumePendingImportIntentMock(id),
+    savePendingImportIntent: (intent: unknown) =>
+        savePendingImportIntentMock(intent),
+}));
+
+const signInSocialMock = vi.fn();
+vi.mock("../account/authClient", () => ({
+    authClient: {
+        signIn: { social: (args: unknown) => signInSocialMock(args) },
+    },
+}));
+
+let mockSessionUser: {
+    id: string;
+    isAnonymous: boolean;
+} | null = { id: "test-user", isAnonymous: false };
+vi.mock("../hooks/useSession", () => ({
+    useSession: () => ({ data: { user: mockSessionUser } }),
+}));
+
 const invalidateQueriesMock = vi.fn();
 vi.mock("@tanstack/react-query", async () => {
     const actual = await vi.importActual<typeof import("@tanstack/react-query")>(
@@ -60,6 +89,8 @@ const sharedAnalytics = {
     shareImported: vi.fn(),
     shareImportDismissed: vi.fn(),
     shareOpened: vi.fn(),
+    signInStarted: vi.fn(),
+    signInFailed: vi.fn(),
 };
 vi.mock("../../analytics/events", () => ({
     shareImportStarted: (...args: unknown[]) =>
@@ -70,6 +101,10 @@ vi.mock("../../analytics/events", () => ({
         sharedAnalytics.shareImportDismissed(...args),
     shareOpened: (...args: unknown[]) =>
         sharedAnalytics.shareOpened(...args),
+    signInStarted: (...args: unknown[]) =>
+        sharedAnalytics.signInStarted(...args),
+    signInFailed: (...args: unknown[]) =>
+        sharedAnalytics.signInFailed(...args),
 }));
 
 import {
@@ -204,15 +239,27 @@ const buildSnapshot = (overrides: SnapshotOverrides) => ({
 
 beforeEach(() => {
     mockHasPersistedGameData = false;
+    mockSessionUser = { id: "test-user", isAnonymous: false };
     routerPushMock.mockReset();
     applyMock.mockReset();
     saveCardPackFromSnapshotMock.mockReset();
+    saveCardPackFromSnapshotMock.mockReturnValue({
+        kind: "saved",
+        pack: { id: "pack-1", label: "My Office", cardSet: { categories: [] } },
+    });
     invalidateQueriesMock.mockReset();
     invalidateQueriesMock.mockResolvedValue(undefined);
+    consumePendingImportIntentMock.mockReset();
+    consumePendingImportIntentMock.mockReturnValue(false);
+    savePendingImportIntentMock.mockReset();
+    signInSocialMock.mockReset();
+    signInSocialMock.mockResolvedValue({ error: null });
     sharedAnalytics.shareImportStarted.mockReset();
     sharedAnalytics.shareImported.mockReset();
     sharedAnalytics.shareImportDismissed.mockReset();
     sharedAnalytics.shareOpened.mockReset();
+    sharedAnalytics.signInStarted.mockReset();
+    sharedAnalytics.signInFailed.mockReset();
 });
 
 const renderImportPage = (snapshot: ReturnType<typeof buildSnapshot>) =>
@@ -421,8 +468,8 @@ describe("ShareImportPage — empty share guard", () => {
 });
 
 describe("ShareImportPage — import action", () => {
-    test("pack-only import saves a card pack and does not overwrite current game", async () => {
-        mockHasPersistedGameData = true;
+    test("pack-only import saves pack, then asks 'Use it now?' (no game in progress)", async () => {
+        mockHasPersistedGameData = false;
         const snapshot = buildSnapshot({
             cardPackData: CUSTOM_PACK_PAYLOAD,
         });
@@ -436,13 +483,58 @@ describe("ShareImportPage — import action", () => {
         await waitFor(() => {
             expect(saveCardPackFromSnapshotMock).toHaveBeenCalledWith(snapshot);
         });
-        expect(screen.queryByText("newGameConfirm")).not.toBeInTheDocument();
+        // Use-it-now confirm fires; "newGameConfirm" is NOT appended
+        // because there's no game in progress.
+        const dialog = await screen.findByRole("alertdialog");
+        expect(dialog.textContent).toContain("packSavedPrompt");
+        expect(dialog.textContent).not.toContain("newGameConfirm");
+        // "Not now" cancels the prompt; pack stays saved but live
+        // setup isn't touched.
+        fireEvent.click(within(dialog).getByText("notNow"));
+
+        await waitFor(() => {
+            expect(routerPushMock).toHaveBeenCalledWith("/play");
+        });
         expect(applyMock).not.toHaveBeenCalled();
-        expect(routerPushMock).toHaveBeenCalledWith("/play");
         expect(invalidateQueriesMock).toHaveBeenCalledTimes(2);
     });
 
-    test("clicking Import calls the hydration hook with the snapshot, then routes to /play", () => {
+    test("pack-only with game in progress → 'Use it now?' message includes overwrite warning", async () => {
+        mockHasPersistedGameData = true;
+        const snapshot = buildSnapshot({
+            cardPackData: CUSTOM_PACK_PAYLOAD,
+        });
+        renderImportPage(snapshot);
+
+        fireEvent.click(
+            document.querySelector("[data-share-import-cta]")!,
+        );
+
+        const dialog = await screen.findByRole("alertdialog");
+        expect(dialog.textContent).toContain("packSavedPrompt");
+        expect(dialog.textContent).toContain("newGameConfirm");
+    });
+
+    test("pack-only 'Start new game' → applies snapshot and routes to /play", async () => {
+        mockHasPersistedGameData = false;
+        const snapshot = buildSnapshot({
+            cardPackData: CUSTOM_PACK_PAYLOAD,
+        });
+        renderImportPage(snapshot);
+
+        fireEvent.click(
+            document.querySelector("[data-share-import-cta]")!,
+        );
+        const dialog = await screen.findByRole("alertdialog");
+        fireEvent.click(within(dialog).getByText("startNewGameWithPack"));
+
+        await waitFor(() => {
+            expect(applyMock).toHaveBeenCalledWith(snapshot);
+            expect(routerPushMock).toHaveBeenCalledWith("/play");
+        });
+    });
+
+    test("invite-style import calls applySnapshot and routes to /play (clean game state)", async () => {
         const snapshot = buildSnapshot({
             cardPackData: CLASSIC_PACK_PAYLOAD,
             playersData: PLAYERS_PAYLOAD_TWO,
@@ -456,8 +548,10 @@ describe("ShareImportPage — import action", () => {
         ) as HTMLButtonElement;
         expect(cta.textContent).toBe("importActionInvite");
         fireEvent.click(cta);
-        expect(applyMock).toHaveBeenCalledWith(snapshot);
-        expect(routerPushMock).toHaveBeenCalledWith("/play");
+        await waitFor(() => {
+            expect(applyMock).toHaveBeenCalledWith(snapshot);
+            expect(routerPushMock).toHaveBeenCalledWith("/play");
+        });
         expect(sharedAnalytics.shareImported).toHaveBeenCalledWith(
             expect.objectContaining({
                 hadPack: true,
@@ -509,5 +603,68 @@ describe("ShareImportPage — import action", () => {
 
         expect(applyMock).not.toHaveBeenCalled();
         expect(routerPushMock).not.toHaveBeenCalled();
+    });
+});
+
+describe("ShareImportPage — sign-in gate", () => {
+    test("anonymous user → CTA reads 'Sign in to import' and click stamps intent + kicks off OAuth", async () => {
+        mockSessionUser = { id: "anon", isAnonymous: true };
+        const snapshot = buildSnapshot({ cardPackData: CUSTOM_PACK_PAYLOAD });
+        renderImportPage(snapshot);
+
+        const cta = document.querySelector(
+            "[data-share-import-cta]",
+        ) as HTMLButtonElement;
+        expect(cta.textContent).toBe("signInToImport");
+
+        fireEvent.click(cta);
+
+        await waitFor(() => {
+            expect(savePendingImportIntentMock).toHaveBeenCalledWith(
+                expect.objectContaining({ shareId: snapshot.id }),
+            );
+            expect(signInSocialMock).toHaveBeenCalledWith(
+                expect.objectContaining({ provider: "google" }),
+            );
+        });
+        // No actual import happened — that fires after OAuth lands the
+        // user back here with a real session.
+        expect(saveCardPackFromSnapshotMock).not.toHaveBeenCalled();
+        expect(applyMock).not.toHaveBeenCalled();
+    });
+
+    test("anonymous → no logged-out user can be tricked into auto-import (no sessionStorage intent)", () => {
+        mockSessionUser = { id: "anon", isAnonymous: true };
+        consumePendingImportIntentMock.mockReturnValue(false);
+        const snapshot = buildSnapshot({ cardPackData: CUSTOM_PACK_PAYLOAD });
+        renderImportPage(snapshot);
+        // Render alone must not auto-fire any imports.
+        expect(saveCardPackFromSnapshotMock).not.toHaveBeenCalled();
+        expect(applyMock).not.toHaveBeenCalled();
+    });
+
+    test("signed-in user with matching pendingImport intent → auto-imports on mount", async () => {
+        mockSessionUser = { id: "test-user", isAnonymous: false };
+        consumePendingImportIntentMock.mockReturnValue(true);
+        const snapshot = buildSnapshot({ cardPackData: CUSTOM_PACK_PAYLOAD });
+        renderImportPage(snapshot);
+
+        await waitFor(() => {
+            expect(consumePendingImportIntentMock).toHaveBeenCalledWith(
+                snapshot.id,
+            );
+            expect(saveCardPackFromSnapshotMock).toHaveBeenCalled();
+        });
+    });
+
+    test("signed-in user without pendingImport intent → renders modal idle (malicious-URL safe)", () => {
+        mockSessionUser = { id: "test-user", isAnonymous: false };
+        consumePendingImportIntentMock.mockReturnValue(false);
+        const snapshot = buildSnapshot({ cardPackData: CUSTOM_PACK_PAYLOAD });
+        renderImportPage(snapshot);
+        // No auto-import without an explicit intent — the user (or a
+        // malicious sender) sending the URL alone can't kick off import.
+        expect(saveCardPackFromSnapshotMock).not.toHaveBeenCalled();
+        expect(applyMock).not.toHaveBeenCalled();
     });
 });

--- a/src/ui/share/ShareImportPage.tsx
+++ b/src/ui/share/ShareImportPage.tsx
@@ -26,7 +26,7 @@
 "use client";
 
 import { Result, Schema } from "effect";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import * as Dialog from "@radix-ui/react-dialog";
 import { useTranslations } from "next-intl";
@@ -36,21 +36,31 @@ import {
     shareImported,
     shareOpened,
     shareImportStarted,
+    signInFailed,
+    signInStarted,
     type ShareDismissVia,
+    type SignInFromContext,
 } from "../../analytics/events";
 import { cardSetEquals } from "../../logic/CardSet";
 import { CARD_SETS } from "../../logic/GameSetup";
 import { cardPackCodec, playersCodec } from "../../logic/ShareCodec";
 import { customCardPacksQueryKey } from "../../data/customCardPacks";
 import { cardPackUsageQueryKey } from "../../data/cardPackUsage";
+import { authClient } from "../account/authClient";
+import { useSession } from "../hooks/useSession";
 import { XIcon } from "../components/Icons";
 import { useConfirm } from "../hooks/useConfirm";
 import {
     hasPersistedGameData,
     saveCardPackFromSnapshot,
     useApplyShareSnapshot,
+    type RecognisedPackResult,
 } from "./useApplyShareSnapshot";
 import { hashShareId } from "./shareAnalytics";
+import {
+    consumePendingImportIntent,
+    savePendingImportIntent,
+} from "./pendingImport";
 
 interface ShareSnapshot {
     readonly id: string;
@@ -67,6 +77,15 @@ interface ShareSnapshot {
 
 const VIA_X: ShareDismissVia = "x_button";
 const VIA_BACKDROP: ShareDismissVia = "backdrop";
+
+// Sign-in is now required to receive any share. The CTA on the
+// receive modal kicks off Better Auth's social sign-in directly —
+// there's no AccountProvider mounted on this route, so we don't
+// reuse the AccountModal sign-in flow. After OAuth lands the user
+// back here, an effect consumes a sessionStorage intent and auto-
+// fires the import.
+const SOCIAL_SIGN_IN_PROVIDER = "google" as const;
+const SIGN_IN_FROM_RECEIVE: SignInFromContext = "share_import";
 
 // How many player names to spell out in the "Players" bullet before
 // collapsing the rest to "+N more". Mirrors the inline-name budget on
@@ -227,10 +246,13 @@ export function ShareImportPage({
     const tCommon = useTranslations("common");
     const router = useRouter();
     const queryClient = useQueryClient();
+    const session = useSession();
     const [open, setOpen] = useState(true);
     const [submitting, setSubmitting] = useState(false);
     const applySnapshot = useApplyShareSnapshot();
     const confirm = useConfirm();
+    const isAnonymous =
+        !session.data?.user || session.data.user.isAnonymous;
 
     const hasPack = snapshot.cardPackData !== null;
     const hasPlayers = snapshot.playersData !== null;
@@ -273,27 +295,91 @@ export function ShareImportPage({
         shareOpened({ shareIdHash: hashShareId(snapshot.id) });
     }, [snapshot.id]);
 
-    const onImport = async (): Promise<void> => {
-        if (receiveFlow !== RECEIVE_FLOW_PACK && hasPersistedGameData()) {
-            const ok = await confirm({
-                message: tToolbar("newGameConfirm"),
-            });
-            if (!ok) return;
-        }
+    /**
+     * User-facing label of the just-saved-or-recognised pack. Used in
+     * the "Card pack X saved" confirm dialog. Empty string when the
+     * sender shipped an unnamed custom pack — the dialog falls back
+     * to a label-free copy variant in that case.
+     */
+    const pickPackResultLabel = (result: RecognisedPackResult): string => {
+        if (result.kind === "saved") return result.pack.label;
+        if (result.kind === "recognised") return result.label;
+        return "";
+    };
+
+    const performImport = async (): Promise<void> => {
         setSubmitting(true);
         shareImportStarted({ shareIdHash: hashShareId(snapshot.id) });
         try {
             if (receiveFlow === RECEIVE_FLOW_PACK) {
-                saveCardPackFromSnapshot(snapshot);
+                const result = saveCardPackFromSnapshot(snapshot);
                 await queryClient.invalidateQueries({
                     queryKey: customCardPacksQueryKey,
                 });
                 await queryClient.invalidateQueries({
                     queryKey: cardPackUsageQueryKey,
                 });
-            } else {
-                applySnapshot(snapshot);
+                shareImported({
+                    shareIdHash: hashShareId(snapshot.id),
+                    hadPack: hasPack,
+                    hadPlayers: hasPlayers,
+                    hadKnownCards: hasKnown,
+                    hadSuggestions: hasSugg,
+                    triggeredNewGame: false,
+                    savedPackToAccount: false,
+                });
+                // Pack-only flow: ask whether to start a new game with
+                // the just-saved pack. Default focus on "Not now" (the
+                // Radix AlertDialog auto-focuses Cancel) so a user
+                // who just wanted to file the pack away doesn't
+                // accidentally clear their in-progress game.
+                const inProgress = hasPersistedGameData();
+                const label = pickPackResultLabel(result);
+                const baseMsg =
+                    label !== ""
+                        ? t("packSavedPrompt", { label })
+                        : t("packSavedPromptUnnamed");
+                const message = inProgress
+                    ? `${baseMsg} ${tToolbar("newGameConfirm")}`
+                    : baseMsg;
+                const startNew = await confirm({
+                    title:
+                        label !== ""
+                            ? t("packSavedTitle", { label })
+                            : t("packSavedTitleUnnamed"),
+                    message,
+                    cancelLabel: tCommon("notNow"),
+                    confirmLabel: t("startNewGameWithPack"),
+                    destructive: inProgress,
+                });
+                if (startNew) {
+                    // Reuse `applyShareSnapshotToLocalStorage` with the
+                    // pack-only snapshot — null fields hydrate as
+                    // empty/cleared, preserving the existing player
+                    // set. This is also where the ongoing-game
+                    // "warning" really takes effect (we already showed
+                    // it as part of the message above).
+                    applySnapshot(snapshot);
+                }
+                router.push("/play");
+                return;
             }
+
+            // Invite / transfer: prompt for overwrite-game confirmation
+            // first; if accepted, hydrate everything and go.
+            if (hasPersistedGameData()) {
+                const ok = await confirm({
+                    message: tToolbar("newGameConfirm"),
+                });
+                if (!ok) return;
+            }
+            applySnapshot(snapshot);
+            await queryClient.invalidateQueries({
+                queryKey: customCardPacksQueryKey,
+            });
+            await queryClient.invalidateQueries({
+                queryKey: cardPackUsageQueryKey,
+            });
             shareImported({
                 shareIdHash: hashShareId(snapshot.id),
                 hadPack: hasPack,
@@ -308,6 +394,54 @@ export function ShareImportPage({
             setSubmitting(false);
         }
     };
+
+    const onSignInToImport = async (): Promise<void> => {
+        // Stamp the intent BEFORE redirect so the post-OAuth mount can
+        // recognise this exact share and auto-fire the import. Saved
+        // even on failure — better-auth's redirect is opaque, so we
+        // can't reliably clean up here, and a stale entry is rejected
+        // by `consumePendingImportIntent`'s shareId + age check.
+        savePendingImportIntent({ shareId: snapshot.id, t: Date.now() });
+        signInStarted({
+            provider: SOCIAL_SIGN_IN_PROVIDER,
+            from: SIGN_IN_FROM_RECEIVE,
+        });
+        const result = await authClient.signIn.social({
+            provider: SOCIAL_SIGN_IN_PROVIDER,
+            callbackURL: window.location.pathname,
+        });
+        if (result.error !== null) {
+            signInFailed({
+                provider: SOCIAL_SIGN_IN_PROVIDER,
+                reason: result.error.code ?? String(result.error.status),
+            });
+        }
+    };
+
+    const onImport = useCallback(async (): Promise<void> => {
+        if (isAnonymous) {
+            await onSignInToImport();
+            return;
+        }
+        await performImport();
+    }, [isAnonymous]);
+
+    /**
+     * Auto-import after OAuth lands the user back here. Guarded by a
+     * single sessionStorage entry that the user themselves wrote when
+     * clicking "Sign in to import". Runs at most once per mount —
+     * `autoImportRanRef` rejects re-entry under React StrictMode (or
+     * any future re-mount). A drive-by malicious URL doesn't trigger
+     * this branch because no intent was ever written.
+     */
+    const autoImportRanRef = useRef(false);
+    useEffect(() => {
+        if (autoImportRanRef.current) return;
+        if (isAnonymous) return;
+        if (!consumePendingImportIntent(snapshot.id)) return;
+        autoImportRanRef.current = true;
+        void performImport();
+    }, [isAnonymous, snapshot.id]);
 
     const close = (via: ShareDismissVia): void => {
         shareImportDismissed({
@@ -487,7 +621,9 @@ export function ShareImportPage({
                             >
                                 {submitting
                                     ? t("importing")
-                                    : t(ACTION_KEY_FOR[receiveFlow])}
+                                    : isAnonymous
+                                        ? t("signInToImport")
+                                        : t(ACTION_KEY_FOR[receiveFlow])}
                             </button>
                         </div>
                     </Dialog.Content>

--- a/src/ui/share/pendingImport.test.ts
+++ b/src/ui/share/pendingImport.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Round-trip tests for the receive-side sign-in intent. The shareId
+ * match + age check is the malicious-URL defence: a third party who
+ * sends a `/share/[id]` URL has no way to write sessionStorage on the
+ * recipient's tab, so an idle visit never auto-imports. These tests
+ * pin the corresponding failure modes.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+    consumePendingImportIntent,
+    savePendingImportIntent,
+} from "./pendingImport";
+
+const KEY = "effect-clue.pending-import.v1";
+
+beforeEach(() => {
+    sessionStorage.clear();
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe("savePendingImportIntent / consumePendingImportIntent", () => {
+    test("save → consume with matching shareId returns true once", () => {
+        savePendingImportIntent({ shareId: "share_abc", t: Date.now() });
+        expect(consumePendingImportIntent("share_abc")).toBe(true);
+        // Single-use: a second consume returns false even with the
+        // same shareId.
+        expect(consumePendingImportIntent("share_abc")).toBe(false);
+    });
+
+    test("consume always clears the entry, even on shareId mismatch", () => {
+        savePendingImportIntent({ shareId: "share_abc", t: Date.now() });
+        // Mismatched shareId → false AND the entry is gone, so a
+        // subsequent legitimate consume can't pick it up either.
+        expect(consumePendingImportIntent("share_xyz")).toBe(false);
+        expect(sessionStorage.getItem(KEY)).toBeNull();
+        expect(consumePendingImportIntent("share_abc")).toBe(false);
+    });
+
+    test("stale intent (older than 10 minutes) → false and cleared", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(2026, 0, 1, 12, 0, 0));
+        savePendingImportIntent({
+            shareId: "share_abc",
+            t: Date.now(),
+        });
+        // Advance 11 minutes.
+        vi.setSystemTime(new Date(2026, 0, 1, 12, 11, 0));
+        expect(consumePendingImportIntent("share_abc")).toBe(false);
+        expect(sessionStorage.getItem(KEY)).toBeNull();
+    });
+
+    test("intent with future timestamp (clock skew) → rejected", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(2026, 0, 1, 12, 0, 0));
+        // Save an entry stamped at "now + 1 minute" — defends against
+        // a malformed sessionStorage value tricking us into accepting.
+        sessionStorage.setItem(
+            KEY,
+            JSON.stringify({
+                shareId: "share_abc",
+                t: Date.now() + 60_000,
+            }),
+        );
+        expect(consumePendingImportIntent("share_abc")).toBe(false);
+    });
+
+    test("malformed sessionStorage value → false", () => {
+        sessionStorage.setItem(KEY, "not-json");
+        expect(consumePendingImportIntent("share_abc")).toBe(false);
+    });
+
+    test("missing required fields → false", () => {
+        sessionStorage.setItem(KEY, JSON.stringify({ shareId: 123, t: 1 }));
+        expect(consumePendingImportIntent("share_abc")).toBe(false);
+    });
+
+    test("no intent stored → false (malicious URL safe path)", () => {
+        // The default state for any drive-by visit to a /share/[id]
+        // URL — no auto-import. The receive page renders the modal
+        // and waits for explicit user action.
+        expect(consumePendingImportIntent("share_abc")).toBe(false);
+    });
+});

--- a/src/ui/share/pendingImport.ts
+++ b/src/ui/share/pendingImport.ts
@@ -1,0 +1,89 @@
+/**
+ * SessionStorage handle for the "I'm signing in to import this share"
+ * intent. Counterpart to `pendingShare.ts` on the sender side.
+ *
+ * The receive page on `/share/[id]` requires a signed-in account to
+ * import. When an anonymous user clicks the in-modal sign-in CTA, we:
+ *
+ *   1. Save `{ shareId, t }` into sessionStorage.
+ *   2. Kick off Better Auth's social sign-in with `callbackURL =
+ *      /share/[id]`.
+ *   3. After OAuth redirects back, the page remounts; an effect calls
+ *      `consumePendingImportIntent(shareId)`. If the stored intent
+ *      matches the page's shareId AND was saved within `MAX_AGE`, the
+ *      effect auto-fires the import — the user doesn't have to click
+ *      "Import" a second time.
+ *
+ * Malicious-URL safety: a third party who sends a `/share/[id]` URL
+ * has no way to populate this sessionStorage entry. The only path that
+ * writes the intent is the user's own click on the in-modal "Sign in
+ * to import" button on this exact page. A drive-by malicious URL
+ * renders the modal with the sign-in CTA and waits for explicit user
+ * action — no auto-import. The shareId match also defends against
+ * cross-share leaks: if the user previously signed in for share A and
+ * now lands on share B, B's own intent is absent and nothing fires.
+ */
+import { Duration } from "effect";
+
+const PENDING_IMPORT_KEY = "effect-clue.pending-import.v1";
+
+/**
+ * The OAuth round-trip is normally a few seconds; ten minutes is
+ * comfortable headroom (a slow network + a password manager + 2FA),
+ * but tight enough that an old, leaked sessionStorage entry from a
+ * previous sign-in flow can't be reused later.
+ */
+const MAX_AGE = Duration.minutes(10);
+
+interface PendingImportIntent {
+    readonly shareId: string;
+    /**
+     * Epoch millis at the moment of save. Stored as a number so
+     * sessionStorage round-trips cleanly through JSON. Compared via
+     * `Date.now()` against `MAX_AGE` (in millis) at consume time.
+     */
+    readonly t: number;
+}
+
+const isPendingImportIntent = (raw: unknown): raw is PendingImportIntent => {
+    if (typeof raw !== "object" || raw === null) return false;
+    const r = raw as Record<string, unknown>;
+    return typeof r["shareId"] === "string" && typeof r["t"] === "number";
+};
+
+export const savePendingImportIntent = (intent: PendingImportIntent): void => {
+    try {
+        sessionStorage.setItem(PENDING_IMPORT_KEY, JSON.stringify(intent));
+    } catch {
+        // Non-fatal: OAuth can still proceed. The user will land back
+        // on the share page and just have to click Import a second
+        // time — graceful degradation, not a hard failure.
+    }
+};
+
+/**
+ * Read & remove the intent. Returns `true` only when the saved entry
+ * matches `expectedShareId` AND was saved within `MAX_AGE` of now.
+ * Always clears the entry from storage (even on mismatch / expiry) so
+ * stale intents don't accumulate or trigger surprise auto-imports
+ * later.
+ */
+export const consumePendingImportIntent = (
+    expectedShareId: string,
+): boolean => {
+    let parsed: unknown = null;
+    try {
+        const raw = sessionStorage.getItem(PENDING_IMPORT_KEY);
+        if (raw === null) return false;
+        sessionStorage.removeItem(PENDING_IMPORT_KEY);
+        parsed = JSON.parse(raw);
+    } catch {
+        return false;
+    }
+    if (!isPendingImportIntent(parsed)) return false;
+    if (parsed.shareId !== expectedShareId) return false;
+    const ageMillis = Date.now() - parsed.t;
+    if (ageMillis < 0) return false;
+    if (ageMillis > Duration.toMillis(MAX_AGE)) return false;
+    return true;
+};

--- a/src/ui/share/resolveActivePackLabel.test.ts
+++ b/src/ui/share/resolveActivePackLabel.test.ts
@@ -1,0 +1,103 @@
+/**
+ * The receive-modal "Card pack: My Cool Deck (custom)" line depends
+ * on the wire payload's `name` field, which the sender only embeds
+ * when the create-side modal knows the active pack's label. Invite
+ * and transfer openers don't pass a forced label; this helper recovers
+ * it from the most-recently-used custom pack whose contents still
+ * match the live deck.
+ */
+import { DateTime } from "effect";
+import { describe, expect, test } from "vitest";
+import { Card, CardCategory } from "../../logic/GameObjects";
+import { CardSet, CardEntry, Category } from "../../logic/CardSet";
+import type { CustomCardSet } from "../../logic/CustomCardSets";
+import { resolveActivePackLabel } from "./resolveActivePackLabel";
+
+const PACK_A = CardSet({
+    categories: [
+        Category({
+            id: CardCategory("category-a"),
+            name: "A",
+            cards: [
+                CardEntry({ id: Card("card-a-1"), name: "A1" }),
+                CardEntry({ id: Card("card-a-2"), name: "A2" }),
+            ],
+        }),
+    ],
+});
+const PACK_B = CardSet({
+    categories: [
+        Category({
+            id: CardCategory("category-b"),
+            name: "B",
+            cards: [CardEntry({ id: Card("card-b-1"), name: "B1" })],
+        }),
+    ],
+});
+
+const customA: CustomCardSet = { id: "id-a", label: "Pack A", cardSet: PACK_A };
+const customB: CustomCardSet = { id: "id-b", label: "Pack B", cardSet: PACK_B };
+
+const usageOf = (
+    entries: ReadonlyArray<readonly [string, string]>,
+): ReadonlyMap<string, DateTime.Utc> =>
+    new Map(
+        entries.map(([id, iso]) => [
+            id,
+            DateTime.makeUnsafe(new Date(iso).getTime()),
+        ]),
+    );
+
+describe("resolveActivePackLabel", () => {
+    test("explicit label wins (picker-supplied label is authoritative)", () => {
+        expect(
+            resolveActivePackLabel(PACK_A, [customA], new Map(), "Picker"),
+        ).toBe("Picker");
+    });
+
+    test("MRU custom pack whose deck still matches → returns its label", () => {
+        const usage = usageOf([
+            ["id-b", "2026-01-01T00:00:00Z"],
+            ["id-a", "2026-01-02T00:00:00Z"], // most recent
+        ]);
+        expect(
+            resolveActivePackLabel(
+                PACK_A,
+                [customA, customB],
+                usage,
+                undefined,
+            ),
+        ).toBe("Pack A");
+    });
+
+    test("MRU pack whose deck no longer matches the live setup → undefined", () => {
+        // User loaded Pack A, then edited it. Live deck (PACK_B-shaped)
+        // no longer matches the saved pack contents.
+        const usage = usageOf([["id-a", "2026-01-02T00:00:00Z"]]);
+        expect(
+            resolveActivePackLabel(PACK_B, [customA], usage, undefined),
+        ).toBeUndefined();
+    });
+
+    test("MRU id is a built-in (not in customPacks) → undefined", () => {
+        // We don't need to embed names for built-in packs — receivers
+        // detect them by structural equality.
+        const usage = usageOf([["builtin-classic", "2026-01-02T00:00:00Z"]]);
+        expect(
+            resolveActivePackLabel(PACK_A, [customA], usage, undefined),
+        ).toBeUndefined();
+    });
+
+    test("empty explicit string is treated as no explicit label", () => {
+        const usage = usageOf([["id-a", "2026-01-02T00:00:00Z"]]);
+        expect(
+            resolveActivePackLabel(PACK_A, [customA], usage, ""),
+        ).toBe("Pack A");
+    });
+
+    test("empty usage map and no explicit → undefined", () => {
+        expect(
+            resolveActivePackLabel(PACK_A, [customA], new Map(), undefined),
+        ).toBeUndefined();
+    });
+});

--- a/src/ui/share/resolveActivePackLabel.ts
+++ b/src/ui/share/resolveActivePackLabel.ts
@@ -1,0 +1,41 @@
+/**
+ * Pure helper used by `ShareCreateModal` to recover the user-facing
+ * label of the currently-loaded custom pack when the caller didn't
+ * pass an explicit `forcedCardPackLabel` (true for invite/transfer
+ * shares — those open from the overflow menu / setup pane and don't
+ * know which custom pack the live deck came from).
+ *
+ * Mirrors the active-pill resolution in `CardPackRow`: the
+ * most-recently-used pack id whose `cardSet` still equals the live
+ * `setup.cardSet`. Returning `undefined` here causes the modal to
+ * fall back to its existing "no label" behaviour, which round-trips
+ * as the receiver's `isUnnamedCustom` branch.
+ */
+import { DateTime } from "effect";
+import { cardSetEquals, type CardSet } from "../../logic/CardSet";
+import type { CustomCardSet } from "../../logic/CustomCardSets";
+
+export const resolveActivePackLabel = (
+    cardSet: CardSet,
+    customPacks: ReadonlyArray<CustomCardSet>,
+    usage: ReadonlyMap<string, DateTime.Utc>,
+    explicit: string | undefined,
+): string | undefined => {
+    if (explicit !== undefined && explicit !== "") return explicit;
+    let candidateId: string | undefined;
+    let mostRecent: DateTime.Utc | undefined;
+    for (const [id, at] of usage.entries()) {
+        if (
+            !mostRecent ||
+            DateTime.toEpochMillis(at) > DateTime.toEpochMillis(mostRecent)
+        ) {
+            mostRecent = at;
+            candidateId = id;
+        }
+    }
+    if (candidateId === undefined) return undefined;
+    const candidate = customPacks.find((p) => p.id === candidateId);
+    if (candidate === undefined) return undefined;
+    if (!cardSetEquals(cardSet, candidate.cardSet)) return undefined;
+    return candidate.label;
+};

--- a/src/ui/share/useApplyShareSnapshot.test.ts
+++ b/src/ui/share/useApplyShareSnapshot.test.ts
@@ -370,6 +370,135 @@ describe("saveCardPackFromSnapshot — pack-only receive", () => {
         expect(loadFromLocalStorage()).toEqual(currentSession);
     });
 
+    test("recognises an existing custom pack with same content AND label", async () => {
+        const { saveCustomCardSet, loadCustomCardSets } = await import(
+            "../../logic/CustomCardSets"
+        );
+        // Pre-seed an existing custom pack with the same structural
+        // contents AND the same label as what the share carries
+        // (SHARE_PACK is "Classic" with the two-card Suspect category).
+        // Wire-format ids may differ — content equality is via
+        // cardSetEquals, label equality is exact-string.
+        const existing = saveCustomCardSet(
+            "Classic",
+            CardSet({
+                categories: [
+                    Category({
+                        id: CardCategory("local-suspect"),
+                        name: "Suspect",
+                        cards: [
+                            CardEntry({
+                                id: Card("local-scarlet"),
+                                name: "Miss Scarlet",
+                            }),
+                            CardEntry({
+                                id: Card("local-mustard"),
+                                name: "Colonel Mustard",
+                            }),
+                        ],
+                    }),
+                ],
+            }),
+        );
+
+        const result = saveCardPackFromSnapshot(
+            sampleSnapshot({ cardPack: true }),
+        );
+
+        expect(result.kind).toBe("recognised");
+        if (result.kind !== "recognised") return;
+        expect(result.id).toBe(existing.id);
+        expect(result.label).toBe("Classic");
+        expect(loadCustomCardSets()).toHaveLength(1);
+        expect(loadCardPackUsage().has(existing.id)).toBe(true);
+    });
+
+    test("does NOT recognise an existing custom pack when contents match but the label differs", async () => {
+        const { saveCustomCardSet, loadCustomCardSets } = await import(
+            "../../logic/CustomCardSets"
+        );
+        // Same content as the wire payload, different label. Users
+        // distinguish two structurally-identical decks by label, so
+        // we treat them as separate packs — the import goes through
+        // the `saved` branch and the user ends up with both entries
+        // in their library.
+        saveCustomCardSet(
+            "My Renamed Classic",
+            CardSet({
+                categories: [
+                    Category({
+                        id: CardCategory("local-suspect"),
+                        name: "Suspect",
+                        cards: [
+                            CardEntry({
+                                id: Card("local-scarlet"),
+                                name: "Miss Scarlet",
+                            }),
+                            CardEntry({
+                                id: Card("local-mustard"),
+                                name: "Colonel Mustard",
+                            }),
+                        ],
+                    }),
+                ],
+            }),
+        );
+
+        const result = saveCardPackFromSnapshot(
+            sampleSnapshot({ cardPack: true }),
+        );
+
+        expect(result.kind).toBe("saved");
+        if (result.kind !== "saved") return;
+        expect(result.pack.label).toBe("Classic");
+        // Two distinct entries in the library — same shape, different
+        // labels.
+        expect(loadCustomCardSets()).toHaveLength(2);
+    });
+
+    test("when multiple existing customs match content+label, prefers the most-recently-used", async () => {
+        const { saveCustomCardSet } = await import(
+            "../../logic/CustomCardSets"
+        );
+        const { recordCardPackUse } = await import(
+            "../../logic/CardPackUsage"
+        );
+        const matchingCardSet = CardSet({
+            categories: [
+                Category({
+                    id: CardCategory("local-suspect"),
+                    name: "Suspect",
+                    cards: [
+                        CardEntry({
+                            id: Card("local-scarlet"),
+                            name: "Miss Scarlet",
+                        }),
+                        CardEntry({
+                            id: Card("local-mustard"),
+                            name: "Colonel Mustard",
+                        }),
+                    ],
+                }),
+            ],
+        });
+        // Both packs carry the same label as the wire payload
+        // ("Classic") — saveCustomCardSet does not enforce label
+        // uniqueness, so this is a real (if rare) state.
+        const older = saveCustomCardSet("Classic", matchingCardSet);
+        recordCardPackUse(older.id);
+        await new Promise((r) => setTimeout(r, 5));
+        const newer = saveCustomCardSet("Classic", matchingCardSet);
+        recordCardPackUse(newer.id);
+
+        const result = saveCardPackFromSnapshot(
+            sampleSnapshot({ cardPack: true }),
+        );
+
+        expect(result.kind).toBe("recognised");
+        if (result.kind !== "recognised") return;
+        expect(result.id).toBe(newer.id);
+    });
+
     test("recognises a built-in pack instead of duplicating it", () => {
         // The receiver-side detection compares structurally against
         // CARD_SETS, so a snapshot whose wire deck matches built-in

--- a/src/ui/share/useApplyShareSnapshot.test.ts
+++ b/src/ui/share/useApplyShareSnapshot.test.ts
@@ -19,7 +19,7 @@ import { Card, CardCategory, Player } from "../../logic/GameObjects";
 import { emptyHypotheses } from "../../logic/Hypothesis";
 import { newAccusationId } from "../../logic/Accusation";
 import { newSuggestionId } from "../../logic/Suggestion";
-import { GameSetup } from "../../logic/GameSetup";
+import { CARD_SETS, GameSetup } from "../../logic/GameSetup";
 import { CardSet, CardEntry, Category } from "../../logic/CardSet";
 import { PlayerSet } from "../../logic/PlayerSet";
 import {
@@ -354,15 +354,58 @@ describe("saveCardPackFromSnapshot — pack-only receive", () => {
         };
         saveToLocalStorage(currentSession);
 
-        const savedPack = saveCardPackFromSnapshot(
+        const result = saveCardPackFromSnapshot(
             sampleSnapshot({ cardPack: true }),
         );
 
-        expect(savedPack.label).toBe("Classic");
-        expect(savedPack.cardSet.categories[0]!.name).toBe("Suspect");
-        expect(loadCustomCardSets()).toContainEqual(savedPack);
-        expect(loadCardPackUsage().has(savedPack.id)).toBe(true);
+        // SHARE_PACK is a custom pack carrying the wire `name: "Classic"`
+        // but a structurally different deck from the built-in Classic, so
+        // `saveOrRecognisePack` falls through to the `saved` branch.
+        expect(result.kind).toBe("saved");
+        if (result.kind !== "saved") return;
+        expect(result.pack.label).toBe("Classic");
+        expect(result.pack.cardSet.categories[0]!.name).toBe("Suspect");
+        expect(loadCustomCardSets()).toContainEqual(result.pack);
+        expect(loadCardPackUsage().has(result.pack.id)).toBe(true);
         expect(loadFromLocalStorage()).toEqual(currentSession);
+    });
+
+    test("recognises a built-in pack instead of duplicating it", () => {
+        // The receiver-side detection compares structurally against
+        // CARD_SETS, so a snapshot whose wire deck matches built-in
+        // Classic deduplicates: nothing in customCardSets, but the
+        // built-in id is recorded as MRU so the active pill resolves
+        // correctly post-import.
+        const builtInClassic = CARD_SETS[0]!;
+        const wirePack = {
+            name: builtInClassic.label,
+            categories: builtInClassic.cardSet.categories.map((c) => ({
+                id: c.id,
+                name: c.name,
+                cards: c.cards.map((card) => ({
+                    id: card.id,
+                    name: card.name,
+                })),
+            })),
+        };
+        const snapshot: ShareSnapshotForHydration = {
+            cardPackData: Schema.encodeSync(cardPackCodec)(wirePack),
+            playersData: null,
+            handSizesData: null,
+            knownCardsData: null,
+            suggestionsData: null,
+            accusationsData: null,
+            hypothesesData: null,
+        };
+
+        const result = saveCardPackFromSnapshot(snapshot);
+
+        expect(result.kind).toBe("recognised");
+        if (result.kind !== "recognised") return;
+        expect(result.id).toBe(builtInClassic.id);
+        expect(result.label).toBe(builtInClassic.label);
+        expect(loadCustomCardSets()).toEqual([]);
+        expect(loadCardPackUsage().has(builtInClassic.id)).toBe(true);
     });
 
     test("missing cardPackData throws without touching saved packs", () => {
@@ -378,6 +421,44 @@ describe("saveCardPackFromSnapshot — pack-only receive", () => {
             }),
         ).toThrow(ShareSnapshotDecodeError);
         expect(loadCustomCardSets()).toEqual([]);
+    });
+});
+
+describe("applyShareSnapshotToLocalStorage — pack save side effect", () => {
+    test("invite/transfer hydration also feeds the imported pack into the local registry", () => {
+        const snapshot = sampleSnapshot({
+            cardPack: true,
+            players: true,
+            handSizes: true,
+        });
+        const session = applyShareSnapshotToLocalStorage(snapshot);
+
+        // GameSession is the imported game.
+        expect(session.setup.cardSet.categories[0]!.name).toBe("Suspect");
+        // The pack is also saved + marked MRU so CardPackRow's pill
+        // resolution can light it up post-import.
+        const saved = loadCustomCardSets();
+        expect(saved).toHaveLength(1);
+        expect(saved[0]!.label).toBe("Classic");
+        expect(loadCardPackUsage().has(saved[0]!.id)).toBe(true);
+    });
+
+    test("snapshots without a pack don't touch the local pack registry", () => {
+        const snapshot: ShareSnapshotForHydration = {
+            cardPackData: null,
+            playersData: Schema.encodeSync(playersCodec)([
+                Player("Alice"),
+                Player("Bob"),
+            ]),
+            handSizesData: null,
+            knownCardsData: null,
+            suggestionsData: null,
+            accusationsData: null,
+            hypothesesData: null,
+        };
+        applyShareSnapshotToLocalStorage(snapshot);
+        expect(loadCustomCardSets()).toEqual([]);
+        expect(loadCardPackUsage().size).toBe(0);
     });
 });
 

--- a/src/ui/share/useApplyShareSnapshot.ts
+++ b/src/ui/share/useApplyShareSnapshot.ts
@@ -33,11 +33,12 @@
 import { Result, Schema } from "effect";
 import { Accusation, newAccusationId } from "../../logic/Accusation";
 import {
+    cardSetEquals,
     CardSet,
     CardEntry,
     Category,
 } from "../../logic/CardSet";
-import { DEFAULT_SETUP, GameSetup } from "../../logic/GameSetup";
+import { CARD_SETS, DEFAULT_SETUP, GameSetup } from "../../logic/GameSetup";
 import { HashMap } from "effect";
 import {
     CaseFileOwner,
@@ -283,12 +284,28 @@ export const buildSessionFromSnapshot = (
     };
 };
 
-export const saveCardPackFromSnapshot = (
+/**
+ * Distinct outcome of `saveOrRecognisePack`. `recognised` means the
+ * snapshot's pack matched a built-in by structural equality, so we
+ * just stamped the built-in id as MRU; nothing was added to the
+ * custom-pack list. `saved` means the pack was new (or didn't match
+ * any built-in) and was persisted to `customCardSets` plus stamped
+ * MRU. `none` means the snapshot has no pack at all (defensive — the
+ * receive page gates Import out of that branch).
+ */
+export type RecognisedPackResult =
+    | { readonly kind: "saved"; readonly pack: CustomCardSet }
+    | {
+          readonly kind: "recognised";
+          readonly id: string;
+          readonly label: string;
+      }
+    | { readonly kind: "none" };
+
+const decodeAndBuildCardSet = (
     snapshot: ShareSnapshotForHydration,
-): CustomCardSet => {
-    if (snapshot.cardPackData === null) {
-        throw new ShareSnapshotDecodeError(F_CARD_PACK_DATA);
-    }
+): { readonly cardSet: CardSet; readonly name: string } | null => {
+    if (snapshot.cardPackData === null) return null;
     const decoded = decodeField(
         F_CARD_PACK_DATA,
         snapshot.cardPackData,
@@ -305,12 +322,49 @@ export const saveCardPackFromSnapshot = (
             }),
         ),
     });
-    const savedPack = saveCustomCardSet(
-        decoded.name ?? "",
-        cardSet,
+    return { cardSet, name: decoded.name ?? "" };
+};
+
+/**
+ * Persist the snapshot's pack into the local card-pack registry and
+ * mark it as the most-recently-used pack. When the decoded pack
+ * matches one of `CARD_SETS` by structural equality, skip the custom
+ * write and just stamp the built-in id as MRU — otherwise we'd seed
+ * a duplicate Classic / Master Detective into the user's library on
+ * every received share. Used by both the pack-only receive flow and
+ * the invite/transfer flow so the post-import pill resolution lights
+ * up the right pack.
+ */
+const saveOrRecognisePack = (
+    snapshot: ShareSnapshotForHydration,
+): RecognisedPackResult => {
+    const decoded = decodeAndBuildCardSet(snapshot);
+    if (decoded === null) return { kind: "none" };
+    const builtIn = CARD_SETS.find((s) =>
+        cardSetEquals(decoded.cardSet, s.cardSet),
     );
+    if (builtIn !== undefined) {
+        recordCardPackUse(builtIn.id);
+        return { kind: "recognised", id: builtIn.id, label: builtIn.label };
+    }
+    const savedPack = saveCustomCardSet(decoded.name, decoded.cardSet);
     recordCardPackUse(savedPack.id);
-    return savedPack;
+    return { kind: "saved", pack: savedPack };
+};
+
+/**
+ * Pack-only receive flow: persists the pack and returns the saved
+ * descriptor (or null when the snapshot's pack matches a built-in).
+ * Callers that need the user-facing label can read it from either
+ * branch — see `pickPackResultLabel` in `ShareImportPage`.
+ */
+export const saveCardPackFromSnapshot = (
+    snapshot: ShareSnapshotForHydration,
+): RecognisedPackResult => {
+    if (snapshot.cardPackData === null) {
+        throw new ShareSnapshotDecodeError(F_CARD_PACK_DATA);
+    }
+    return saveOrRecognisePack(snapshot);
 };
 
 export const applyShareSnapshotToLocalStorage = (
@@ -323,6 +377,10 @@ export const applyShareSnapshotToLocalStorage = (
         currentSession?.setup.playerSet ?? DEFAULT_SETUP.playerSet,
     );
     saveToLocalStorage(session);
+    // Invite/transfer also feeds the imported pack into the local
+    // card-pack registry so `CardPackRow` can light its pill up post-
+    // import. Built-ins are recognised, not duplicated.
+    if (snapshot.cardPackData !== null) saveOrRecognisePack(snapshot);
     return session;
 };
 

--- a/src/ui/share/useApplyShareSnapshot.ts
+++ b/src/ui/share/useApplyShareSnapshot.ts
@@ -30,7 +30,7 @@
  */
 "use client";
 
-import { Result, Schema } from "effect";
+import { DateTime, Result, Schema } from "effect";
 import { Accusation, newAccusationId } from "../../logic/Accusation";
 import {
     cardSetEquals,
@@ -56,10 +56,14 @@ import {
     type GameSession,
 } from "../../logic/Persistence";
 import {
+    loadCustomCardSets,
     saveCustomCardSet,
     type CustomCardSet,
 } from "../../logic/CustomCardSets";
-import { recordCardPackUse } from "../../logic/CardPackUsage";
+import {
+    loadCardPackUsage,
+    recordCardPackUse,
+} from "../../logic/CardPackUsage";
 import { PlayerSet } from "../../logic/PlayerSet";
 import {
     accusationsCodec,
@@ -286,11 +290,12 @@ export const buildSessionFromSnapshot = (
 
 /**
  * Distinct outcome of `saveOrRecognisePack`. `recognised` means the
- * snapshot's pack matched a built-in by structural equality, so we
- * just stamped the built-in id as MRU; nothing was added to the
- * custom-pack list. `saved` means the pack was new (or didn't match
- * any built-in) and was persisted to `customCardSets` plus stamped
- * MRU. `none` means the snapshot has no pack at all (defensive — the
+ * snapshot's pack matched something already in the user's library —
+ * either a built-in (`CARD_SETS`) or a saved custom pack — by
+ * structural equality, so we just stamped that pack's id as MRU and
+ * left the registry alone. `saved` means the pack was structurally
+ * new and was persisted to `customCardSets` plus stamped MRU.
+ * `none` means the snapshot has no pack at all (defensive — the
  * receive page gates Import out of that branch).
  */
 export type RecognisedPackResult =
@@ -327,13 +332,36 @@ const decodeAndBuildCardSet = (
 
 /**
  * Persist the snapshot's pack into the local card-pack registry and
- * mark it as the most-recently-used pack. When the decoded pack
- * matches one of `CARD_SETS` by structural equality, skip the custom
- * write and just stamp the built-in id as MRU — otherwise we'd seed
- * a duplicate Classic / Master Detective into the user's library on
- * every received share. Used by both the pack-only receive flow and
- * the invite/transfer flow so the post-import pill resolution lights
- * up the right pack.
+ * mark it as the most-recently-used pack. Two short-circuits before
+ * we'd otherwise duplicate-write:
+ *
+ *   1. Built-in match: when the decoded deck structurally equals one
+ *      of `CARD_SETS` (Classic / Master Detective), stamp that id as
+ *      MRU and return — receiving Classic shouldn't seed a "Classic"
+ *      copy into the user's customCardSets every time. The wire-name
+ *      is ignored for built-ins; they're identified by content.
+ *   2. Existing custom-pack match: when the decoded deck structurally
+ *      equals a pack the user already has saved AND carries the same
+ *      label, stamp the existing id and return. The name has to match
+ *      because users distinguish two structurally-identical decks by
+ *      label ("Mike's Office" vs "The Office Pack" with the same
+ *      cards are deliberately separate packs); duplicating content
+ *      across labels is a feature, not a bug. Without the name match
+ *      we'd incorrectly fold one into the other on re-import.
+ *
+ * Content equality is `cardSetEquals` — the same name-based
+ * structural comparison `CardPackRow` uses to decide which pack pill
+ * is active. IDs aren't compared (the wire-format IDs from a sender
+ * may differ from the receiver's local IDs even for content-identical
+ * packs). Label equality is exact-string (no trim/case-folding) for
+ * the same reason: users see the label they chose, so any character
+ * difference is meaningful.
+ *
+ * Tie-breaker when multiple existing custom packs match content+label
+ * (rare — would mean the user saved the same pack twice under the
+ * same name): pick the most-recently-used one, falling back to the
+ * first match. Keeps the active-pill resolution stable across
+ * re-imports.
  */
 const saveOrRecognisePack = (
     snapshot: ShareSnapshotForHydration,
@@ -347,9 +375,55 @@ const saveOrRecognisePack = (
         recordCardPackUse(builtIn.id);
         return { kind: "recognised", id: builtIn.id, label: builtIn.label };
     }
+    const existing = pickExistingCustomMatch(decoded.cardSet, decoded.name);
+    if (existing !== undefined) {
+        recordCardPackUse(existing.id);
+        return {
+            kind: "recognised",
+            id: existing.id,
+            label: existing.label,
+        };
+    }
     const savedPack = saveCustomCardSet(decoded.name, decoded.cardSet);
     recordCardPackUse(savedPack.id);
     return { kind: "saved", pack: savedPack };
+};
+
+/**
+ * Find a saved custom pack whose contents structurally match
+ * `cardSet` AND whose label exactly matches `label`. When more than
+ * one matches, prefer the most-recently-used; when none has been
+ * used (or usage map is empty), the first match wins.
+ */
+const pickExistingCustomMatch = (
+    cardSet: CardSet,
+    label: string,
+): CustomCardSet | undefined => {
+    const candidates = loadCustomCardSets().filter(
+        (p) => p.label === label && cardSetEquals(p.cardSet, cardSet),
+    );
+    if (candidates.length === 0) return undefined;
+    if (candidates.length === 1) return candidates[0];
+    const usage = loadCardPackUsage();
+    let best = candidates[0]!;
+    let bestAt: number | undefined = epochOf(usage, best.id);
+    for (let i = 1; i < candidates.length; i += 1) {
+        const c = candidates[i]!;
+        const at = epochOf(usage, c.id);
+        if (at !== undefined && (bestAt === undefined || at > bestAt)) {
+            best = c;
+            bestAt = at;
+        }
+    }
+    return best;
+};
+
+const epochOf = (
+    usage: ReturnType<typeof loadCardPackUsage>,
+    id: string,
+): number | undefined => {
+    const at = usage.get(id);
+    return at === undefined ? undefined : DateTime.toEpochMillis(at);
 };
 
 /**


### PR DESCRIPTION
User-visible:
- Receive modal now shows the actual pack name (e.g. "Card pack: My
  Office (custom)") for invite/transfer shares, not just "(custom)".
- Joining an invite/transfer share now saves the imported pack into
  the local card-pack registry and stamps it most-recently-used so
  the pack pill on /play lights up.
- Pack-only shares no longer auto-load the pack into the live setup.
  After import they pop a confirm: "Card pack {name} saved. Would you
  like to start a new game with this pack?" with default focus on
  "Not now"; when there's a game in progress, the standard overwrite
  warning is appended to the message.
- Receiving any share now requires sign-in. Anonymous users see a
  "Sign in to import" CTA. After OAuth lands the user back on the
  share page, the import auto-fires for that one share — gated by a
  sessionStorage intent the user wrote when clicking Sign in, so a
  malicious share URL can't trick a recipient into auto-importing.

Technical:
- ShareCreateModal: backfill the wire payload's cardPack.name field
  via resolveActivePackLabel when invite/transfer openers don't pass
  a forcedCardPackLabel, using the same MRU-resolves-to-loaded-pack
  pattern CardPackRow uses for the active pill.
- useApplyShareSnapshot: extract saveOrRecognisePack — built-in
  packs are recognised (just stamp MRU); customs are saved to
  customCardSets + stamped MRU. Both the pack-only flow and
  applyShareSnapshotToLocalStorage route through it.
- pendingImport: new sessionStorage helper with shareId match +
  10-minute age cap + single-use semantics. Documents the malicious-
  URL safety property.
- ShareImportPage: sign-in gate, post-OAuth auto-import effect, and
  the post-save "Use it now?" confirm. Branches the flow by
  receiveFlow type so invite/transfer keep the existing overwrite
  warning while pack-only goes through the new prompt.
- Docs: updated docs/shares-and-sync.md (Receiver flow section,
  new Universal sign-in (receive side) section, error code table,
  sync intersection) and docs/card-pack-sync.md (new edge case
  describing how share-receive now feeds the local pack registry).

https://claude.ai/code/session_01KYUEHQY411thdhKLZ3ddJx