### PR TITLE
Persist suggestion drafts across mobile tab swaps and reloads

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -222,6 +222,11 @@
     "suggestions": {
         "title": "Suggestion log",
         "addTitle": "Add a <suggestionTab>suggestion<kbd> ({suggestionKey})</kbd></suggestionTab> or <accusationTab>accusation<kbd> ({accusationKey})</kbd></accusationTab>",
+        "addTitleArticleA": "Add a",
+        "addTitleArticleAn": "Add an",
+        "addTitleConnector": "or",
+        "addTitleSuggestionTab": "suggestion<kbd> ({suggestionKey})</kbd>",
+        "addTitleAccusationTab": "accusation<kbd> ({accusationKey})</kbd>",
         "recommendationsTitle": "Next-suggestion recommendations",
         "suggestingAs": "Suggesting as: ",
         "resolveContradictionFirst": "Resolve the contradiction to see recommendations.",

--- a/src/logic/ClueState.ts
+++ b/src/logic/ClueState.ts
@@ -37,6 +37,38 @@ export interface DraftSuggestion {
 }
 
 /**
+ * Marker for an explicit "Nobody" choice on optional suggestion-form
+ * slots — distinct from `null` ("not yet decided"). Structurally
+ * identical to the UI-layer `Nobody` constant in `SuggestionPills.tsx`,
+ * so values constructed in either place are mutually assignable.
+ */
+interface PendingNobody {
+    readonly kind: "nobody";
+}
+
+/**
+ * Mid-flight new-suggestion form state, persisted in `ClueState` so it
+ * survives mobile tab swaps (where `SuggestionLogPanel` and the form
+ * underneath unmount) and full-page reloads.
+ *
+ * Mirrors the form-internal `FormState` shape one-to-one. Lives in the
+ * logic layer so persistence and the reducer don't have to import
+ * across the UI boundary.
+ *
+ * Only used for the new-suggestion flow; the edit-existing flow keeps
+ * its own component-local buffer because edits already have a saved
+ * source-of-truth in `state.suggestions`.
+ */
+export interface PendingSuggestionDraft {
+    readonly id: string;
+    readonly suggester: Player | null;
+    readonly cards: ReadonlyArray<Card | null>;
+    readonly nonRefuters: ReadonlyArray<Player> | PendingNobody | null;
+    readonly refuter: Player | PendingNobody | null;
+    readonly seenCard: Card | PendingNobody | null;
+}
+
+/**
  * UI-level shape of a failed accusation that hasn't been converted to a
  * Data.Class record yet. Mirrors `DraftSuggestion` but carries only the
  * accuser and the named triple — no refuter / seen card, since a failed
@@ -107,7 +139,8 @@ export type ClueAction =
     | { type: "setUiMode"; mode: UiMode }
     | { type: "setHypothesis"; cell: Cell; value: HypothesisValue }
     | { type: "clearHypothesis"; cell: Cell }
-    | { type: "replaceSession"; session: GameSession };
+    | { type: "replaceSession"; session: GameSession }
+    | { type: "setPendingSuggestion"; draft: PendingSuggestionDraft | null };
 
 export interface ClueState {
     readonly setup: GameSetup;
@@ -124,4 +157,15 @@ export interface ClueState {
      * contradiction banner. See {@link Hypothesis} for the model.
      */
     readonly hypotheses: HypothesisMap;
+    /**
+     * In-progress new-suggestion form state. Persisted so the form
+     * survives mobile tab swaps (which unmount `SuggestionLogPanel`)
+     * and full-page reloads. `null` means "no draft in flight" — the
+     * form mounts empty.
+     *
+     * Only the new-suggestion flow reads/writes this; the
+     * edit-existing flow keeps its own component-local buffer because
+     * edits already have a saved source-of-truth in `suggestions`.
+     */
+    readonly pendingSuggestion: PendingSuggestionDraft | null;
 }

--- a/src/logic/Persistence.test.ts
+++ b/src/logic/Persistence.test.ts
@@ -17,7 +17,8 @@ import {
 } from "./Persistence";
 import { emptyHypotheses } from "./Hypothesis";
 
-const STORAGE_KEY = "effect-clue.session.v7";
+const STORAGE_KEY = "effect-clue.session.v8";
+const LEGACY_STORAGE_KEY_V7 = "effect-clue.session.v7";
 const LEGACY_STORAGE_KEY_V6 = "effect-clue.session.v6";
 
 const setup = CLASSIC_SETUP_3P;
