### PR TITLE
Spell out "nobody passed" and "card not seen" in prior-suggestion lines

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -243,7 +243,7 @@
         "cancelEditAria": "Cancel edit",
         "priorEmpty": "No suggestions yet. Add one above.",
         "suggestedLine": "<strong>{suggester}</strong> suggested {cards}",
-        "refutationLine": "{status, select, refutedSeenPassed {refuted by <strong>{refuter}</strong> (showed {seen}) · passed: {passers}} refutedSeen {refuted by <strong>{refuter}</strong> (showed {seen})} refutedPassed {refuted by <strong>{refuter}</strong> · passed: {passers}} refuted {refuted by <strong>{refuter}</strong>} nobodyPassed {nobody could refute · passed: {passers}} other {nobody could refute}}",
+        "refutationLine": "{status, select, refutedSeenPassed {Passed by {passers}; refuted by <strong>{refuter}</strong> (showed {seen})} refutedSeen {Nobody passed; refuted by <strong>{refuter}</strong> (showed {seen})} refutedPassed {Passed by {passers}; refuted by <strong>{refuter}</strong> (card not seen)} refuted {Nobody passed; refuted by <strong>{refuter}</strong> (card not seen)} nobodyPassed {Passed by {passers}; nobody refuted} other {Nobody passed; nobody refuted}}",
         "removeAction": "Remove suggestion",
         "removeConfirm": "Remove this suggestion?",
         "cancelAction": "Cancel",

--- a/src/ui/components/SuggestionLogPanel.refutation.test.tsx
+++ b/src/ui/components/SuggestionLogPanel.refutation.test.tsx
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "vitest";
+import { CLASSIC_SETUP_3P } from "../../logic/GameSetup";
+import { Player } from "../../logic/GameObjects";
+import { newSuggestionId } from "../../logic/Suggestion";
+import { cardByName } from "../../logic/test-utils/CardByName";
+import type { DraftSuggestion } from "../../logic/ClueState";
+import { refutationStatus } from "./SuggestionLogPanel";
+
+// ---------------------------------------------------------------------------
+// `refutationStatus` picks the ICU select branch the prior-suggestion line
+// will render. Each branch maps to a distinct copy template in
+// `suggestions.refutationLine`; the post-M3 copy is:
+//
+//   refutedSeenPassed -> "Passed by {passers}; refuted by X (showed Y)"
+//   refutedSeen       -> "Nobody passed; refuted by X (showed Y)"
+//   refutedPassed     -> "Passed by {passers}; refuted by X (card not seen)"
+//   refuted           -> "Nobody passed; refuted by X (card not seen)"
+//   nobodyPassed      -> "Passed by {passers}; nobody refuted"
+//   nobody            -> "Nobody passed; nobody refuted"
+//
+// Pinning every branch here means re-shuffling the predicate above won't
+// silently flip a copy variant.
+// ---------------------------------------------------------------------------
+
+const A = Player("Anisha");
+const B = Player("Bob");
+const C = Player("Cho");
+const SUSPECT = cardByName(CLASSIC_SETUP_3P, "Col. Mustard");
+const KNIFE = cardByName(CLASSIC_SETUP_3P, "Knife");
+const KITCHEN = cardByName(CLASSIC_SETUP_3P, "Kitchen");
+
+const draft = (overrides: Partial<DraftSuggestion> = {}): DraftSuggestion => ({
+    id: newSuggestionId(),
+    suggester: A,
+    cards: [SUSPECT, KNIFE, KITCHEN],
+    nonRefuters: [],
+    ...overrides,
+});
+
+describe("refutationStatus — all six branches", () => {
+    test("refutedSeenPassed: refuter + seen card + at least one passer", () => {
+        expect(
+            refutationStatus(
+                draft({
+                    nonRefuters: [B],
+                    refuter: C,
+                    seenCard: KNIFE,
+                }),
+            ),
+        ).toBe("refutedSeenPassed");
+    });
+
+    test("refutedSeen: refuter + seen card, no passers", () => {
+        expect(
+            refutationStatus(
+                draft({
+                    nonRefuters: [],
+                    refuter: B,
+                    seenCard: KNIFE,
+                }),
+            ),
+        ).toBe("refutedSeen");
+    });
+
+    test("refutedPassed: refuter without seen card, with passers", () => {
+        expect(
+            refutationStatus(
+                draft({
+                    nonRefuters: [B],
+                    refuter: C,
+                }),
+            ),
+        ).toBe("refutedPassed");
+    });
+
+    test("refuted: refuter without seen card and without passers", () => {
+        expect(
+            refutationStatus(
+                draft({
+                    nonRefuters: [],
+                    refuter: B,
+                }),
+            ),
+        ).toBe("refuted");
+    });
+
+    test("nobodyPassed: no refuter but passers exist", () => {
+        expect(
+            refutationStatus(
+                draft({
+                    nonRefuters: [B, C],
+                }),
+            ),
+        ).toBe("nobodyPassed");
+    });
+
+    test("nobody: no refuter and no passers", () => {
+        expect(
+            refutationStatus(
+                draft({
+                    nonRefuters: [],
+                }),
+            ),
+        ).toBe("nobody");
+    });
+});

