### PR TITLE
M10: Frame the checklistSuggest tour with "two halves" intro steps

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -502,6 +502,10 @@
             }
         },
         "checklist": {
+            "intro": {
+                "title": "Checklist — read deductions",
+                "body": "This half is where the solver shows what it's figured out. Cells fill in as facts come in."
+            },
             "cell": {
                 "title": "Each cell is a deduction",
                 "body": "Y means a player holds that card; N means they don't. The solver runs after every change and fills in everything it can derive."
@@ -509,13 +513,13 @@
             "caseFile": {
                 "title": "The case file",
                 "body": "When the solver narrows a category to a single suspect / weapon / room, the case-file column shows it — that's your accusation."
-            },
-            "gotoSuggest": {
-                "title": "Tap Suggest to log a suggestion",
-                "body": "Suggestions live on the Suggest pane. Tap the tab to switch over and log the first one."
             }
         },
         "suggest": {
+            "intro": {
+                "title": "Suggest — log suggestions",
+                "body": "The other half logs suggestions you observe. Both halves work together — on desktop side-by-side, on mobile via the tabs at the bottom."
+            },
             "addForm": {
                 "title": "Add the first suggestion of the game to get started!",
                 "body": "After adding, switch to the checklist to see updated deductions."

--- a/src/ui/components/PlayLayout.tsx
+++ b/src/ui/components/PlayLayout.tsx
@@ -60,7 +60,17 @@ function DesktopPlayLayout() {
     return (
         <div className="grid grid-cols-[minmax(0,1fr)_minmax(320px,420px)] items-start gap-5">
             <Checklist />
-            <div className="sticky right-5 top-[calc(var(--contradiction-banner-offset,0px)+var(--header-offset,0px)+1.5rem)] max-h-[calc(100dvh-var(--contradiction-banner-offset,0px)-var(--header-offset,0px)-3rem)] min-w-0 overflow-y-auto">
+            {/* The M10 swap-discoverability tour anchors here to
+                spotlight the entire suggest column on desktop, mirror
+                of `desktop-checklist-area` on the Checklist side. The
+                anchor is intentionally on the sticky outer wrapper
+                (not on `<SuggestionLogPanel>` itself) so the
+                spotlight covers the visible viewport-pinned region
+                even after vertical scroll. */}
+            <div
+                data-tour-anchor="desktop-suggest-area"
+                className="sticky right-5 top-[calc(var(--contradiction-banner-offset,0px)+var(--header-offset,0px)+1.5rem)] max-h-[calc(100dvh-var(--contradiction-banner-offset,0px)-var(--header-offset,0px)-3rem)] min-w-0 overflow-y-auto"
+            >
                 <SuggestionLogPanel />
             </div>
         </div>

--- a/src/ui/tour/TourProvider.test.tsx
+++ b/src/ui/tour/TourProvider.test.tsx
@@ -164,25 +164,20 @@ describe("TourProvider — persistence on close", () => {
 // ─────────────────────────────────────────────────────────────────────────
 
 describe("TourProvider — viewport filter", () => {
-    test("checklistSuggest exposes 4 steps on desktop (mobile-only step filtered)", () => {
+    test("checklistSuggest exposes the same 6 steps on desktop and mobile (no viewport-locked steps post-M10)", () => {
+        // M10 collapsed the older mobile-only `bottom-nav-suggest`
+        // wayfinding step into the new Suggest intro step, which
+        // runs on both viewports. The tour is now the same length
+        // on either breakpoint.
         stubMatchMedia(true); // desktop
         const api = mount();
         act(() => api.current().startTour("checklistSuggest"));
-        expect(api.current().steps?.length).toBe(4);
-        // The mobile-only `bottom-nav-suggest` step is excluded.
-        expect(
-            api.current().steps?.map(s => s.anchor),
-        ).not.toContain("bottom-nav-suggest");
-    });
+        expect(api.current().steps?.length).toBe(6);
 
-    test("checklistSuggest exposes 5 steps on mobile (mobile-only step included)", () => {
         stubMatchMedia(false); // mobile
-        const api = mount();
-        act(() => api.current().startTour("checklistSuggest"));
-        expect(api.current().steps?.length).toBe(5);
-        expect(
-            api.current().steps?.map(s => s.anchor),
-        ).toContain("bottom-nav-suggest");
+        const api2 = mount();
+        act(() => api2.current().startTour("checklistSuggest"));
+        expect(api2.current().steps?.length).toBe(6);
     });
 
     test("setup tour has the same 6 steps at both breakpoints (no viewport-locked steps)", () => {
@@ -197,22 +192,20 @@ describe("TourProvider — viewport filter", () => {
         expect(api2.current().steps?.length).toBe(6);
     });
 
-    test("isLastStep is computed from the post-filter list", () => {
-        stubMatchMedia(true); // desktop — 4 steps
+    test("isLastStep is true on the final step of checklistSuggest", () => {
+        stubMatchMedia(true); // desktop — 6 steps
         const api = mount();
         act(() => api.current().startTour("checklistSuggest"));
-        // Step 0 of 4: not last.
+        // Step 0 of 6: not last.
         expect(api.current().isLastStep).toBe(false);
-        // Walk to step 3 (the wrap-up `suggest-add-form`).
+        // Walk to step 5 (the wrap-up `suggest-add-form`).
         act(() => api.current().nextStep());
         act(() => api.current().nextStep());
         act(() => api.current().nextStep());
-        // Step 3 of 4 (0-indexed) IS the last on desktop.
+        act(() => api.current().nextStep());
+        act(() => api.current().nextStep());
+        // Step 5 of 6 (0-indexed) IS the last.
         expect(api.current().isLastStep).toBe(true);
-        // Without the filter, step 3 would be the mobile-only
-        // `bottom-nav-suggest` and isLastStep would be false at this
-        // point — pinning isLastStep at desktop step 3 confirms the
-        // filter is wiring through.
     });
 });
 

--- a/src/ui/tour/tours.test.ts
+++ b/src/ui/tour/tours.test.ts
@@ -90,33 +90,58 @@ describe("TOURS — setup tour", () => {
 });
 
 describe("TOURS — checklistSuggest tour", () => {
-    test("has the expected step list including the mobile-only Suggest-tab step", () => {
+    test("has the expected six steps in declaration order", () => {
+        // M10 added the two intro steps that establish the "two
+        // halves" mental model (Checklist + Suggest) before drilling
+        // into individual content. The older mobile-only
+        // `bottom-nav-suggest` wayfinding step was folded into the
+        // new Suggest intro — both viewports now run the same step
+        // count.
         expect(TOURS.checklistSuggest.map(s => s.anchor)).toEqual([
+            "desktop-checklist-area",
             "checklist-cell",
             "checklist-case-file",
-            "bottom-nav-suggest", // mobile-only — `viewport: "mobile"` filters it on desktop
+            "desktop-suggest-area",
             "suggest-prior-log",
             "suggest-add-form",
         ]);
     });
 
-    test("bottom-nav-suggest is mobile-only (filtered out on desktop)", () => {
-        const step = findStep(TOURS.checklistSuggest, "bottom-nav-suggest");
-        expect(step.viewport).toBe("mobile");
-        // The step requires `checklist` uiMode so the BottomNav's
-        // Suggest tab is the natural CTA — switching to suggest is
-        // the user's next action.
-        expect(step.requiredUiMode).toBe("checklist");
+    test("intro steps use viewport-conditional anchors + popoverAnchor", () => {
+        // The Checklist + Suggest intros spotlight large regions
+        // (whole column on desktop, BottomNav tab on mobile) but pin
+        // the popover to a smaller element on desktop so it doesn't
+        // get pushed off-screen.
+        const checklistIntro = findStep(
+            TOURS.checklistSuggest,
+            "desktop-checklist-area",
+        );
+        expect(checklistIntro.anchorByViewport).toEqual({
+            mobile: "bottom-nav-checklist",
+            desktop: "desktop-checklist-area",
+        });
+        expect(checklistIntro.popoverAnchor).toBe("checklist-case-file");
+
+        const suggestIntro = findStep(
+            TOURS.checklistSuggest,
+            "desktop-suggest-area",
+        );
+        expect(suggestIntro.anchorByViewport).toEqual({
+            mobile: "bottom-nav-suggest",
+            desktop: "desktop-suggest-area",
+        });
+        expect(suggestIntro.popoverAnchor).toBe("suggest-add-form-header");
     });
 
-    test("no other step is viewport-locked", () => {
-        // Only the Suggest-tab step is viewport-conditional today.
-        // If you add another viewport-locked step, update this
+    test("no step is viewport-locked", () => {
+        // After the M10 intro steps replaced the older mobile-only
+        // wayfinding step, every step in the tour runs on both
+        // viewports. If you add a viewport-locked step, update this
         // assertion AND walk both breakpoints.
         const lockedSteps = TOURS.checklistSuggest.filter(
             s => s.viewport !== undefined && s.viewport !== "both",
         );
-        expect(lockedSteps.map(s => s.anchor)).toEqual(["bottom-nav-suggest"]);
+        expect(lockedSteps).toEqual([]);
     });
 
     test("suggest-add-form spotlight covers the whole form, popover sits outside via sideByViewport", () => {
@@ -136,12 +161,11 @@ describe("TOURS — checklistSuggest tour", () => {
         expect(step.finishLabelKey).toBe("startPlaying");
     });
 
-    test("every step except the mobile-only one has a requiredUiMode", () => {
-        // The driver dispatches `setUiMode` to land on the right pane
-        // before each step renders on mobile (since panes don't
-        // co-exist on mobile). The mobile-only Suggest-tab step
-        // explicitly stays on the checklist pane (the user is about
-        // to switch panes themselves).
+    test("every step has a requiredUiMode", () => {
+        // The driver dispatches `setUiMode` to land on the right
+        // pane before each step renders on mobile (since panes don't
+        // co-exist on mobile). On desktop the dispatch is a no-op
+        // since both panes render side-by-side.
         for (const step of TOURS.checklistSuggest) {
             expect(step.requiredUiMode).toBeDefined();
         }

--- a/src/ui/tour/tours.ts
+++ b/src/ui/tour/tours.ts
@@ -273,6 +273,32 @@ export const TOURS: Record<ScreenKey, ReadonlyArray<TourStep>> = {
     ],
     checklistSuggest: [
         {
+            // M10 — swap-discoverability intro. Establish the "two
+            // halves" mental model before drilling into either side.
+            // Mobile spotlight points at the BottomNav Checklist tab
+            // (the swap target the user is currently on); desktop
+            // spotlight covers the entire Checklist column. The
+            // popover anchor falls back to a small element at the
+            // top of the column on desktop (so the popover doesn't
+            // get pushed off-screen against a wide column) — same
+            // pattern as `firstSuggestion`.
+            anchor: "desktop-checklist-area",
+            anchorByViewport: {
+                mobile: "bottom-nav-checklist",
+                desktop: "desktop-checklist-area",
+            },
+            popoverAnchor: "checklist-case-file",
+            titleKey: "checklist.intro.title",
+            bodyKey: "checklist.intro.body",
+            side: "bottom",
+            align: "start",
+            sideByViewport: {
+                mobile: { side: "top", align: "center" },
+                desktop: { side: "bottom", align: "start" },
+            },
+            requiredUiMode: "checklist",
+        },
+        {
             anchor: "checklist-cell",
             titleKey: "checklist.cell.title",
             bodyKey: "checklist.cell.body",
@@ -289,19 +315,32 @@ export const TOURS: Record<ScreenKey, ReadonlyArray<TourStep>> = {
             requiredUiMode: "checklist",
         },
         {
-            // Mobile-only: on a narrow layout the checklist and
-            // suggest panes don't co-exist, so we have to hand the
-            // user the wayfinding cue ("tap Suggest to log a
-            // suggestion") before the next step actually flips
-            // them over to that pane. Skipped on desktop where
-            // both panes are visible at the same time.
-            anchor: "bottom-nav-suggest",
-            titleKey: "checklist.gotoSuggest.title",
-            bodyKey: "checklist.gotoSuggest.body",
+            // M10 — swap-discoverability second half. Mirror of the
+            // intro step but spotlights the Suggest side. Mobile
+            // anchor is the BottomNav Suggest tab (still visible
+            // while the user is on checklist mode); desktop anchor
+            // covers the sticky right column. Popover anchor on
+            // desktop is the suggest form header — small element
+            // at the top of the column for stable popover placement.
+            //
+            // Replaces the older mobile-only `gotoSuggest` wayfinding
+            // step. The auto-swap to suggest pane still happens on
+            // the NEXT step's `requiredUiMode: "suggest"` transition.
+            anchor: "desktop-suggest-area",
+            anchorByViewport: {
+                mobile: "bottom-nav-suggest",
+                desktop: "desktop-suggest-area",
+            },
+            popoverAnchor: "suggest-add-form-header",
+            titleKey: "suggest.intro.title",
+            bodyKey: "suggest.intro.body",
             side: "top",
             align: "center",
+            sideByViewport: {
+                mobile: { side: "top", align: "center" },
+                desktop: { side: "bottom", align: "end" },
+            },
             requiredUiMode: "checklist",
-            viewport: "mobile",
         },
         {
             // The user sees the suggestion log BEFORE we point at


### PR DESCRIPTION
## Summary

The `checklistSuggest` tour used to drill straight into a checklist cell at step 1, leaving new users without a mental model of where the Suggest pane fits in. New users on the test playthrough kept missing that the suggest column / tab is half of the workflow, not a secondary detail.

The tour now opens with two intro steps that establish the "two halves" framing:

- **Step 1 — "Checklist — read deductions"**: spotlights the entire deduction grid on desktop / the BottomNav Checklist tab on mobile.
- **Step 4 — "Suggest — log suggestions"**: spotlights the sticky right column on desktop / the BottomNav Suggest tab on mobile.

The older mobile-only `bottom-nav-suggest` wayfinding step is folded into the new Suggest intro — it covered the same ground (point at the Suggest tab + prepare for the upcoming swap) but only on mobile, while the new step does the same job on both viewports. The tour is now 6 steps on both breakpoints (was 4 desktop / 5 mobile).

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm knip && pnpm i18n:check` all green (1314 tests).
- [x] Walked the tour end-to-end at desktop (1280×800) — all 6 popovers fully on-screen.
- [x] Walked the tour end-to-end at mobile (375×812) — all 6 popovers fully on-screen.
- [x] Verified the new viewport-aware anchors resolve correctly (`desktop-checklist-area` / `bottom-nav-checklist` and `desktop-suggest-area` / `bottom-nav-suggest`).

## Commits

1. `M10: Frame the checklistSuggest tour with "two halves" intro steps` — adds the two intro steps + `desktop-suggest-area` anchor + i18n + test updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)