### PR TITLE
Bigger suggestion pills + auto-deselect on role conflict

### DIFF
--- a/src/ui/components/PillForm.tsx
+++ b/src/ui/components/PillForm.tsx
@@ -311,7 +311,7 @@ export const PillForm = forwardRef<PillFormHandle, PillFormProps>(
                 clearInputsLabel !== undefined);
 
         const submitButtonClass =
-            "rounded border-none px-3 py-2 text-[13px] " +
+            "min-h-[44px] rounded border-none px-4 py-2.5 text-[15px] " +
             (canSubmit
                 ? "cursor-pointer bg-accent text-white"
                 : "cursor-not-allowed bg-unknown-bg text-muted/70");
@@ -376,7 +376,7 @@ export const PillForm = forwardRef<PillFormHandle, PillFormProps>(
                     {onCancel !== undefined && (
                         <button
                             type="button"
-                            className="cursor-pointer rounded border border-border bg-white px-3 py-2 text-[13px]"
+                            className="min-h-[44px] cursor-pointer rounded border border-border bg-white px-4 py-2.5 text-[15px]"
                             onClick={onCancel}
                         >
                             {cancelLabel ?? null}

--- a/src/ui/components/SuggestionForm.test.tsx
+++ b/src/ui/components/SuggestionForm.test.tsx
@@ -1,0 +1,233 @@
+import { describe, expect, test } from "vitest";
+import { Card, Player } from "../../logic/GameObjects";
+import {
+    applyPassersMove,
+    applyRefuterMove,
+    applySuggesterMove,
+    type FormState,
+} from "./SuggestionForm";
+import { NOBODY } from "./SuggestionPills";
+
+// ---------------------------------------------------------------------------
+// Role-move helpers (M1 #6)
+//
+// All-options-everywhere: selecting a player into one role moves them out of
+// any other role they currently occupy. The previous behaviour filtered the
+// candidate lists by role, which trapped users in a sequencing puzzle (clear
+// the old role first, then pick again). These helpers keep the form in a
+// consistent state without forcing manual cleanup.
+// ---------------------------------------------------------------------------
+
+const A = Player("Anisha");
+const B = Player("Bob");
+const C = Player("Cho");
+const D = Player("Dani");
+
+const WRENCH = Card("Wrench");
+const ROPE = Card("Rope");
+
+const baseForm = (overrides: Partial<FormState> = {}): FormState => ({
+    id: "test-form",
+    suggester: null,
+    cards: [],
+    nonRefuters: null,
+    refuter: null,
+    seenCard: null,
+    ...overrides,
+});
+
+describe("applySuggesterMove", () => {
+    test("sets suggester when no conflict", () => {
+        const next = applySuggesterMove(baseForm(), A);
+        expect(next.suggester).toBe(A);
+        expect(next.refuter).toBe(null);
+        expect(next.nonRefuters).toBe(null);
+    });
+
+    test("removes the new suggester from the passers list", () => {
+        const next = applySuggesterMove(
+            baseForm({ nonRefuters: [B, A, C] }),
+            A,
+        );
+        expect(next.suggester).toBe(A);
+        expect(next.nonRefuters).toEqual([B, C]);
+    });
+
+    test("clears the refuter and shown card when the new suggester was the refuter", () => {
+        const next = applySuggesterMove(
+            baseForm({ refuter: A, seenCard: WRENCH }),
+            A,
+        );
+        expect(next.suggester).toBe(A);
+        expect(next.refuter).toBe(null);
+        expect(next.seenCard).toBe(null);
+    });
+
+    test("preserves refuter and shown card when no conflict", () => {
+        const next = applySuggesterMove(
+            baseForm({ refuter: B, seenCard: WRENCH }),
+            A,
+        );
+        expect(next.refuter).toBe(B);
+        expect(next.seenCard).toBe(WRENCH);
+    });
+
+    test("preserves NOBODY refuter (no player to conflict with)", () => {
+        const next = applySuggesterMove(
+            baseForm({ refuter: NOBODY }),
+            A,
+        );
+        expect(next.refuter).toBe(NOBODY);
+    });
+
+    test("preserves NOBODY passers", () => {
+        const next = applySuggesterMove(
+            baseForm({ nonRefuters: NOBODY }),
+            A,
+        );
+        expect(next.nonRefuters).toBe(NOBODY);
+    });
+
+    test("preserves null passers (not yet decided)", () => {
+        const next = applySuggesterMove(
+            baseForm({ nonRefuters: null }),
+            A,
+        );
+        expect(next.nonRefuters).toBe(null);
+    });
+});
+
+describe("applyPassersMove", () => {
+    test("sets passers when no conflict", () => {
+        const next = applyPassersMove(baseForm(), [B, C]);
+        expect(next.nonRefuters).toEqual([B, C]);
+        expect(next.suggester).toBe(null);
+        expect(next.refuter).toBe(null);
+    });
+
+    test("clears the suggester when they show up in the new passers list", () => {
+        const next = applyPassersMove(
+            baseForm({ suggester: A }),
+            [A, B],
+        );
+        expect(next.nonRefuters).toEqual([A, B]);
+        expect(next.suggester).toBe(null);
+    });
+
+    test("clears the refuter and shown card when refuter shows up in the new passers list", () => {
+        const next = applyPassersMove(
+            baseForm({ refuter: B, seenCard: ROPE }),
+            [A, B],
+        );
+        expect(next.nonRefuters).toEqual([A, B]);
+        expect(next.refuter).toBe(null);
+        expect(next.seenCard).toBe(null);
+    });
+
+    test("preserves the suggester and refuter when neither is in the new passers list", () => {
+        const next = applyPassersMove(
+            baseForm({ suggester: A, refuter: B, seenCard: ROPE }),
+            [C, D],
+        );
+        expect(next.suggester).toBe(A);
+        expect(next.refuter).toBe(B);
+        expect(next.seenCard).toBe(ROPE);
+    });
+
+    test("NOBODY passes through and does not clear other roles", () => {
+        const next = applyPassersMove(
+            baseForm({ suggester: A, refuter: B, seenCard: ROPE }),
+            NOBODY,
+        );
+        expect(next.nonRefuters).toBe(NOBODY);
+        expect(next.suggester).toBe(A);
+        expect(next.refuter).toBe(B);
+        expect(next.seenCard).toBe(ROPE);
+    });
+
+    test("null passes through and does not clear other roles", () => {
+        const next = applyPassersMove(
+            baseForm({ suggester: A, refuter: B }),
+            null,
+        );
+        expect(next.nonRefuters).toBe(null);
+        expect(next.suggester).toBe(A);
+        expect(next.refuter).toBe(B);
+    });
+
+    test("empty array clears nothing (nobody actively listed yet)", () => {
+        const next = applyPassersMove(
+            baseForm({ suggester: A, refuter: B }),
+            [],
+        );
+        expect(next.nonRefuters).toEqual([]);
+        expect(next.suggester).toBe(A);
+        expect(next.refuter).toBe(B);
+    });
+});
+
+describe("applyRefuterMove", () => {
+    test("sets refuter when no conflict", () => {
+        const next = applyRefuterMove(baseForm(), A);
+        expect(next.refuter).toBe(A);
+        expect(next.suggester).toBe(null);
+        expect(next.nonRefuters).toBe(null);
+    });
+
+    test("removes the new refuter from the passers list", () => {
+        const next = applyRefuterMove(
+            baseForm({ nonRefuters: [A, B, C] }),
+            B,
+        );
+        expect(next.refuter).toBe(B);
+        expect(next.nonRefuters).toEqual([A, C]);
+    });
+
+    test("clears the suggester when the new refuter was the suggester", () => {
+        const next = applyRefuterMove(
+            baseForm({ suggester: A }),
+            A,
+        );
+        expect(next.refuter).toBe(A);
+        expect(next.suggester).toBe(null);
+    });
+
+    test("preserves the shown card when refuter is a resolved player", () => {
+        const next = applyRefuterMove(
+            baseForm({ seenCard: WRENCH }),
+            A,
+        );
+        expect(next.seenCard).toBe(WRENCH);
+    });
+
+    test("clears the shown card when refuter becomes NOBODY", () => {
+        const next = applyRefuterMove(
+            baseForm({ refuter: A, seenCard: WRENCH }),
+            NOBODY,
+        );
+        expect(next.refuter).toBe(NOBODY);
+        expect(next.seenCard).toBe(null);
+    });
+
+    test("preserves NOBODY passers when committing a real refuter", () => {
+        const next = applyRefuterMove(
+            baseForm({ nonRefuters: NOBODY }),
+            A,
+        );
+        expect(next.nonRefuters).toBe(NOBODY);
+    });
+
+    test("clears suggester AND removes from passers if both conflict (defensive)", () => {
+        // The form shouldn't normally reach a state where the same player
+        // is suggester AND in passers (the move helpers prevent it for new
+        // suggestions), but a loaded draft could. Refuter-move resolves
+        // both conflicts at once.
+        const next = applyRefuterMove(
+            baseForm({ suggester: A, nonRefuters: [A, B] }),
+            A,
+        );
+        expect(next.refuter).toBe(A);
+        expect(next.suggester).toBe(null);
+        expect(next.nonRefuters).toEqual([B]);
+    });
+});

--- a/src/ui/components/SuggestionForm.tsx
+++ b/src/ui/components/SuggestionForm.tsx
@@ -249,7 +249,7 @@ export const SuggestionForm = forwardRef<
         (value: Player | Nobody) => {
             if (isNobody(value)) return;
             commitAndAdvance(
-                { ...form, suggester: value },
+                applySuggesterMove(form, value),
                 PILL_SUGGESTER,
             );
         },
@@ -272,7 +272,7 @@ export const SuggestionForm = forwardRef<
             value: ReadonlyArray<Player> | Nobody,
             opts: { advance: boolean } = { advance: true },
         ) => {
-            const next = { ...form, nonRefuters: value };
+            const next = applyPassersMove(form, value);
             if (opts.advance) {
                 commitAndAdvance(next, PILL_PASSERS);
             } else {
@@ -283,15 +283,14 @@ export const SuggestionForm = forwardRef<
     );
     const commitRefuter = useCallback(
         (value: Player | Nobody) => {
-            // If refuter becomes NOBODY, the shown-card pill turns
-            // unreachable (disabled) — clear any old seenCard so the
-            // user can't leave a stale value stranded. When refuter
-            // switches to a different resolved player, keep seenCard
-            // as-is: if it's no longer in the suggested cards, the
-            // error-state will surface the mismatch in PILL_SEEN.
-            const nextSeenCard = isNobody(value) ? null : form.seenCard;
+            // applyRefuterMove handles clearing seenCard when refuter
+            // becomes NOBODY (otherwise the shown-card pill turns
+            // unreachable and a stale value would strand). When
+            // refuter switches to a different resolved player, seenCard
+            // is preserved — if it's no longer in the suggested cards,
+            // the error-state surfaces the mismatch in PILL_SEEN.
             commitAndAdvance(
-                { ...form, refuter: value, seenCard: nextSeenCard },
+                applyRefuterMove(form, value),
                 PILL_REFUTER,
             );
         },
@@ -484,7 +483,7 @@ export const SuggestionForm = forwardRef<
                 : {}),
             content: (
                 <SingleSelectList<Player>
-                    options={suggesterOptions(setup, form)}
+                    options={playerOptions(setup)}
                     selected={form.suggester}
                     onCommit={commitSuggester}
                     nobodyLabel={null}
@@ -533,7 +532,7 @@ export const SuggestionForm = forwardRef<
                 : {}),
             content: (
                 <MultiSelectList
-                    options={passersOptions(setup, form)}
+                    options={playerOptions(setup)}
                     selected={
                         Array.isArray(form.nonRefuters)
                             ? form.nonRefuters
@@ -563,7 +562,7 @@ export const SuggestionForm = forwardRef<
                 : {}),
             content: (
                 <SingleSelectList<Player>
-                    options={refuterOptions(setup, form)}
+                    options={playerOptions(setup)}
                     selected={
                         isNobody(form.refuter) ? null : form.refuter
                     }
@@ -829,11 +828,13 @@ type PillErrorCode =
  * a pill has multiple problems the first-listed rule wins.
  *
  * Most cross-role paradoxes are prevented at input time by the
- * option-builder filters (e.g. `suggesterOptions` excludes the
- * current refuter). This validator is the RETROACTIVE safety net
- * for values that were valid at entry but became stale after a
- * later edit — most commonly, a `seenCard` whose corresponding
- * category card was subsequently changed.
+ * role-move helpers (`applySuggesterMove` etc.) — selecting a
+ * player into a role automatically removes them from any other
+ * role they currently occupy. This validator is the RETROACTIVE
+ * safety net for values that were valid at entry but became stale
+ * after a later edit — most commonly, a `seenCard` whose
+ * corresponding category card was subsequently changed, or a
+ * loaded draft whose saved shape happens to violate Clue rules.
  */
 export const validateFormConsistency = (
     form: FormState,
@@ -920,60 +921,98 @@ const formatFieldList = (fields: ReadonlyArray<string>): string => {
 // ---- Candidate list helpers ------------------------------------------
 
 /**
- * Players available for the suggester slot. Excludes anyone already
- * playing the refuter or passer roles in this suggestion — Clue
- * grammar makes those disjoint.
+ * Every player in the setup, as a candidate option. The suggester /
+ * passers / refuter pills all show the same full list — they used
+ * to filter to "not in another role" but that created a sequencing
+ * trap (selecting Alice as refuter then trying to make her a passer
+ * required clearing refuter first). Now selection moves the player
+ * between roles automatically; see `applyRoleMove*` below.
  */
-const suggesterOptions = (
+const playerOptions = (
     setup: GameSetup,
+): ReadonlyArray<Option<Player>> =>
+    setup.players.map(p => ({ value: p, label: String(p) }));
+
+// ---- Role-move helpers ----------------------------------------------
+
+/**
+ * Apply a player to the suggester slot, removing them from any other
+ * role they currently occupy (passers list, refuter slot). Pure;
+ * exported for testing.
+ */
+export const applySuggesterMove = (
     form: FormState,
-): ReadonlyArray<Option<Player>> => {
-    const excluded = new Set<Player>();
-    if (form.refuter !== null && !isNobody(form.refuter)) {
-        excluded.add(form.refuter);
-    }
-    if (Array.isArray(form.nonRefuters)) {
-        for (const p of form.nonRefuters) excluded.add(p);
-    }
-    return setup.players
-        .filter(p => !excluded.has(p))
-        .map(p => ({ value: p, label: String(p) }));
+    player: Player,
+): FormState => {
+    const nextNonRefuters = Array.isArray(form.nonRefuters)
+        ? form.nonRefuters.filter(p => p !== player)
+        : form.nonRefuters;
+    const refuterMatches =
+        form.refuter !== null &&
+        !isNobody(form.refuter) &&
+        form.refuter === player;
+    return {
+        ...form,
+        suggester: player,
+        nonRefuters: nextNonRefuters,
+        refuter: refuterMatches ? null : form.refuter,
+        // Clearing refuter mirrors the existing commitRefuter behaviour:
+        // shown card is meaningless without a resolved refuter.
+        seenCard: refuterMatches ? null : form.seenCard,
+    };
 };
 
 /**
- * Players available for the passers list. Excludes the suggester
- * and the refuter (both disjoint from passing in Clue rules).
+ * Apply a passers value, removing each passer from any other role
+ * they currently occupy. NOBODY and null pass through unchanged
+ * (no players to move). Pure; exported for testing.
  */
-const passersOptions = (
-    setup: GameSetup,
+export const applyPassersMove = (
     form: FormState,
-): ReadonlyArray<Option<Player>> => {
-    const excluded = new Set<Player>();
-    if (form.suggester !== null) excluded.add(form.suggester);
-    if (form.refuter !== null && !isNobody(form.refuter)) {
-        excluded.add(form.refuter);
+    value: ReadonlyArray<Player> | Nobody | null,
+): FormState => {
+    if (value === null || isNobody(value)) {
+        return { ...form, nonRefuters: value };
     }
-    return setup.players
-        .filter(p => !excluded.has(p))
-        .map(p => ({ value: p, label: String(p) }));
+    const newPassers = new Set<Player>(value);
+    const suggesterMatches =
+        form.suggester !== null && newPassers.has(form.suggester);
+    const refuterMatches =
+        form.refuter !== null &&
+        !isNobody(form.refuter) &&
+        newPassers.has(form.refuter);
+    return {
+        ...form,
+        nonRefuters: value,
+        suggester: suggesterMatches ? null : form.suggester,
+        refuter: refuterMatches ? null : form.refuter,
+        seenCard: refuterMatches ? null : form.seenCard,
+    };
 };
 
 /**
- * Players available for the refuter slot. Excludes the suggester
- * and anyone already in the passers list.
+ * Apply a refuter value, removing them from any other role they
+ * currently occupy (suggester slot, passers list). NOBODY clears
+ * any stale shown card (existing behaviour). Pure; exported for
+ * testing.
  */
-const refuterOptions = (
-    setup: GameSetup,
+export const applyRefuterMove = (
     form: FormState,
-): ReadonlyArray<Option<Player>> => {
-    const excluded = new Set<Player>();
-    if (form.suggester !== null) excluded.add(form.suggester);
-    if (Array.isArray(form.nonRefuters)) {
-        for (const p of form.nonRefuters) excluded.add(p);
+    value: Player | Nobody,
+): FormState => {
+    if (isNobody(value)) {
+        return { ...form, refuter: value, seenCard: null };
     }
-    return setup.players
-        .filter(p => !excluded.has(p))
-        .map(p => ({ value: p, label: String(p) }));
+    const nextNonRefuters = Array.isArray(form.nonRefuters)
+        ? form.nonRefuters.filter(p => p !== value)
+        : form.nonRefuters;
+    const suggesterMatches = form.suggester === value;
+    return {
+        ...form,
+        refuter: value,
+        nonRefuters: nextNonRefuters,
+        suggester: suggesterMatches ? null : form.suggester,
+    };
 };
 
 /**

--- a/src/ui/components/SuggestionPills.tsx
+++ b/src/ui/components/SuggestionPills.tsx
@@ -229,7 +229,7 @@ export function PillPopover({
             layout
             transition={widthTransition}
             className={
-                "inline-flex items-center gap-1.5 rounded-full border px-3 py-2 text-[13px] " +
+                "inline-flex min-h-[44px] items-center gap-1.5 rounded-full border px-4 py-2.5 text-[15px] " +
                 tone
             }
         >

--- a/src/ui/components/SuggestionPills.tsx
+++ b/src/ui/components/SuggestionPills.tsx
@@ -528,7 +528,7 @@ export function SingleSelectList<T>({
                         role="option"
                         aria-selected={isSelected}
                         className={
-                            "flex cursor-pointer items-center gap-1.5 rounded px-3 py-2 text-[13px]" +
+                            "flex min-h-[44px] cursor-pointer items-center gap-1.5 rounded px-3 py-2.5 text-[15px]" +
                             (highlighted ? " bg-accent/15" : "") +
                             (row.kind === "nobody"
                                 ? " border-b border-border/60 text-muted"
@@ -704,7 +704,7 @@ export function MultiSelectList({
                     role="option"
                     aria-selected={nobodyChosen}
                     className={
-                        "flex cursor-pointer items-center gap-1.5 rounded border-b border-border/60 px-3 py-2 text-[13px] text-muted" +
+                        "flex min-h-[44px] cursor-pointer items-center gap-1.5 rounded border-b border-border/60 px-3 py-2.5 text-[15px] text-muted" +
                         (focusedIdx === 0 ? " bg-accent/15" : "")
                     }
                     onMouseEnter={() => setFocusedIdx(0)}
@@ -726,7 +726,7 @@ export function MultiSelectList({
                             role="option"
                             aria-selected={checked}
                             className={
-                                "flex cursor-pointer items-center gap-1.5 rounded px-3 py-2 text-[13px]" +
+                                "flex min-h-[44px] cursor-pointer items-center gap-1.5 rounded px-3 py-2.5 text-[15px]" +
                                 (highlighted ? " bg-accent/15" : "")
                             }
                             onMouseEnter={() => setFocusedIdx(rowIdx)}


### PR DESCRIPTION
## Summary

Two M1 fixes from the [UX backlog](.claude/plans/ux-backlog-from-test-game.md):

- **Bigger suggestion pills (#4).** Pills in the Add-a-suggestion form jump from `px-3 py-2 text-[13px]` to `px-4 py-2.5 text-[15px] min-h-[44px]` so they hit the standard ~44px tap target on mobile. The mobile Suggest pane still fits the viewport (no horizontal overflow); the desktop pill row stays inside its sticky-right column.

- **Auto-deselect on role conflict (#6).** Every role's candidate list now shows every player. Selecting a player into one role moves them out of any other role they currently occupy. Previously, picking Alice as refuter and then wanting her as a passer required clearing refuter first — Alice didn't appear in the passers list. Now selecting her there clears her refuter slot (and the shown card, since it's meaningless without a resolved refuter). Same for suggester ↔ refuter and suggester ↔ passers.

## Implementation

- New pure helpers `applySuggesterMove`, `applyPassersMove`, `applyRefuterMove` exported from `SuggestionForm.tsx`. Each takes a `FormState` + new value and returns the updated `FormState` with conflicting roles cleaned up.
- The three filtering option-builders (`suggesterOptions`, `passersOptions`, `refuterOptions`) collapse into one non-filtering `playerOptions(setup)`.
- `commitSuggester` / `commitPassers` / `commitRefuter` route through the helpers.
- `validateFormConsistency` keeps its `suggesterIsRefuter` / `suggesterInPassers` / `refuterInPassers` checks as a defensive net for loaded drafts. Docblock updated.

## Test plan

- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — green
- [x] `pnpm test` — green (1282 passed, 21 new)
- [x] `pnpm knip` — green
- [x] `pnpm i18n:check` — green
- [x] Desktop preview (1280×800): bigger pills render at 44px min-height, role-move works (selected Player 1 as refuter while suggester → suggester cleared)
- [x] Mobile preview (375×812): no horizontal overflow, pills wrap cleanly, same dimensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)