@@ -41,6 +42,7 @@ const minimalSession: GameSession = {
     suggestions: [],
     accusations: [],
     hypotheses: emptyHypotheses,
+    pendingSuggestion: null,
 };
 
 const richSession = (): GameSession => ({
@@ -93,6 +95,7 @@ const richSession = (): GameSession => ({
         }),
     ],
     hypotheses: emptyHypotheses,
+    pendingSuggestion: null,
 });
 
 describe("encode/decode — rich sessions", () => {
@@ -190,11 +193,30 @@ describe("saveToLocalStorage / loadFromLocalStorage", () => {
         expect(loaded?.handSizes).toHaveLength(3);
     });
 
-    test("save writes under the v7-scoped storage key", () => {
+    test("save writes under the v8-scoped storage key", () => {
         saveToLocalStorage(minimalSession);
         const raw = window.localStorage.getItem(STORAGE_KEY);
         expect(raw).not.toBeNull();
-        expect(JSON.parse(raw as string).version).toBe(7);
+        expect(JSON.parse(raw as string).version).toBe(8);
+    });
+
+    test("loads a v7 blob (no pendingSuggestion field) and lifts to v8 with null draft", () => {
+        const v7Payload = {
+            version: 7,
+            setup: { players: ["Anisha"], categories: [] },
+            hands: [],
+            handSizes: [],
+            suggestions: [],
+            accusations: [],
+            hypotheses: [],
+        };
+        window.localStorage.setItem(
+            LEGACY_STORAGE_KEY_V7,
+            JSON.stringify(v7Payload),
+        );
+        const loaded = loadFromLocalStorage();
+        expect(loaded).toBeDefined();
+        expect(loaded?.pendingSuggestion).toBeNull();
     });
 
     test("loads a v6 blob (no hypotheses field) and lifts to v7 with empty hypotheses", () => {
@@ -252,6 +274,114 @@ describe("saveToLocalStorage / loadFromLocalStorage", () => {
         const loaded = loadFromLocalStorage();
         expect(loaded?.handSizes).toHaveLength(1);
         expect(loaded?.handSizes[0]?.size).toBe(99);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// pendingSuggestion round-trip (M2)
+//
+// Each optional slot has three runtime states (null / Nobody / value).
+// The persisted form uses paired `*Decided` + `*IsNobody` flags so they
+// all round-trip without `Schema.Union`. Each combination is exercised
+// here to make sure the encoder + decoder agree on every distinguishable
+// state.
+// ---------------------------------------------------------------------------
+describe("pendingSuggestion round-trip", () => {
+    const NOBODY_DRAFT = { kind: "nobody" as const };
+
+    test("null pendingSuggestion round-trips as null", () => {
+        const decoded = decodeSession(encodeSession(minimalSession));
+        expect(decoded?.pendingSuggestion).toBeNull();
+    });
+
+    test("a draft with all optional slots undecided round-trips", () => {
+        const session: GameSession = {
+            ...minimalSession,
+            pendingSuggestion: {
+                id: "draft-1",
+                suggester: A,
+                cards: [MUSTARD, KNIFE, KITCHEN],
+                nonRefuters: null,
+                refuter: null,
+                seenCard: null,
+            },
+        };
+        const decoded = decodeSession(encodeSession(session));
+        expect(decoded?.pendingSuggestion).toEqual(session.pendingSuggestion);
+    });
+
+    test("a draft with explicit-Nobody slots round-trips Nobody markers, not null", () => {
+        const session: GameSession = {
+            ...minimalSession,
+            pendingSuggestion: {
+                id: "draft-2",
+                suggester: A,
+                cards: [MUSTARD, KNIFE, KITCHEN],
+                nonRefuters: NOBODY_DRAFT,
+                refuter: NOBODY_DRAFT,
+                seenCard: NOBODY_DRAFT,
+            },
+        };
+        const decoded = decodeSession(encodeSession(session));
+        // Each slot decodes back to a Nobody marker, not null and not a value.
+        expect(decoded?.pendingSuggestion?.nonRefuters).toEqual(NOBODY_DRAFT);
+        expect(decoded?.pendingSuggestion?.refuter).toEqual(NOBODY_DRAFT);
+        expect(decoded?.pendingSuggestion?.seenCard).toEqual(NOBODY_DRAFT);
+    });
+
+    test("a draft with concrete values in optional slots round-trips them faithfully", () => {
+        const session: GameSession = {
+            ...minimalSession,
+            pendingSuggestion: {
+                id: "draft-3",
+                suggester: A,
+                cards: [MUSTARD, KNIFE, KITCHEN],
+                nonRefuters: [B, C],
+                refuter: B,
+                seenCard: KNIFE,
+            },
+        };
+        const decoded = decodeSession(encodeSession(session));
+        expect(decoded?.pendingSuggestion?.nonRefuters).toEqual([B, C]);
+        expect(decoded?.pendingSuggestion?.refuter).toBe(B);
+        expect(decoded?.pendingSuggestion?.seenCard).toBe(KNIFE);
+    });
+
+    test("a partially-filled draft round-trips with null cards preserved", () => {
+        const session: GameSession = {
+            ...minimalSession,
+            pendingSuggestion: {
+                id: "draft-4",
+                suggester: null,
+                cards: [MUSTARD, null, KITCHEN],
+                nonRefuters: null,
+                refuter: null,
+                seenCard: null,
+            },
+        };
+        const decoded = decodeSession(encodeSession(session));
+        expect(decoded?.pendingSuggestion?.suggester).toBeNull();
+        expect(decoded?.pendingSuggestion?.cards).toEqual([
+            MUSTARD,
+            null,
+            KITCHEN,
+        ]);
+    });
+
+    test("v7 sessions (no pendingSuggestion field) load with null draft", () => {
+        // Hand-craft a v7 payload — no `pendingSuggestion` key at all.
+        const v7Payload = {
+            version: 7,
+            setup: { players: ["Anisha"], categories: [] },
+            hands: [],
+            handSizes: [],
+            suggestions: [],
+            accusations: [],
+            hypotheses: [],
+        };
+        const decoded = decodeSession(v7Payload);
+        expect(decoded).toBeDefined();
+        expect(decoded?.pendingSuggestion).toBeNull();
     });
 });
 

--- a/src/logic/Persistence.ts
+++ b/src/logic/Persistence.ts
@@ -21,10 +21,14 @@ import { Cell } from "./Knowledge";
 import {
     decodeV6Unknown,
     decodeV7Unknown,
+    decodeV8Unknown,
     type PersistedHypothesis,
+    type PersistedPendingSuggestion,
     type PersistedSessionV6,
     type PersistedSessionV7,
+    type PersistedSessionV8,
 } from "./PersistenceSchema";
+import type { PendingSuggestionDraft } from "./ClueState";
 import {
     newSuggestionId,
     Suggestion,
@@ -38,12 +42,14 @@ import {
  * the mutable inputs are serialized; derived knowledge is cheap to
  * recompute, so there's no need to persist it.
  *
- * v7 (current) adds `hypotheses` — per-cell what-if assumptions.
- * v6 reads still work via {@link decodeV6Unknown}; they're auto-lifted
- * to v7 with `hypotheses: []`. Writes always produce v7.
+ * v8 (current) adds `pendingSuggestion` — the in-flight new-suggestion
+ * draft, persisted so it survives mobile tab swaps and reloads.
+ * v7 / v6 reads still work via {@link decodeV7Unknown} / {@link
+ * decodeV6Unknown}; they're auto-lifted with `pendingSuggestion: null`
+ * (and `hypotheses: []` for v6). Writes always produce v8.
  */
-interface PersistedGameV7 {
-    readonly version: 7;
+interface PersistedGameV8 {
+    readonly version: 8;
     readonly setup: {
         readonly players: ReadonlyArray<string>;
         readonly categories: ReadonlyArray<{
@@ -83,9 +89,10 @@ interface PersistedGameV7 {
         readonly card: string;
         readonly value: "Y" | "N";
     }>;
+    readonly pendingSuggestion: PersistedPendingSuggestion | null;
 }
 
-type PersistedGame = PersistedGameV7;
+type PersistedGame = PersistedGameV8;
 
 export interface GameSession {
     setup: GameSetup;
@@ -94,12 +101,13 @@ export interface GameSession {
     suggestions: ReadonlyArray<Suggestion>;
     accusations: ReadonlyArray<Accusation>;
     hypotheses: HypothesisMap;
+    pendingSuggestion: PendingSuggestionDraft | null;
 }
 
 const encodeHypotheses = (
     hypotheses: HypothesisMap,
-): PersistedGameV7["hypotheses"] => {
-    const out: Array<PersistedGameV7["hypotheses"][number]> = [];
+): PersistedGameV8["hypotheses"] => {
+    const out: Array<PersistedGameV8["hypotheses"][number]> = [];
     for (const [cell, value] of hypotheses) {
         const player =
             cell.owner._tag === "Player"
@@ -108,6 +116,110 @@ const encodeHypotheses = (
         out.push({ player, card: String(cell.card), value });
     }
     return out;
+};
+
+// ---- Pending-suggestion encoding -------------------------------------
+//
+// `PendingSuggestionDraft` slots have three runtime states: `null`
+// ("not decided"), Nobody ("explicit no one"), or a typed Player/Card.
+// The persisted form uses a pair of flat booleans + the value field
+// per slot to round-trip them without `Schema.Union`:
+//
+//   decided=false                  -> null
+//   decided=true, isNobody=true    -> Nobody
+//   decided=true, isNobody=false   -> the value (Player / Card / Player[])
+//
+// Mirrors the flat encoding pattern used by the persisted hypothesis
+// schema. See PersistenceSchema.ts for the rationale.
+
+const NOBODY_DRAFT = Object.freeze({
+    kind: "nobody" as const,
+});
+
+const isPendingNobody = (
+    v: unknown,
+): v is { readonly kind: "nobody" } =>
+    typeof v === "object"
+    && v !== null
+    && !Array.isArray(v)
+    && (v as { kind?: unknown }).kind === "nobody";
+
+const encodePendingSuggestion = (
+    pending: PendingSuggestionDraft | null,
+): PersistedPendingSuggestion | null => {
+    if (pending === null) return null;
+    const { nonRefuters, refuter, seenCard } = pending;
+    const nonRefutersDecided = nonRefuters !== null;
+    const nonRefutersIsNobody = isPendingNobody(nonRefuters);
+    const refuterDecided = refuter !== null;
+    const refuterIsNobody = isPendingNobody(refuter);
+    const seenCardDecided = seenCard !== null;
+    const seenCardIsNobody = isPendingNobody(seenCard);
+    return {
+        id: pending.id,
+        suggester: pending.suggester,
+        cards: pending.cards,
+        nonRefutersDecided,
+        nonRefutersIsNobody,
+        nonRefuters:
+            nonRefuters === null || isPendingNobody(nonRefuters)
+                ? []
+                : nonRefuters,
+        refuterDecided,
+        refuterIsNobody,
+        refuter:
+            refuter === null || isPendingNobody(refuter) ? null : refuter,
+        seenCardDecided,
+        seenCardIsNobody,
+        seenCard:
+            seenCard === null || isPendingNobody(seenCard)
+                ? null
+                : seenCard,
+    };
+};
+
+const decodePendingSuggestion = (
+    persisted: PersistedPendingSuggestion | null,
+): PendingSuggestionDraft | null => {
+    if (persisted === null) return null;
+    const decodeNullable = <T,>(
+        decided: boolean,
+        isNobody: boolean,
+        value: T | null,
+    ): T | { readonly kind: "nobody" } | null => {
+        if (!decided) return null;
+        if (isNobody) return NOBODY_DRAFT;
+        return value;
+    };
+    const decodePassers = (
+        decided: boolean,
+        isNobody: boolean,
+        value: ReadonlyArray<Player>,
+    ): ReadonlyArray<Player> | { readonly kind: "nobody" } | null => {
+        if (!decided) return null;
+        if (isNobody) return NOBODY_DRAFT;
+        return value;
+    };
+    return {
+        id: persisted.id,
+        suggester: persisted.suggester,
+        cards: persisted.cards,
+        nonRefuters: decodePassers(
+            persisted.nonRefutersDecided,
+            persisted.nonRefutersIsNobody,
+            persisted.nonRefuters,
+        ),
+        refuter: decodeNullable(
+            persisted.refuterDecided,
+            persisted.refuterIsNobody,
+            persisted.refuter,
+        ),
+        seenCard: decodeNullable(
+            persisted.seenCardDecided,
+            persisted.seenCardIsNobody,
+            persisted.seenCard,
+        ),
+    };
 };
 
 const decodeHypotheses = (
@@ -123,7 +235,7 @@ const decodeHypotheses = (
 };
 
 export const encodeSession = (session: GameSession): PersistedGame => ({
-    version: 7,
+    version: 8,
     setup: {
         players: session.setup.players.map(p => String(p)),
         categories: session.setup.categories.map(c => ({
@@ -159,6 +271,47 @@ export const encodeSession = (session: GameSession): PersistedGame => ({
         loggedAt: a.loggedAt,
     })),
     hypotheses: encodeHypotheses(session.hypotheses),
+    pendingSuggestion: encodePendingSuggestion(session.pendingSuggestion),
+});
+
+const buildSessionFromV8 = (v8: PersistedSessionV8): GameSession => ({
+    setup: GameSetup({
+        players: v8.setup.players,
+        categories: v8.setup.categories.map(c => Category({
+            id: c.id,
+            name: c.name,
+            cards: c.cards.map(card => CardEntry({
+                id: card.id,
+                name: card.name,
+            })),
+        })),
+    }),
+    hands: v8.hands.map(h => ({ player: h.player, cards: h.cards })),
+    handSizes: v8.handSizes.map(h => ({
+        player: h.player,
+        size: h.size,
+    })),
+    suggestions: v8.suggestions.map(s => Suggestion({
+        id: s.id === undefined || s.id === SuggestionId("")
+            ? newSuggestionId()
+            : s.id,
+        suggester: s.suggester,
+        cards: s.cards,
+        nonRefuters: s.nonRefuters,
+        refuter: s.refuter === null ? undefined : s.refuter,
+        seenCard: s.seenCard === null ? undefined : s.seenCard,
+        loggedAt: s.loggedAt,
+    })),
+    accusations: v8.accusations.map(a => Accusation({
+        id: a.id === undefined || a.id === AccusationId("")
+            ? newAccusationId()
+            : a.id,
+        accuser: a.accuser,
+        cards: a.cards,
+        loggedAt: a.loggedAt,
+    })),
+    hypotheses: decodeHypotheses(v8.hypotheses),
+    pendingSuggestion: decodePendingSuggestion(v8.pendingSuggestion),
 });
 
 const buildSessionFromV7 = (v7: PersistedSessionV7): GameSession => ({
@@ -198,11 +351,12 @@ const buildSessionFromV7 = (v7: PersistedSessionV7): GameSession => ({
         loggedAt: a.loggedAt,
     })),
     hypotheses: decodeHypotheses(v7.hypotheses),
+    pendingSuggestion: null,
 });
 
 /**
- * Lift a v6 payload to v7 by attaching an empty hypothesis set.
- * Forward-only and lossless — v7 is a strict superset of v6.
+ * Lift a v6 payload to v8 by attaching an empty hypothesis set and a
+ * null pending-suggestion draft. Forward-only and lossless.
  */
 const liftV6ToV7 = (v6: PersistedSessionV6): GameSession => ({
     setup: GameSetup({
@@ -241,9 +395,12 @@ const liftV6ToV7 = (v6: PersistedSessionV6): GameSession => ({
         loggedAt: a.loggedAt,
     })),
     hypotheses: emptyHypotheses,
+    pendingSuggestion: null,
 });
 
 export const decodeSession = (data: unknown): GameSession | undefined => {
+    const v8 = decodeV8Unknown(data);
+    if (Result.isSuccess(v8)) return buildSessionFromV8(v8.success);
     const v7 = decodeV7Unknown(data);
     if (Result.isSuccess(v7)) return buildSessionFromV7(v7.success);
     const v6 = decodeV6Unknown(data);
@@ -251,7 +408,8 @@ export const decodeSession = (data: unknown): GameSession | undefined => {
     return undefined;
 };
 
-const STORAGE_KEY = "effect-clue.session.v7";
+const STORAGE_KEY = "effect-clue.session.v8";
+const LEGACY_STORAGE_KEY_V7 = "effect-clue.session.v7";
 const LEGACY_STORAGE_KEY_V6 = "effect-clue.session.v6";
 
 export const saveToLocalStorage = (session: GameSession): void => {
@@ -265,7 +423,9 @@ export const saveToLocalStorage = (session: GameSession): void => {
 
 export const loadFromLocalStorage = (): GameSession | undefined => {
     try {
-        const rawV7 = window.localStorage.getItem(STORAGE_KEY);
+        const rawV8 = window.localStorage.getItem(STORAGE_KEY);
+        if (rawV8) return decodeSession(JSON.parse(rawV8));
+        const rawV7 = window.localStorage.getItem(LEGACY_STORAGE_KEY_V7);
         if (rawV7) return decodeSession(JSON.parse(rawV7));
         const rawV6 = window.localStorage.getItem(LEGACY_STORAGE_KEY_V6);
         if (rawV6) return decodeSession(JSON.parse(rawV6));

--- a/src/logic/PersistenceSchema.test.ts
+++ b/src/logic/PersistenceSchema.test.ts
@@ -13,7 +13,7 @@ import { Player } from "./GameObjects";
  * starts a fresh session.
  */
 describe("Schema-backed persistence", () => {
-    test("encode produces version: 7 and round-trips through decode", () => {
+    test("encode produces version: 8 and round-trips through decode", () => {
         const encoded = encodeSession({
             setup: CLASSIC_SETUP_3P,
             hands: [],
@@ -21,8 +21,9 @@ describe("Schema-backed persistence", () => {
             suggestions: [],
             accusations: [],
             hypotheses: emptyHypotheses,
+            pendingSuggestion: null,
         });
-        expect(encoded.version).toBe(7);
+        expect(encoded.version).toBe(8);
 
         const decoded = decodeSession(encoded);
         expect(decoded).toBeDefined();

--- a/src/logic/PersistenceSchema.ts
+++ b/src/logic/PersistenceSchema.ts
@@ -6,16 +6,23 @@ import { SuggestionId } from "./Suggestion";
 /**
  * Effect Schema definitions for the persisted session shape.
  *
- * The current canonical version is v7 (adds `hypotheses`). Reads accept
- * v7 first, then fall back to v6 (auto-lifting with `hypotheses: []`)
- * so that users who roll back-and-forward between builds don't lose
- * suggestion / accusation state. Writes always go to v7.
+ * The current canonical version is v8 (adds `pendingSuggestion`). Reads
+ * accept v8 first, then fall back to v7 (auto-lifting with
+ * `pendingSuggestion: null`), then v6 (auto-lifting with `hypotheses:
+ * []` and `pendingSuggestion: null`), so that users who roll
+ * back-and-forward between builds don't lose suggestion / accusation
+ * state. Writes always go to v8.
  *
  * v6 added the `loggedAt: number` field to each suggestion + accusation,
  * recording the millisecond timestamp at which it was logged.
  *
  * v7 adds `hypotheses: Array<{ owner, card, value }>` — per-cell what-if
  * assumptions the user toggles on. See `src/logic/Hypothesis.ts`.
+ *
+ * v8 adds `pendingSuggestion`: the user's in-flight new-suggestion
+ * draft, persisted so it survives mobile tab swaps (which unmount the
+ * suggestion form) and full-page reloads. See
+ * `src/logic/ClueState.ts`'s `PendingSuggestionDraft`.
  *
  * Branded strings (Player, Card, CardCategory, SuggestionId,
  * AccusationId) are decoded straight into their nominal types via
@@ -92,6 +99,38 @@ const PersistedHypothesisSchema = Schema.Struct({
 });
 
 /**
+ * Persisted shape of `PendingSuggestionDraft`. Each optional slot has
+ * three runtime states: `null` ("not decided"), `Nobody` (explicit
+ * "no one"), or a concrete Player/Card. They round-trip through a
+ * pair of flat fields per slot — `*Decided` and `*IsNobody` — alongside
+ * the value field, mirroring the flat encoding pattern that
+ * `PersistedHypothesisSchema` uses to keep the decoder's
+ * `DecodingServices` channel clean.
+ *
+ *   decided=false                 -> null ("not decided")
+ *   decided=true, isNobody=true   -> Nobody
+ *   decided=true, isNobody=false  -> the Player/Card/array value
+ *
+ * This avoids `Schema.Union`, whose AST widens the surrounding struct's
+ * services to `unknown` and breaks the v8 decoder's `Decoder<unknown>`
+ * constraint.
+ */
+const PersistedPendingSuggestionSchema = Schema.Struct({
+    id: Schema.String,
+    suggester: Schema.NullOr(PlayerSchema),
+    cards: Schema.Array(Schema.NullOr(CardSchema)),
+    nonRefutersDecided: Schema.Boolean,
+    nonRefutersIsNobody: Schema.Boolean,
+    nonRefuters: Schema.Array(PlayerSchema),
+    refuterDecided: Schema.Boolean,
+    refuterIsNobody: Schema.Boolean,
+    refuter: Schema.NullOr(PlayerSchema),
+    seenCardDecided: Schema.Boolean,
+    seenCardIsNobody: Schema.Boolean,
+    seenCard: Schema.NullOr(CardSchema),
+});
+
+/**
  * Convenience array wrappers for the share codec — the shares wire
  * format ships these as top-level JSON arrays rather than wrapped
  * inside a versioned envelope.
@@ -133,8 +172,7 @@ const PersistedSessionV6Schema = Schema.Struct({
 });
 
 /**
- * Canonical v7 session shape. Adds `hypotheses` — per-cell what-if
- * assumptions. See `src/logic/Hypothesis.ts`.
+ * v7 session shape — kept for back-compat reads. v8 supersedes it.
  */
 const PersistedSessionV7Schema = Schema.Struct({
     version: Schema.Literal(7),
@@ -144,6 +182,22 @@ const PersistedSessionV7Schema = Schema.Struct({
     suggestions: Schema.Array(PersistedSuggestionSchema),
     accusations: Schema.Array(PersistedAccusationSchema),
     hypotheses: HypothesesArraySchema,
+});
+
+/**
+ * Canonical v8 session shape. Adds `pendingSuggestion` — the user's
+ * in-flight new-suggestion draft. Encoded as `null` when no draft
+ * exists; otherwise the persisted form-state shape.
+ */
+const PersistedSessionV8Schema = Schema.Struct({
+    version: Schema.Literal(8),
+    setup: PersistedGameSetupSchema,
+    hands: Schema.Array(PersistedHandSchema),
+    handSizes: Schema.Array(PersistedHandSizeSchema),
+    suggestions: Schema.Array(PersistedSuggestionSchema),
+    accusations: Schema.Array(PersistedAccusationSchema),
+    hypotheses: HypothesesArraySchema,
+    pendingSuggestion: Schema.NullOr(PersistedPendingSuggestionSchema),
 });
 
 /**
@@ -157,13 +211,20 @@ export const decodeV6Unknown = Schema.decodeUnknownResult(
 export const decodeV7Unknown = Schema.decodeUnknownResult(
     PersistedSessionV7Schema,
 );
+export const decodeV8Unknown = Schema.decodeUnknownResult(
+    PersistedSessionV8Schema,
+);
 
 /**
  * Runtime types of decoded sessions — the branded, Schema-validated
- * payload `decodeV{6,7}Unknown` hand back. Callers construct the
+ * payload `decodeV{6,7,8}Unknown` hand back. Callers construct the
  * GameSession domain value from this.
  */
 export type PersistedSessionV6 = Schema.Schema.Type<typeof PersistedSessionV6Schema>;
 export type PersistedSessionV7 = Schema.Schema.Type<typeof PersistedSessionV7Schema>;
+export type PersistedSessionV8 = Schema.Schema.Type<typeof PersistedSessionV8Schema>;
 
 export type PersistedHypothesis = Schema.Schema.Type<typeof PersistedHypothesisSchema>;
+export type PersistedPendingSuggestion = Schema.Schema.Type<
+    typeof PersistedPendingSuggestionSchema
+>;

--- a/src/logic/describeAction.test.ts
+++ b/src/logic/describeAction.test.ts
@@ -75,6 +75,7 @@ const baseState: ClueState = {
     accusations: [],
     uiMode: "checklist",
     hypotheses: emptyHypotheses,
+    pendingSuggestion: null,
 };
 
 const accusationA: DraftAccusation = {

--- a/src/logic/describeAction.ts
+++ b/src/logic/describeAction.ts
@@ -217,6 +217,7 @@ export const describeAction = (
         case "setSetup":
         case "setUiMode":
         case "replaceSession":
+        case "setPendingSuggestion":
             return t("unknownAction");
     }
 };

--- a/src/ui/Clue.flow.test.tsx
+++ b/src/ui/Clue.flow.test.tsx
@@ -219,7 +219,7 @@ describe("Clue — full user-journey umbrella", () => {
             document.querySelectorAll<HTMLElement>(
                 'button[role="tab"][aria-selected="false"]',
             ),
-        ).find(el => el.textContent?.includes("[chunk:accusationTab]"));
+        ).find(el => el.textContent?.includes("AccusationTab"));
         if (!accusationTab) throw new Error("accusation tab missing");
         await user.click(accusationTab);
         await waitFor(() => {

--- a/src/ui/Clue.flow.test.tsx
+++ b/src/ui/Clue.flow.test.tsx
@@ -121,6 +121,7 @@ const seedSetupSession = (): void => {
         suggestions: [],
         accusations: [],
         hypotheses: emptyHypotheses,
+        pendingSuggestion: null,
     });
 };
 

--- a/src/ui/Clue.test.tsx
+++ b/src/ui/Clue.test.tsx
@@ -271,6 +271,7 @@ describe("Clue — URL-based view hydration", () => {
             ],
             accusations: [],
             hypotheses: emptyHypotheses,
+            pendingSuggestion: null,
         });
         render(<Clue />, { wrapper: TestQueryClientProvider });
         await waitFor(() => {

--- a/src/ui/components/AccusationForm.tsx
+++ b/src/ui/components/AccusationForm.tsx
@@ -44,6 +44,11 @@ import {
  */
 export interface AccusationFormHandle {
     readonly focusFirstPill: (options?: { readonly clear?: boolean }) => void;
+    /**
+     * Reset every pill to empty. Used by the section-header X button
+     * (in `AddSuggestion`) to clear the form without re-mounting it.
+     */
+    readonly clearInputs: () => void;
 }
 
 interface AccusationFormProps {
@@ -62,6 +67,12 @@ interface AccusationFormProps {
      * Cmd+Enter from anywhere in the row commits the draft.
      */
     readonly keyboardScopeRef?: React.RefObject<HTMLElement | null>;
+    /**
+     * Notify the parent whenever the form transitions between empty
+     * and "has at least one filled slot." Drives the section-header
+     * "Add a suggestion / accusation" copy + clear-inputs X button.
+     */
+    readonly onHasAnyInputChange?: (hasAnyInput: boolean) => void;
 }
 
 /**
@@ -93,6 +104,7 @@ export const AccusationForm = forwardRef<
         showHeader = true,
         submitLabel,
         keyboardScopeRef,
+        onHasAnyInputChange,
     },
     ref,
 ): React.ReactElement {
@@ -142,6 +154,11 @@ export const AccusationForm = forwardRef<
         [pillSequence],
     );
 
+    const onClearInputs = useCallback(() => {
+        setForm(emptyFormState(setup));
+        setOpenPillId(null);
+    }, [setup]);
+
     useImperativeHandle(
         ref,
         () => ({
@@ -149,12 +166,25 @@ export const AccusationForm = forwardRef<
                 if (clear) setForm(emptyFormState(setup));
                 pillFormRef.current?.focusFirstPill();
             },
+            clearInputs: onClearInputs,
         }),
-        [setup],
+        [setup, onClearInputs],
     );
 
     const draft = useMemo(() => buildDraftFromForm(form), [form]);
     const canSubmit = draft !== null;
+
+    // Mirror has-any-input to the parent. Held behind a ref so the
+    // effect doesn't re-fire when the callback's identity changes.
+    const hasAnyInput =
+        form.accuser !== null || form.cards.some(c => c !== null);
+    const onHasAnyInputChangeRef = useRef(onHasAnyInputChange);
+    useEffect(() => {
+        onHasAnyInputChangeRef.current = onHasAnyInputChange;
+    });
+    useEffect(() => {
+        onHasAnyInputChangeRef.current?.(hasAnyInput);
+    }, [hasAnyInput]);
 
     const onSubmitClick = useCallback(() => {
         if (draft === null) return;

--- a/src/ui/components/PillForm.tsx
+++ b/src/ui/components/PillForm.tsx
@@ -16,6 +16,7 @@ import {
     PillPopover,
     type PillStatus,
 } from "./SuggestionPills";
+import { XIcon } from "./Icons";
 import { Tooltip } from "./Tooltip";
 
 /**
@@ -92,8 +93,12 @@ interface PillFormProps {
      * clear-inputs affordance are absent.
      */
     readonly headerTitle?: ReactNode;
-    /** Optional clear-inputs link in the right side of the header bar. */
-    readonly clearInputsLabel?: ReactNode;
+    /**
+     * Aria-label for the icon-only clear-inputs button rendered at the
+     * right edge of the header bar. The button is visible only when
+     * `hasAnyInput === true` and `onClearInputs` is provided.
+     */
+    readonly clearInputsLabel?: string;
     readonly hasAnyInput?: boolean;
     readonly onClearInputs?: () => void;
     /**
@@ -319,23 +324,18 @@ export const PillForm = forwardRef<PillFormHandle, PillFormProps>(
         return (
             <div ref={formRootRef}>
                 {showHeaderBar && (
-                    <div className="mb-2 flex items-center justify-between gap-2">
+                    <div className="mb-3 flex items-center justify-between gap-2">
                         {headerTitle ?? <span />}
                         {onClearInputs !== undefined &&
                             hasAnyInput === true &&
                             clearInputsLabel !== undefined && (
                                 <button
                                     type="button"
+                                    aria-label={clearInputsLabel}
                                     onClick={onClearInputs}
-                                    className="inline-flex cursor-pointer items-center gap-1 border-none bg-transparent p-0 text-[12px] text-muted hover:text-accent"
+                                    className="inline-flex min-h-[44px] min-w-[44px] cursor-pointer items-center justify-center rounded border-none bg-transparent text-muted hover:text-accent"
                                 >
-                                    <span
-                                        aria-hidden
-                                        className="text-[14px] leading-none"
-                                    >
-                                        ×
-                                    </span>
-                                    {clearInputsLabel}
+                                    <XIcon size={18} />
                                 </button>
                             )}
                     </div>

--- a/src/ui/components/SuggestionForm.draft.test.tsx
+++ b/src/ui/components/SuggestionForm.draft.test.tsx
@@ -1,0 +1,319 @@
+import { describe, expect, test, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { forwardRef, createElement, useState } from "react";
+import type { ReactNode } from "react";
+
+// -----------------------------------------------------------------------
+// ESM mocks. Vitest hoists `vi.mock` calls to the top of the file, so
+// regular top-level imports below see the mocked modules — no deferred-
+// import dance required.
+// -----------------------------------------------------------------------
+
+vi.mock("next-intl", () => {
+    const t = (key: string, values?: Record<string, unknown>): string =>
+        values ? `${key}:${JSON.stringify(values)}` : key;
+    (t as unknown as { rich: unknown }).rich = (
+        key: string,
+        _values?: Record<string, unknown>,
+    ): string => key;
+    return { useTranslations: () => t };
+});
+
+vi.mock("motion/react", () => {
+    const motion = new Proxy(
+        {},
+        {
+            get: (_t, tag: string) =>
+                forwardRef(
+                    (
+                        props: Record<string, unknown>,
+                        ref: React.Ref<HTMLElement>,
+                    ) => {
+                        const {
+                            layout: _layout,
+                            initial: _initial,
+                            animate: _animate,
+                            exit: _exit,
+                            transition: _transition,
+                            whileHover: _whileHover,
+                            whileTap: _whileTap,
+                            ...rest
+                        } = props;
+                        return createElement(tag, { ...rest, ref });
+                    },
+                ),
+        },
+    );
+    return {
+        motion,
+        AnimatePresence: ({ children }: { children: ReactNode }) => children,
+        useReducedMotion: () => false,
+        LayoutGroup: ({ children }: { children: ReactNode }) => children,
+    };
+});
+
+import { SuggestionForm, type FormState } from "./SuggestionForm";
+import { TooltipProvider } from "./Tooltip";
+import { CLASSIC_SETUP_3P as setup } from "../../logic/GameSetup";
+import { SuggestionId } from "../../logic/Suggestion";
+import type { PendingSuggestionDraft } from "../../logic/ClueState";
+import { Player } from "../../logic/GameObjects";
+import { cardByName } from "../../logic/test-utils/CardByName";
+
+const renderForm = (ui: React.ReactElement) =>
+    render(<TooltipProvider>{ui}</TooltipProvider>);
+
+const SUSPECT = cardByName(setup, "Col. Mustard");
+const KNIFE = cardByName(setup, "Knife");
+const KITCHEN = cardByName(setup, "Kitchen");
+const ANISHA = Player("Anisha");
+
+// -----------------------------------------------------------------------
+// pendingDraft seeding (M2)
+//
+// New-suggestion flow: when the parent supplies a `pendingDraft`, the
+// form renders pre-filled with those values. The edit-existing flow
+// (suggestion prop present) ignores the draft entirely — it has its own
+// saved source-of-truth.
+// -----------------------------------------------------------------------
+describe("SuggestionForm — pendingDraft seeding", () => {
+    test("seeds form values from a non-null pendingDraft on mount", () => {
+        const draft: PendingSuggestionDraft = {
+            id: "draft-1",
+            suggester: ANISHA,
+            cards: [SUSPECT, KNIFE, KITCHEN],
+            nonRefuters: null,
+            refuter: null,
+            seenCard: null,
+        };
+        renderForm(
+            <SuggestionForm
+                setup={setup}
+                onSubmit={vi.fn()}
+                pendingDraft={draft}
+                onPendingDraftChange={vi.fn()}
+            />,
+        );
+        // The suggester pill renders the player's name when filled,
+        // and the card pills render their card names.
+        expect(screen.getByRole("button", { name: /Anisha/ })).toBeDefined();
+        expect(screen.getByRole("button", { name: /Mustard/ })).toBeDefined();
+        expect(screen.getByRole("button", { name: /Knife/ })).toBeDefined();
+        expect(screen.getByRole("button", { name: /Kitchen/ })).toBeDefined();
+    });
+
+    test("falls back to an empty form when pendingDraft is null", () => {
+        renderForm(
+            <SuggestionForm
+                setup={setup}
+                onSubmit={vi.fn()}
+                pendingDraft={null}
+                onPendingDraftChange={vi.fn()}
+            />,
+        );
+        // Empty suggester pill renders the placeholder label.
+        expect(
+            screen.getByRole("button", { name: /pillSuggester/ }),
+        ).toBeDefined();
+    });
+
+    test("falls back to an empty form when pendingDraft.cards length doesn't match the setup (stale draft)", () => {
+        // 5-card draft against a 3-category setup — the reducer drops
+        // these on setup change but the form is also defensive.
+        const stale: PendingSuggestionDraft = {
+            id: "draft-stale",
+            suggester: ANISHA,
+            cards: [SUSPECT, KNIFE, KITCHEN, SUSPECT, KNIFE],
+            nonRefuters: null,
+            refuter: null,
+            seenCard: null,
+        };
+        renderForm(
+            <SuggestionForm
+                setup={setup}
+                onSubmit={vi.fn()}
+                pendingDraft={stale}
+                onPendingDraftChange={vi.fn()}
+            />,
+        );
+        // No populated pills — the suggester slot fell back to empty.
+        expect(
+            screen.queryByRole("button", { name: /Anisha/ }),
+        ).toBeNull();
+    });
+
+    test("edit flow ignores pendingDraft entirely and uses the suggestion prop", () => {
+        const SECOND_SUSPECT = cardByName(setup, "Mrs. White");
+        // Draft says one suspect; suggestion prop says another. Form
+        // must render the suggestion's value.
+        const draft: PendingSuggestionDraft = {
+            id: "draft-ignored",
+            suggester: ANISHA,
+            cards: [SUSPECT, KNIFE, KITCHEN],
+            nonRefuters: null,
+            refuter: null,
+            seenCard: null,
+        };
+        renderForm(
+            <SuggestionForm
+                setup={setup}
+                onSubmit={vi.fn()}
+                suggestion={{
+                    id: SuggestionId("test-existing"),
+                    suggester: Player("Bob"),
+                    cards: [SECOND_SUSPECT, KNIFE, KITCHEN],
+                    nonRefuters: [],
+                }}
+                pendingDraft={draft}
+                onPendingDraftChange={vi.fn()}
+            />,
+        );
+        expect(screen.getByRole("button", { name: /Bob/ })).toBeDefined();
+        expect(
+            screen.queryByRole("button", { name: /Mustard/ }),
+        ).toBeNull();
+        expect(
+            screen.queryByRole("button", { name: /Anisha/ }),
+        ).toBeNull();
+        expect(screen.getByRole("button", { name: /White/ })).toBeDefined();
+    });
+});
+
+// -----------------------------------------------------------------------
+// onPendingDraftChange mirroring (M2)
+//
+// Every form-state change in the new-suggestion flow fires the callback,
+// so the parent can persist into ClueState. Edit flow doesn't fire it.
+// "Empty form" mirrors as `null` so a fresh form re-mount doesn't pick
+// up a stale empty draft.
+// -----------------------------------------------------------------------
+describe("SuggestionForm — onPendingDraftChange mirroring", () => {
+    test("does not fire on initial mount", () => {
+        const onPendingDraftChange = vi.fn();
+        renderForm(
+            <SuggestionForm
+                setup={setup}
+                onSubmit={vi.fn()}
+                pendingDraft={null}
+                onPendingDraftChange={onPendingDraftChange}
+            />,
+        );
+        expect(onPendingDraftChange).not.toHaveBeenCalled();
+    });
+
+    test("fires on user-driven form change", async () => {
+        const user = userEvent.setup();
+        const onPendingDraftChange = vi.fn();
+        renderForm(
+            <SuggestionForm
+                setup={setup}
+                onSubmit={vi.fn()}
+                pendingDraft={null}
+                onPendingDraftChange={onPendingDraftChange}
+            />,
+        );
+        // Open suggester pill, pick Anisha.
+        await user.click(screen.getByRole("button", { name: /pillSuggester/ }));
+        await user.click(screen.getByRole("option", { name: /Anisha/ }));
+        // The callback fired with a draft whose suggester is Anisha.
+        expect(onPendingDraftChange).toHaveBeenCalled();
+        const lastCall =
+            onPendingDraftChange.mock.calls[
+                onPendingDraftChange.mock.calls.length - 1
+            ];
+        const draft = lastCall?.[0] as PendingSuggestionDraft | null;
+        expect(draft).not.toBeNull();
+        expect(draft?.suggester).toBe(ANISHA);
+    });
+
+    test("does not fire in edit flow", async () => {
+        const user = userEvent.setup();
+        const onPendingDraftChange = vi.fn();
+        renderForm(
+            <SuggestionForm
+                setup={setup}
+                onSubmit={vi.fn()}
+                suggestion={{
+                    id: SuggestionId("test-edit"),
+                    suggester: Player("Bob"),
+                    cards: [SUSPECT, KNIFE, KITCHEN],
+                    nonRefuters: [],
+                }}
+                pendingDraft={null}
+                onPendingDraftChange={onPendingDraftChange}
+            />,
+        );
+        // Change the suggester to trigger setForm.
+        await user.click(screen.getByRole("button", { name: /Bob/ }));
+        await user.click(screen.getByRole("option", { name: /Anisha/ }));
+        expect(onPendingDraftChange).not.toHaveBeenCalled();
+    });
+});
+
+// -----------------------------------------------------------------------
+// Cross-mount survival (M2)
+//
+// The bug we fix: the mobile `MobilePlayLayout` unmounts
+// `SuggestionLogPanel` (and the form inside) when the user swaps to the
+// Checklist pane. With the form's local state owning the draft, a swap
+// dropped everything. The fix lifts the draft into the parent — so a
+// mount/unmount cycle with the parent passing the persisted draft back
+// in re-seeds the form to the same values.
+// -----------------------------------------------------------------------
+describe("SuggestionForm — cross-mount survival via parent-owned draft", () => {
+    test("draft survives unmount/remount when the parent persists it", async () => {
+        const user = userEvent.setup();
+
+        function Harness() {
+            const [draft, setDraft] = useState<FormState | null>(null);
+            const [mounted, setMounted] = useState(true);
+            return (
+                <div>
+                    <button
+                        type="button"
+                        data-testid="toggle"
+                        onClick={() => setMounted(m => !m)}
+                    >
+                        toggle
+                    </button>
+                    {mounted ? (
+                        <SuggestionForm
+                            setup={setup}
+                            onSubmit={vi.fn()}
+                            pendingDraft={draft}
+                            onPendingDraftChange={setDraft}
+                        />
+                    ) : null}
+                </div>
+            );
+        }
+
+        renderForm(<Harness />);
+
+        // Pre-state: form is mounted, no values.
+        expect(
+            screen.queryByRole("button", { name: /Anisha/ }),
+        ).toBeNull();
+
+        // Fill the suggester pill.
+        await user.click(screen.getByRole("button", { name: /pillSuggester/ }));
+        await user.click(screen.getByRole("option", { name: /Anisha/ }));
+
+        // The form now shows Anisha.
+        expect(screen.getByRole("button", { name: /Anisha/ })).toBeDefined();
+
+        // Unmount the form (simulates mobile tab swap).
+        await user.click(screen.getByTestId("toggle"));
+        expect(
+            screen.queryByRole("button", { name: /pillSuggester/ }),
+        ).toBeNull();
+
+        // Re-mount.
+        await user.click(screen.getByTestId("toggle"));
+
+        // The form re-mounts seeded from the parent's draft — Anisha
+        // is back without re-typing.
+        expect(screen.getByRole("button", { name: /Anisha/ })).toBeDefined();
+    });
+});

--- a/src/ui/components/SuggestionForm.tsx
+++ b/src/ui/components/SuggestionForm.tsx
@@ -51,6 +51,11 @@ import {
  */
 export interface SuggestionFormHandle {
     readonly focusFirstPill: (options?: { readonly clear?: boolean }) => void;
+    /**
+     * Reset every pill to empty. Used by the section-header X button
+     * (in `AddSuggestion`) to clear the form without re-mounting it.
+     */
+    readonly clearInputs: () => void;
 }
 
 interface SuggestionFormProps {
@@ -111,6 +116,12 @@ interface SuggestionFormProps {
     readonly onPendingDraftChange?: (
         draft: PendingSuggestionDraft | null,
     ) => void;
+    /**
+     * Notify the parent whenever the form transitions between empty
+     * and "has at least one filled slot." Drives the section-header
+     * "Add a suggestion / accusation" copy + clear-inputs X button.
+     */
+    readonly onHasAnyInputChange?: (hasAnyInput: boolean) => void;
 }
 
 /**
@@ -164,6 +175,7 @@ export const SuggestionForm = forwardRef<
         afterSubmit,
         pendingDraft,
         onPendingDraftChange,
+        onHasAnyInputChange,
     },
     ref,
 ): React.ReactElement {
@@ -495,6 +507,17 @@ export const SuggestionForm = forwardRef<
         setOpenPillId(null);
     }, [setup]);
 
+    // Mirror the empty-vs-non-empty boolean to the parent. Held behind
+    // a ref (matching the `onPendingDraftChange` pattern) so the effect
+    // doesn't re-fire when the callback's identity changes.
+    const onHasAnyInputChangeRef = useRef(onHasAnyInputChange);
+    useEffect(() => {
+        onHasAnyInputChangeRef.current = onHasAnyInputChange;
+    });
+    useEffect(() => {
+        onHasAnyInputChangeRef.current?.(hasAnyInput);
+    }, [hasAnyInput]);
+
     // Imperative handle: callers (e.g. AddSuggestion wiring up the
     // global Cmd+K shortcut) drive focus through `focusFirstPill`. The
     // form itself stays oblivious to global keyboard bindings.
@@ -505,8 +528,9 @@ export const SuggestionForm = forwardRef<
                 if (clear === true) setForm(emptyFormState(setup));
                 setOpenPillId(PILL_SUGGESTER);
             },
+            clearInputs: onClearInputs,
         }),
-        [setup],
+        [setup, onClearInputs],
     );
 
     // Per-pill clear callbacks for the optional pills. Wired into the

--- a/src/ui/components/SuggestionForm.tsx
+++ b/src/ui/components/SuggestionForm.tsx
@@ -10,7 +10,10 @@ import {
     useRef,
     useState,
 } from "react";
-import type { DraftSuggestion } from "../../logic/ClueState";
+import type {
+    DraftSuggestion,
+    PendingSuggestionDraft,
+} from "../../logic/ClueState";
 import type { GameSetup } from "../../logic/GameSetup";
 import { categoryOfCard } from "../../logic/GameSetup";
 import type { Card, Player } from "../../logic/GameObjects";
@@ -92,6 +95,22 @@ interface SuggestionFormProps {
      * context after the form unmounts.
      */
     readonly afterSubmit?: () => void;
+    /**
+     * Persisted draft to seed from on mount, and to mirror back to
+     * via `onPendingDraftChange` on every change. New-suggestion
+     * flow only — the edit-existing flow already has a saved
+     * source-of-truth in `state.suggestions` and ignores both fields.
+     *
+     * Both must be provided together: passing `pendingDraft` without
+     * `onPendingDraftChange` would seed a draft that the form then
+     * silently mutates locally without persisting. Passing the
+     * callback alone is allowed — it just means the form starts
+     * empty and writes its first state through.
+     */
+    readonly pendingDraft?: PendingSuggestionDraft | null;
+    readonly onPendingDraftChange?: (
+        draft: PendingSuggestionDraft | null,
+    ) => void;
 }
 
 /**
@@ -143,6 +162,8 @@ export const SuggestionForm = forwardRef<
         submitLabel,
         keyboardScopeRef,
         afterSubmit,
+        pendingDraft,
+        onPendingDraftChange,
     },
     ref,
 ): React.ReactElement {
@@ -153,11 +174,25 @@ export const SuggestionForm = forwardRef<
     const hasKeyboard = useHasKeyboard();
 
     // --- Form state ----------------------------------------------------
-    const [form, setForm] = useState<FormState>(() =>
-        suggestion !== undefined
-            ? formStateFromDraft(suggestion, setup)
-            : emptyFormState(setup),
-    );
+    const isEditFlow = suggestion !== undefined;
+    const [form, setForm] = useState<FormState>(() => {
+        if (suggestion !== undefined) {
+            return formStateFromDraft(suggestion, setup);
+        }
+        // New-suggestion flow: seed from a persisted pending draft when
+        // the parent supplies one and it's structurally compatible
+        // with the current setup (same number of card slots; ref-only
+        // shape match — the reducer drops the whole draft on setup
+        // changes, so getting here with a stale draft is rare).
+        if (
+            pendingDraft !== undefined
+            && pendingDraft !== null
+            && pendingDraft.cards.length === setup.categories.length
+        ) {
+            return pendingDraft;
+        }
+        return emptyFormState(setup);
+    });
 
     // Re-seed when the suggestion prop changes (covers the "edit
     // different row" case without remounting the whole component).
@@ -171,6 +206,32 @@ export const SuggestionForm = forwardRef<
                 : emptyFormState(setup),
         );
     }, [suggestion, setup]);
+
+    // Mirror new-suggestion form state into the parent on every change
+    // so a mount/unmount cycle (mobile tab swap, full reload) survives.
+    // Edit flow has its own saved source-of-truth and skips the mirror.
+    //
+    // The callback is held behind a ref so a non-memoized parent
+    // doesn't re-run the effect every render — the mirror should fire
+    // when `form` changes, not when `onPendingDraftChange`'s identity
+    // does.
+    const onPendingDraftChangeRef = useRef(onPendingDraftChange);
+    useEffect(() => {
+        onPendingDraftChangeRef.current = onPendingDraftChange;
+    });
+    const initialMirrorRef = useRef(true);
+    useEffect(() => {
+        if (isEditFlow) return;
+        if (initialMirrorRef.current) {
+            initialMirrorRef.current = false;
+            return;
+        }
+        // Mirror null when the form is back to its empty default —
+        // submit-success and "× Clear inputs" both reset the form,
+        // and we don't want a stale empty draft re-seeding the next
+        // mount.
+        onPendingDraftChangeRef.current?.(isEmptyFormState(form) ? null : form);
+    }, [form, isEditFlow]);
 
     // --- Pill sequence for auto-advance -------------------------------
     //
@@ -671,14 +732,16 @@ export const SuggestionForm = forwardRef<
 
 // ---- Form state -------------------------------------------------------
 
-export interface FormState {
-    readonly id: string;
-    readonly suggester: Player | null;
-    readonly cards: ReadonlyArray<Card | null>;
-    readonly nonRefuters: ReadonlyArray<Player> | Nobody | null;
-    readonly refuter: Player | Nobody | null;
-    readonly seenCard: Card | Nobody | null;
-}
+/**
+ * Form-internal shape — alias of the persistable
+ * `PendingSuggestionDraft` so the form's local state can be lifted
+ * directly into `ClueState` without a translation layer. Structurally
+ * identical to a record of `Player | Card | Nobody | null` slots; the
+ * UI-layer `Nobody` constant from `SuggestionPills` is a structural
+ * match for the `{ kind: "nobody" }` shape declared in the logic
+ * layer's `PendingSuggestionDraft`.
+ */
+export type FormState = PendingSuggestionDraft;
 
 const emptyFormState = (setup: GameSetup): FormState => ({
     id: String(newSuggestionId()),
@@ -688,6 +751,18 @@ const emptyFormState = (setup: GameSetup): FormState => ({
     refuter: null,
     seenCard: null,
 });
+
+/**
+ * True when every value-bearing slot of the form is unfilled. Used to
+ * decide whether to mirror the form back to the parent as a real
+ * draft or as `null` (no draft in flight).
+ */
+const isEmptyFormState = (f: FormState): boolean =>
+    f.suggester === null
+    && f.cards.every(c => c === null)
+    && f.nonRefuters === null
+    && f.refuter === null
+    && f.seenCard === null;
 
 const formStateFromDraft = (
     s: DraftSuggestion,

--- a/src/ui/components/SuggestionLogPanel.editMode.test.tsx
+++ b/src/ui/components/SuggestionLogPanel.editMode.test.tsx
@@ -116,6 +116,7 @@ const seedOneSuggestionAndMount = async (
         ],
         accusations: [],
         hypotheses: emptyHypotheses,
+        pendingSuggestion: null,
     });
     if (view === "suggest") {
         // The mobile play layout only mounts the active pane, so

--- a/src/ui/components/SuggestionLogPanel.modeToggle.test.tsx
+++ b/src/ui/components/SuggestionLogPanel.modeToggle.test.tsx
@@ -169,9 +169,10 @@ beforeEach(() => {
 describe("Add-form tab toggle — click", () => {
     test("the suggestion tab is active by default; the form is the suggestion form", async () => {
         await mountClue();
-        // The active tab text contains [chunk:suggestionTab] (from the
-        // smart rich-text mock).
-        expect(findActiveTab().textContent).toContain("suggestionTab");
+        // The active tab renders the addTitleSuggestionTab i18n key
+        // (mirrored back as text by the mock-`t.rich`).
+        expect(findActiveTab().textContent).toContain("SuggestionTab");
+        expect(findActiveTab().textContent).not.toContain("AccusationTab");
         expect(isSuggestionForm()).toBe(true);
         expect(isAccusationForm()).toBe(false);
     });

--- a/src/ui/components/SuggestionLogPanel.tsx
+++ b/src/ui/components/SuggestionLogPanel.tsx
@@ -254,6 +254,13 @@ function AddSuggestion() {
                             ref={suggestionFormRef}
                             setup={state.setup}
                             showHeader={false}
+                            pendingDraft={state.pendingSuggestion}
+                            onPendingDraftChange={draft =>
+                                dispatch({
+                                    type: "setPendingSuggestion",
+                                    draft,
+                                })
+                            }
                             onSubmit={draft => {
                                 dispatch({
                                     type: "addSuggestion",

--- a/src/ui/components/SuggestionLogPanel.tsx
+++ b/src/ui/components/SuggestionLogPanel.tsx
@@ -5,7 +5,7 @@ import { newAccusationId } from "../../logic/Accusation";
 import type { Card } from "../../logic/GameObjects";
 import { AnimatePresence, motion } from "motion/react";
 import { useTranslations } from "next-intl";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
     accusationFormOpened,
     accusationLogged,
@@ -152,6 +152,20 @@ function AddSuggestion() {
     const accusationFormRef = useRef<AccusationFormHandle>(null);
 
     const [mode, setMode] = useState<Mode>(SUGGESTION_MODE);
+    // Tracks whether the *active* form has any pill filled. Drives the
+    // section header's conditional copy ("Add a suggestion" vs "Add a
+    // suggestion or accusation") and the right-aligned X button.
+    // Each form mirrors its empty-vs-non-empty state into this via
+    // `onHasAnyInputChange`; the inactive form is unmounted by
+    // `AnimatePresence`, so only the active form drives the value.
+    const [hasAnyInput, setHasAnyInput] = useState(false);
+    const handleClearInputs = useCallback(() => {
+        if (mode === SUGGESTION_MODE) {
+            suggestionFormRef.current?.clearInputs();
+        } else {
+            accusationFormRef.current?.clearInputs();
+        }
+    }, [mode]);
     const [pendingFocus, setPendingFocus] = useState<{
         readonly target: Mode;
         readonly clear: boolean;
@@ -246,7 +260,12 @@ function AddSuggestion() {
             onKeyDown={onWrapperActivity}
             onFocus={onWrapperActivity}
         >
-            <AddFormTabHeader mode={mode} setMode={setMode} />
+            <AddFormTabHeader
+                mode={mode}
+                setMode={setMode}
+                hasAnyInput={hasAnyInput}
+                onClearInputs={handleClearInputs}
+            />
             <AnimatePresence mode={PRESENCE_WAIT_MODE} initial={false}>
                 {mode === SUGGESTION_MODE ? (
                     <FormSlide key="suggestion" direction={-1}>
@@ -254,6 +273,8 @@ function AddSuggestion() {
                             ref={suggestionFormRef}
                             setup={state.setup}
                             showHeader={false}
+                            showClearInputs={false}
+                            onHasAnyInputChange={setHasAnyInput}
                             pendingDraft={state.pendingSuggestion}
                             onPendingDraftChange={draft =>
                                 dispatch({
@@ -293,6 +314,7 @@ function AddSuggestion() {
                             ref={accusationFormRef}
                             setup={state.setup}
                             showHeader={false}
+                            onHasAnyInputChange={setHasAnyInput}
                             onSubmit={draft => {
                                 dispatch({
                                     type: "addAccusation",
@@ -325,14 +347,22 @@ function AddSuggestion() {
     function AddFormTabHeader({
         mode,
         setMode,
+        hasAnyInput,
+        onClearInputs,
     }: {
         readonly mode: Mode;
         readonly setMode: (m: Mode) => void;
+        readonly hasAnyInput: boolean;
+        readonly onClearInputs: () => void;
     }): React.ReactElement {
         const hasKeyboard = useHasKeyboard();
         const tabIndicatorTransition = useReducedTransition({
             ...T_STANDARD,
             duration: 0.22,
+        });
+        const titleTransition = useReducedTransition({
+            ...T_STANDARD,
+            duration: 0.18,
         });
         const onTabKeyDown = (
             e: React.KeyboardEvent<HTMLButtonElement>,
@@ -354,9 +384,41 @@ function AddSuggestion() {
             setMode(next);
         };
 
+        // Three render states the user perceives:
+        //   - empty: both tabs visible, "Add a [suggestion] or [accusation]"
+        //   - suggesting (active form has any pill filled): "Add a [suggestion]" + X
+        //   - accusing  (active form has any pill filled): "Add an [accusation]" + X
+        // Each visible piece is its own `motion.span` with `layout`, so
+        // when siblings come/go (the inactive tab + " or " connector
+        // collapse out, the X fades in) the active tab slides smoothly
+        // to its new position rather than crossfading. Pieces that
+        // mount/unmount go through `<AnimatePresence>`.
+        const showSuggestionTab = !hasAnyInput || mode === SUGGESTION_MODE;
+        const showAccusationTab = !hasAnyInput || mode === ACCUSATION_MODE;
+        const showConnector = !hasAnyInput;
+        const articleKey:
+            | "addTitleArticleA"
+            | "addTitleArticleAn" =
+            hasAnyInput && mode === ACCUSATION_MODE
+                // eslint-disable-next-line i18next/no-literal-string -- ICU template key
+                ? "addTitleArticleAn"
+                // eslint-disable-next-line i18next/no-literal-string -- ICU template key
+                : "addTitleArticleA";
+        const tabRichHandlers = {
+            suggestionKey: label("global.gotoPlay"),
+            accusationKey: label("global.gotoAccusation"),
+            kbd: hasKeyboard
+                ? (chunks: React.ReactNode) => (
+                      <span className="ml-0.5 font-normal text-muted">
+                          {chunks}
+                      </span>
+                  )
+                : () => null,
+        };
+
         return (
             <h3
-                className={`${SECTION_TITLE} leading-[1.5]`}
+                className={`${SECTION_TITLE} leading-[1.5] mb-3 flex items-center justify-between gap-2`}
                 // Tour anchor: the wrap-up step of the
                 // checklist+suggest tour anchors its popover here
                 // (rather than the full form below) so the popover
@@ -364,47 +426,118 @@ function AddSuggestion() {
                 // form sits at the bottom of the panel.
                 data-tour-anchor="suggest-add-form-header"
             >
-                {t.rich("addTitle", {
-                    suggestionKey: label("global.gotoPlay"),
-                    accusationKey: label("global.gotoAccusation"),
-                    suggestionTab: chunks => (
-                        <TabButton
-                            isActive={mode === SUGGESTION_MODE}
-                            indicatorTransition={tabIndicatorTransition}
-                            onClick={() => setMode(SUGGESTION_MODE)}
-                            onKeyDown={onTabKeyDown}
+                <span className="flex flex-wrap items-center gap-x-1.5 gap-y-1">
+                    <AnimatePresence
+                        // eslint-disable-next-line i18next/no-literal-string -- AnimatePresence mode value
+                        mode="popLayout"
+                        initial={false}
+                    >
+                        <motion.span
+                            key={articleKey}
+                            layout
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 1 }}
+                            exit={{ opacity: 0 }}
+                            transition={titleTransition}
                         >
-                            {chunks}
-                        </TabButton>
-                    ),
-                    accusationTab: chunks => (
-                        <TabButton
-                            isActive={mode === ACCUSATION_MODE}
-                            indicatorTransition={tabIndicatorTransition}
-                            onClick={() => {
-                                setMode(ACCUSATION_MODE);
-                                accusationFormOpened({
-                                    source: "toggle_link",
-                                });
-                            }}
-                            onKeyDown={onTabKeyDown}
+                            {t(articleKey)}
+                        </motion.span>
+                        {showSuggestionTab && (
+                            <motion.span
+                                key="suggestion-tab"
+                                // `layoutId` (instead of `layout`)
+                                // tracks the tab's position across
+                                // mount/unmount cycles — when the
+                                // tab re-mounts after the inactive
+                                // sibling went away, it slides from
+                                // its last-known position.
+                                layoutId="suggestion-tab"
+                                initial={{ opacity: 0 }}
+                                animate={{ opacity: 1 }}
+                                exit={{ opacity: 0 }}
+                                transition={titleTransition}
+                            >
+                                <TabButton
+                                    isActive={mode === SUGGESTION_MODE}
+                                    indicatorTransition={
+                                        tabIndicatorTransition
+                                    }
+                                    onClick={() => setMode(SUGGESTION_MODE)}
+                                    onKeyDown={onTabKeyDown}
+                                >
+                                    {t.rich(
+                                        "addTitleSuggestionTab",
+                                        tabRichHandlers,
+                                    )}
+                                </TabButton>
+                            </motion.span>
+                        )}
+                        {showConnector && (
+                            <motion.span
+                                key="connector"
+                                layout
+                                initial={{ opacity: 0 }}
+                                animate={{ opacity: 1 }}
+                                exit={{ opacity: 0 }}
+                                transition={titleTransition}
+                            >
+                                {t("addTitleConnector")}
+                            </motion.span>
+                        )}
+                        {showAccusationTab && (
+                            <motion.span
+                                key="accusation-tab"
+                                layoutId="accusation-tab"
+                                initial={{ opacity: 0 }}
+                                animate={{ opacity: 1 }}
+                                exit={{ opacity: 0 }}
+                                transition={titleTransition}
+                            >
+                                <TabButton
+                                    isActive={mode === ACCUSATION_MODE}
+                                    indicatorTransition={
+                                        tabIndicatorTransition
+                                    }
+                                    onClick={() => {
+                                        setMode(ACCUSATION_MODE);
+                                        accusationFormOpened({
+                                            source: "toggle_link",
+                                        });
+                                    }}
+                                    onKeyDown={onTabKeyDown}
+                                >
+                                    {t.rich(
+                                        "addTitleAccusationTab",
+                                        tabRichHandlers,
+                                    )}
+                                </TabButton>
+                            </motion.span>
+                        )}
+                    </AnimatePresence>
+                </span>
+                <AnimatePresence initial={false}>
+                    {hasAnyInput && (
+                        <motion.button
+                            key="clear-inputs"
+                            type="button"
+                            aria-label={t("clearInputs")}
+                            onClick={onClearInputs}
+                            initial={{ opacity: 0 }}
+                            animate={{ opacity: 1 }}
+                            exit={{ opacity: 0 }}
+                            transition={titleTransition}
+                            // Visually fits the heading line-height —
+                            // the icon is the only content; an
+                            // invisible `before:` pseudo-element
+                            // extends the hit target outward to a
+                            // mobile-friendly ~40px without inflating
+                            // the header's intrinsic height.
+                            className="relative inline-flex shrink-0 cursor-pointer items-center justify-center rounded-sm border-none bg-transparent p-0.5 text-muted hover:text-accent before:absolute before:inset-[-10px] before:content-['']"
                         >
-                            {chunks}
-                        </TabButton>
-                    ),
-                    // Shortcut hint inside each tab. Stays muted on
-                    // both active + inactive variants — text colour
-                    // doesn't change with state any more, only the
-                    // outline does. Hidden entirely on touch-only
-                    // devices where the user can't act on it.
-                    kbd: hasKeyboard
-                        ? chunks => (
-                              <span className="ml-0.5 font-normal text-muted">
-                                  {chunks}
-                              </span>
-                          )
-                        : () => null,
-                })}
+                            <XIcon size={16} />
+                        </motion.button>
+                    )}
+                </AnimatePresence>
             </h3>
         );
     }

--- a/src/ui/share/ShareCreateModal.test.tsx
+++ b/src/ui/share/ShareCreateModal.test.tsx
@@ -372,6 +372,7 @@ describe("ShareCreateModal — wire payload by variant", () => {
             suggestions: [],
             accusations: [],
             hypotheses: emptyHypotheses,
+            pendingSuggestion: null,
         });
 
         mockSession = {

--- a/src/ui/share/ShareCreateModal.tsx
+++ b/src/ui/share/ShareCreateModal.tsx
@@ -504,6 +504,10 @@ export function ShareCreateModal({
             suggestions: derived.suggestionsAsData,
             accusations: derived.accusationsAsData,
             hypotheses: state.hypotheses,
+            // Drafts aren't part of the share wire format — the
+            // receiver enters their own. The local `pendingSuggestion`
+            // exists in `state` but doesn't ride the share.
+            pendingSuggestion: null,
         };
         if (variant === VARIANT_INVITE) {
             return buildInviteInput(

--- a/src/ui/share/useApplyShareSnapshot.test.ts
+++ b/src/ui/share/useApplyShareSnapshot.test.ts
@@ -324,6 +324,7 @@ describe("applyShareSnapshotToLocalStorage — receive page handoff", () => {
             suggestions: [],
             accusations: [],
             hypotheses: emptyHypotheses,
+            pendingSuggestion: null,
         });
 
         const session = applyShareSnapshotToLocalStorage(
@@ -351,6 +352,7 @@ describe("saveCardPackFromSnapshot — pack-only receive", () => {
             suggestions: [],
             accusations: [],
             hypotheses: emptyHypotheses,
+            pendingSuggestion: null,
         };
         saveToLocalStorage(currentSession);
 
@@ -603,6 +605,7 @@ describe("share receive dirty-state detection", () => {
             suggestions: [],
             accusations: [],
             hypotheses: emptyHypotheses,
+            pendingSuggestion: null,
         };
 
         expect(sessionHasGameData(clean)).toBe(false);
@@ -622,6 +625,7 @@ describe("share receive dirty-state detection", () => {
                 suggestions: [],
                 accusations: [],
                 hypotheses: emptyHypotheses,
+                pendingSuggestion: null,
             }),
         ).toBe(true);
         expect(
@@ -637,6 +641,7 @@ describe("share receive dirty-state detection", () => {
                 suggestions: [],
                 accusations: [],
                 hypotheses: emptyHypotheses,
+                pendingSuggestion: null,
             }),
         ).toBe(true);
     });
@@ -653,6 +658,7 @@ describe("share receive dirty-state detection", () => {
             suggestions: [],
             accusations: [],
             hypotheses: emptyHypotheses,
+            pendingSuggestion: null,
         });
         expect(hasPersistedGameData()).toBe(true);
     });

--- a/src/ui/share/useApplyShareSnapshot.ts
+++ b/src/ui/share/useApplyShareSnapshot.ts
@@ -285,6 +285,8 @@ export const buildSessionFromSnapshot = (
         suggestions,
         accusations,
         hypotheses,
+        // Drafts are local-only; the receiver enters their own.
+        pendingSuggestion: null,
     };
 };
 

--- a/src/ui/state.test.tsx
+++ b/src/ui/state.test.tsx
@@ -8,6 +8,7 @@ import { CLASSIC_SETUP_3P, DEFAULT_SETUP } from "../logic/GameSetup";
 import { emptyHypotheses } from "../logic/Hypothesis";
 import { KnownCard } from "../logic/InitialKnowledge";
 import type { GameSession } from "../logic/Persistence";
+import type { PendingSuggestionDraft } from "../logic/ClueState";
 import { PlayerOwner } from "../logic/GameObjects";
 import { Cell, N as N_VAL, Y as Y_VAL } from "../logic/Knowledge";
 import { Result } from "effect";
@@ -677,6 +678,7 @@ describe("replaceSession", () => {
             ],
             accusations: [],
             hypotheses: emptyHypotheses,
+            pendingSuggestion: null,
         };
         act(() => result.current.dispatch({ type: "replaceSession", session }));
         expect(result.current.state.setup).toBe(CLASSIC_SETUP_3P);
@@ -699,6 +701,7 @@ describe("replaceSession", () => {
                 suggestions: [],
                 accusations: [],
                 hypotheses: emptyHypotheses,
+                pendingSuggestion: null,
             },
         }));
         // Even though state changed, canUndo remains false for the
@@ -828,6 +831,7 @@ describe("derived values", () => {
                     suggestions: [],
                     accusations: [],
                     hypotheses: emptyHypotheses,
+                    pendingSuggestion: null,
                 } satisfies GameSession,
             });
         });
@@ -891,6 +895,7 @@ describe("derived values", () => {
                     suggestions: [],
                     accusations: [],
                     hypotheses: emptyHypotheses,
+                    pendingSuggestion: null,
                 } satisfies GameSession,
             });
         });
@@ -957,5 +962,201 @@ describe("accusations end-to-end", () => {
         expect(
             Result.isSuccess(result.current.derived.deductionResult),
         ).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// pendingSuggestion (M2)
+//
+// A persisted in-flight new-suggestion draft survives mobile tab swaps
+// (which unmount `SuggestionLogPanel` → `SuggestionForm`) and full-page
+// reloads. The reducer owns the clear-on-submit / clear-on-newGame /
+// stale-ref-on-setup-change semantics; the form layer owns the read/write
+// mirror.
+// ---------------------------------------------------------------------------
+describe("pendingSuggestion", () => {
+    const suspect = cardByName(CLASSIC_SETUP_3P, "Col. Mustard");
+    const knife = cardByName(CLASSIC_SETUP_3P, "Knife");
+    const kitchen = cardByName(CLASSIC_SETUP_3P, "Kitchen");
+    const sampleDraft = (
+        overrides: Record<string, unknown> = {},
+    ): PendingSuggestionDraft => ({
+        id: "draft-test-1",
+        suggester: Player("Player 1"),
+        cards: [suspect, knife, kitchen],
+        nonRefuters: null,
+        refuter: null,
+        seenCard: null,
+        ...overrides,
+    });
+
+    test("setPendingSuggestion writes the field", () => {
+        const { result } = renderClue();
+        expect(result.current.state.pendingSuggestion).toBeNull();
+        const d = sampleDraft();
+        act(() =>
+            result.current.dispatch({
+                type: "setPendingSuggestion",
+                draft: d,
+            }),
+        );
+        expect(result.current.state.pendingSuggestion).toEqual(d);
+    });
+
+    test("setPendingSuggestion bypasses undo history (form keystrokes shouldn't fill the stack)", () => {
+        const { result } = renderClue();
+        const d = sampleDraft();
+        act(() =>
+            result.current.dispatch({
+                type: "setPendingSuggestion",
+                draft: d,
+            }),
+        );
+        expect(result.current.canUndo).toBe(false);
+    });
+
+    test("addSuggestion clears any pending draft", () => {
+        const { result } = renderClue();
+        act(() =>
+            result.current.dispatch({
+                type: "setPendingSuggestion",
+                draft: sampleDraft(),
+            }),
+        );
+        expect(result.current.state.pendingSuggestion).not.toBeNull();
+        act(() =>
+            result.current.dispatch({
+                type: "addSuggestion",
+                suggestion: {
+                    id: newSuggestionId(),
+                    suggester: Player("Player 1"),
+                    cards: [suspect, knife, kitchen],
+                    nonRefuters: [],
+                },
+            }),
+        );
+        expect(result.current.state.pendingSuggestion).toBeNull();
+    });
+
+    test("newGame clears any pending draft", () => {
+        const { result } = renderClue();
+        act(() =>
+            result.current.dispatch({
+                type: "setPendingSuggestion",
+                draft: sampleDraft(),
+            }),
+        );
+        act(() => result.current.dispatch({ type: "newGame" }));
+        expect(result.current.state.pendingSuggestion).toBeNull();
+    });
+
+    test("loadCardSet clears any pending draft (cards reference the old deck)", () => {
+        const { result } = renderClue();
+        act(() =>
+            result.current.dispatch({
+                type: "setPendingSuggestion",
+                draft: sampleDraft(),
+            }),
+        );
+        const altPack = CARD_SETS.find(p => p.id !== "classic");
+        if (!altPack) throw new Error("expected at least two bundled packs");
+        act(() =>
+            result.current.dispatch({
+                type: "loadCardSet",
+                cardSet: altPack.cardSet,
+                label: altPack.label,
+            }),
+        );
+        expect(result.current.state.pendingSuggestion).toBeNull();
+    });
+
+    test("removePlayer clears any pending draft (player ref might be stale)", () => {
+        const { result } = renderClue();
+        act(() =>
+            result.current.dispatch({
+                type: "setPendingSuggestion",
+                draft: sampleDraft({ suggester: Player("Player 1") }),
+            }),
+        );
+        act(() =>
+            result.current.dispatch({
+                type: "removePlayer",
+                player: Player("Player 1"),
+            }),
+        );
+        expect(result.current.state.pendingSuggestion).toBeNull();
+    });
+
+    test("renamePlayer remaps Player refs inside the draft, doesn't drop", () => {
+        const { result } = renderClue();
+        const oldName = Player("Player 1");
+        const newName = Player("Alice");
+        act(() =>
+            result.current.dispatch({
+                type: "setPendingSuggestion",
+                draft: sampleDraft({
+                    suggester: oldName,
+                    nonRefuters: [oldName, Player("Player 2")],
+                    refuter: oldName,
+                }),
+            }),
+        );
+        act(() =>
+            result.current.dispatch({
+                type: "renamePlayer",
+                oldName,
+                newName,
+            }),
+        );
+        const after = result.current.state.pendingSuggestion;
+        expect(after?.suggester).toBe(newName);
+        expect(after?.refuter).toBe(newName);
+        expect(after?.nonRefuters).toEqual([newName, Player("Player 2")]);
+    });
+
+    test("replaceSession picks up the imported pendingSuggestion (defaulting to null)", () => {
+        const { result } = renderClue();
+        // Pre-state: a local draft.
+        act(() =>
+            result.current.dispatch({
+                type: "setPendingSuggestion",
+                draft: sampleDraft(),
+            }),
+        );
+        // replaceSession with a session that has no draft — the local
+        // one is dropped.
+        act(() =>
+            result.current.dispatch({
+                type: "replaceSession",
+                session: {
+                    setup: CLASSIC_SETUP_3P,
+                    hands: [],
+                    handSizes: [],
+                    suggestions: [],
+                    accusations: [],
+                    hypotheses: emptyHypotheses,
+                    pendingSuggestion: null,
+                },
+            }),
+        );
+        expect(result.current.state.pendingSuggestion).toBeNull();
+    });
+
+    test("setSetup (deck pruning) clears the draft defensively", () => {
+        const { result } = renderClue();
+        act(() =>
+            result.current.dispatch({
+                type: "setPendingSuggestion",
+                draft: sampleDraft(),
+            }),
+        );
+        // setSetup runs through pruneSessionToSetup.
+        act(() =>
+            result.current.dispatch({
+                type: "setSetup",
+                setup: CLASSIC_SETUP_3P,
+            }),
+        );
+        expect(result.current.state.pendingSuggestion).toBeNull();
     });
 });

--- a/src/ui/state.tsx
+++ b/src/ui/state.tsx
@@ -150,7 +150,11 @@ function needsPaneSettle(fromMode: UiMode, toMode: UiMode): boolean {
 }
 
 export type { DraftSuggestion } from "../logic/ClueState";
-import type { ClueAction, ClueState } from "../logic/ClueState";
+import type {
+    ClueAction,
+    ClueState,
+    PendingSuggestionDraft,
+} from "../logic/ClueState";
 
 const initialState: ClueState = {
     setup: DEFAULT_SETUP,
@@ -160,6 +164,7 @@ const initialState: ClueState = {
     accusations: [],
     uiMode: "setup",
     hypotheses: emptyHypotheses,
+    pendingSuggestion: null,
 };
 
 const reducer = (state: ClueState, action: ClueAction): ClueState => {
@@ -177,7 +182,8 @@ const reducer = (state: ClueState, action: ClueAction): ClueState => {
             // Swap the deck; keep the current player roster. Hand
             // sizes, known cards, suggestions, accusations, and
             // hypotheses reference card ids from the old deck and are
-            // discarded.
+            // discarded. Any in-flight pending-suggestion draft also
+            // references the old deck's cards, so drop it too.
             return {
                 ...state,
                 setup: GameSetup({
@@ -189,6 +195,7 @@ const reducer = (state: ClueState, action: ClueAction): ClueState => {
                 suggestions: [],
                 accusations: [],
                 hypotheses: emptyHypotheses,
+                pendingSuggestion: null,
             };
 
         case "setSetup":
@@ -357,9 +364,13 @@ const reducer = (state: ClueState, action: ClueAction): ClueState => {
         }
 
         case "addSuggestion":
+            // Submitting the draft also clears it — the form re-mounts
+            // empty for the next entry, and a stale persisted draft
+            // would otherwise re-seed the next form.
             return {
                 ...state,
                 suggestions: [...state.suggestions, action.suggestion],
+                pendingSuggestion: null,
             };
 
         case "updateSuggestion":
@@ -445,6 +456,9 @@ const reducer = (state: ClueState, action: ClueAction): ClueState => {
                 accusations: state.accusations.filter(
                     a => a.accuser !== action.player,
                 ),
+                // The in-flight draft may reference the removed player
+                // in any of its slots; drop it rather than partial-prune.
+                pendingSuggestion: null,
             };
 
         case "movePlayer": {
@@ -470,6 +484,28 @@ const reducer = (state: ClueState, action: ClueAction): ClueState => {
         case "renamePlayer": {
             if (action.oldName === action.newName) return state;
             const { oldName, newName } = action;
+            const pending = state.pendingSuggestion;
+            const renamedPending: PendingSuggestionDraft | null =
+                pending === null
+                    ? null
+                    : {
+                          ...pending,
+                          suggester:
+                              pending.suggester === oldName
+                                  ? newName
+                                  : pending.suggester,
+                          nonRefuters:
+                              pending.nonRefuters === null ||
+                              isPendingNobody(pending.nonRefuters)
+                                  ? pending.nonRefuters
+                                  : pending.nonRefuters.map(p =>
+                                        p === oldName ? newName : p,
+                                    ),
+                          refuter:
+                              pending.refuter === oldName
+                                  ? newName
+                                  : pending.refuter,
+                      };
             return {
                 ...state,
                 setup: GameSetup({
@@ -501,6 +537,7 @@ const reducer = (state: ClueState, action: ClueAction): ClueState => {
                     ...a,
                     accuser: a.accuser === oldName ? newName : a.accuser,
                 })),
+                pendingSuggestion: renamedPending,
             };
         }
 
@@ -549,9 +586,23 @@ const reducer = (state: ClueState, action: ClueAction): ClueState => {
                     cards: Array.from(a.cards),
                 })),
                 hypotheses: session.hypotheses,
+                // Imported sessions don't carry a draft. Drop any
+                // local in-flight draft so the new game starts clean.
+                pendingSuggestion: session.pendingSuggestion ?? null,
             };
         }
+
+        case "setPendingSuggestion":
+            return { ...state, pendingSuggestion: action.draft };
     }
+};
+
+const isPendingNobody = (
+    v: ReadonlyArray<Player> | { readonly kind: "nobody" } | null,
+): v is { readonly kind: "nobody" } => {
+    if (v === null) return false;
+    if (Array.isArray(v)) return false;
+    return (v as { readonly kind: "nobody" }).kind === "nobody";
 };
 
 // ---- Derived ------------------------------------------------------------
@@ -726,7 +777,14 @@ const historyReducer = (h: History, action: HistoryAction): History => {
     const newCurrent = reducer(h.current, action);
     if (newCurrent === h.current) return h;
     // Ephemeral / restore actions don't participate in history.
-    if (action.type === "replaceSession" || action.type === "setUiMode") {
+    // `setPendingSuggestion` fires per keystroke as the form-side
+    // mirror updates ClueState; making it undoable would mean every
+    // typed character pushes a frame onto the undo stack.
+    if (
+        action.type === "replaceSession"
+        || action.type === "setUiMode"
+        || action.type === "setPendingSuggestion"
+    ) {
         return { ...h, current: newCurrent };
     }
     return {
@@ -831,6 +889,7 @@ export function ClueProvider({ children }: { children: ReactNode }) {
             } else if (
                 action.type !== "setUiMode"
                 && action.type !== "replaceSession"
+                && action.type !== "setPendingSuggestion"
             ) {
                 markGameTouched(DateTime.nowUnsafe());
             }
@@ -1231,6 +1290,7 @@ export function ClueProvider({ children }: { children: ReactNode }) {
             suggestions: suggestionsAsData,
             accusations: accusationsAsData,
             hypotheses: state.hypotheses,
+            pendingSuggestion: state.pendingSuggestion,
         };
         saveToLocalStorage(session);
         queryClient.setQueryData(gameSessionQueryKey, session);
@@ -1469,5 +1529,10 @@ const pruneSessionToSetup = (
             .filter(a => playerSet.has(String(a.accuser)))
             .filter(a => a.cards.every(c => cardIdSet.has(String(c)))),
         hypotheses: prunedHypotheses,
+        // The in-flight draft references Player and Card ids. Rather
+        // than partial-prune slots in place, drop the whole draft when
+        // the setup changes — the user is mid-flow at the keyboard, so
+        // re-entering is cheaper than auditing per-slot validity.
+        pendingSuggestion: null,
     };
 };


### PR DESCRIPTION
## Summary

- Lifts the in-flight new-suggestion form state into `ClueState` as `pendingSuggestion`, so drafts survive mobile tab swaps (which unmount `SuggestionLogPanel`) and full-page reloads.
- The form mirrors its state into the reducer on every change (new-suggestion flow only); the edit-existing flow keeps its own local buffer because it already has a saved source-of-truth.
- Persistence v7 → v8 lift adds `pendingSuggestion: null` defaults so existing localStorage sessions load without surprise. Sharing wire format stays unchanged — drafts are local-only.
- This is M2 from the [UX overhaul rollout plan](.claude/plans/ux-backlog-from-test-game.md), addressing #12 (\"My drafted suggestion was lost when I swapped tabs\").

## What the user sees

- Mobile: swap Checklist → Suggest → back without losing pill values you've filled in.
- Reload: pills you've started filling in survive a refresh.
- Submit: form resets to empty, persisted draft cleared.
- New Game: persisted draft cleared.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm knip && pnpm i18n:check` all green (1306 tests, +24 new from this milestone).
- [x] Mobile preview at 375×812: filled suggester + 2 cards on Suggest, swapped to Checklist, swapped back — values still there. Reloaded — values still there. Filled the third card and submitted — pendingSuggestion cleared, suggestions log shows the new entry.
- [x] Round-trip tests cover all three slot states (`null` / `Nobody` / value) per optional slot.
- [x] Reducer-level tests pin: clear-on-submit, clear-on-newGame, clear-on-loadCardSet, clear-on-removePlayer, rename-remaps-Player-refs, setSetup prunes the draft.
- [x] Component-level tests pin: pendingDraft seeds the form on mount, edit flow ignores it, mirror callback fires on user changes, mount/unmount/remount cycle preserves form state via parent-owned draft.

## Commits

- **Persist suggestion drafts across mobile tab swaps and reloads** — Adds `pendingSuggestion: PendingSuggestionDraft | null` to ClueState. Form reads/writes via reducer through new `setPendingSuggestion` action (bypasses undo history). Reducer clears on submit / newGame / setup mutations that could leave stale Player/Card refs, and remaps refs in `renamePlayer`. Persistence lifts to v8 with flat-flag (`*Decided` + `*IsNobody`) encoding for the optional slots' three-way discriminator — matches the codebase's existing `PersistedHypothesisSchema` pattern, avoiding `Schema.Union`'s services-widening issue. Share-receive paths default the new field to null.

🤖 Generated with [Claude Code](https://claude.com/claude-code)