### PR TITLE
M6 PR-A1: setup-wizard state plumbing (selfPlayerId, firstDealtPlayerId, reorder actions)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -79,7 +79,14 @@
             "removeAccusation": "removing Accusation #{number} by {player} ({cards})",
             "removeAccusationUnknown": "removing an accusation",
             "setHypothesis": "setting hypothesis: {owner} {value, select, Y {owns} other {doesn't own}} {card}",
-            "clearHypothesis": "clearing hypothesis on {owner} / {card}"
+            "clearHypothesis": "clearing hypothesis on {owner} / {card}",
+            "reorderPlayers": "reordering players",
+            "reorderCategories": "reordering categories",
+            "reorderCardsInCategory": "reordering cards in {category}",
+            "setSelfPlayer": "identifying yourself as {player}",
+            "clearSelfPlayer": "clearing your identity",
+            "setFirstDealtPlayer": "marking {player} as the first dealt",
+            "clearFirstDealtPlayer": "clearing the first-dealt player"
         }
     },
     "setup": {

--- a/src/logic/ClueState.ts
+++ b/src/logic/ClueState.ts
@@ -1,7 +1,7 @@
 import type { AccusationId } from "./Accusation";
 import type { CardSet } from "./CardSet";
 import type { Card, CardCategory, Player } from "./GameObjects";
-import type { GameSetup } from "./GameSetup";
+import type { CardEntry, Category, GameSetup } from "./GameSetup";
 import type { HypothesisMap, HypothesisValue } from "./Hypothesis";
 import type { KnownCard } from "./InitialKnowledge";
 import type { Cell } from "./Knowledge";
@@ -136,11 +136,50 @@ export type ClueAction =
     | { type: "removePlayer"; player: Player }
     | { type: "renamePlayer"; oldName: Player; newName: Player }
     | { type: "movePlayer"; player: Player; direction: "left" | "right" }
+    /**
+     * Bulk-replace the player list with `players`. Used by the M6
+     * setup wizard's drag-to-reorder UI — `movePlayer` stays around
+     * for arrow-key a11y, but a drag drops the whole new ordering at
+     * once instead of N consecutive swaps. The reducer validates the
+     * input is a permutation of the current list.
+     */
+    | { type: "reorderPlayers"; players: ReadonlyArray<Player> }
+    /**
+     * Bulk-replace the category list with `categories`. Used by the
+     * M6 wizard's customize sub-flow drag-to-reorder. Validated as a
+     * permutation against the current setup.
+     */
+    | { type: "reorderCategories"; categories: ReadonlyArray<Category> }
+    /**
+     * Bulk-replace one category's card list. Used by the M6 wizard's
+     * customize sub-flow's per-category drag-to-reorder.
+     */
+    | {
+          type: "reorderCardsInCategory";
+          categoryId: CardCategory;
+          cards: ReadonlyArray<CardEntry>;
+      }
     | { type: "setUiMode"; mode: UiMode }
     | { type: "setHypothesis"; cell: Cell; value: HypothesisValue }
     | { type: "clearHypothesis"; cell: Cell }
     | { type: "replaceSession"; session: GameSession }
-    | { type: "setPendingSuggestion"; draft: PendingSuggestionDraft | null };
+    | { type: "setPendingSuggestion"; draft: PendingSuggestionDraft | null }
+    /**
+     * Set (or clear) the player the user identifies AS. Drives the
+     * M6 wizard's "Who are you?" step + the M8 My-cards panel +
+     * refute hint. `null` means "skipped / cleared". Reference
+     * invariants: cleared automatically on `removePlayer`, follows
+     * the rename on `renamePlayer`.
+     */
+    | { type: "setSelfPlayer"; player: Player | null }
+    /**
+     * Set (or clear) the player who was dealt the first card. `null`
+     * means "default to first in turn order" — keep the math centralized
+     * via `firstDealt.ts` in the wizard rather than inlining it.
+     * Reference invariants: cleared on `removePlayer`, follows the
+     * rename on `renamePlayer`.
+     */
+    | { type: "setFirstDealtPlayer"; player: Player | null };
 
 export interface ClueState {
     readonly setup: GameSetup;
@@ -168,4 +207,31 @@ export interface ClueState {
      * edits already have a saved source-of-truth in `suggestions`.
      */
     readonly pendingSuggestion: PendingSuggestionDraft | null;
+    /**
+     * The player the user identifies AS in this game. `null` means
+     * skipped / not set — every UI feature gated on identity is
+     * hidden in that case (no "set yourself" empty states; the
+     * `<SetupSummary>` row is the discoverable path back). Driven
+     * by the M6 wizard's "Who are you?" step. Read by M8's MyHand
+     * panel + suggestion-form refute hint.
+     *
+     * Reference invariants enforced in the reducer:
+     * - cleared on `removePlayer` if the removed player matches
+     * - renamed on `renamePlayer` if the renamed player matches
+     * - reset to `null` on `newGame`
+     * - defaulted to `null` on `replaceSession` (imported games — the
+     *   share wire format does NOT carry identity; the receiver picks
+     *   their own)
+     */
+    readonly selfPlayerId: Player | null;
+    /**
+     * The player who was dealt the first card. `null` means "default
+     * to the first player in turn order" — `firstDealt.ts` (added in
+     * a later M6 sub-PR) reads through this to derive per-player
+     * default hand sizes without inlining the math. Driven by the
+     * "Adjust dealing" affordance on the wizard's hand-sizes step.
+     *
+     * Same reference invariants as `selfPlayerId`.
+     */
+    readonly firstDealtPlayerId: Player | null;
 }

--- a/src/logic/Persistence.test.ts
+++ b/src/logic/Persistence.test.ts
@@ -17,7 +17,8 @@ import {
 } from "./Persistence";
 import { emptyHypotheses } from "./Hypothesis";
 
-const STORAGE_KEY = "effect-clue.session.v8";
+const STORAGE_KEY = "effect-clue.session.v9";
+const LEGACY_STORAGE_KEY_V8 = "effect-clue.session.v8";
 const LEGACY_STORAGE_KEY_V7 = "effect-clue.session.v7";
 const LEGACY_STORAGE_KEY_V6 = "effect-clue.session.v6";
 
@@ -43,6 +44,8 @@ const minimalSession: GameSession = {
     accusations: [],
     hypotheses: emptyHypotheses,
     pendingSuggestion: null,
+    selfPlayerId: null,
+    firstDealtPlayerId: null,
 };
 
 const richSession = (): GameSession => ({
@@ -96,6 +99,8 @@ const richSession = (): GameSession => ({
     ],
     hypotheses: emptyHypotheses,
     pendingSuggestion: null,
+    selfPlayerId: null,
+    firstDealtPlayerId: null,
 });
 
 describe("encode/decode — rich sessions", () => {
@@ -193,11 +198,35 @@ describe("saveToLocalStorage / loadFromLocalStorage", () => {
         expect(loaded?.handSizes).toHaveLength(3);
     });
 
-    test("save writes under the v8-scoped storage key", () => {
+    test("save writes under the v9-scoped storage key", () => {
         saveToLocalStorage(minimalSession);
         const raw = window.localStorage.getItem(STORAGE_KEY);
         expect(raw).not.toBeNull();
-        expect(JSON.parse(raw as string).version).toBe(8);
+        expect(JSON.parse(raw as string).version).toBe(9);
+    });
+
+    test("loads a v8 blob and lifts to v9 with null identity fields", () => {
+        // v8 lacked `selfPlayerId` and `firstDealtPlayerId`. The lift
+        // defaults both to null — same value the M6 wizard produces
+        // when the user skips the identity step on a fresh game.
+        const v8Payload = {
+            version: 8,
+            setup: { players: ["Anisha"], categories: [] },
+            hands: [],
+            handSizes: [],
+            suggestions: [],
+            accusations: [],
+            hypotheses: [],
+            pendingSuggestion: null,
+        };
+        window.localStorage.setItem(
+            LEGACY_STORAGE_KEY_V8,
+            JSON.stringify(v8Payload),
+        );
+        const loaded = loadFromLocalStorage();
+        expect(loaded).toBeDefined();
+        expect(loaded?.selfPlayerId).toBeNull();
+        expect(loaded?.firstDealtPlayerId).toBeNull();
     });
 
     test("loads a v7 blob (no pendingSuggestion field) and lifts to v8 with null draft", () => {

--- a/src/logic/Persistence.ts
+++ b/src/logic/Persistence.ts
@@ -22,11 +22,13 @@ import {
     decodeV6Unknown,
     decodeV7Unknown,
     decodeV8Unknown,
+    decodeV9Unknown,
     type PersistedHypothesis,
     type PersistedPendingSuggestion,
     type PersistedSessionV6,
     type PersistedSessionV7,
     type PersistedSessionV8,
+    type PersistedSessionV9,
 } from "./PersistenceSchema";
 import type { PendingSuggestionDraft } from "./ClueState";
 import {
@@ -42,14 +44,13 @@ import {
  * the mutable inputs are serialized; derived knowledge is cheap to
  * recompute, so there's no need to persist it.
  *
- * v8 (current) adds `pendingSuggestion` — the in-flight new-suggestion
- * draft, persisted so it survives mobile tab swaps and reloads.
- * v7 / v6 reads still work via {@link decodeV7Unknown} / {@link
- * decodeV6Unknown}; they're auto-lifted with `pendingSuggestion: null`
- * (and `hypotheses: []` for v6). Writes always produce v8.
+ * v9 (current) adds `selfPlayerId` + `firstDealtPlayerId` — identity-
+ * related fields driven by the M6 setup wizard. v8 / v7 / v6 reads
+ * still work via the corresponding decoders; they're auto-lifted
+ * with the new fields defaulted to null. Writes always produce v9.
  */
-interface PersistedGameV8 {
-    readonly version: 8;
+interface PersistedGameV9 {
+    readonly version: 9;
     readonly setup: {
         readonly players: ReadonlyArray<string>;
         readonly categories: ReadonlyArray<{
@@ -90,9 +91,11 @@ interface PersistedGameV8 {
         readonly value: "Y" | "N";
     }>;
     readonly pendingSuggestion: PersistedPendingSuggestion | null;
+    readonly selfPlayerId: string | null;
+    readonly firstDealtPlayerId: string | null;
 }
 
-type PersistedGame = PersistedGameV8;
+type PersistedGame = PersistedGameV9;
 
 export interface GameSession {
     setup: GameSetup;
@@ -102,12 +105,14 @@ export interface GameSession {
     accusations: ReadonlyArray<Accusation>;
     hypotheses: HypothesisMap;
     pendingSuggestion: PendingSuggestionDraft | null;
+    selfPlayerId: Player | null;
+    firstDealtPlayerId: Player | null;
 }
 
 const encodeHypotheses = (
     hypotheses: HypothesisMap,
-): PersistedGameV8["hypotheses"] => {
-    const out: Array<PersistedGameV8["hypotheses"][number]> = [];
+): PersistedGameV9["hypotheses"] => {
+    const out: Array<PersistedGameV9["hypotheses"][number]> = [];
     for (const [cell, value] of hypotheses) {
         const player =
             cell.owner._tag === "Player"
@@ -235,7 +240,7 @@ const decodeHypotheses = (
 };
 
 export const encodeSession = (session: GameSession): PersistedGame => ({
-    version: 8,
+    version: 9,
     setup: {
         players: session.setup.players.map(p => String(p)),
         categories: session.setup.categories.map(c => ({
@@ -272,6 +277,54 @@ export const encodeSession = (session: GameSession): PersistedGame => ({
     })),
     hypotheses: encodeHypotheses(session.hypotheses),
     pendingSuggestion: encodePendingSuggestion(session.pendingSuggestion),
+    selfPlayerId:
+        session.selfPlayerId === null ? null : String(session.selfPlayerId),
+    firstDealtPlayerId:
+        session.firstDealtPlayerId === null
+            ? null
+            : String(session.firstDealtPlayerId),
+});
+
+const buildSessionFromV9 = (v9: PersistedSessionV9): GameSession => ({
+    setup: GameSetup({
+        players: v9.setup.players,
+        categories: v9.setup.categories.map(c => Category({
+            id: c.id,
+            name: c.name,
+            cards: c.cards.map(card => CardEntry({
+                id: card.id,
+                name: card.name,
+            })),
+        })),
+    }),
+    hands: v9.hands.map(h => ({ player: h.player, cards: h.cards })),
+    handSizes: v9.handSizes.map(h => ({
+        player: h.player,
+        size: h.size,
+    })),
+    suggestions: v9.suggestions.map(s => Suggestion({
+        id: s.id === undefined || s.id === SuggestionId("")
+            ? newSuggestionId()
+            : s.id,
+        suggester: s.suggester,
+        cards: s.cards,
+        nonRefuters: s.nonRefuters,
+        refuter: s.refuter === null ? undefined : s.refuter,
+        seenCard: s.seenCard === null ? undefined : s.seenCard,
+        loggedAt: s.loggedAt,
+    })),
+    accusations: v9.accusations.map(a => Accusation({
+        id: a.id === undefined || a.id === AccusationId("")
+            ? newAccusationId()
+            : a.id,
+        accuser: a.accuser,
+        cards: a.cards,
+        loggedAt: a.loggedAt,
+    })),
+    hypotheses: decodeHypotheses(v9.hypotheses),
+    pendingSuggestion: decodePendingSuggestion(v9.pendingSuggestion),
+    selfPlayerId: v9.selfPlayerId,
+    firstDealtPlayerId: v9.firstDealtPlayerId,
 });
 
 const buildSessionFromV8 = (v8: PersistedSessionV8): GameSession => ({
@@ -312,6 +365,12 @@ const buildSessionFromV8 = (v8: PersistedSessionV8): GameSession => ({
     })),
     hypotheses: decodeHypotheses(v8.hypotheses),
     pendingSuggestion: decodePendingSuggestion(v8.pendingSuggestion),
+    // v8 → v9 lift: identity fields default to null. Existing
+    // sessions don't lose state on the upgrade — the M6 wizard's
+    // identity step is skippable, so null is the same value a
+    // fresh wizard skip produces.
+    selfPlayerId: null,
+    firstDealtPlayerId: null,
 });
 
 const buildSessionFromV7 = (v7: PersistedSessionV7): GameSession => ({
@@ -352,11 +411,16 @@ const buildSessionFromV7 = (v7: PersistedSessionV7): GameSession => ({
     })),
     hypotheses: decodeHypotheses(v7.hypotheses),
     pendingSuggestion: null,
+    // v7 → v9 lift: identity fields default to null (skippable
+    // wizard step's natural value).
+    selfPlayerId: null,
+    firstDealtPlayerId: null,
 });
 
 /**
- * Lift a v6 payload to v8 by attaching an empty hypothesis set and a
- * null pending-suggestion draft. Forward-only and lossless.
+ * Lift a v6 payload to v9 by attaching an empty hypothesis set, a
+ * null pending-suggestion draft, and null identity fields. Forward-
+ * only and lossless.
  */
 const liftV6ToV7 = (v6: PersistedSessionV6): GameSession => ({
     setup: GameSetup({
@@ -396,9 +460,13 @@ const liftV6ToV7 = (v6: PersistedSessionV6): GameSession => ({
     })),
     hypotheses: emptyHypotheses,
     pendingSuggestion: null,
+    selfPlayerId: null,
+    firstDealtPlayerId: null,
 });
 
 export const decodeSession = (data: unknown): GameSession | undefined => {
+    const v9 = decodeV9Unknown(data);
+    if (Result.isSuccess(v9)) return buildSessionFromV9(v9.success);
     const v8 = decodeV8Unknown(data);
     if (Result.isSuccess(v8)) return buildSessionFromV8(v8.success);
     const v7 = decodeV7Unknown(data);
@@ -408,7 +476,8 @@ export const decodeSession = (data: unknown): GameSession | undefined => {
     return undefined;
 };
 
-const STORAGE_KEY = "effect-clue.session.v8";
+const STORAGE_KEY = "effect-clue.session.v9";
+const LEGACY_STORAGE_KEY_V8 = "effect-clue.session.v8";
 const LEGACY_STORAGE_KEY_V7 = "effect-clue.session.v7";
 const LEGACY_STORAGE_KEY_V6 = "effect-clue.session.v6";
 
@@ -423,7 +492,9 @@ export const saveToLocalStorage = (session: GameSession): void => {
 
 export const loadFromLocalStorage = (): GameSession | undefined => {
     try {
-        const rawV8 = window.localStorage.getItem(STORAGE_KEY);
+        const rawV9 = window.localStorage.getItem(STORAGE_KEY);
+        if (rawV9) return decodeSession(JSON.parse(rawV9));
+        const rawV8 = window.localStorage.getItem(LEGACY_STORAGE_KEY_V8);
         if (rawV8) return decodeSession(JSON.parse(rawV8));
         const rawV7 = window.localStorage.getItem(LEGACY_STORAGE_KEY_V7);
         if (rawV7) return decodeSession(JSON.parse(rawV7));

--- a/src/logic/PersistenceSchema.test.ts
+++ b/src/logic/PersistenceSchema.test.ts
@@ -13,7 +13,7 @@ import { Player } from "./GameObjects";
  * starts a fresh session.
  */
 describe("Schema-backed persistence", () => {
-    test("encode produces version: 8 and round-trips through decode", () => {
+    test("encode produces version: 9 and round-trips through decode", () => {
         const encoded = encodeSession({
             setup: CLASSIC_SETUP_3P,
             hands: [],
@@ -22,8 +22,10 @@ describe("Schema-backed persistence", () => {
             accusations: [],
             hypotheses: emptyHypotheses,
             pendingSuggestion: null,
+            selfPlayerId: null,
+            firstDealtPlayerId: null,
         });
-        expect(encoded.version).toBe(8);
+        expect(encoded.version).toBe(9);
 
         const decoded = decodeSession(encoded);
         expect(decoded).toBeDefined();

--- a/src/logic/PersistenceSchema.ts
+++ b/src/logic/PersistenceSchema.ts
@@ -6,12 +6,13 @@ import { SuggestionId } from "./Suggestion";
 /**
  * Effect Schema definitions for the persisted session shape.
  *
- * The current canonical version is v8 (adds `pendingSuggestion`). Reads
- * accept v8 first, then fall back to v7 (auto-lifting with
- * `pendingSuggestion: null`), then v6 (auto-lifting with `hypotheses:
- * []` and `pendingSuggestion: null`), so that users who roll
- * back-and-forward between builds don't lose suggestion / accusation
- * state. Writes always go to v8.
+ * The current canonical version is v9 (adds `selfPlayerId` and
+ * `firstDealtPlayerId`). Reads accept v9 first, then fall back to v8
+ * (auto-lifting with `selfPlayerId: null` and `firstDealtPlayerId:
+ * null`), then v7 (auto-lifting with `pendingSuggestion: null`),
+ * then v6 (auto-lifting with `hypotheses: []` and the v7+v8+v9
+ * defaults), so users who roll back-and-forward between builds
+ * don't lose suggestion / accusation state. Writes always go to v9.
  *
  * v6 added the `loggedAt: number` field to each suggestion + accusation,
  * recording the millisecond timestamp at which it was logged.
@@ -23,6 +24,11 @@ import { SuggestionId } from "./Suggestion";
  * draft, persisted so it survives mobile tab swaps (which unmount the
  * suggestion form) and full-page reloads. See
  * `src/logic/ClueState.ts`'s `PendingSuggestionDraft`.
+ *
+ * v9 adds `selfPlayerId` + `firstDealtPlayerId` — identity-related
+ * fields driven by the M6 setup wizard. The local round-trip
+ * preserves them; the share wire format does not (receivers pick
+ * their own identity post-import).
  *
  * Branded strings (Player, Card, CardCategory, SuggestionId,
  * AccusationId) are decoded straight into their nominal types via
@@ -185,9 +191,7 @@ const PersistedSessionV7Schema = Schema.Struct({
 });
 
 /**
- * Canonical v8 session shape. Adds `pendingSuggestion` — the user's
- * in-flight new-suggestion draft. Encoded as `null` when no draft
- * exists; otherwise the persisted form-state shape.
+ * v8 session shape — kept for back-compat reads. v9 supersedes it.
  */
 const PersistedSessionV8Schema = Schema.Struct({
     version: Schema.Literal(8),
@@ -198,6 +202,37 @@ const PersistedSessionV8Schema = Schema.Struct({
     accusations: Schema.Array(PersistedAccusationSchema),
     hypotheses: HypothesesArraySchema,
     pendingSuggestion: Schema.NullOr(PersistedPendingSuggestionSchema),
+});
+
+/**
+ * Canonical v9 session shape. Adds two identity-related fields
+ * driven by the M6 setup wizard:
+ *
+ *   - `selfPlayerId`: the player the user identifies AS in this
+ *     game. Drives the M8 my-cards panel + the suggestion-form
+ *     refute hint. `null` when the user skipped the identity step.
+ *
+ *   - `firstDealtPlayerId`: the player who was dealt the first
+ *     card. `null` when the user accepts "first in turn order" as
+ *     the default.
+ *
+ * Both are stored on the local-storage round-trip so reload
+ * preserves identity, but the share wire format does NOT include
+ * them — receivers pick their own identity post-import. See
+ * `useApplyShareSnapshot.ts` (defaults both to null) and
+ * `ShareCodec.ts` (the wire format stays seven fields, unchanged).
+ */
+const PersistedSessionV9Schema = Schema.Struct({
+    version: Schema.Literal(9),
+    setup: PersistedGameSetupSchema,
+    hands: Schema.Array(PersistedHandSchema),
+    handSizes: Schema.Array(PersistedHandSizeSchema),
+    suggestions: Schema.Array(PersistedSuggestionSchema),
+    accusations: Schema.Array(PersistedAccusationSchema),
+    hypotheses: HypothesesArraySchema,
+    pendingSuggestion: Schema.NullOr(PersistedPendingSuggestionSchema),
+    selfPlayerId: Schema.NullOr(PlayerSchema),
+    firstDealtPlayerId: Schema.NullOr(PlayerSchema),
 });
 
 /**
@@ -214,15 +249,19 @@ export const decodeV7Unknown = Schema.decodeUnknownResult(
 export const decodeV8Unknown = Schema.decodeUnknownResult(
     PersistedSessionV8Schema,
 );
+export const decodeV9Unknown = Schema.decodeUnknownResult(
+    PersistedSessionV9Schema,
+);
 
 /**
  * Runtime types of decoded sessions — the branded, Schema-validated
- * payload `decodeV{6,7,8}Unknown` hand back. Callers construct the
+ * payload `decodeV{6,7,8,9}Unknown` hand back. Callers construct the
  * GameSession domain value from this.
  */
 export type PersistedSessionV6 = Schema.Schema.Type<typeof PersistedSessionV6Schema>;
 export type PersistedSessionV7 = Schema.Schema.Type<typeof PersistedSessionV7Schema>;
 export type PersistedSessionV8 = Schema.Schema.Type<typeof PersistedSessionV8Schema>;
+export type PersistedSessionV9 = Schema.Schema.Type<typeof PersistedSessionV9Schema>;
 
 export type PersistedHypothesis = Schema.Schema.Type<typeof PersistedHypothesisSchema>;
 export type PersistedPendingSuggestion = Schema.Schema.Type<

--- a/src/logic/describeAction.test.ts
+++ b/src/logic/describeAction.test.ts
@@ -76,6 +76,8 @@ const baseState: ClueState = {
     uiMode: "checklist",
     hypotheses: emptyHypotheses,
     pendingSuggestion: null,
+    selfPlayerId: null,
+    firstDealtPlayerId: null,
 };
 
 const accusationA: DraftAccusation = {

--- a/src/logic/describeAction.ts
+++ b/src/logic/describeAction.ts
@@ -212,6 +212,26 @@ export const describeAction = (
                     findCardEntry(setup, action.cell.card)?.name ??
                     String(action.cell.card),
             });
+        case "reorderPlayers":
+            return t("actions.reorderPlayers");
+        case "reorderCategories":
+            return t("actions.reorderCategories");
+        case "reorderCardsInCategory":
+            return t("actions.reorderCardsInCategory", {
+                category: categoryName(setup, action.categoryId),
+            });
+        case "setSelfPlayer":
+            return action.player === null
+                ? t("actions.clearSelfPlayer")
+                : t("actions.setSelfPlayer", {
+                      player: String(action.player),
+                  });
+        case "setFirstDealtPlayer":
+            return action.player === null
+                ? t("actions.clearFirstDealtPlayer")
+                : t("actions.setFirstDealtPlayer", {
+                      player: String(action.player),
+                  });
         // Non-undoable actions — should never reach the describer
         // because the history reducer bypasses them.
         case "setSetup":

--- a/src/ui/Clue.flow.test.tsx
+++ b/src/ui/Clue.flow.test.tsx
@@ -122,6 +122,8 @@ const seedSetupSession = (): void => {
         accusations: [],
         hypotheses: emptyHypotheses,
         pendingSuggestion: null,
+        selfPlayerId: null,
+        firstDealtPlayerId: null,
     });
 };
 

--- a/src/ui/Clue.test.tsx
+++ b/src/ui/Clue.test.tsx
@@ -272,6 +272,8 @@ describe("Clue — URL-based view hydration", () => {
             accusations: [],
             hypotheses: emptyHypotheses,
             pendingSuggestion: null,
+            selfPlayerId: null,
+            firstDealtPlayerId: null,
         });
         render(<Clue />, { wrapper: TestQueryClientProvider });
         await waitFor(() => {

--- a/src/ui/components/SuggestionLogPanel.editMode.test.tsx
+++ b/src/ui/components/SuggestionLogPanel.editMode.test.tsx
@@ -117,6 +117,8 @@ const seedOneSuggestionAndMount = async (
         accusations: [],
         hypotheses: emptyHypotheses,
         pendingSuggestion: null,
+        selfPlayerId: null,
+        firstDealtPlayerId: null,
     });
     if (view === "suggest") {
         // The mobile play layout only mounts the active pane, so

--- a/src/ui/share/ShareCreateModal.test.tsx
+++ b/src/ui/share/ShareCreateModal.test.tsx
@@ -373,6 +373,8 @@ describe("ShareCreateModal — wire payload by variant", () => {
             accusations: [],
             hypotheses: emptyHypotheses,
             pendingSuggestion: null,
+            selfPlayerId: null,
+            firstDealtPlayerId: null,
         });
 
         mockSession = {

--- a/src/ui/share/ShareCreateModal.tsx
+++ b/src/ui/share/ShareCreateModal.tsx
@@ -508,6 +508,12 @@ export function ShareCreateModal({
             // receiver enters their own. The local `pendingSuggestion`
             // exists in `state` but doesn't ride the share.
             pendingSuggestion: null,
+            // Identity is per-user and stays local. The wire format
+            // does NOT carry these — receivers pick their own
+            // identity post-import (see `useApplyShareSnapshot.ts`,
+            // which defaults both to null on the receive side).
+            selfPlayerId: null,
+            firstDealtPlayerId: null,
         };
         if (variant === VARIANT_INVITE) {
             return buildInviteInput(

--- a/src/ui/share/useApplyShareSnapshot.test.ts
+++ b/src/ui/share/useApplyShareSnapshot.test.ts
@@ -325,6 +325,8 @@ describe("applyShareSnapshotToLocalStorage — receive page handoff", () => {
             accusations: [],
             hypotheses: emptyHypotheses,
             pendingSuggestion: null,
+            selfPlayerId: null,
+            firstDealtPlayerId: null,
         });
 
         const session = applyShareSnapshotToLocalStorage(
@@ -353,6 +355,8 @@ describe("saveCardPackFromSnapshot — pack-only receive", () => {
             accusations: [],
             hypotheses: emptyHypotheses,
             pendingSuggestion: null,
+            selfPlayerId: null,
+            firstDealtPlayerId: null,
         };
         saveToLocalStorage(currentSession);
 
@@ -606,6 +610,8 @@ describe("share receive dirty-state detection", () => {
             accusations: [],
             hypotheses: emptyHypotheses,
             pendingSuggestion: null,
+            selfPlayerId: null,
+            firstDealtPlayerId: null,
         };
 
         expect(sessionHasGameData(clean)).toBe(false);
@@ -626,6 +632,8 @@ describe("share receive dirty-state detection", () => {
                 accusations: [],
                 hypotheses: emptyHypotheses,
                 pendingSuggestion: null,
+                selfPlayerId: null,
+                firstDealtPlayerId: null,
             }),
         ).toBe(true);
         expect(
@@ -642,6 +650,8 @@ describe("share receive dirty-state detection", () => {
                 accusations: [],
                 hypotheses: emptyHypotheses,
                 pendingSuggestion: null,
+                selfPlayerId: null,
+                firstDealtPlayerId: null,
             }),
         ).toBe(true);
     });
@@ -659,6 +669,8 @@ describe("share receive dirty-state detection", () => {
             accusations: [],
             hypotheses: emptyHypotheses,
             pendingSuggestion: null,
+            selfPlayerId: null,
+            firstDealtPlayerId: null,
         });
         expect(hasPersistedGameData()).toBe(true);
     });

--- a/src/ui/share/useApplyShareSnapshot.ts
+++ b/src/ui/share/useApplyShareSnapshot.ts
@@ -287,6 +287,13 @@ export const buildSessionFromSnapshot = (
         hypotheses,
         // Drafts are local-only; the receiver enters their own.
         pendingSuggestion: null,
+        // Identity is local-only too — the share wire format
+        // intentionally does NOT carry `selfPlayerId` /
+        // `firstDealtPlayerId`. The receiver picks their own
+        // identity post-import (the M6 wizard's "Who are you?" step
+        // is skippable, so null is the right starting value).
+        selfPlayerId: null,
+        firstDealtPlayerId: null,
     };
 };
 

--- a/src/ui/state.test.tsx
+++ b/src/ui/state.test.tsx
@@ -612,6 +612,112 @@ describe("player roster", () => {
         expect(result.current.state).toBe(before);
     });
 
+    test("reorderPlayers bulk-replaces the player order when the input is a permutation", () => {
+        const { result } = renderClue();
+        const [p1, p2, p3, p4] = result.current.state.setup.players;
+        act(() =>
+            result.current.dispatch({
+                type: "reorderPlayers",
+                players: [p4!, p1!, p3!, p2!],
+            }),
+        );
+        expect(result.current.state.setup.players.map(p => String(p))).toEqual([
+            "Player 4",
+            "Player 1",
+            "Player 3",
+            "Player 2",
+        ]);
+    });
+
+    test("reorderPlayers rejects an input that isn't a permutation of the current list", () => {
+        // Wizard DnD would never produce a malformed list, but the
+        // reducer guards against it so a stray dispatch can't silently
+        // drop or invent players. State pointer stays unchanged on
+        // reject so React skips the re-render.
+        const { result } = renderClue();
+        const before = result.current.state;
+        const players = result.current.state.setup.players;
+        act(() =>
+            result.current.dispatch({
+                type: "reorderPlayers",
+                players: [
+                    ...players.slice(0, -1),
+                    Player("Stranger"),
+                ],
+            }),
+        );
+        expect(result.current.state).toBe(before);
+        // Length mismatch also rejected.
+        act(() =>
+            result.current.dispatch({
+                type: "reorderPlayers",
+                players: players.slice(0, -1),
+            }),
+        );
+        expect(result.current.state).toBe(before);
+    });
+
+    test("reorderCategories bulk-replaces the category order on a permutation", () => {
+        // CLASSIC_SETUP has 3 categories; flip the first two.
+        const { result } = renderClue();
+        const cats = result.current.state.setup.categories;
+        const [a, b, c] = cats;
+        act(() =>
+            result.current.dispatch({
+                type: "reorderCategories",
+                categories: [b!, a!, c!],
+            }),
+        );
+        const after = result.current.state.setup.categories;
+        expect(after[0]?.id).toBe(b!.id);
+        expect(after[1]?.id).toBe(a!.id);
+        expect(after[2]?.id).toBe(c!.id);
+    });
+
+    test("reorderCategories rejects a length mismatch", () => {
+        const { result } = renderClue();
+        const before = result.current.state;
+        const cats = result.current.state.setup.categories;
+        act(() =>
+            result.current.dispatch({
+                type: "reorderCategories",
+                categories: cats.slice(0, -1),
+            }),
+        );
+        expect(result.current.state).toBe(before);
+    });
+
+    test("reorderCardsInCategory bulk-replaces the per-category card order", () => {
+        const { result } = renderClue();
+        const cat = result.current.state.setup.categories[0]!;
+        const [c1, c2, ...rest] = cat.cards;
+        act(() =>
+            result.current.dispatch({
+                type: "reorderCardsInCategory",
+                categoryId: cat.id,
+                cards: [c2!, c1!, ...rest],
+            }),
+        );
+        const updated = result.current.state.setup.categories.find(
+            c => c.id === cat.id,
+        )!;
+        expect(updated.cards[0]?.id).toBe(c2!.id);
+        expect(updated.cards[1]?.id).toBe(c1!.id);
+    });
+
+    test("reorderCardsInCategory rejects an unknown category id", () => {
+        const { result } = renderClue();
+        const before = result.current.state;
+        act(() =>
+            result.current.dispatch({
+                type: "reorderCardsInCategory",
+                categoryId: "non-existent-cat-id" as never,
+                cards: [],
+            }),
+        );
+        expect(result.current.state).toBe(before);
+    });
+
     test("movePlayer preserves knownCards, handSizes, and suggestions by name", () => {
         const { result } = renderClue();
         const p1 = Player("Player 1");
@@ -657,6 +763,112 @@ describe("player roster", () => {
     });
 });
 
+describe("M6: identity (selfPlayerId / firstDealtPlayerId)", () => {
+    test("setSelfPlayer / setFirstDealtPlayer write the values, null clears", () => {
+        const { result } = renderClue();
+        const p1 = Player("Player 1");
+        const p2 = Player("Player 2");
+        act(() =>
+            result.current.dispatch({ type: "setSelfPlayer", player: p1 }),
+        );
+        expect(result.current.state.selfPlayerId).toBe(p1);
+        act(() =>
+            result.current.dispatch({
+                type: "setFirstDealtPlayer",
+                player: p2,
+            }),
+        );
+        expect(result.current.state.firstDealtPlayerId).toBe(p2);
+        // null clears.
+        act(() =>
+            result.current.dispatch({ type: "setSelfPlayer", player: null }),
+        );
+        expect(result.current.state.selfPlayerId).toBeNull();
+    });
+
+    test("removePlayer clears selfPlayerId / firstDealtPlayerId when the removed player matches", () => {
+        // Without this, a UI feature gated on identity would keep
+        // showing for a non-existent player after they're removed.
+        const { result } = renderClue();
+        const p1 = Player("Player 1");
+        const p2 = Player("Player 2");
+        act(() => {
+            result.current.dispatch({ type: "setSelfPlayer", player: p1 });
+            result.current.dispatch({
+                type: "setFirstDealtPlayer",
+                player: p1,
+            });
+        });
+        act(() =>
+            result.current.dispatch({ type: "removePlayer", player: p1 }),
+        );
+        expect(result.current.state.selfPlayerId).toBeNull();
+        expect(result.current.state.firstDealtPlayerId).toBeNull();
+        // Removing a different player leaves identity untouched.
+        act(() =>
+            result.current.dispatch({ type: "setSelfPlayer", player: p2 }),
+        );
+        act(() =>
+            result.current.dispatch({
+                type: "removePlayer",
+                player: Player("Player 3"),
+            }),
+        );
+        expect(result.current.state.selfPlayerId).toBe(p2);
+    });
+
+    test("renamePlayer updates selfPlayerId / firstDealtPlayerId when they match", () => {
+        const { result } = renderClue();
+        const oldName = Player("Player 1");
+        const newName = Player("Anisha");
+        act(() => {
+            result.current.dispatch({
+                type: "setSelfPlayer",
+                player: oldName,
+            });
+            result.current.dispatch({
+                type: "setFirstDealtPlayer",
+                player: oldName,
+            });
+        });
+        act(() =>
+            result.current.dispatch({
+                type: "renamePlayer",
+                oldName,
+                newName,
+            }),
+        );
+        expect(result.current.state.selfPlayerId).toBe(newName);
+        expect(result.current.state.firstDealtPlayerId).toBe(newName);
+    });
+
+    test("newGame resets identity to null", () => {
+        const { result } = renderClue();
+        const p1 = Player("Player 1");
+        act(() =>
+            result.current.dispatch({ type: "setSelfPlayer", player: p1 }),
+        );
+        act(() => result.current.dispatch({ type: "newGame" }));
+        expect(result.current.state.selfPlayerId).toBeNull();
+        expect(result.current.state.firstDealtPlayerId).toBeNull();
+    });
+
+    test("hasGameData() returns true when only selfPlayerId is set", () => {
+        // The brand-new-user redirect uses hasGameData() as the
+        // "is this a fresh visitor" gate. A user who set just their
+        // identity has expressed intent and should not be redirected.
+        const { result } = renderClue();
+        expect(result.current.hasGameData()).toBe(false);
+        act(() =>
+            result.current.dispatch({
+                type: "setSelfPlayer",
+                player: Player("Player 1"),
+            }),
+        );
+        expect(result.current.hasGameData()).toBe(true);
+    });
+});
+
 describe("replaceSession", () => {
     test("replaces the entire session and mints fresh ids for empty-id suggestions", () => {
         const { result } = renderClue();
@@ -679,6 +891,8 @@ describe("replaceSession", () => {
             accusations: [],
             hypotheses: emptyHypotheses,
             pendingSuggestion: null,
+            selfPlayerId: null,
+            firstDealtPlayerId: null,
         };
         act(() => result.current.dispatch({ type: "replaceSession", session }));
         expect(result.current.state.setup).toBe(CLASSIC_SETUP_3P);
@@ -702,6 +916,8 @@ describe("replaceSession", () => {
                 accusations: [],
                 hypotheses: emptyHypotheses,
                 pendingSuggestion: null,
+                selfPlayerId: null,
+                firstDealtPlayerId: null,
             },
         }));
         // Even though state changed, canUndo remains false for the
@@ -832,6 +1048,8 @@ describe("derived values", () => {
                     accusations: [],
                     hypotheses: emptyHypotheses,
                     pendingSuggestion: null,
+                    selfPlayerId: null,
+                    firstDealtPlayerId: null,
                 } satisfies GameSession,
             });
         });
@@ -896,6 +1114,8 @@ describe("derived values", () => {
                     accusations: [],
                     hypotheses: emptyHypotheses,
                     pendingSuggestion: null,
+                    selfPlayerId: null,
+                    firstDealtPlayerId: null,
                 } satisfies GameSession,
             });
         });
@@ -1136,6 +1356,8 @@ describe("pendingSuggestion", () => {
                     accusations: [],
                     hypotheses: emptyHypotheses,
                     pendingSuggestion: null,
+                    selfPlayerId: null,
+                    firstDealtPlayerId: null,
                 },
             }),
         );

--- a/src/ui/state.tsx
+++ b/src/ui/state.tsx
@@ -165,6 +165,8 @@ const initialState: ClueState = {
     uiMode: "setup",
     hypotheses: emptyHypotheses,
     pendingSuggestion: null,
+    selfPlayerId: null,
+    firstDealtPlayerId: null,
 };
 
 const reducer = (state: ClueState, action: ClueAction): ClueState => {
@@ -459,6 +461,17 @@ const reducer = (state: ClueState, action: ClueAction): ClueState => {
                 // The in-flight draft may reference the removed player
                 // in any of its slots; drop it rather than partial-prune.
                 pendingSuggestion: null,
+                // Identity references must follow the player set: a
+                // dangling `selfPlayerId` would gate UI on a non-
+                // existent player. Same for `firstDealtPlayerId`.
+                selfPlayerId:
+                    state.selfPlayerId === action.player
+                        ? null
+                        : state.selfPlayerId,
+                firstDealtPlayerId:
+                    state.firstDealtPlayerId === action.player
+                        ? null
+                        : state.firstDealtPlayerId,
             };
 
         case "movePlayer": {
@@ -538,6 +551,17 @@ const reducer = (state: ClueState, action: ClueAction): ClueState => {
                     accuser: a.accuser === oldName ? newName : a.accuser,
                 })),
                 pendingSuggestion: renamedPending,
+                // Identity references follow the rename so a user
+                // who set themselves as "Alice" stays identified as
+                // "Alice" after a typo fix.
+                selfPlayerId:
+                    state.selfPlayerId === oldName
+                        ? newName
+                        : state.selfPlayerId,
+                firstDealtPlayerId:
+                    state.firstDealtPlayerId === oldName
+                        ? newName
+                        : state.firstDealtPlayerId,
             };
         }
 
@@ -589,11 +613,86 @@ const reducer = (state: ClueState, action: ClueAction): ClueState => {
                 // Imported sessions don't carry a draft. Drop any
                 // local in-flight draft so the new game starts clean.
                 pendingSuggestion: session.pendingSuggestion ?? null,
+                // Localstorage round-trip carries identity through
+                // (so a reload preserves "I'm Alice"), but the share
+                // wire format does NOT — receivers pick their own.
+                // The codec defaults missing fields to null so this
+                // works for both paths.
+                selfPlayerId: session.selfPlayerId ?? null,
+                firstDealtPlayerId: session.firstDealtPlayerId ?? null,
             };
         }
 
         case "setPendingSuggestion":
             return { ...state, pendingSuggestion: action.draft };
+
+        case "setSelfPlayer":
+            return { ...state, selfPlayerId: action.player };
+
+        case "setFirstDealtPlayer":
+            return { ...state, firstDealtPlayerId: action.player };
+
+        case "reorderPlayers": {
+            // Validate the input is a permutation of the current
+            // player list — otherwise the action is a malformed
+            // bulk-replace and we'd silently drop or invent players.
+            const current = state.setup.players;
+            const next = action.players;
+            if (next.length !== current.length) return state;
+            const currentSet = new Set(current as ReadonlyArray<Player>);
+            for (const p of next) {
+                if (!currentSet.has(p)) return state;
+            }
+            // Same set, possibly reordered. Accept.
+            return {
+                ...state,
+                setup: GameSetup({
+                    players: next,
+                    categories: state.setup.categories,
+                }),
+            };
+        }
+
+        case "reorderCategories": {
+            const current = state.setup.categories;
+            const next = action.categories;
+            if (next.length !== current.length) return state;
+            const currentIds = new Set(current.map(c => c.id));
+            for (const c of next) {
+                if (!currentIds.has(c.id)) return state;
+            }
+            return {
+                ...state,
+                setup: GameSetup({
+                    players: state.setup.players,
+                    categories: next,
+                }),
+            };
+        }
+
+        case "reorderCardsInCategory": {
+            const cat = state.setup.categories.find(
+                c => c.id === action.categoryId,
+            );
+            if (cat === undefined) return state;
+            // Permutation check on the card ids.
+            if (action.cards.length !== cat.cards.length) return state;
+            const currentIds = new Set(cat.cards.map(c => c.id));
+            for (const card of action.cards) {
+                if (!currentIds.has(card.id)) return state;
+            }
+            return {
+                ...state,
+                setup: GameSetup({
+                    players: state.setup.players,
+                    categories: state.setup.categories.map(c =>
+                        c.id === action.categoryId
+                            ? Category({ ...c, cards: action.cards })
+                            : c,
+                    ),
+                }),
+            };
+        }
     }
 };
 
@@ -1323,6 +1422,8 @@ export function ClueProvider({ children }: { children: ReactNode }) {
             accusations: accusationsAsData,
             hypotheses: state.hypotheses,
             pendingSuggestion: state.pendingSuggestion,
+            selfPlayerId: state.selfPlayerId,
+            firstDealtPlayerId: state.firstDealtPlayerId,
         };
         saveToLocalStorage(session);
         queryClient.setQueryData(gameSessionQueryKey, session);
@@ -1425,6 +1526,11 @@ export function ClueProvider({ children }: { children: ReactNode }) {
         if (state.handSizes.length > 0) return true;
         if (state.suggestions.length > 0) return true;
         if (state.accusations.length > 0) return true;
+        // M6: a user who only set their identity has expressed intent
+        // ("I'm Alice in this game") that the brand-new-user redirect
+        // shouldn't override. Same for first-dealt-player.
+        if (state.selfPlayerId !== null) return true;
+        if (state.firstDealtPlayerId !== null) return true;
         const players = state.setup.players;
         if (players.length !== DEFAULT_SETUP.players.length) return true;
         for (let i = 0; i < players.length; i++) {


### PR DESCRIPTION
## Summary

State-only sub-PR. Builds the plumbing the M6 setup-wizard sub-PRs (A2, A3, A4) consume to introduce the wizard UI. **No UI changes here** — a follow-up PR lights this up. Running the app at this commit looks identical to HEAD~1.

The M6 plan splits the keystone milestone into 5 sub-PRs to keep each one reviewable. PR-A1 is the smallest — pure state plumbing with no consumers yet.

### ClueState additions

- `selfPlayerId: Player | null` — the player the user identifies AS in this game. Drives the M8 my-cards panel + the suggestion-form refute hint. `null` means "skipped / not set"; every UI feature gated on identity is hidden in that case.
- `firstDealtPlayerId: Player | null` — the player who was dealt the first card. `null` means "default to first in turn order"; a later sub-PR centralizes the dealing math behind this.

### ClueAction additions

- `setSelfPlayer { player }` / `setFirstDealtPlayer { player }` (null clears).
- `reorderPlayers { players }` — bulk-replace the player list. Used by the wizard's drag-to-reorder UI; `movePlayer` stays for arrow-key a11y.
- `reorderCategories { categories }` and `reorderCardsInCategory { categoryId, cards }` — bulk reorder for the wizard's customize sub-flow.

All three reorder reducers validate the input is a permutation of the current list (length + membership) and bail to a no-op on malformed dispatches.

### Reference invariants

- `removePlayer` clears `selfPlayerId` / `firstDealtPlayerId` if they match the removed player.
- `renamePlayer` rewrites both fields when they match the renamed player.
- `newGame` resets both to null (initialState).
- `replaceSession` defaults both to null on import (the share wire format intentionally does NOT carry identity — receivers pick their own).
- `hasGameData()` counts a non-null `selfPlayerId` / `firstDealtPlayerId` as game data so the brand-new-user redirect doesn't override a user who only set their identity.

### Persistence v8 → v9

- New v9 schema adds `selfPlayerId` + `firstDealtPlayerId` (NullOr Player).
- Decoder chain reads v9 first, then v8 / v7 / v6 with null defaults for the new fields.
- Encoder always writes v9. Storage key bumps to `effect-clue.session.v9`; v8 / v7 / v6 keys are read on load and the next save normalises everything to v9.
- `useApplyShareSnapshot.ts`'s `buildSessionFromSnapshot` defaults both fields to null on the receive side.
- `ShareCreateModal.tsx`'s `GameSession` construction does the same on the send side (defensive — the codecs don't read these fields, but a literal `GameSession` literal needs to satisfy the type).

### describeAction

Six new keys for the action descriptions surfaced in undo/redo tooltips: `reorderPlayers`, `reorderCategories`, `reorderCardsInCategory`, `setSelfPlayer` / `clearSelfPlayer`, `setFirstDealtPlayer` / `clearFirstDealtPlayer`.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm knip && pnpm i18n:check` all green (1326 tests; +12 vs pre-PR).
- [x] Reducer tests: `setSelfPlayer` / `setFirstDealtPlayer` write/clear, `removePlayer` / `renamePlayer` reference invariants, `newGame` reset, `hasGameData()` counts identity, `reorder*` on a permutation accepts, `reorder*` on a malformed dispatch bails.
- [x] Persistence tests: v9 encode round-trips through decode; storage key + version flipped to v9; v8 blob loads and lifts to v9 with `null` identity fields.

## Commits

1. `M6 PR-A1: setup-wizard state plumbing — selfPlayerId, firstDealtPlayerId, reorder actions` — all of the above as one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)