### PR TITLE
M6 PR-A3: setup-wizard steps 1, 5, 6 + customize sub-flow (still feature-flagged off)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -145,6 +145,27 @@
         "next": "Next",
         "skip": "Skip",
         "newGame": "Start over",
+        "cardPack": {
+            "title": "Pick a card pack",
+            "helperText": "The deck decides what cards exist. You can save your own custom packs after editing.",
+            "summary": "{categories} {categories, plural, one {category} other {categories}}, {cards} {cards, plural, one {card} other {cards}}",
+            "summaryEmpty": "No cards yet",
+            "validationEmpty": "Add at least one category to continue.",
+            "loadConfirm": "Loading a card pack will discard your current hand sizes, known cards, and suggestions. Continue?",
+            "customizeExpand": "Customize cards",
+            "customizeCollapse": "Done customizing",
+            "customize": {
+                "helperText": "Rename, add, or remove categories and cards. Drag-to-reorder + save-as-pack are coming soon.",
+                "addCategory": "+ add category",
+                "addCard": "+ add card",
+                "categoryNameAria": "Rename category {name}",
+                "cardNameAria": "Rename card {name}",
+                "removeCategoryTitle": "Remove category {name}",
+                "removeCategoryConfirm": "Remove {name}? Known-card marks and suggestions referencing its cards will be cleared.",
+                "removeCardTitle": "Remove card {name}",
+                "removeCardConfirm": "Remove {card}? Known-card marks and suggestions referencing this card will be cleared."
+            }
+        },
         "players": {
             "title": "Who's playing?",
             "turnOrderHint": "Enter players in turn order — the first player you list will be dealt first.",
@@ -170,6 +191,23 @@
             "adjustDealingTitle": "Adjust dealing",
             "firstDealtLegend": "Who was dealt the first card?",
             "firstDealtAuto": "Automatic — first player in turn order"
+        },
+        "myCards": {
+            "title": "Which cards do you have?",
+            "helperText": "Tick the cards you were dealt — the solver knows you don't have anything else.",
+            "yourHand": "Your hand",
+            "summary": "{count} {count, plural, one {card} other {cards}} marked",
+            "summaryEmpty": "No cards marked"
+        },
+        "knownCards": {
+            "title": "Do you know any other player's cards?",
+            "helperText": "If you've seen another player's card — refuted, snuck a peek, etc. — mark it here.",
+            "noOtherPlayers": "Add more players to mark other-player cards.",
+            "summary": "{count} {count, plural, one {card} other {cards}} marked across other players",
+            "summaryEmpty": "No other-player cards marked",
+            "prevPlayer": "Previous player",
+            "nextPlayer": "Next player",
+            "paginator": "{current} of {total} · {player}"
         }
     },
     "deduce": {

--- a/src/ui/setup/SetupWizard.test.tsx
+++ b/src/ui/setup/SetupWizard.test.tsx
@@ -117,14 +117,19 @@ const waitForWizard = async (): Promise<HTMLElement> => {
 };
 
 describe("SetupWizard — accordion shell", () => {
-    test("renders only the implemented steps (players, identity, handSizes)", async () => {
+    test("renders all five default visible steps (cardPack, players, identity, handSizes, knownCards)", async () => {
         render(<Clue />, { wrapper: TestQueryClientProvider });
         const wizard = await waitForWizard();
 
-        // The mocked translation returns the key itself.
+        // Default state has selfPlayerId === null, so myCards is
+        // hidden by visibleSteps(). The other five render.
+        expect(within(wizard).getByText(/setupWizard\.cardPack\.title/)).toBeInTheDocument();
         expect(within(wizard).getByText(/setupWizard\.players\.title/)).toBeInTheDocument();
         expect(within(wizard).getByText(/setupWizard\.identity\.title/)).toBeInTheDocument();
         expect(within(wizard).getByText(/setupWizard\.handSizes\.title/)).toBeInTheDocument();
+        expect(within(wizard).getByText(/setupWizard\.knownCards\.title/)).toBeInTheDocument();
+        // myCards is hidden until selfPlayerId is set.
+        expect(within(wizard).queryByText(/setupWizard\.myCards\.title/)).toBeNull();
     });
 
     test("identity step is hidden from canonical visibleSteps for null self, but the panel renders (skippable)", async () => {
@@ -132,6 +137,32 @@ describe("SetupWizard — accordion shell", () => {
         const wizard = await waitForWizard();
         // Identity panel exists; user can pick a player or skip.
         expect(within(wizard).getByText(/setupWizard\.identity\.title/)).toBeInTheDocument();
+    });
+
+    test("clicking a player pill in identity reveals the myCards step", async () => {
+        const user = userEvent.setup();
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        const wizard = await waitForWizard();
+
+        // myCards is hidden initially.
+        expect(
+            within(wizard).queryByText(/setupWizard\.myCards\.title/),
+        ).toBeNull();
+
+        // Click the first player pill in identity to set selfPlayerId.
+        // The default 4-player preset uses "Player 1" through "Player 4";
+        // clicking the first one renders an aria-pressed=true pill.
+        const player1 = within(wizard).getByRole("button", {
+            name: /^Player 1$/,
+        });
+        await user.click(player1);
+
+        // myCards step should now appear in the accordion.
+        await waitFor(() => {
+            expect(
+                within(wizard).getByText(/setupWizard\.myCards\.title/),
+            ).toBeInTheDocument();
+        });
     });
 
     test("clicking a complete step's header re-enters editing for that step", async () => {

--- a/src/ui/setup/SetupWizard.tsx
+++ b/src/ui/setup/SetupWizard.tsx
@@ -7,8 +7,11 @@ import { gameSetupStarted } from "../../analytics/events";
 import { useConfirm } from "../hooks/useConfirm";
 import { useClue } from "../state";
 import { useSetupWizardFocus } from "./SetupWizardFocusContext";
+import { SetupStepCardPack } from "./steps/SetupStepCardPack";
 import { SetupStepHandSizes } from "./steps/SetupStepHandSizes";
 import { SetupStepIdentity } from "./steps/SetupStepIdentity";
+import { SetupStepKnownCards } from "./steps/SetupStepKnownCards";
+import { SetupStepMyCards } from "./steps/SetupStepMyCards";
 import { SetupStepPlayers } from "./steps/SetupStepPlayers";
 import {
     isStepDataComplete,
@@ -60,19 +63,12 @@ export function SetupWizard() {
     const confirm = useConfirm();
     const focus = useSetupWizardFocus();
 
-    // Only the three steps shipping in PR-A2 are implemented; future
-    // PRs add the rest. Filter against both the plan's `visibleSteps`
-    // (data-driven; e.g. `myCards` hidden when selfPlayerId is null)
-    // AND the implemented set.
-    const IMPLEMENTED: ReadonlySet<WizardStepId> = useMemo(
-        () => new Set<WizardStepId>(["players", "identity", "handSizes"]),
-        [],
-    );
-    const steps = useMemo(
-        () =>
-            visibleSteps(state).filter(id => IMPLEMENTED.has(id)),
-        [state, IMPLEMENTED],
-    );
+    // PR-A3 ships steps 1, 5, 6 alongside the existing 2-4 — every
+    // step in `visibleSteps(state)` is now implemented, so the filter
+    // is a no-op until a future PR adds steps that need a render-time
+    // gate (e.g., shipped behind a sub-flag). Keep the filter wired
+    // in so adding a stub step doesn't break the wizard.
+    const steps = useMemo(() => visibleSteps(state), [state]);
 
     // Initial completed set: any step whose data is already filled
     // in. Lets the user re-enter a populated wizard at the right
@@ -151,13 +147,19 @@ export function SetupWizard() {
     };
 
     // Required visible steps (subset that block "Start playing"):
-    // today the only required step is `players` (identity and hand
-    // sizes are skippable per their step config). Always-allow the
-    // CTA once a game is in progress (mid-game edits to setup don't
-    // re-gate the user out of play).
+    // today the required steps are `cardPack` (every game needs a
+    // deck) and `players` (every game needs at least 2 players).
+    // Identity, hand sizes, my cards, and other-player cards are
+    // skippable per their step config. Always-allow the CTA once
+    // a game is in progress (mid-game edits to setup don't re-gate
+    // the user out of play).
+    const REQUIRED: ReadonlySet<WizardStepId> = useMemo(
+        () => new Set<WizardStepId>(["cardPack", "players"]),
+        [],
+    );
     const requiredVisible = useMemo(
-        () => steps.filter(id => id === "players"),
-        [steps],
+        () => steps.filter(id => REQUIRED.has(id)),
+        [steps, REQUIRED],
     );
     const allRequiredComplete = requiredVisible.every(id =>
         completed.has(id),
@@ -206,6 +208,18 @@ export function SetupWizard() {
                     const stepNumber = idx + 1;
                     const totalSteps = steps.length;
                     const panelState = stepStateFor(id);
+                    if (id === "cardPack") {
+                        return (
+                            <SetupStepCardPack
+                                key={id}
+                                state={panelState}
+                                stepNumber={stepNumber}
+                                totalSteps={totalSteps}
+                                onAdvance={() => advance(id)}
+                                onClickToEdit={() => reEnter(id)}
+                            />
+                        );
+                    }
                     if (id === "players") {
                         return (
                             <SetupStepPlayers
@@ -234,6 +248,37 @@ export function SetupWizard() {
                     if (id === "handSizes") {
                         return (
                             <SetupStepHandSizes
+                                key={id}
+                                state={panelState}
+                                stepNumber={stepNumber}
+                                totalSteps={totalSteps}
+                                onAdvance={() => advance(id)}
+                                onSkip={() => advance(id)}
+                                onClickToEdit={() => reEnter(id)}
+                            />
+                        );
+                    }
+                    if (id === "myCards") {
+                        // visibleSteps already gates this on
+                        // selfPlayerId !== null, but TypeScript needs
+                        // the runtime guard to narrow the prop.
+                        if (state.selfPlayerId === null) return null;
+                        return (
+                            <SetupStepMyCards
+                                key={id}
+                                state={panelState}
+                                stepNumber={stepNumber}
+                                totalSteps={totalSteps}
+                                selfPlayerId={state.selfPlayerId}
+                                onAdvance={() => advance(id)}
+                                onSkip={() => advance(id)}
+                                onClickToEdit={() => reEnter(id)}
+                            />
+                        );
+                    }
+                    if (id === "knownCards") {
+                        return (
+                            <SetupStepKnownCards
                                 key={id}
                                 state={panelState}
                                 stepNumber={stepNumber}

--- a/src/ui/setup/shared/PlayerColumnCardList.tsx
+++ b/src/ui/setup/shared/PlayerColumnCardList.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useMemo } from "react";
+import { KnownCard } from "../../../logic/InitialKnowledge";
+import type { Card, Player } from "../../../logic/GameObjects";
+import { useClue } from "../../state";
+
+/**
+ * One column of "does this player own this card?" toggles.
+ *
+ * Used by the M6 wizard's step 5 (My cards) and step 6 (Other
+ * players' cards). The legacy `<Checklist inSetup>` cell-based grid
+ * solves the same problem but carries deductions, popovers, leads,
+ * and status glyphs that are overkill for "tick the cards you have."
+ *
+ * Toggle dispatches `addKnownCard` / `removeKnownCard` against the
+ * existing `knownCards` slice. Layout:
+ *
+ * - One header row with the player name (or a custom heading from
+ *   the parent for "My cards" — pass `heading` to override).
+ * - One row per category, with the category name as a sub-heading
+ *   followed by checkbox rows for each card in that category.
+ *
+ * The component doesn't paginate; the parent controls layout
+ * (single column on mobile, grid on desktop) by stacking instances.
+ */
+interface Props {
+    readonly player: Player;
+    readonly heading?: string;
+}
+
+export function PlayerColumnCardList({ player, heading }: Props) {
+    const tSetup = useTranslations("setup");
+    const { state, dispatch } = useClue();
+    const setup = state.setup;
+    const knownCards = state.knownCards;
+
+    // Cache "owns this card?" lookups per render so the per-row
+    // toggle doesn't scan `knownCards` linearly.
+    const ownedSet = useMemo(() => {
+        const set = new Set<Card>();
+        for (const kc of knownCards) {
+            if (kc.player === player) set.add(kc.card);
+        }
+        return set;
+    }, [knownCards, player]);
+
+    const toggle = (card: Card) => {
+        if (ownedSet.has(card)) {
+            const idx = knownCards.findIndex(
+                kc => kc.player === player && kc.card === card,
+            );
+            if (idx >= 0) {
+                dispatch({ type: "removeKnownCard", index: idx });
+            }
+        } else {
+            dispatch({
+                type: "addKnownCard",
+                card: KnownCard({ player, card }),
+            });
+        }
+    };
+
+    const heading_ = heading ?? String(player);
+
+    return (
+        <div className="flex min-w-0 flex-col gap-2 rounded border border-border/40 p-3">
+            <h3 className="m-0 truncate text-[14px] font-semibold">
+                {heading_}
+            </h3>
+            <div className="flex flex-col gap-3">
+                {setup.categories.map(category => (
+                    <div
+                        key={String(category.id)}
+                        className="flex flex-col gap-1"
+                    >
+                        <span className="text-[11px] uppercase tracking-wide text-muted">
+                            {category.name}
+                        </span>
+                        <ul className="m-0 flex list-none flex-col gap-1 p-0">
+                            {category.cards.map(entry => {
+                                const owned = ownedSet.has(entry.id);
+                                return (
+                                    <li
+                                        key={String(entry.id)}
+                                        className="flex items-center gap-2"
+                                    >
+                                        <label className="flex w-full cursor-pointer items-center gap-2 rounded px-1 py-0.5 hover:bg-hover">
+                                            <input
+                                                type="checkbox"
+                                                checked={owned}
+                                                onChange={() =>
+                                                    toggle(entry.id)
+                                                }
+                                                aria-label={tSetup(
+                                                    "knownCardCheckboxAria",
+                                                    {
+                                                        player: String(player),
+                                                        card: entry.name,
+                                                    },
+                                                )}
+                                            />
+                                            <span className="text-[13px]">
+                                                {entry.name}
+                                            </span>
+                                        </label>
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}
+

--- a/src/ui/setup/steps/SetupStepCardPack.tsx
+++ b/src/ui/setup/steps/SetupStepCardPack.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useMemo, useState } from "react";
+import { useCustomCardPacks } from "../../../data/customCardPacks";
+import type { CardSet } from "../../../logic/CardSet";
+import { CARD_SETS } from "../../../logic/GameSetup";
+import { useConfirm } from "../../hooks/useConfirm";
+import { useClue } from "../../state";
+import { SetupStepCardPackCustomize } from "./SetupStepCardPackCustomize";
+import { SetupStepPanel } from "../SetupStepPanel";
+import {
+    VALID,
+    VALIDATION_BLOCKED,
+    type StepValidation,
+} from "../wizardSteps";
+import type { StepPanelState } from "../SetupStepPanel";
+
+const STEP_ID = "cardPack" as const;
+
+interface Props {
+    readonly state: StepPanelState;
+    readonly stepNumber: number;
+    readonly totalSteps: number;
+    readonly onAdvance: () => void;
+    readonly onClickToEdit: () => void;
+}
+
+interface Pill {
+    readonly id: string;
+    readonly label: string;
+    readonly load: () => void;
+}
+
+/**
+ * Step 1 — "Pick a card pack."
+ *
+ * Pill row: every available pack — bundled (Classic, Master
+ * Detective) + the user's saved custom packs. Click a pill to load
+ * the deck. Below the pills, a "Customize" button expands the
+ * panel into the customize sub-flow (rename / add / remove
+ * categories and cards inline).
+ *
+ * Not skippable — every game needs a deck. The default new-game
+ * preset has Classic loaded, so the user can advance with one
+ * click. Validation blocks if `setup.categories.length === 0`
+ * (defensive — bundled packs always have categories, but the
+ * customize sub-flow could in principle empty them).
+ */
+export function SetupStepCardPack({
+    state,
+    stepNumber,
+    totalSteps,
+    onAdvance,
+    onClickToEdit,
+}: Props) {
+    const t = useTranslations("setupWizard.cardPack");
+    const { state: clue, dispatch } = useClue();
+    const confirm = useConfirm();
+    const customPacksQuery = useCustomCardPacks();
+    const customPacks = customPacksQuery.data ?? [];
+    const setup = clue.setup;
+
+    const [showCustomize, setShowCustomize] = useState(false);
+
+    const hasDestructiveData =
+        clue.knownCards.length > 0 ||
+        clue.suggestions.length > 0 ||
+        clue.handSizes.length > 0;
+
+    const load = async (input: {
+        readonly cardSet: CardSet;
+        readonly label: string;
+    }) => {
+        if (
+            hasDestructiveData &&
+            !(await confirm({ message: t("loadConfirm") }))
+        ) {
+            return;
+        }
+        dispatch({
+            type: "loadCardSet",
+            cardSet: input.cardSet,
+            label: input.label,
+        });
+    };
+
+    const pills = useMemo<ReadonlyArray<Pill>>(() => {
+        const builtIn: ReadonlyArray<Pill> = CARD_SETS.map(p => ({
+            id: p.id,
+            label: p.label,
+            load: () => {
+                void load({ cardSet: p.cardSet, label: p.label });
+            },
+        }));
+        const custom: ReadonlyArray<Pill> = customPacks.map(p => ({
+            id: p.id,
+            label: p.label,
+            load: () => {
+                void load({ cardSet: p.cardSet, label: p.label });
+            },
+        }));
+        return [...builtIn, ...custom];
+    }, [customPacks]);
+
+    const cardCount = setup.categories.reduce(
+        (acc, c) => acc + c.cards.length,
+        0,
+    );
+    const summary =
+        setup.categories.length === 0
+            ? t("summaryEmpty")
+            : t("summary", {
+                  categories: setup.categories.length,
+                  cards: cardCount,
+              });
+
+    const validation: StepValidation =
+        setup.categories.length < 1
+            ? { level: VALIDATION_BLOCKED, message: t("validationEmpty") }
+            : VALID;
+
+    return (
+        <SetupStepPanel
+            stepId={STEP_ID}
+            state={state}
+            stepNumber={stepNumber}
+            totalSteps={totalSteps}
+            title={t("title")}
+            summary={summary}
+            skippable={false}
+            validation={validation}
+            onAdvance={onAdvance}
+            onClickToEdit={onClickToEdit}
+        >
+            <p className="m-0 text-[13px] text-muted">{t("helperText")}</p>
+
+            <div className="flex flex-wrap gap-2">
+                {pills.map(pill => (
+                    <button
+                        key={pill.id}
+                        type="button"
+                        className="cursor-pointer rounded-full border border-border bg-bg px-3 py-1.5 text-[13px] hover:bg-hover"
+                        onClick={pill.load}
+                    >
+                        {pill.label}
+                    </button>
+                ))}
+            </div>
+
+            <div className="flex flex-col gap-2">
+                <button
+                    type="button"
+                    className="self-start cursor-pointer rounded border border-border bg-bg px-3 py-1.5 text-[13px] hover:bg-hover"
+                    onClick={() => setShowCustomize(prev => !prev)}
+                    aria-expanded={showCustomize}
+                >
+                    {showCustomize
+                        ? t("customizeCollapse")
+                        : t("customizeExpand")}
+                </button>
+                {showCustomize && <SetupStepCardPackCustomize />}
+            </div>
+        </SetupStepPanel>
+    );
+}

--- a/src/ui/setup/steps/SetupStepCardPackCustomize.tsx
+++ b/src/ui/setup/steps/SetupStepCardPackCustomize.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
+import {
+    type Category,
+    type CardEntry,
+} from "../../../logic/CardSet";
+import { useConfirm } from "../../hooks/useConfirm";
+import { useClue } from "../../state";
+import { TrashIcon } from "../../components/Icons";
+
+/**
+ * Inline customize sub-flow for the M6 wizard's step 1.
+ *
+ * Lets the user rename, add, and remove categories and cards. The
+ * sub-flow doesn't reorder via drag-and-drop yet — that's deferred
+ * to a follow-up since the existing `reorderCategories` /
+ * `reorderCardsInCategory` actions (PR-A1) are wired but the UI
+ * component isn't.
+ *
+ * Edits dispatch immediately, mirroring today's inSetup behavior.
+ * The confirm dialogs gate destructive removals when the action
+ * would also drop known cards / suggestions referencing them
+ * (matching the legacy `<Checklist inSetup>` patterns).
+ *
+ * Save-as / update-pack will land in a follow-up PR alongside the
+ * DnD reorder UI; for now the user can save and reuse via the
+ * legacy CardPackRow pill bar (still mounted under the feature
+ * flag's "off" code path) or the existing share modal.
+ */
+export function SetupStepCardPackCustomize() {
+    const t = useTranslations("setupWizard.cardPack.customize");
+    const { state, dispatch } = useClue();
+    const confirm = useConfirm();
+    const setup = state.setup;
+
+    return (
+        <div className="flex flex-col gap-3 rounded border border-border/30 p-3">
+            <p className="m-0 text-[13px] text-muted">{t("helperText")}</p>
+
+            <ul className="m-0 flex list-none flex-col gap-3 p-0">
+                {setup.categories.map(category => (
+                    <li
+                        key={String(category.id)}
+                        className="flex flex-col gap-2 rounded border border-border/40 p-2"
+                    >
+                        <CategoryHeader
+                            category={category}
+                            canRemove={setup.categories.length > 1}
+                            onRemove={async () => {
+                                const hasReferences =
+                                    state.knownCards.some(kc =>
+                                        category.cards.some(
+                                            c => c.id === kc.card,
+                                        ),
+                                    ) || state.suggestions.length > 0;
+                                if (hasReferences) {
+                                    const ok = await confirm({
+                                        message: t("removeCategoryConfirm", {
+                                            name: category.name,
+                                        }),
+                                    });
+                                    if (!ok) return;
+                                }
+                                dispatch({
+                                    type: "removeCategoryById",
+                                    categoryId: category.id,
+                                });
+                            }}
+                        />
+                        <ul className="m-0 flex list-none flex-col gap-1 p-0">
+                            {category.cards.map(entry => (
+                                <li
+                                    key={String(entry.id)}
+                                    className="flex items-center gap-2"
+                                >
+                                    <CardRow
+                                        entry={entry}
+                                        canRemove={category.cards.length > 1}
+                                        onRemove={async () => {
+                                            const hasReferences =
+                                                state.knownCards.some(
+                                                    kc => kc.card === entry.id,
+                                                ) ||
+                                                state.suggestions.length > 0;
+                                            if (hasReferences) {
+                                                const ok = await confirm({
+                                                    message: t(
+                                                        "removeCardConfirm",
+                                                        {
+                                                            card: entry.name,
+                                                        },
+                                                    ),
+                                                });
+                                                if (!ok) return;
+                                            }
+                                            dispatch({
+                                                type: "removeCardById",
+                                                cardId: entry.id,
+                                            });
+                                        }}
+                                    />
+                                </li>
+                            ))}
+                        </ul>
+                        <button
+                            type="button"
+                            className="self-start cursor-pointer rounded border border-border bg-bg px-2 py-1 text-[12px] hover:bg-hover"
+                            onClick={() =>
+                                dispatch({
+                                    type: "addCardToCategoryById",
+                                    categoryId: category.id,
+                                })
+                            }
+                        >
+                            {t("addCard")}
+                        </button>
+                    </li>
+                ))}
+            </ul>
+            <button
+                type="button"
+                className="self-start cursor-pointer rounded border border-border bg-bg px-2 py-1 text-[12px] hover:bg-hover"
+                onClick={() => dispatch({ type: "addCategory" })}
+            >
+                {t("addCategory")}
+            </button>
+        </div>
+    );
+}
+
+function CategoryHeader({
+    category,
+    canRemove,
+    onRemove,
+}: {
+    readonly category: Category;
+    readonly canRemove: boolean;
+    readonly onRemove: () => void;
+}) {
+    const t = useTranslations("setupWizard.cardPack.customize");
+    const { dispatch } = useClue();
+    const [draft, setDraft] = useState(category.name);
+    useEffect(() => {
+        setDraft(category.name);
+    }, [category]);
+
+    const commit = () => {
+        const trimmed = draft.trim();
+        if (!trimmed || trimmed === category.name) {
+            setDraft(category.name);
+            return;
+        }
+        dispatch({
+            type: "renameCategory",
+            categoryId: category.id,
+            name: trimmed,
+        });
+    };
+
+    return (
+        <div className="flex items-center gap-2">
+            <input
+                type="text"
+                className="box-border min-w-0 flex-1 rounded border border-border px-2 py-1 text-[13px] font-semibold uppercase tracking-wide"
+                value={draft}
+                aria-label={t("categoryNameAria", {
+                    name: category.name,
+                })}
+                onChange={e => setDraft(e.currentTarget.value)}
+                onBlur={commit}
+                onKeyDown={e => {
+                    if (e.key === "Enter") {
+                        commit();
+                        (e.currentTarget as HTMLInputElement).blur();
+                    } else if (e.key === "Escape") {
+                        setDraft(category.name);
+                        (e.currentTarget as HTMLInputElement).blur();
+                    }
+                }}
+            />
+            {canRemove && (
+                <button
+                    type="button"
+                    className="shrink-0 cursor-pointer rounded border border-border bg-bg p-1 text-fg hover:bg-hover"
+                    aria-label={t("removeCategoryTitle", {
+                        name: category.name,
+                    })}
+                    onClick={onRemove}
+                >
+                    <TrashIcon size={14} />
+                </button>
+            )}
+        </div>
+    );
+}
+
+function CardRow({
+    entry,
+    canRemove,
+    onRemove,
+}: {
+    readonly entry: CardEntry;
+    readonly canRemove: boolean;
+    readonly onRemove: () => void;
+}) {
+    const t = useTranslations("setupWizard.cardPack.customize");
+    const { dispatch } = useClue();
+    const [draft, setDraft] = useState(entry.name);
+    useEffect(() => {
+        setDraft(entry.name);
+    }, [entry]);
+
+    const commit = () => {
+        const trimmed = draft.trim();
+        if (!trimmed || trimmed === entry.name) {
+            setDraft(entry.name);
+            return;
+        }
+        dispatch({
+            type: "renameCard",
+            cardId: entry.id,
+            name: trimmed,
+        });
+    };
+
+    return (
+        <div className="flex w-full items-center gap-2">
+            <input
+                type="text"
+                className="box-border min-w-0 flex-1 rounded border border-border px-2 py-1 text-[13px]"
+                value={draft}
+                aria-label={t("cardNameAria", { name: entry.name })}
+                onChange={e => setDraft(e.currentTarget.value)}
+                onBlur={commit}
+                onKeyDown={e => {
+                    if (e.key === "Enter") {
+                        commit();
+                        (e.currentTarget as HTMLInputElement).blur();
+                    } else if (e.key === "Escape") {
+                        setDraft(entry.name);
+                        (e.currentTarget as HTMLInputElement).blur();
+                    }
+                }}
+            />
+            {canRemove && (
+                <button
+                    type="button"
+                    className="shrink-0 cursor-pointer rounded border border-border bg-bg p-1 text-fg hover:bg-hover"
+                    aria-label={t("removeCardTitle", { name: entry.name })}
+                    onClick={onRemove}
+                >
+                    <TrashIcon size={14} />
+                </button>
+            )}
+        </div>
+    );
+}

--- a/src/ui/setup/steps/SetupStepKnownCards.tsx
+++ b/src/ui/setup/steps/SetupStepKnownCards.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useEffect, useState } from "react";
+import type { Player } from "../../../logic/GameObjects";
+import { useClue } from "../../state";
+import { ChevronLeftIcon, ChevronRightIcon } from "../../components/Icons";
+import { PlayerColumnCardList } from "../shared/PlayerColumnCardList";
+import { SetupStepPanel } from "../SetupStepPanel";
+import { VALID } from "../wizardSteps";
+import type { StepPanelState } from "../SetupStepPanel";
+
+const STEP_ID = "knownCards" as const;
+
+interface Props {
+    readonly state: StepPanelState;
+    readonly stepNumber: number;
+    readonly totalSteps: number;
+    readonly onAdvance: () => void;
+    readonly onSkip: () => void;
+    readonly onClickToEdit: () => void;
+}
+
+/**
+ * Step 6 — "Do you know any other player's cards?" (skippable).
+ *
+ * Iterates non-self players when `selfPlayerId` is set, or every
+ * player when it isn't. Layout:
+ *
+ * - **Desktop (≥ 800px):** all relevant `<PlayerColumnCardList>`
+ *   columns rendered side-by-side in a horizontal grid.
+ * - **Mobile (< 800px):** single column with paginator (left / right
+ *   arrow buttons + a "Player N of M" indicator).
+ *
+ * Same component on both layouts; only the container differs. The
+ * mobile variant uses local state (`activeIndex`) to track which
+ * player's column is showing; the desktop variant ignores it.
+ */
+export function SetupStepKnownCards({
+    state,
+    stepNumber,
+    totalSteps,
+    onAdvance,
+    onSkip,
+    onClickToEdit,
+}: Props) {
+    const t = useTranslations("setupWizard.knownCards");
+    const { state: clue } = useClue();
+    const players = clue.setup.players;
+    const selfPlayerId = clue.selfPlayerId;
+    const targets =
+        selfPlayerId === null
+            ? players
+            : players.filter(p => p !== selfPlayerId);
+
+    const [activeIndex, setActiveIndex] = useState(0);
+    useEffect(() => {
+        if (activeIndex >= targets.length) {
+            setActiveIndex(Math.max(0, targets.length - 1));
+        }
+    }, [targets.length, activeIndex]);
+
+    const otherKnownCount = clue.knownCards.filter(
+        kc => kc.player !== selfPlayerId,
+    ).length;
+    const summary =
+        otherKnownCount === 0
+            ? t("summaryEmpty")
+            : t("summary", { count: otherKnownCount });
+
+    if (targets.length === 0) {
+        return (
+            <SetupStepPanel
+                stepId={STEP_ID}
+                state={state}
+                stepNumber={stepNumber}
+                totalSteps={totalSteps}
+                title={t("title")}
+                summary={t("summaryEmpty")}
+                skippable={true}
+                validation={VALID}
+                onAdvance={onAdvance}
+                onSkip={onSkip}
+                onClickToEdit={onClickToEdit}
+            >
+                <p className="m-0 text-[13px] text-muted">
+                    {t("noOtherPlayers")}
+                </p>
+            </SetupStepPanel>
+        );
+    }
+
+    const currentPlayer = targets[activeIndex] as Player;
+
+    return (
+        <SetupStepPanel
+            stepId={STEP_ID}
+            state={state}
+            stepNumber={stepNumber}
+            totalSteps={totalSteps}
+            title={t("title")}
+            summary={summary}
+            skippable={true}
+            validation={VALID}
+            onAdvance={onAdvance}
+            onSkip={onSkip}
+            onClickToEdit={onClickToEdit}
+        >
+            <p className="m-0 text-[13px] text-muted">{t("helperText")}</p>
+
+            {/* Desktop: side-by-side grid. */}
+            <div className="hidden gap-3 [@media(min-width:800px)]:grid [@media(min-width:800px)]:grid-cols-[repeat(auto-fit,minmax(220px,1fr))]">
+                {targets.map(player => (
+                    <PlayerColumnCardList
+                        key={String(player)}
+                        player={player}
+                    />
+                ))}
+            </div>
+
+            {/* Mobile: paginated. */}
+            <div className="flex flex-col gap-2 [@media(min-width:800px)]:hidden">
+                <div className="flex items-center justify-between gap-2">
+                    <button
+                        type="button"
+                        className="cursor-pointer rounded border border-border bg-bg p-1.5 hover:bg-hover disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-bg"
+                        disabled={activeIndex === 0}
+                        aria-label={t("prevPlayer")}
+                        onClick={() =>
+                            setActiveIndex(i => Math.max(0, i - 1))
+                        }
+                    >
+                        <ChevronLeftIcon size={16} />
+                    </button>
+                    <span className="text-[12px] text-muted">
+                        {t("paginator", {
+                            current: activeIndex + 1,
+                            total: targets.length,
+                            player: String(currentPlayer),
+                        })}
+                    </span>
+                    <button
+                        type="button"
+                        className="cursor-pointer rounded border border-border bg-bg p-1.5 hover:bg-hover disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-bg"
+                        disabled={activeIndex >= targets.length - 1}
+                        aria-label={t("nextPlayer")}
+                        onClick={() =>
+                            setActiveIndex(i =>
+                                Math.min(targets.length - 1, i + 1),
+                            )
+                        }
+                    >
+                        <ChevronRightIcon size={16} />
+                    </button>
+                </div>
+                <PlayerColumnCardList player={currentPlayer} />
+            </div>
+        </SetupStepPanel>
+    );
+}

--- a/src/ui/setup/steps/SetupStepMyCards.tsx
+++ b/src/ui/setup/steps/SetupStepMyCards.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import type { Player } from "../../../logic/GameObjects";
+import { useClue } from "../../state";
+import { PlayerColumnCardList } from "../shared/PlayerColumnCardList";
+import { SetupStepPanel } from "../SetupStepPanel";
+import { VALID } from "../wizardSteps";
+import type { StepPanelState } from "../SetupStepPanel";
+
+const STEP_ID = "myCards" as const;
+
+interface Props {
+    readonly state: StepPanelState;
+    readonly stepNumber: number;
+    readonly totalSteps: number;
+    readonly selfPlayerId: Player;
+    readonly onAdvance: () => void;
+    readonly onSkip: () => void;
+    readonly onClickToEdit: () => void;
+}
+
+/**
+ * Step 5 — "Which cards do you have?"
+ *
+ * Rendered only when `selfPlayerId !== null`; the parent guards
+ * mounting via `visibleSteps()`, so the step receives the resolved
+ * `selfPlayerId` as a prop and never has to handle null.
+ *
+ * Skippable. The user may not want to mark every card up front, and
+ * setting them later via the cell-popover sightings (M9) is fine.
+ */
+export function SetupStepMyCards({
+    state,
+    stepNumber,
+    totalSteps,
+    selfPlayerId,
+    onAdvance,
+    onSkip,
+    onClickToEdit,
+}: Props) {
+    const t = useTranslations("setupWizard.myCards");
+    const { state: clue } = useClue();
+    const ownedCount = clue.knownCards.filter(
+        kc => kc.player === selfPlayerId,
+    ).length;
+    const summary =
+        ownedCount === 0
+            ? t("summaryEmpty")
+            : t("summary", { count: ownedCount });
+
+    return (
+        <SetupStepPanel
+            stepId={STEP_ID}
+            state={state}
+            stepNumber={stepNumber}
+            totalSteps={totalSteps}
+            title={t("title")}
+            summary={summary}
+            skippable={true}
+            validation={VALID}
+            onAdvance={onAdvance}
+            onSkip={onSkip}
+            onClickToEdit={onClickToEdit}
+        >
+            <p className="m-0 text-[13px] text-muted">{t("helperText")}</p>
+            <PlayerColumnCardList
+                player={selfPlayerId}
+                heading={t("yourHand")}
+            />
+        </SetupStepPanel>
+    );
+}


### PR DESCRIPTION
## Summary

Third PR in the M6 setup-wizard rollout. Adds the remaining three steps (Card pack, My cards, Other players' cards) and a customize sub-flow inside step 1. Wizard still ships behind the `effect-clue.flag.setup-wizard.v1` localStorage flag (off by default) — legacy `<Checklist inSetup>` continues to be the live setup surface for everyone. PR-A4 will flip the default once the wizard rounds out.

## What's behind the flag now

- **Step 1 — Pick a card pack.** Pill row of every available pack (built-in + the user's saved customs). Click a pill to load. "Customize cards" expand reveals an inline category/card editor (rename, add, remove). Confirms before loading a pack when there's destructive data.
- **Step 5 — Which cards do you have?** Rendered only when `selfPlayerId !== null`; the parent guards mounting via `visibleSteps()` so the step receives the resolved `selfPlayerId` directly. Skippable.
- **Step 6 — Do you know any other player's cards?** Iterates non-self players (or every player when identity is unset). Desktop renders a side-by-side grid of `<PlayerColumnCardList>` columns; mobile uses a left/right paginator over a single column. Skippable.

Shared widget:

- **`<PlayerColumnCardList>`** — one player, one column of category-grouped checkbox rows. Toggles dispatch `addKnownCard` / `removeKnownCard` against the existing `knownCards` slice. Used by both step 5 and step 6.

## Customize sub-flow scope

Ships rename / add / remove for both categories and cards (today's inSetup capability set), with confirm dialogs before destructive removes. **Drag-to-reorder + save-as-new-pack land in a follow-up** — the `reorderCategories` / `reorderCardsInCategory` actions from PR-A1 are wired but their UI isn't yet. Users wanting save-as can still use the legacy pill bar by leaving the wizard flag off.

## Wizard plumbing

- Required-step set bumped to `{cardPack, players}`. Every game needs both a deck and at least 2 players. Identity, hand sizes, my cards, and known-cards stay skippable.
- The implemented-set filter in `<SetupWizard>` is now a no-op (all six steps in `visibleSteps` have implementations).

## Local opt-in for testing

```js
localStorage.setItem("effect-clue.flag.setup-wizard.v1", "1")
```

Reload to see the wizard. Set to `"0"` (or remove the key) to revert.

## Test plan

- [x] Pre-commit checks green (typecheck, lint, test, knip, i18n:check)
- [x] 1345 tests passing (+1 new — myCards visibility transition)
- [x] Browser preview verifies all 6 steps render with correct titles, summaries, and counters at desktop. No console errors after a fresh dev-server start.
- [x] `myCards` step hides when `selfPlayerId === null` and appears after picking a player pill in the identity step
- [ ] Smoke-test the customize sub-flow's rename / add / remove on real devices once the wizard ships user-facing in PR-A4

## Follow-ups before PR-A4

- Drag-to-reorder UI for categories and cards inside customize (actions exist in PR-A1; UI is the gap)
- Save-as-new-pack and update-pack buttons inside customize (orchestrator hook `useCardPackActions` is ready; UI is the gap)
- Tour rework + analytics + flip the feature flag → PR-A4

🤖 Generated with [Claude Code](https://claude.com/claude-code)