--- a/src/ui/components/SuggestionLogPanel.tsx
+++ b/src/ui/components/SuggestionLogPanel.tsx
@@ -632,8 +632,10 @@ function FormSlide({
  * with the seen-card and non-refuters axes via select keeps the copy
  * as a single translatable sentence per case rather than a
  * concatenation of fragments.
+ *
+ * Exported for unit-test coverage of all six branches.
  */
-const refutationStatus = (
+export const refutationStatus = (
     s: DraftSuggestion,
 ):
     | "refutedSeenPassed"


### PR DESCRIPTION
## Summary

Rewrites the six branches of the prior-suggestion summary line so every variant explicitly states both axes:

- Who passed before the refuter (or that nobody passed at all).
- Whether the refuter's shown card was seen by the user (or "card not seen").

This is **M3** from the [UX overhaul rollout plan](https://github.com/LetsGetIntoIt/effect-clue/blob/main/.claude/plans/another-session-generated-claude-plans-u-rustling-anchor.md), addressing #8 from the [test-game backlog](https://github.com/LetsGetIntoIt/effect-clue/blob/main/.claude/plans/ux-backlog-from-test-game.md).

### Old → New copy

| Branch              | Old                                                | New                                                 |
| ------------------- | -------------------------------------------------- | --------------------------------------------------- |
| refutedSeenPassed   | refuted by **Alice** (showed Knife) · passed: Bob | Passed by Bob; refuted by **Alice** (showed Knife)  |
| refutedSeen         | refuted by **Alice** (showed Knife)                | Nobody passed; refuted by **Alice** (showed Knife)  |
| refutedPassed       | refuted by **Alice** · passed: Bob                | Passed by Bob; refuted by **Alice** (card not seen) |
| refuted             | refuted by **Alice**                               | Nobody passed; refuted by **Alice** (card not seen) |
| nobodyPassed        | nobody could refute · passed: Bob                  | Passed by Bob; nobody refuted                       |
| nobody              | nobody could refute                                | Nobody passed; nobody refuted                       |

The branch keys are unchanged, so `refutationStatus()`'s predicate logic carries through. The change is one i18n template rewrite plus exporting `refutationStatus` and pinning all six branches under a new test file.

### Issues / decisions to raise

- **\"Nobody passed\" applies even when the user didn't fill in the passers pill.** The `DraftSuggestion.nonRefuters` array is empty in two cases — user explicitly chose Nobody, or user didn't fill the pill at all. The current model collapses both to \"Nobody passed.\" The old copy had the same conflation (\"nobody could refute · passed: …\" was only shown when refuter was empty), but the new copy is more assertive about it. If you want the unfilled-pill case to stay implicit, we'd need to either preserve the Nobody sentinel through to the saved draft (a state-shape change) or accept the conflation. Flagging for product call.
- **Capitalization shift.** Old copy was lowercase fragments (\"refuted by …\", \"nobody could refute …\"). New copy starts with a capital so each line reads as a self-contained sentence. This matches how the line displays — its own row, distinct from the suggestion line above it. If you want it to read more like a continuation of the suggested-line, we can drop the capitals.
- **Plan adjustments.** None to the milestone roadmap. Plan listed \"refutedSeenPassed\" / \"refutedSeen\" copy as having both passers AND seen card ordering — implemented as \"Passed by …; refuted by … (showed …)\" which puts passers first to match the chronological flow (everyone passes, then the refuter shows). Matches the plan's example shape.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm knip && pnpm i18n:check` all green (1312 tests, +6 new).
- [x] Manually verified by seeding a session with one suggestion per branch — all six lines render with the new copy.
- [ ] Manual UX review on the Vercel preview build for tone / capitalization / ordering.

## Commits

- **Spell out \"nobody passed\" and \"card not seen\" in prior-suggestion lines** — Updates the six branches of `suggestions.refutationLine` and pins each via a new exported `refutationStatus` predicate test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)