### PR TITLE
M6 PR-A2: setup-wizard shell + steps 2-4 (feature-flagged off)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -138,6 +138,40 @@
         "startPlaying": "Start playing →{shortcut}",
         "continuePlaying": "Continue playing →{shortcut}"
     },
+    "setupWizard": {
+        "heading": "Set up your game",
+        "subheading": "Walk through each step in order. You can come back to anything by clicking it.",
+        "stepCounter": "Step {step} of {total}",
+        "next": "Next",
+        "skip": "Skip",
+        "newGame": "Start over",
+        "players": {
+            "title": "Who's playing?",
+            "turnOrderHint": "Enter players in turn order — the first player you list will be dealt first.",
+            "summary": "{count, plural, one {# player} other {# players}}: {names}",
+            "summaryEmpty": "No players yet",
+            "validationMin": "Add at least two players to continue."
+        },
+        "identity": {
+            "title": "Which player are you?",
+            "helperText": "Optional — set this to enable My Cards and refute hints later. Skipping is fine; you can set it from setup later.",
+            "noPlayersHint": "Add players first to pick yourself.",
+            "summary": "You: {player}",
+            "summarySkipped": "Skipped"
+        },
+        "handSizes": {
+            "title": "How many cards does each player have?",
+            "noPlayersHint": "Add players first to set hand sizes.",
+            "handSizeAria": "Hand size for {player}",
+            "summary": "Total: {total} {total, plural, one {card} other {cards}}",
+            "summaryPartial": "Some hand sizes are still blank",
+            "summaryNoPlayers": "No players yet",
+            "mismatch": "Hand sizes total {total} but should total {expected}.",
+            "adjustDealingTitle": "Adjust dealing",
+            "firstDealtLegend": "Who was dealt the first card?",
+            "firstDealtAuto": "Automatic — first player in turn order"
+        }
+    },
     "deduce": {
         "title": "Deduction grid",
         "caseFileProgress": "Case file · {percent}% solved",

--- a/src/ui/Clue.tsx
+++ b/src/ui/Clue.tsx
@@ -25,6 +25,9 @@ import { StartupCoordinatorProvider, useStartupCoordinator } from "./onboarding/
 import { SplashModal } from "./components/SplashModal";
 import { StaleGameModal } from "./components/StaleGameModal";
 import { useStaleGameGate } from "./hooks/useStaleGameGate";
+import { useSetupWizardEnabled } from "./setup/featureFlag";
+import { SetupWizard } from "./setup/SetupWizard";
+import { SetupWizardFocusProvider } from "./setup/SetupWizardFocusContext";
 import { ClueProvider, useClue } from "./state";
 import { TourProvider, useTour } from "./tour/TourProvider";
 import { TourPopover } from "./tour/TourPopover";
@@ -150,7 +153,9 @@ export function Clue() {
            <ConfirmProvider>
            <PromptProvider>
            <SelectionProvider>
+           <SetupWizardFocusProvider>
             <CoordinatedShell headerRef={headerRef} />
+           </SetupWizardFocusProvider>
            </SelectionProvider>
            </PromptProvider>
            </ConfirmProvider>
@@ -479,6 +484,7 @@ function TabContent() {
     const { state, hydrated } = useClue();
     const mode = state.uiMode;
     const transition = useReducedTransition(T_STANDARD, { fadeMs: 120 });
+    const wizardEnabled = useSetupWizardEnabled();
 
     // Track the previous mode to compute slide direction. Updates
     // via useEffect so render sees the PREVIOUS value alongside the
@@ -532,7 +538,7 @@ function TabContent() {
                         transition={transition}
                         className="[grid-area:stack] min-w-0"
                     >
-                        <Checklist />
+                        {wizardEnabled ? <SetupWizard /> : <Checklist />}
                     </motion.div>
                 ) : (
                     <motion.div

--- a/src/ui/setup/SetupStepPanel.tsx
+++ b/src/ui/setup/SetupStepPanel.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { AnimatePresence, motion } from "motion/react";
+import { useTranslations } from "next-intl";
+import type { ReactNode } from "react";
+import { T_STANDARD, useReducedTransition } from "../motion";
+import { AlertIcon, CheckIcon } from "../components/Icons";
+import type { StepValidation, WizardStepId } from "./wizardSteps";
+
+export type StepPanelState = "pending" | "editing" | "complete";
+
+interface Props {
+    readonly stepId: WizardStepId;
+    readonly state: StepPanelState;
+    readonly stepNumber: number;
+    readonly totalSteps: number;
+    readonly title: string;
+    readonly summary: ReactNode;
+    readonly children: ReactNode;
+    readonly skippable: boolean;
+    readonly validation: StepValidation;
+    readonly onAdvance: () => void;
+    readonly onSkip?: () => void;
+    readonly onClickToEdit?: () => void;
+}
+
+/**
+ * Generic accordion panel for one step of the M6 setup wizard.
+ *
+ * Three render states (per the plan's 0c decision):
+ *
+ * - **pending** — locked, greyed out. Shows the title only, with a
+ *   placeholder summary. Not interactively expandable.
+ * - **editing** — the active step. Full controls (`children`)
+ *   visible, validation banner above the action row, "Next" / "Skip"
+ *   buttons at the bottom.
+ * - **complete** — collapsed back to header + summary. Click to
+ *   re-enter editing for that step. The shell coordinates the
+ *   transition (the previously-editing panel collapses to complete).
+ *
+ * Exactly one panel is in `editing` state at a time; the shell owns
+ * that invariant. The expand / collapse is a height transition via
+ * `AnimatePresence` on the body, NOT a horizontal slide — the
+ * outer Setup ↔ Play slide stays in `Clue.tsx`.
+ */
+export function SetupStepPanel({
+    state,
+    stepNumber,
+    totalSteps,
+    title,
+    summary,
+    children,
+    skippable,
+    validation,
+    onAdvance,
+    onSkip,
+    onClickToEdit,
+}: Props) {
+    const t = useTranslations("setupWizard");
+    const transition = useReducedTransition(T_STANDARD, { fadeMs: 120 });
+
+    const isPending = state === "pending";
+    const isEditing = state === "editing";
+    const isComplete = state === "complete";
+
+    const headerTextClass = isPending
+        ? "text-muted opacity-60"
+        : "text-fg";
+
+    const headerClickable = isComplete && onClickToEdit !== undefined;
+
+    return (
+        <section
+            className={`rounded-[var(--radius)] border bg-panel transition-colors ${
+                isEditing
+                    ? "border-accent/40 shadow-[0_2px_12px_rgba(0,0,0,0.06)]"
+                    : "border-border/40"
+            }`}
+            aria-current={isEditing ? "step" : undefined}
+        >
+            <button
+                type="button"
+                className={`flex w-full items-center justify-between gap-3 rounded-t-[var(--radius)] px-4 py-3 text-left ${
+                    headerClickable
+                        ? "cursor-pointer hover:bg-hover"
+                        : "cursor-default"
+                }`}
+                onClick={headerClickable ? onClickToEdit : undefined}
+                disabled={!headerClickable}
+                aria-expanded={isEditing}
+            >
+                <div className={`flex min-w-0 items-center gap-3 ${headerTextClass}`}>
+                    <span
+                        className={`inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full border text-[12px] font-semibold ${
+                            isComplete
+                                ? "border-accent bg-accent text-white"
+                                : isEditing
+                                  ? "border-accent text-accent"
+                                  : "border-border/60 text-muted"
+                        }`}
+                        aria-hidden
+                    >
+                        {isComplete ? (
+                            <CheckIcon size={14} />
+                        ) : (
+                            stepNumber
+                        )}
+                    </span>
+                    <div className="flex min-w-0 flex-col">
+                        <h2 className="m-0 text-[15px] font-semibold leading-tight">
+                            {title}
+                        </h2>
+                        <span className="text-[11px] uppercase tracking-wide text-muted">
+                            {t("stepCounter", {
+                                step: stepNumber,
+                                total: totalSteps,
+                            })}
+                        </span>
+                    </div>
+                </div>
+                {isComplete && (
+                    <span className="shrink-0 text-[12px] text-muted">
+                        {summary}
+                    </span>
+                )}
+            </button>
+
+            <AnimatePresence initial={false}>
+                {isEditing && (
+                    <motion.div
+                        key="body"
+                        initial={{ height: 0, opacity: 0 }}
+                        // eslint-disable-next-line i18next/no-literal-string -- CSS auto value
+                        animate={{ height: "auto", opacity: 1 }}
+                        exit={{ height: 0, opacity: 0 }}
+                        transition={transition}
+                        className="overflow-hidden"
+                    >
+                        <div className="border-t border-border/30 px-4 py-4">
+                            <div className="flex flex-col gap-4">
+                                {children}
+
+                                {validation.message && validation.level !== "valid" && (
+                                    <div
+                                        role="alert"
+                                        className={`flex items-start gap-2 rounded-[var(--radius)] border px-3 py-2 text-[13px] ${
+                                            validation.level === "blocked"
+                                                ? "border-danger/40 bg-danger/5 text-danger"
+                                                : "border-amber-500/40 bg-amber-500/5 text-amber-700 dark:text-amber-400"
+                                        }`}
+                                    >
+                                        <AlertIcon size={16} />
+                                        <span>{validation.message}</span>
+                                    </div>
+                                )}
+
+                                <div className="flex flex-wrap items-center justify-end gap-2 border-t border-border/20 pt-3">
+                                    {skippable && onSkip && (
+                                        <button
+                                            type="button"
+                                            className="cursor-pointer rounded border border-border bg-bg px-3 py-1.5 text-[13px] hover:bg-hover"
+                                            onClick={onSkip}
+                                        >
+                                            {t("skip")}
+                                        </button>
+                                    )}
+                                    <button
+                                        type="button"
+                                        className="cursor-pointer rounded border-none bg-accent px-4 py-1.5 text-[13px] font-semibold text-white hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
+                                        onClick={onAdvance}
+                                        disabled={validation.level === "blocked"}
+                                    >
+                                        {t("next")}
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </motion.div>
+                )}
+            </AnimatePresence>
+
+            {isPending && (
+                <div className="border-t border-border/20 px-4 py-2 text-[12px] text-muted">
+                    {summary}
+                </div>
+            )}
+        </section>
+    );
+}

--- a/src/ui/setup/SetupWizard.test.tsx
+++ b/src/ui/setup/SetupWizard.test.tsx
@@ -1,0 +1,223 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { forwardRef, createElement } from "react";
+import type { ReactNode } from "react";
+
+vi.mock("next-intl", () => {
+    // Namespace-prefixing mock so tests can target a specific key
+    // via the `setupWizard.players.title` style. `t.rich` ignores
+    // chunks and just emits the key, same as the simple version.
+    const useTranslations = (ns?: string) => {
+        const t = (key: string, values?: Record<string, unknown>): string => {
+            const full = ns ? `${ns}.${key}` : key;
+            return values ? `${full}:${JSON.stringify(values)}` : full;
+        };
+        (t as unknown as { rich: unknown }).rich = (key: string): string =>
+            ns ? `${ns}.${key}` : key;
+        return t;
+    };
+    return {
+        useTranslations,
+        useLocale: () => "en",
+    };
+});
+
+vi.mock("motion/react", () => {
+    const motionCache: Record<string, React.ComponentType<unknown>> = {};
+    const motion = new Proxy(
+        {},
+        {
+            get: (_t, tag: string) => {
+                if (motionCache[tag] === undefined) {
+                    motionCache[tag] = forwardRef(
+                        (
+                            props: Record<string, unknown>,
+                            ref: React.Ref<HTMLElement>,
+                        ) => {
+                            const {
+                                layout: _layout,
+                                layoutId: _layoutId,
+                                initial: _initial,
+                                animate: _animate,
+                                exit: _exit,
+                                transition: _transition,
+                                variants: _variants,
+                                custom: _custom,
+                                whileHover: _whileHover,
+                                whileTap: _whileTap,
+                                drag: _drag,
+                                ...rest
+                            } = props;
+                            return createElement(tag, { ...rest, ref });
+                        },
+                    ) as React.ComponentType<unknown>;
+                }
+                return motionCache[tag];
+            },
+        },
+    );
+    // Reorder.Group → ul; Reorder.Item → li; the test layer doesn't
+    // need real drag behavior, only that the children render.
+    const ReorderGroup = forwardRef(
+        (props: Record<string, unknown>, ref: React.Ref<HTMLElement>) => {
+            const {
+                axis: _axis,
+                values: _values,
+                onReorder: _onReorder,
+                ...rest
+            } = props;
+            return createElement("ul", { ...rest, ref });
+        },
+    ) as React.ComponentType<unknown>;
+    const ReorderItem = forwardRef(
+        (props: Record<string, unknown>, ref: React.Ref<HTMLElement>) => {
+            const {
+                value: _value,
+                onDragEnd: _onDragEnd,
+                drag: _drag,
+                ...rest
+            } = props;
+            return createElement("li", { ...rest, ref });
+        },
+    ) as React.ComponentType<unknown>;
+    return {
+        motion,
+        AnimatePresence: ({ children }: { children: ReactNode }) => children,
+        useReducedMotion: () => false,
+        LayoutGroup: ({ children }: { children: ReactNode }) => children,
+        Reorder: { Group: ReorderGroup, Item: ReorderItem },
+    };
+});
+
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Clue } from "../Clue";
+import { TestQueryClientProvider } from "../../test-utils/queryClient";
+import { seedOnboardingDismissed } from "../../test-utils/onboardingSeed";
+
+const enableWizardFlag = () => {
+    window.localStorage.setItem("effect-clue.flag.setup-wizard.v1", "1");
+};
+
+beforeEach(() => {
+    window.localStorage.clear();
+    seedOnboardingDismissed();
+    enableWizardFlag();
+    window.history.replaceState(null, "", "/?view=setup");
+});
+
+const waitForWizard = async (): Promise<HTMLElement> => {
+    await waitFor(() => {
+        expect(
+            document.querySelector('[data-tour-anchor="setup-wizard-shell"]'),
+        ).toBeInTheDocument();
+    });
+    return document.querySelector(
+        '[data-tour-anchor="setup-wizard-shell"]',
+    ) as HTMLElement;
+};
+
+describe("SetupWizard — accordion shell", () => {
+    test("renders only the implemented steps (players, identity, handSizes)", async () => {
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        const wizard = await waitForWizard();
+
+        // The mocked translation returns the key itself.
+        expect(within(wizard).getByText(/setupWizard\.players\.title/)).toBeInTheDocument();
+        expect(within(wizard).getByText(/setupWizard\.identity\.title/)).toBeInTheDocument();
+        expect(within(wizard).getByText(/setupWizard\.handSizes\.title/)).toBeInTheDocument();
+    });
+
+    test("identity step is hidden from canonical visibleSteps for null self, but the panel renders (skippable)", async () => {
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        const wizard = await waitForWizard();
+        // Identity panel exists; user can pick a player or skip.
+        expect(within(wizard).getByText(/setupWizard\.identity\.title/)).toBeInTheDocument();
+    });
+
+    test("clicking a complete step's header re-enters editing for that step", async () => {
+        const user = userEvent.setup();
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        const wizard = await waitForWizard();
+
+        // The default 4-player Classic preset → players step is
+        // already complete-eligible (>= 2 players). On mount the
+        // first incomplete step (identity) is focused; players is
+        // either complete or pending. Click the Next button to mark
+        // it complete deterministically.
+        const nextButtons = within(wizard).getAllByText("setupWizard.next");
+        await user.click(nextButtons[0]);
+
+        // After advance, Identity panel is focused. Its Skip button
+        // is visible.
+        await waitFor(() => {
+            expect(
+                within(wizard).getByText("setupWizard.skip"),
+            ).toBeInTheDocument();
+        });
+    });
+
+    test("Start playing CTA is enabled with the default 4-player preset", async () => {
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        await waitForWizard();
+        // CTA lives in the sticky bottom bar, sibling of the wizard
+        // shell. Locate at document scope to avoid the within(wizard)
+        // boundary.
+        const cta = document.querySelector(
+            '[data-tour-anchor="setup-start-playing"]',
+        ) as HTMLButtonElement | null;
+        expect(cta).not.toBeNull();
+        expect(cta).not.toBeDisabled();
+    });
+
+    test("identity skip path leaves selfPlayerId as null", async () => {
+        const user = userEvent.setup();
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        const wizard = await waitForWizard();
+
+        // Advance Players → identity is now editing.
+        const next = within(wizard).getAllByText("setupWizard.next");
+        await user.click(next[0]);
+
+        // Click skip on identity.
+        const skip = await within(wizard).findByText("setupWizard.skip");
+        await user.click(skip);
+
+        // Wizard's `setup` localStorage doesn't carry selfPlayerId;
+        // the persistence v9 lift defaults it to null. Verify the
+        // session-backed identity stayed null by inspecting state
+        // through the reducer's persistence: localStorage's session
+        // payload should NOT mention any player as selfPlayerId.
+        await waitFor(() => {
+            const raw = window.localStorage.getItem(
+                "effect-clue.session.v9",
+            );
+            expect(raw).not.toBeNull();
+            const parsed = JSON.parse(raw!) as { selfPlayerId: unknown };
+            expect(parsed.selfPlayerId).toBeNull();
+        });
+    });
+});
+
+describe("SetupWizard — feature flag", () => {
+    test("when the flag is off, the legacy Checklist renders instead", async () => {
+        // Override the seeded flag to OFF.
+        window.localStorage.setItem(
+            "effect-clue.flag.setup-wizard.v1",
+            "0",
+        );
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+
+        // Wait long enough for the wizard mount path to stabilize;
+        // it should NOT show.
+        await waitFor(() => {
+            // Setup CTA from the legacy Checklist is the unique
+            // signal of the legacy path.
+            expect(
+                document.querySelector("[data-setup-cta]"),
+            ).toBeInTheDocument();
+        });
+        expect(
+            document.querySelector('[data-tour-anchor="setup-wizard-shell"]'),
+        ).toBeNull();
+    });
+});

--- a/src/ui/setup/SetupWizard.test.tsx
+++ b/src/ui/setup/SetupWizard.test.tsx
@@ -88,7 +88,7 @@ vi.mock("motion/react", () => {
     };
 });
 
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { render, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Clue } from "../Clue";
 import { TestQueryClientProvider } from "../../test-utils/queryClient";
@@ -145,7 +145,9 @@ describe("SetupWizard — accordion shell", () => {
         // either complete or pending. Click the Next button to mark
         // it complete deterministically.
         const nextButtons = within(wizard).getAllByText("setupWizard.next");
-        await user.click(nextButtons[0]);
+        const firstNext = nextButtons[0];
+        if (!firstNext) throw new Error("expected at least one Next button");
+        await user.click(firstNext);
 
         // After advance, Identity panel is focused. Its Skip button
         // is visible.
@@ -176,7 +178,9 @@ describe("SetupWizard — accordion shell", () => {
 
         // Advance Players → identity is now editing.
         const next = within(wizard).getAllByText("setupWizard.next");
-        await user.click(next[0]);
+        const firstNext = next[0];
+        if (!firstNext) throw new Error("expected at least one Next button");
+        await user.click(firstNext);
 
         // Click skip on identity.
         const skip = await within(wizard).findByText("setupWizard.skip");

--- a/src/ui/setup/SetupWizard.tsx
+++ b/src/ui/setup/SetupWizard.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useEffect, useMemo, useState } from "react";
+import { startSetup } from "../../analytics/gameSession";
+import { gameSetupStarted } from "../../analytics/events";
+import { useConfirm } from "../hooks/useConfirm";
+import { useClue } from "../state";
+import { useSetupWizardFocus } from "./SetupWizardFocusContext";
+import { SetupStepHandSizes } from "./steps/SetupStepHandSizes";
+import { SetupStepIdentity } from "./steps/SetupStepIdentity";
+import { SetupStepPlayers } from "./steps/SetupStepPlayers";
+import {
+    isStepDataComplete,
+    visibleSteps,
+    type WizardStepId,
+} from "./wizardSteps";
+import type { StepPanelState } from "./SetupStepPanel";
+
+// Module-scope discriminators so the i18next/no-literal-string lint
+// rule treats these as identifiers, not user-facing copy.
+const STEP_EDITING: StepPanelState = "editing";
+const STEP_COMPLETE: StepPanelState = "complete";
+const STEP_PENDING: StepPanelState = "pending";
+
+/**
+ * M6 setup wizard — accordion of step panels rendered when the
+ * `setup-wizard` feature flag is on AND `state.uiMode === "setup"`.
+ *
+ * **Accordion shell** (per the plan's 0c decision): a vertical
+ * stack of panels rendered identically at every breakpoint, max
+ * width ~720px centered on desktop. Exactly one panel is in
+ * `editing` state at a time; the others are `pending` (lock; below
+ * the active step) or `complete` (collapsed; above the active
+ * step). Clicking a complete panel re-enters editing for that step
+ * and the previously-editing panel becomes complete.
+ *
+ * **Step set in PR-A2:** Players (step 2), Identity (step 3), Hand
+ * sizes (step 4). The plan's full step list is six (Card pack, …,
+ * My cards, Other players' cards) — those land in PR-A3. Until then
+ * the wizard renders only the three implemented steps; the renumbering
+ * is a no-op for review purposes since the flag stays off.
+ *
+ * **Sticky bottom CTA** kicks the user from setup to play once all
+ * required (non-skippable) visible steps are complete OR the user
+ * has already played at least one suggestion (mid-game edits don't
+ * re-gate "Continue Playing"). The CTA dispatches
+ * `setUiMode("checklist")`.
+ *
+ * **Wizard navigation state** (focusedStepId, completedSteps) lives
+ * in local React state, NOT in `ClueState` — it's pure UI nav,
+ * doesn't survive refresh meaningfully, doesn't go through undo/
+ * redo. Only data the steps edit goes through dispatch.
+ */
+export function SetupWizard() {
+    const t = useTranslations("setupWizard");
+    const tSetup = useTranslations("setup");
+    const tToolbar = useTranslations("toolbar");
+    const { state, dispatch } = useClue();
+    const confirm = useConfirm();
+    const focus = useSetupWizardFocus();
+
+    // Only the three steps shipping in PR-A2 are implemented; future
+    // PRs add the rest. Filter against both the plan's `visibleSteps`
+    // (data-driven; e.g. `myCards` hidden when selfPlayerId is null)
+    // AND the implemented set.
+    const IMPLEMENTED: ReadonlySet<WizardStepId> = useMemo(
+        () => new Set<WizardStepId>(["players", "identity", "handSizes"]),
+        [],
+    );
+    const steps = useMemo(
+        () =>
+            visibleSteps(state).filter(id => IMPLEMENTED.has(id)),
+        [state, IMPLEMENTED],
+    );
+
+    // Initial completed set: any step whose data is already filled
+    // in. Lets the user re-enter a populated wizard at the right
+    // place if they returned from play mode.
+    const [completed, setCompleted] = useState<ReadonlySet<WizardStepId>>(
+        () =>
+            new Set(steps.filter(id => isStepDataComplete(id, state))),
+    );
+
+    // Initial focused step: the focus-context hint (M7 jumps), else
+    // the first non-completed step, else the last step. Covers both
+    // "fresh start" (lands on step 1) and "returning user" (lands on
+    // first incomplete step).
+    const [focusedStep, setFocusedStep] = useState<WizardStepId | null>(
+        () => {
+            const hinted = focus?.consumeFocusHint() ?? null;
+            if (hinted !== null && steps.includes(hinted)) return hinted;
+            const firstIncomplete = steps.find(
+                id => !isStepDataComplete(id, state),
+            );
+            return firstIncomplete ?? steps[steps.length - 1] ?? null;
+        },
+    );
+
+    // If the visible-step set changes (e.g. selfPlayerId toggled to
+    // null mid-wizard), drop any focusedStep / completed entries
+    // that no longer apply.
+    useEffect(() => {
+        const visibleSet = new Set(steps);
+        setCompleted(prev => {
+            let next: Set<WizardStepId> | null = null;
+            for (const id of prev) {
+                if (!visibleSet.has(id)) {
+                    if (next === null) next = new Set(prev);
+                    next.delete(id);
+                }
+            }
+            return next ?? prev;
+        });
+        setFocusedStep(prev =>
+            prev !== null && visibleSet.has(prev) ? prev : (steps[0] ?? null),
+        );
+    }, [steps]);
+
+    const stepStateFor = (id: WizardStepId): StepPanelState => {
+        if (id === focusedStep) return STEP_EDITING;
+        if (completed.has(id)) return STEP_COMPLETE;
+        return STEP_PENDING;
+    };
+
+    const advance = (currentId: WizardStepId) => {
+        // Mark current step complete; pick the next non-completed
+        // step in canonical order; if all visible steps are done,
+        // collapse without focus (CTA takes over).
+        const nextCompleted = new Set(completed);
+        nextCompleted.add(currentId);
+        setCompleted(nextCompleted);
+        const remaining = steps.find(id => !nextCompleted.has(id));
+        setFocusedStep(remaining ?? null);
+    };
+
+    const reEnter = (id: WizardStepId) => {
+        // Clicking a complete step: collapse the previously-editing
+        // panel into "complete" with current values, expand the
+        // clicked one. The previously-editing panel may not have
+        // been "really" complete yet (the user clicked away mid-
+        // edit) — mark it complete anyway since they've moved on,
+        // matching the accordion's "you can always come back" model.
+        const nextCompleted = new Set(completed);
+        if (focusedStep !== null && focusedStep !== id) {
+            nextCompleted.add(focusedStep);
+        }
+        nextCompleted.delete(id);
+        setCompleted(nextCompleted);
+        setFocusedStep(id);
+    };
+
+    // Required visible steps (subset that block "Start playing"):
+    // today the only required step is `players` (identity and hand
+    // sizes are skippable per their step config). Always-allow the
+    // CTA once a game is in progress (mid-game edits to setup don't
+    // re-gate the user out of play).
+    const requiredVisible = useMemo(
+        () => steps.filter(id => id === "players"),
+        [steps],
+    );
+    const allRequiredComplete = requiredVisible.every(id =>
+        completed.has(id),
+    );
+    const hasGameProgress =
+        state.suggestions.length > 0 || state.accusations.length > 0;
+    const ctaEnabled = allRequiredComplete || hasGameProgress;
+    const ctaLabel = hasGameProgress
+        ? tSetup("continuePlaying", { shortcut: "" })
+        : tSetup("startPlaying", { shortcut: "" });
+
+    const startPlaying = () => {
+        if (!ctaEnabled) return;
+        if (!hasGameProgress) {
+            startSetup();
+            gameSetupStarted();
+        }
+        dispatch({ type: "setUiMode", mode: "checklist" });
+    };
+
+    const newGame = async () => {
+        const ok = await confirm({
+            message: tToolbar("newGameConfirm"),
+        });
+        if (ok) {
+            dispatch({ type: "newGame" });
+        }
+    };
+
+    return (
+        <div className="mx-auto flex w-full max-w-[720px] flex-col gap-4">
+            <header className="flex flex-col gap-1">
+                <h1 className="m-0 text-[24px] font-semibold tracking-tight">
+                    {t("heading")}
+                </h1>
+                <p className="m-0 text-[14px] text-muted">
+                    {t("subheading")}
+                </p>
+            </header>
+
+            <div
+                className="flex flex-col gap-3"
+                data-tour-anchor="setup-wizard-shell"
+            >
+                {steps.map((id, idx) => {
+                    const stepNumber = idx + 1;
+                    const totalSteps = steps.length;
+                    const panelState = stepStateFor(id);
+                    if (id === "players") {
+                        return (
+                            <SetupStepPlayers
+                                key={id}
+                                state={panelState}
+                                stepNumber={stepNumber}
+                                totalSteps={totalSteps}
+                                onAdvance={() => advance(id)}
+                                onClickToEdit={() => reEnter(id)}
+                            />
+                        );
+                    }
+                    if (id === "identity") {
+                        return (
+                            <SetupStepIdentity
+                                key={id}
+                                state={panelState}
+                                stepNumber={stepNumber}
+                                totalSteps={totalSteps}
+                                onAdvance={() => advance(id)}
+                                onSkip={() => advance(id)}
+                                onClickToEdit={() => reEnter(id)}
+                            />
+                        );
+                    }
+                    if (id === "handSizes") {
+                        return (
+                            <SetupStepHandSizes
+                                key={id}
+                                state={panelState}
+                                stepNumber={stepNumber}
+                                totalSteps={totalSteps}
+                                onAdvance={() => advance(id)}
+                                onSkip={() => advance(id)}
+                                onClickToEdit={() => reEnter(id)}
+                            />
+                        );
+                    }
+                    return null;
+                })}
+            </div>
+
+            <div className="sticky bottom-0 z-10 -mx-2 flex flex-wrap items-center justify-between gap-3 border-t border-border/30 bg-bg/95 px-2 py-3 backdrop-blur supports-[backdrop-filter]:bg-bg/80">
+                <button
+                    type="button"
+                    className="cursor-pointer rounded border border-border bg-bg px-3 py-1.5 text-[13px] hover:bg-hover"
+                    onClick={newGame}
+                >
+                    {t("newGame")}
+                </button>
+                <button
+                    type="button"
+                    className="cursor-pointer rounded border-none bg-accent px-4 py-2 text-[14px] font-semibold text-white hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
+                    onClick={startPlaying}
+                    disabled={!ctaEnabled}
+                    data-tour-anchor="setup-start-playing"
+                >
+                    {ctaLabel}
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/ui/setup/SetupWizardFocusContext.tsx
+++ b/src/ui/setup/SetupWizardFocusContext.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import {
+    createContext,
+    useCallback,
+    useContext,
+    useMemo,
+    useRef,
+    type ReactNode,
+} from "react";
+import type { WizardStepId } from "./wizardSteps";
+
+/**
+ * One-shot focus hint for the wizard. M7's `<SetupSummary>` will set
+ * a step id before dispatching `setUiMode("setup")`; the wizard reads
+ * it on mount, scrolls to (and expands) that panel, and clears the
+ * hint so a re-render doesn't re-fire focus.
+ *
+ * The hint lives in a ref to avoid render churn — the only consumer
+ * is the wizard's mount effect, which reads-and-clears once.
+ */
+interface FocusContextValue {
+    readonly setFocusOnNextMount: (stepId: WizardStepId) => void;
+    readonly consumeFocusHint: () => WizardStepId | null;
+}
+
+const Context = createContext<FocusContextValue | null>(null);
+
+export function SetupWizardFocusProvider({
+    children,
+}: {
+    readonly children: ReactNode;
+}) {
+    const hintRef = useRef<WizardStepId | null>(null);
+
+    const setFocusOnNextMount = useCallback((stepId: WizardStepId) => {
+        hintRef.current = stepId;
+    }, []);
+
+    const consumeFocusHint = useCallback((): WizardStepId | null => {
+        const hint = hintRef.current;
+        hintRef.current = null;
+        return hint;
+    }, []);
+
+    const value = useMemo(
+        () => ({ setFocusOnNextMount, consumeFocusHint }),
+        [setFocusOnNextMount, consumeFocusHint],
+    );
+
+    return <Context.Provider value={value}>{children}</Context.Provider>;
+}
+
+/**
+ * Hook for setting the focus hint from outside the wizard. The
+ * wizard itself uses `useWizardConsumeFocusHint` so the read-and-clear
+ * is type-distinct.
+ *
+ * Returns null when the wizard provider isn't mounted (e.g. the
+ * legacy Checklist setup path, with the wizard feature flag off).
+ * Callers should fall back to a plain `dispatch({type: "setUiMode"})`
+ * in that case.
+ */
+export function useSetupWizardFocus(): FocusContextValue | null {
+    return useContext(Context);
+}

--- a/src/ui/setup/featureFlag.ts
+++ b/src/ui/setup/featureFlag.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Feature flag for the M6 setup wizard. Off by default — the
+ * `<Checklist inSetup>` legacy path keeps rendering. The flag exists
+ * as a code-organization aid so PR-A2/A3 can ship the wizard plumbing
+ * without exposing it; PR-A4 flips the default once the wizard is
+ * complete.
+ *
+ * Two override channels for local development before that happens:
+ *
+ * - **localStorage:** `effect-clue.flag.setup-wizard.v1 = "1"` enables;
+ *   `"0"` disables. Set this in DevTools and reload to test the wizard.
+ *   The localStorage value wins over the default — useful for the
+ *   "pause for me to test" workflow during PR-A2.
+ *
+ * - **Module default:** `WIZARD_DEFAULT_ENABLED` constant. Flipping it
+ *   to `true` enables the wizard for everyone with no localStorage
+ *   override. PR-A4 flips this.
+ *
+ * The hook is SSR-safe — returns `WIZARD_DEFAULT_ENABLED` on the
+ * server and the first client render, then re-renders to pick up the
+ * localStorage override after mount. This avoids hydration mismatches
+ * between SSR and the client.
+ */
+
+const STORAGE_KEY = "effect-clue.flag.setup-wizard.v1";
+const ENABLED_VALUE = "1";
+const DISABLED_VALUE = "0";
+
+const WIZARD_DEFAULT_ENABLED = false;
+
+function readFlag(): boolean {
+    if (typeof window === "undefined") return WIZARD_DEFAULT_ENABLED;
+    try {
+        const raw = window.localStorage.getItem(STORAGE_KEY);
+        if (raw === ENABLED_VALUE) return true;
+        if (raw === DISABLED_VALUE) return false;
+        return WIZARD_DEFAULT_ENABLED;
+    } catch {
+        return WIZARD_DEFAULT_ENABLED;
+    }
+}
+
+export function useSetupWizardEnabled(): boolean {
+    const [enabled, setEnabled] = useState(WIZARD_DEFAULT_ENABLED);
+    useEffect(() => {
+        setEnabled(readFlag());
+    }, []);
+    return enabled;
+}

--- a/src/ui/setup/firstDealt.test.ts
+++ b/src/ui/setup/firstDealt.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "vitest";
+import { Player } from "../../logic/GameObjects";
+import { CardSet } from "../../logic/CardSet";
+import { CLASSIC_SETUP_3P, GameSetup } from "../../logic/GameSetup";
+import { PlayerSet } from "../../logic/PlayerSet";
+import { firstDealtHandSizes } from "./firstDealt";
+
+const fourPlayerClassic = () =>
+    GameSetup({
+        cardSet: CardSet({ categories: CLASSIC_SETUP_3P.cardSet.categories }),
+        playerSet: PlayerSet({
+            players: [Player("A"), Player("B"), Player("C"), Player("D")],
+        }),
+    });
+
+describe("firstDealtHandSizes", () => {
+    test("null first-dealt with even split: every player gets the same", () => {
+        // Classic deck = 21 cards, 3 case-file cards → 18 dealt
+        // across 3 players → 6 each.
+        expect(firstDealtHandSizes(CLASSIC_SETUP_3P, null)).toEqual([
+            [Player("Anisha"), 6],
+            [Player("Bob"), 6],
+            [Player("Cho"), 6],
+        ]);
+    });
+
+    test("null first-dealt with uneven split: first players get the extras", () => {
+        // 4 players, 18 dealt → 4 base + 2 extras, first two players
+        // in dealing order (= turn order, since first-dealt is null)
+        // get 5; the rest get 4.
+        const sizes = firstDealtHandSizes(fourPlayerClassic(), null);
+        expect(sizes).toEqual([
+            [Player("A"), 5],
+            [Player("B"), 5],
+            [Player("C"), 4],
+            [Player("D"), 4],
+        ]);
+    });
+
+    test("non-null first-dealt rotates the extras around the dealing order", () => {
+        // 4 players, 18 dealt, first-dealt = C → dealing order
+        // C, D, A, B. First two (C, D) get the extras → C=5, D=5,
+        // A=4, B=4. Returned rows stay in turn order.
+        const sizes = firstDealtHandSizes(fourPlayerClassic(), Player("C"));
+        expect(sizes).toEqual([
+            [Player("A"), 4],
+            [Player("B"), 4],
+            [Player("C"), 5],
+            [Player("D"), 5],
+        ]);
+    });
+
+    test("empty player set returns empty array", () => {
+        const empty = GameSetup({
+            cardSet: CLASSIC_SETUP_3P.cardSet,
+            playerSet: PlayerSet({ players: [] }),
+        });
+        expect(firstDealtHandSizes(empty, null)).toEqual([]);
+    });
+});

--- a/src/ui/setup/firstDealt.ts
+++ b/src/ui/setup/firstDealt.ts
@@ -1,0 +1,63 @@
+import type { Player } from "../../logic/GameObjects";
+import type { GameSetup } from "../../logic/GameSetup";
+
+/**
+ * Compute the per-player default hand size for a `firstDealt` pin.
+ *
+ * The dealer hands one card to each player in turn, starting with the
+ * first-dealt player. With an uneven deck, the first few players in
+ * the dealing order get one extra card. `firstDealtPlayer === null`
+ * means "default to first in turn order" — equivalent to dealing from
+ * `players[0]`.
+ *
+ * Centralized here (per the plan) so consumers don't inline the math:
+ * - Step 4 (Hand sizes) renders these as the default for each row.
+ * - The "Adjust dealing" affordance dispatches `setFirstDealtPlayer`
+ *   and re-runs this helper for the new defaults.
+ *
+ * The math:
+ * 1. `dealt = totalCards - categoryCount` (the case file holds one of
+ *    each category, so the rest is dealt out).
+ * 2. `base = floor(dealt / playerCount)` — every player gets at least
+ *    this many.
+ * 3. `extras = dealt - base * playerCount` — the first `extras`
+ *    players in the dealing order each get one more.
+ * 4. The dealing order starts at `firstDealtPlayer` and wraps around
+ *    the player list; equivalent to rotating the player array so the
+ *    pinned player sits at index 0.
+ */
+export function firstDealtHandSizes(
+    setup: GameSetup,
+    firstDealtPlayer: Player | null,
+): ReadonlyArray<readonly [Player, number]> {
+    const players = setup.playerSet.players;
+    const n = players.length;
+    if (n === 0) return [];
+
+    const totalCards = setup.cardSet.categories.reduce(
+        (acc, c) => acc + c.cards.length,
+        0,
+    );
+    const dealt = totalCards - setup.cardSet.categories.length;
+    if (dealt <= 0) {
+        return players.map(p => [p, 0] as const);
+    }
+
+    const base = Math.floor(dealt / n);
+    const extras = dealt - base * n;
+
+    const startIdx =
+        firstDealtPlayer === null
+            ? 0
+            : Math.max(
+                  0,
+                  players.findIndex(p => p === firstDealtPlayer),
+              );
+
+    return players.map((player, i) => {
+        // Distance from the first-dealt position in the dealing order.
+        const dealingIdx = (i - startIdx + n) % n;
+        const size = base + (dealingIdx < extras ? 1 : 0);
+        return [player, size] as const;
+    });
+}

--- a/src/ui/setup/shared/PlayerListReorder.tsx
+++ b/src/ui/setup/shared/PlayerListReorder.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import { Reorder } from "motion/react";
+import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
+import type { Player } from "../../../logic/GameObjects";
+import { useClue } from "../../state";
+import { ChevronLeftIcon, ChevronRightIcon } from "../../components/Icons";
+import { PlayerNameInput } from "./PlayerNameInput";
+
+// Reorder.Group axis prop value — module-scope constant so the
+// i18next/no-literal-string lint treats it as a wire identifier.
+const REORDER_AXIS_Y = "y" as const;
+
+// Decorative drag-handle glyph (two vertical ellipses). Hoisted to
+// module scope so the i18next lint rule reads it as a font glyph,
+// not a translatable string.
+const DRAG_HANDLE_GLYPH = "⋮⋮";
+
+/**
+ * Drag-to-reorder list of players, plus inline name + remove
+ * controls per row and explicit up/down arrow buttons for keyboard
+ * a11y.
+ *
+ * Drag drops dispatch a single `reorderPlayers` action with the new
+ * full ordering — one undo step per user-perceived reorder, not one
+ * per index swap.
+ *
+ * The arrow buttons drive the existing `movePlayer` action (left/
+ * right semantics) for keyboard a11y. Visually they're stacked
+ * vertically; "left" maps to "up" / "right" maps to "down" so a
+ * vertical list reads correctly.
+ *
+ * Local state mirrors `state.setup.players` so the dragging hand
+ * stays smooth; we only dispatch on drag end. A `useEffect` resets
+ * the local list whenever the canonical order changes (via arrow
+ * buttons, undo, or another tab's localStorage sync).
+ */
+export function PlayerListReorder() {
+    const tSetup = useTranslations("setup");
+    const { state, dispatch } = useClue();
+    const players = state.setup.players;
+
+    const [draft, setDraft] = useState<ReadonlyArray<Player>>(players);
+    useEffect(() => {
+        setDraft(players);
+    }, [players]);
+
+    const commitReorder = (next: ReadonlyArray<Player>) => {
+        const sameOrder =
+            next.length === players.length &&
+            next.every((p, i) => p === players[i]);
+        if (sameOrder) return;
+        dispatch({ type: "reorderPlayers", players: next });
+    };
+
+    return (
+        <div className="flex flex-col gap-2">
+            <Reorder.Group
+                axis={REORDER_AXIS_Y}
+                values={[...draft]}
+                onReorder={(next: ReadonlyArray<Player>) => {
+                    setDraft(next);
+                }}
+                className="m-0 flex list-none flex-col gap-2 p-0"
+            >
+                {draft.map((player, i) => (
+                    <Reorder.Item
+                        key={player}
+                        value={player}
+                        onDragEnd={() => commitReorder(draft)}
+                        className="flex touch-none items-center gap-2 rounded border border-border/50 bg-bg px-2 py-1.5"
+                    >
+                        <span
+                            aria-hidden
+                            className="cursor-grab select-none text-[18px] leading-none text-muted"
+                        >
+                            {DRAG_HANDLE_GLYPH}
+                        </span>
+                        <PlayerNameInput
+                            player={player}
+                            allPlayers={players}
+                        />
+                        <div className="flex shrink-0 flex-col">
+                            <button
+                                type="button"
+                                className="flex h-6 w-7 cursor-pointer items-center justify-center rounded border-none bg-transparent text-fg hover:bg-hover disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
+                                disabled={i === 0}
+                                aria-label={tSetup("movePlayerLeftTitle", {
+                                    player: String(player),
+                                })}
+                                onClick={() =>
+                                    dispatch({
+                                        type: "movePlayer",
+                                        player,
+                                        direction: "left",
+                                    })
+                                }
+                            >
+                                <ChevronLeftIcon
+                                    size={14}
+                                    className="-rotate-90"
+                                />
+                            </button>
+                            <button
+                                type="button"
+                                className="flex h-6 w-7 cursor-pointer items-center justify-center rounded border-none bg-transparent text-fg hover:bg-hover disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
+                                disabled={i === players.length - 1}
+                                aria-label={tSetup("movePlayerRightTitle", {
+                                    player: String(player),
+                                })}
+                                onClick={() =>
+                                    dispatch({
+                                        type: "movePlayer",
+                                        player,
+                                        direction: "right",
+                                    })
+                                }
+                            >
+                                <ChevronRightIcon
+                                    size={14}
+                                    className="-rotate-90"
+                                />
+                            </button>
+                        </div>
+                    </Reorder.Item>
+                ))}
+            </Reorder.Group>
+
+            <button
+                type="button"
+                className="self-start cursor-pointer rounded border border-border bg-bg px-3 py-1.5 text-[13px] hover:bg-hover"
+                onClick={() => dispatch({ type: "addPlayer" })}
+            >
+                {tSetup("addPlayerLabel")}
+            </button>
+        </div>
+    );
+}

--- a/src/ui/setup/shared/PlayerNameInput.tsx
+++ b/src/ui/setup/shared/PlayerNameInput.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Player } from "../../../logic/GameObjects";
+import { useClue } from "../../state";
+import { useConfirm } from "../../hooks/useConfirm";
+import { TrashIcon } from "../../components/Icons";
+
+/**
+ * Editable player-name input for the setup wizard's player list.
+ *
+ * Differs from the legacy `<PlayerNameInput>` inside `Checklist.tsx` in
+ * that it doesn't participate in the Checklist grid keyboard nav
+ * (no `data-cell-row` / `data-cell-col`) — the wizard's accordion is
+ * a vertical list, not a 2D grid, so arrow-key navigation between
+ * rows is delegated to the up/down buttons in `PlayerListReorder`.
+ *
+ * Duplicate-name guard runs locally (the reducer doesn't validate);
+ * shows an inline error and reverts to the previous value if the
+ * user blurs without resolving.
+ */
+export function PlayerNameInput({
+    player,
+    allPlayers,
+    onCommit,
+}: {
+    readonly player: Player;
+    readonly allPlayers: ReadonlyArray<Player>;
+    readonly onCommit?: (newName: Player) => void;
+}) {
+    const t = useTranslations("setup");
+    const { state, dispatch } = useClue();
+    const confirm = useConfirm();
+    const [editing, setEditing] = useState(String(player));
+    const [error, setError] = useState("");
+
+    useEffect(() => {
+        setEditing(String(player));
+        setError("");
+    }, [player]);
+
+    const commit = () => {
+        const trimmed = editing.trim();
+        if (!trimmed) {
+            setEditing(String(player));
+            setError("");
+            return;
+        }
+        if (trimmed === String(player)) {
+            setError("");
+            return;
+        }
+        if (allPlayers.some(p => String(p) === trimmed)) {
+            setError(t("duplicateName"));
+            return;
+        }
+        const next = Player(trimmed);
+        dispatch({
+            type: "renamePlayer",
+            oldName: player,
+            newName: next,
+        });
+        setError("");
+        onCommit?.(next);
+    };
+
+    // Removing a player can drop their known cards and any
+    // suggestions referencing them — confirm in that case.
+    const onRemove = async () => {
+        const hasKnownCards = state.knownCards.some(
+            kc => kc.player === player,
+        );
+        const hasSuggestions = state.suggestions.some(
+            s =>
+                s.suggester === player ||
+                s.refuter === player ||
+                s.nonRefuters.some(p => p === player),
+        );
+        if (hasKnownCards || hasSuggestions) {
+            const ok = await confirm({
+                message: t("removePlayerConfirm", {
+                    player: String(player),
+                }),
+            });
+            if (!ok) return;
+        }
+        dispatch({ type: "removePlayer", player });
+    };
+
+    return (
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <div className="flex min-w-0 items-center gap-2">
+                <input
+                    type="text"
+                    className="box-border min-w-0 flex-1 rounded border border-border px-2 py-1.5 text-[14px]"
+                    value={editing}
+                    onChange={e => {
+                        setEditing(e.currentTarget.value);
+                        setError("");
+                    }}
+                    onBlur={commit}
+                    onKeyDown={e => {
+                        if (e.key === "Enter") {
+                            commit();
+                            (e.currentTarget as HTMLInputElement).blur();
+                        } else if (e.key === "Escape") {
+                            setEditing(String(player));
+                            setError("");
+                            (e.currentTarget as HTMLInputElement).blur();
+                        }
+                    }}
+                />
+                <button
+                    type="button"
+                    className="shrink-0 cursor-pointer rounded border border-border bg-bg p-1.5 text-fg hover:bg-hover"
+                    aria-label={t("removePlayerTitle", {
+                        player: String(player),
+                    })}
+                    onClick={onRemove}
+                >
+                    <TrashIcon size={16} />
+                </button>
+            </div>
+            {error && (
+                <span className="text-[11px] text-danger">
+                    {error}
+                </span>
+            )}
+        </div>
+    );
+}

--- a/src/ui/setup/steps/SetupStepHandSizes.tsx
+++ b/src/ui/setup/steps/SetupStepHandSizes.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useState } from "react";
+import { allCardIds, caseFileSize } from "../../../logic/CardSet";
+import type { Player } from "../../../logic/GameObjects";
+import { useClue } from "../../state";
+import { firstDealtHandSizes } from "../firstDealt";
+import { SetupStepPanel } from "../SetupStepPanel";
+import {
+    VALID,
+    VALIDATION_WARNING,
+    type StepValidation,
+} from "../wizardSteps";
+import type { StepPanelState } from "../SetupStepPanel";
+
+const STEP_ID = "handSizes" as const;
+
+interface Props {
+    readonly state: StepPanelState;
+    readonly stepNumber: number;
+    readonly totalSteps: number;
+    readonly onAdvance: () => void;
+    readonly onSkip: () => void;
+    readonly onClickToEdit: () => void;
+}
+
+/**
+ * Step 4 — "How many cards does each person have?" (skippable).
+ *
+ * One row per player with the dealing-default as placeholder and an
+ * editable number input. Defaults are computed from `firstDealtHandSizes`
+ * so the "Adjust dealing" affordance below changes them in lockstep
+ * with the user's pick.
+ *
+ * "Adjust dealing" is a `<details>` so the default state is clean —
+ * most users won't open it. Inside it, a radio group picks the
+ * first-dealt player; "(automatic — first in turn order)" is the
+ * `null` choice.
+ *
+ * Validation: warning banner when totals don't add up. Doesn't block
+ * advancement (today's checklist also warns without blocking).
+ */
+export function SetupStepHandSizes({
+    state,
+    stepNumber,
+    totalSteps,
+    onAdvance,
+    onSkip,
+    onClickToEdit,
+}: Props) {
+    const t = useTranslations("setupWizard.handSizes");
+    const { state: clue, dispatch } = useClue();
+    const setup = clue.setup;
+    const players = setup.players;
+
+    const handSizeMap = new Map(clue.handSizes);
+    const defaults = new Map(
+        firstDealtHandSizes(setup, clue.firstDealtPlayerId),
+    );
+    const totalDealt = allCardIds(setup).length - caseFileSize(setup);
+    const setSizes = players
+        .map(p => handSizeMap.get(p))
+        .filter((n): n is number => typeof n === "number");
+    const allSet = setSizes.length === players.length && players.length > 0;
+    const totalEntered = setSizes.reduce((a, b) => a + b, 0);
+    const mismatch = allSet && totalEntered !== totalDealt;
+
+    const validation: StepValidation = mismatch
+        ? {
+              level: VALIDATION_WARNING,
+              message: t("mismatch", {
+                  total: totalEntered,
+                  expected: totalDealt,
+              }),
+          }
+        : VALID;
+
+    const onChange = (player: Player, raw: string) => {
+        if (raw === "") {
+            dispatch({ type: "setHandSize", player, size: undefined });
+            return;
+        }
+        const n = Number(raw);
+        if (Number.isFinite(n) && n >= 0) {
+            dispatch({ type: "setHandSize", player, size: n });
+        }
+    };
+
+    const summary = (() => {
+        if (players.length === 0) return t("summaryNoPlayers");
+        if (allSet) {
+            return t("summary", { total: totalEntered });
+        }
+        return t("summaryPartial");
+    })();
+
+    return (
+        <SetupStepPanel
+            stepId={STEP_ID}
+            state={state}
+            stepNumber={stepNumber}
+            totalSteps={totalSteps}
+            title={t("title")}
+            summary={summary}
+            skippable={true}
+            validation={validation}
+            onAdvance={onAdvance}
+            onSkip={onSkip}
+            onClickToEdit={onClickToEdit}
+        >
+            {players.length === 0 ? (
+                <p className="m-0 text-[13px] text-muted">
+                    {t("noPlayersHint")}
+                </p>
+            ) : (
+                <ul className="m-0 flex list-none flex-col gap-2 p-0">
+                    {players.map(player => {
+                        const current = handSizeMap.get(player);
+                        const def = defaults.get(player);
+                        return (
+                            <li
+                                key={String(player)}
+                                className="flex items-center justify-between gap-3 rounded border border-border/40 px-3 py-2"
+                            >
+                                <span className="min-w-0 truncate text-[14px]">
+                                    {String(player)}
+                                </span>
+                                <input
+                                    type="number"
+                                    min={0}
+                                    max={allCardIds(setup).length}
+                                    className="w-16 rounded border border-border px-2 py-1 text-center text-[14px]"
+                                    value={
+                                        current === undefined
+                                            ? ""
+                                            : String(current)
+                                    }
+                                    placeholder={
+                                        def === undefined ? "" : String(def)
+                                    }
+                                    aria-label={t("handSizeAria", {
+                                        player: String(player),
+                                    })}
+                                    onChange={e =>
+                                        onChange(player, e.currentTarget.value)
+                                    }
+                                />
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
+
+            <AdjustDealing />
+        </SetupStepPanel>
+    );
+}
+
+/**
+ * Collapsed-by-default `<details>` that lets the user pick a
+ * first-dealt player. The radio group binds to `firstDealtPlayerId`;
+ * the `null` option is "(automatic — first in turn order)" and is
+ * the default.
+ */
+function AdjustDealing() {
+    const t = useTranslations("setupWizard.handSizes");
+    const { state, dispatch } = useClue();
+    const players = state.setup.players;
+    const firstDealt = state.firstDealtPlayerId;
+
+    const [open, setOpen] = useState(firstDealt !== null);
+
+    if (players.length === 0) return null;
+
+    return (
+        <details
+            className="rounded border border-border/30 px-3 py-2"
+            open={open}
+            onToggle={e => setOpen((e.target as HTMLDetailsElement).open)}
+        >
+            <summary className="cursor-pointer text-[13px] text-muted">
+                {t("adjustDealingTitle")}
+            </summary>
+            <fieldset className="m-0 mt-3 flex flex-col gap-2 border-none p-0">
+                <legend className="m-0 mb-1 p-0 text-[12px] text-muted">
+                    {t("firstDealtLegend")}
+                </legend>
+                <label className="flex cursor-pointer items-center gap-2 text-[13px]">
+                    <input
+                        type="radio"
+                        name="first-dealt"
+                        checked={firstDealt === null}
+                        onChange={() =>
+                            dispatch({
+                                type: "setFirstDealtPlayer",
+                                player: null,
+                            })
+                        }
+                    />
+                    {t("firstDealtAuto")}
+                </label>
+                {players.map(player => (
+                    <label
+                        key={String(player)}
+                        className="flex cursor-pointer items-center gap-2 text-[13px]"
+                    >
+                        <input
+                            type="radio"
+                            name="first-dealt"
+                            checked={firstDealt === player}
+                            onChange={() =>
+                                dispatch({
+                                    type: "setFirstDealtPlayer",
+                                    player,
+                                })
+                            }
+                        />
+                        {String(player)}
+                    </label>
+                ))}
+            </fieldset>
+        </details>
+    );
+}

--- a/src/ui/setup/steps/SetupStepIdentity.tsx
+++ b/src/ui/setup/steps/SetupStepIdentity.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useClue } from "../../state";
+import { SetupStepPanel } from "../SetupStepPanel";
+import { VALID } from "../wizardSteps";
+import type { StepPanelState } from "../SetupStepPanel";
+
+const STEP_ID = "identity" as const;
+
+interface Props {
+    readonly state: StepPanelState;
+    readonly stepNumber: number;
+    readonly totalSteps: number;
+    readonly onAdvance: () => void;
+    readonly onSkip: () => void;
+    readonly onClickToEdit: () => void;
+}
+
+/**
+ * Step 3 — "Who are you?" (skippable, no consequences).
+ *
+ * Renders one pill per player — clicking sets `selfPlayerId`,
+ * clicking the active pill clears it. The skip explainer below
+ * mentions what's gated on identity (My cards, refute hints) so the
+ * user knows what they're trading for; no shaming copy if they
+ * skip.
+ *
+ * Always validates `valid` — identity is fully optional.
+ */
+export function SetupStepIdentity({
+    state,
+    stepNumber,
+    totalSteps,
+    onAdvance,
+    onSkip,
+    onClickToEdit,
+}: Props) {
+    const t = useTranslations("setupWizard.identity");
+    const { state: clue, dispatch } = useClue();
+    const players = clue.setup.players;
+    const selfPlayerId = clue.selfPlayerId;
+
+    const summary =
+        selfPlayerId === null
+            ? t("summarySkipped")
+            : t("summary", { player: String(selfPlayerId) });
+
+    return (
+        <SetupStepPanel
+            stepId={STEP_ID}
+            state={state}
+            stepNumber={stepNumber}
+            totalSteps={totalSteps}
+            title={t("title")}
+            summary={summary}
+            skippable={true}
+            validation={VALID}
+            onAdvance={onAdvance}
+            onSkip={() => {
+                if (selfPlayerId !== null) {
+                    dispatch({ type: "setSelfPlayer", player: null });
+                }
+                onSkip();
+            }}
+            onClickToEdit={onClickToEdit}
+        >
+            <p className="m-0 text-[13px] text-muted">
+                {t("helperText")}
+            </p>
+            {players.length === 0 ? (
+                <p className="m-0 text-[13px] text-muted">
+                    {t("noPlayersHint")}
+                </p>
+            ) : (
+                <div className="flex flex-wrap gap-2">
+                    {players.map(player => {
+                        const active = selfPlayerId === player;
+                        return (
+                            <button
+                                key={String(player)}
+                                type="button"
+                                className={`cursor-pointer rounded-full border px-3 py-1.5 text-[13px] transition-colors ${
+                                    active
+                                        ? "border-accent bg-accent text-white hover:bg-accent-hover"
+                                        : "border-border bg-bg text-fg hover:bg-hover"
+                                }`}
+                                aria-pressed={active}
+                                onClick={() =>
+                                    dispatch({
+                                        type: "setSelfPlayer",
+                                        player: active ? null : player,
+                                    })
+                                }
+                            >
+                                {String(player)}
+                            </button>
+                        );
+                    })}
+                </div>
+            )}
+        </SetupStepPanel>
+    );
+}

--- a/src/ui/setup/steps/SetupStepPlayers.tsx
+++ b/src/ui/setup/steps/SetupStepPlayers.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useClue } from "../../state";
+import { PlayerListReorder } from "../shared/PlayerListReorder";
+import { SetupStepPanel } from "../SetupStepPanel";
+import {
+    VALID,
+    VALIDATION_BLOCKED,
+    type StepValidation,
+} from "../wizardSteps";
+import type { StepPanelState } from "../SetupStepPanel";
+
+// Step id discriminator hoisted so it isn't flagged as user copy.
+const STEP_ID = "players" as const;
+
+interface Props {
+    readonly state: StepPanelState;
+    readonly stepNumber: number;
+    readonly totalSteps: number;
+    readonly onAdvance: () => void;
+    readonly onClickToEdit: () => void;
+}
+
+/**
+ * Step 2 — "Who are the players?"
+ *
+ * Renders the helper text first (turn-order hint), then the
+ * `<PlayerListReorder>` widget for drag/keyboard reordering, name
+ * editing, and add/remove. Validation: blocked when fewer than two
+ * players. The duplicate-name guard is per-row (inline) and doesn't
+ * surface here.
+ *
+ * Not skippable — at least two players are required for any
+ * meaningful Clue game.
+ */
+export function SetupStepPlayers({
+    state,
+    stepNumber,
+    totalSteps,
+    onAdvance,
+    onClickToEdit,
+}: Props) {
+    const t = useTranslations("setupWizard.players");
+    const { state: clue } = useClue();
+    const players = clue.setup.players;
+
+    const validation: StepValidation =
+        players.length < 2
+            ? { level: VALIDATION_BLOCKED, message: t("validationMin") }
+            : VALID;
+
+    const summary =
+        players.length === 0
+            ? t("summaryEmpty")
+            : t("summary", {
+                  count: players.length,
+                  names: players.map(p => String(p)).join(", "),
+              });
+
+    return (
+        <SetupStepPanel
+            stepId={STEP_ID}
+            state={state}
+            stepNumber={stepNumber}
+            totalSteps={totalSteps}
+            title={t("title")}
+            summary={summary}
+            skippable={false}
+            validation={validation}
+            onAdvance={onAdvance}
+            onClickToEdit={onClickToEdit}
+        >
+            <p className="m-0 text-[13px] text-muted">
+                {t("turnOrderHint")}
+            </p>
+            <PlayerListReorder />
+        </SetupStepPanel>
+    );
+}

--- a/src/ui/setup/wizardSteps.test.ts
+++ b/src/ui/setup/wizardSteps.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "vitest";
+import type { ClueState } from "../../logic/ClueState";
+import { CardSet } from "../../logic/CardSet";
+import { Player } from "../../logic/GameObjects";
+import { CLASSIC_SETUP_3P, GameSetup } from "../../logic/GameSetup";
+import { emptyHypotheses } from "../../logic/Hypothesis";
+import { PlayerSet } from "../../logic/PlayerSet";
+import { isStepDataComplete, visibleSteps } from "./wizardSteps";
+
+const baseState: ClueState = {
+    setup: CLASSIC_SETUP_3P,
+    handSizes: [],
+    knownCards: [],
+    suggestions: [],
+    accusations: [],
+    uiMode: "setup",
+    hypotheses: emptyHypotheses,
+    pendingSuggestion: null,
+    selfPlayerId: null,
+    firstDealtPlayerId: null,
+};
+
+describe("visibleSteps", () => {
+    test("hides myCards when selfPlayerId is null", () => {
+        const visible = visibleSteps(baseState);
+        expect(visible).not.toContain("myCards");
+        expect(visible).toContain("players");
+        expect(visible).toContain("identity");
+    });
+
+    test("includes myCards when selfPlayerId is set", () => {
+        const visible = visibleSteps({
+            ...baseState,
+            selfPlayerId: Player("Anisha"),
+        });
+        expect(visible).toContain("myCards");
+    });
+
+    test("preserves canonical step order", () => {
+        const visible = visibleSteps({
+            ...baseState,
+            selfPlayerId: Player("Anisha"),
+        });
+        expect(visible).toEqual([
+            "cardPack",
+            "players",
+            "identity",
+            "handSizes",
+            "myCards",
+            "knownCards",
+        ]);
+    });
+});
+
+describe("isStepDataComplete", () => {
+    test("players: requires at least 2", () => {
+        const empty = GameSetup({
+            cardSet: CardSet({ categories: [] }),
+            playerSet: PlayerSet({ players: [] }),
+        });
+        expect(
+            isStepDataComplete("players", { ...baseState, setup: empty }),
+        ).toBe(false);
+        expect(isStepDataComplete("players", baseState)).toBe(true);
+    });
+
+    test("identity: complete when selfPlayerId is set", () => {
+        expect(isStepDataComplete("identity", baseState)).toBe(false);
+        expect(
+            isStepDataComplete("identity", {
+                ...baseState,
+                selfPlayerId: Player("Anisha"),
+            }),
+        ).toBe(true);
+    });
+
+    test("handSizes: complete when any hand size is set", () => {
+        expect(isStepDataComplete("handSizes", baseState)).toBe(false);
+        expect(
+            isStepDataComplete("handSizes", {
+                ...baseState,
+                handSizes: [[Player("Anisha"), 6]],
+            }),
+        ).toBe(true);
+    });
+
+    test("myCards: hidden when selfPlayerId is null (independent of cards)", () => {
+        expect(
+            isStepDataComplete("myCards", {
+                ...baseState,
+                selfPlayerId: null,
+            }),
+        ).toBe(false);
+    });
+
+    test("myCards: complete only when selfPlayerId is set AND owns a card", () => {
+        const anisha = Player("Anisha");
+        // Self set, no cards → false.
+        expect(
+            isStepDataComplete("myCards", {
+                ...baseState,
+                selfPlayerId: anisha,
+            }),
+        ).toBe(false);
+        // Self set + owns a card → true.
+        const anyKnownCard = { player: anisha } as ClueState["knownCards"][number];
+        expect(
+            isStepDataComplete("myCards", {
+                ...baseState,
+                selfPlayerId: anisha,
+                knownCards: [anyKnownCard],
+            }),
+        ).toBe(true);
+    });
+});

--- a/src/ui/setup/wizardSteps.ts
+++ b/src/ui/setup/wizardSteps.ts
@@ -1,0 +1,125 @@
+import type { ClueState } from "../../logic/ClueState";
+
+/**
+ * Identity for each step in the M6 setup wizard. Used as a stable
+ * discriminator across the accordion shell, the focus context, and
+ * the eventual analytics events. The string values double as DOM
+ * `data-step-id` attributes on each panel.
+ *
+ * PR-A2 wires steps 2–4 (`players`, `identity`, `handSizes`). PR-A3
+ * adds `cardPack`, `myCards`, and `knownCards`. The constants are
+ * declared upfront so cross-step plumbing (focus context, validation
+ * lookups) doesn't have to expand the union later.
+ */
+export type WizardStepId =
+    | "cardPack"
+    | "players"
+    | "identity"
+    | "handSizes"
+    | "myCards"
+    | "knownCards";
+
+/**
+ * Canonical ordering of the steps. The accordion renders panels in
+ * this order; `visibleSteps` filters this array based on state.
+ */
+const ALL_STEP_IDS: ReadonlyArray<WizardStepId> = [
+    "cardPack",
+    "players",
+    "identity",
+    "handSizes",
+    "myCards",
+    "knownCards",
+];
+
+/**
+ * Filter the canonical step list to those that should render given
+ * the current state. The only conditional today is `myCards`, which
+ * is hidden entirely when `selfPlayerId === null` (per the plan's
+ * 0i decision: gated steps are hidden, not shown with apologetic
+ * empty-state copy). The accordion renders the remaining steps in
+ * order; the user goes step 4 → step 6 directly when identity is
+ * unset.
+ *
+ * `cardPack`, `myCards`, `knownCards` aren't shipped in PR-A2 — they
+ * still appear here so this helper is stable across the rollout. The
+ * shell renders only the steps it has implementations for, by
+ * intersecting this output with the registered step components.
+ */
+export function visibleSteps(state: ClueState): ReadonlyArray<WizardStepId> {
+    return ALL_STEP_IDS.filter(id => {
+        if (id === "myCards") return state.selfPlayerId !== null;
+        return true;
+    });
+}
+
+/**
+ * Step completion check. A step is "complete" when its data is
+ * present in the state. The accordion uses this on mount to seed
+ * which panels render as `complete` vs `editing` vs `pending`, and
+ * after each user action to update the set.
+ *
+ * The semantics are deliberately permissive — "complete" means "the
+ * user has touched this step and the data is non-empty," not "the
+ * step's validation is passing." Validation is a separate concern;
+ * a step with totals-don't-add-up still counts as complete (the
+ * panel gets a warning banner, not a pending lock).
+ *
+ * Skippable steps (identity, hand sizes, my cards, known cards) are
+ * marked complete the moment the user clicks Skip — that's wired in
+ * the shell via an explicit `markComplete(stepId)` call. The reads
+ * here are about post-mount inference, not the runtime advance flow.
+ */
+export function isStepDataComplete(
+    stepId: WizardStepId,
+    state: ClueState,
+): boolean {
+    switch (stepId) {
+        case "cardPack":
+            return state.setup.categories.length > 0;
+        case "players":
+            return state.setup.players.length >= 2;
+        case "identity":
+            return state.selfPlayerId !== null;
+        case "handSizes":
+            return state.handSizes.length > 0;
+        case "myCards":
+            if (state.selfPlayerId === null) return false;
+            return state.knownCards.some(
+                kc => kc.player === state.selfPlayerId,
+            );
+        case "knownCards":
+            return state.knownCards.length > 0;
+    }
+}
+
+/**
+ * Validation envelope for a step. The shell decides whether to
+ * enable Next based on `level`, and renders the optional banner
+ * inside the editing panel above the action row.
+ *
+ * `valid` — Next enabled, no banner.
+ * `warning` — Next enabled, banner shown (e.g. hand-sizes don't
+ * add up; we let the user proceed because today's checklist also
+ * warns without blocking).
+ * `blocked` — Next disabled, banner shown.
+ */
+type StepValidationLevel = "valid" | "warning" | "blocked";
+
+export interface StepValidation {
+    readonly level: StepValidationLevel;
+    readonly message: string | null;
+}
+
+// Discriminator constants — pulled to module scope so the
+// i18next/no-literal-string lint treats them as identifiers, not
+// user-facing copy. Callers compose them into StepValidation
+// objects without inlining string literals.
+const VALIDATION_VALID: StepValidationLevel = "valid";
+export const VALIDATION_WARNING: StepValidationLevel = "warning";
+export const VALIDATION_BLOCKED: StepValidationLevel = "blocked";
+
+export const VALID: StepValidation = {
+    level: VALIDATION_VALID,
+    message: null,
+};


### PR DESCRIPTION
## Summary

Second PR in the M6 setup-wizard rollout. Ships the accordion shell + steps 2 (Players), 3 (Identity), 4 (Hand sizes) **behind a feature flag that's off by default** — `<Checklist inSetup>` continues to render as the primary setup surface for everyone. PR-A4 will flip the default once the wizard is complete.

This is a code-organization PR: nothing changes for end users. The flag exists so PR-A2 / A3 can ship the wizard plumbing without exposing it.

## What's behind the flag

- **Accordion** of step panels — exactly one panel in `editing` state at a time, the rest are `pending` (locked, below) or `complete` (collapsed summary, above). Click a complete panel to re-enter; the previously-editing panel collapses cleanly.
- **Step 2 Players** — `<PlayerListReorder>` (framer-motion `Reorder.Group` + up/down arrow buttons for keyboard a11y) wired to the new `reorderPlayers` action; per-row `<PlayerNameInput>` for inline rename + remove.
- **Step 3 Identity** — skippable. Pill picker per player, dispatches `setSelfPlayer`. Skip path leaves `selfPlayerId === null`.
- **Step 4 Hand sizes** — skippable. Warning banner (not blocking) when totals don't add up. Defaults computed from the new `firstDealtHandSizes` helper, which respects `firstDealtPlayerId`. "Adjust dealing" `<details>` affordance picks the first-dealt player; `null` = automatic.
- **Sticky bottom CTA** — "Start playing" enabled once required visible steps are complete OR the user has play progress.

## Architecture decisions baked in

Per the M6 plan's resolved decisions (0c, 0g, 0i):

- **Single layout at every breakpoint** — vertical accordion, max-width 720px, centered. No slide between steps; the outer Setup ↔ Play slide stays in `Clue.tsx`. Internal expand/collapse is a height transition.
- **Wizard nav state lives in React local state**, NOT in `ClueState`. Only data the steps edit goes through dispatch. Pure UI nav, doesn't survive refresh meaningfully, doesn't go through undo/redo.
- **`selfPlayerId === null` is fully OK** — no shaming empty states, no back-link CTAs. Steps gated on identity (My cards, refute hint, etc.) are hidden via `visibleSteps()` rather than rendered with apologetic copy.
- Steps 1, 5, 6 (cardPack, myCards, knownCards) are scaffolded in the registry/types but not implemented — PR-A3 ships them.

## Local opt-in for testing

```js
localStorage.setItem("effect-clue.flag.setup-wizard.v1", "1")
```

Reload to see the wizard. Set to `"0"` (or remove the key) to revert.

## Test plan

- [x] Pre-commit checks green (typecheck, lint, test, knip, i18n:check)
- [x] 1344 tests passing (+18 new under `src/ui/setup/`)
- [x] Visual verification at desktop and mobile widths in the next-dev preview — three step panels render correctly (complete / editing / pending), CTA enabled with the default 4-player preset, splash/tour overlays don't conflict with the new layout
- [ ] Smoke-test the players reorder (drag + arrows) on real devices once the wizard ships user-facing in PR-A4

## Files

```
src/ui/setup/
  featureFlag.ts                  — localStorage-backed `useSetupWizardEnabled()`
  wizardSteps.ts                  — step registry, `visibleSteps`, `isStepDataComplete`, validation envelope
  firstDealt.ts                   — pure dealing-defaults math
  SetupWizardFocusContext.tsx     — one-shot focus hint (consumed by M7 `<SetupSummary>`)
  SetupStepPanel.tsx              — generic accordion panel (3 states, validation banner, action row)
  SetupWizard.tsx                 — accordion shell + sticky CTA
  shared/PlayerNameInput.tsx
  shared/PlayerListReorder.tsx
  steps/SetupStepPlayers.tsx
  steps/SetupStepIdentity.tsx
  steps/SetupStepHandSizes.tsx
  firstDealt.test.ts
  wizardSteps.test.ts
  SetupWizard.test.tsx
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)