### PR TITLE
M6 PR-A4: setup-wizard becomes the live setup surface

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -555,29 +555,25 @@
         "gotIt": "Got it",
         "takeTour": "Take tour",
         "setup": {
+            "welcome": {
+                "title": "Set up your game step by step",
+                "body": "We'll walk you through the deck, who's playing, and the cards you're holding. You can always come back to any step."
+            },
             "cardPack": {
                 "title": "Pick a card pack",
-                "body": "Start with the Classic deck, swap to Master Detective, or roll your own and save it as a custom pack."
+                "body": "Pick a pack — Classic, Master Detective, or one of your saved customs. Hit Customize to build your own."
             },
             "players": {
-                "title": "Add the players",
-                "body": "Type each player's name. Use + Player for as many as you need — Clue traditionally has 3-6, but the solver scales to any size."
-            },
-            "handSize": {
-                "title": "Set hand sizes",
-                "body": "How many cards each player was dealt. The solver uses this to deduce who can't be holding which card."
+                "title": "Players in turn order",
+                "body": "Enter players in turn order — the first one listed will be dealt first. Drag to reorder, or use the up/down buttons."
             },
             "knownCard": {
                 "title": "Mark the cards you were dealt",
-                "body": "Click a cell to mark the cards you were dealt, plus any other cards you happen to know. Maybe you snuck a peek. We won't judge."
+                "body": "Tick the cards you have — the solver uses your hand to rule everything else out for you."
             },
             "overflow": {
-                "title": "Everything else lives here",
-                "body": "The ⋯ menu has Game setup, Take tour, New game, About, and (after sign-in) your account."
-            },
-            "start": {
-                "title": "Ready to play",
-                "body": "Click Start playing to flip into Play mode. The deducer keeps running in the background as you log suggestions and disproofs."
+                "title": "Come back later",
+                "body": "Use the ⋯ menu anytime to come back here, restart this tour, or start a new game."
             }
         },
         "checklist": {

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -824,3 +824,43 @@ export const deducerRun = (props: {
     cardCount: number;
     result: "success" | "error";
 }): void => capture("deducer_run", props);
+
+// ── Setup wizard (M6) ─────────────────────────────────────────────────────
+// One event per user-visible state transition in the accordion. The
+// `step` payload uses the wizard's stable WizardStepId discriminators
+// ("cardPack", "players", "identity", "handSizes", "myCards",
+// "knownCards") so renaming a step is a TypeScript-checked change at
+// every call site. Used to re-point the existing onboarding funnel
+// (`gameSetupStarted → playerAdded → cardsDealt → gameStarted`) at
+// the wizard's emit boundaries — `cardsDealt` now fires on step 5's
+// first checkbox toggle (or step 6's, when identity is skipped).
+type WizardStep =
+    | "cardPack"
+    | "players"
+    | "identity"
+    | "handSizes"
+    | "myCards"
+    | "knownCards";
+
+export const setupWizardStepAdvanced = (props: {
+    step: WizardStep;
+}): void => capture("setup_wizard_step_advanced", props);
+
+export const setupWizardStepSkipped = (props: {
+    step: WizardStep;
+}): void => capture("setup_wizard_step_skipped", props);
+
+export const setupWizardStepReentered = (props: {
+    step: WizardStep;
+}): void => capture("setup_wizard_step_reentered", props);
+
+export const setupWizardCompleted = (): void =>
+    capture("setup_wizard_completed");
+
+export const setupSelfPlayerSet = (props: {
+    cleared: boolean;
+}): void => capture("setup_self_player_set", props);
+
+export const setupFirstDealtPlayerSet = (props: {
+    auto: boolean;
+}): void => capture("setup_first_dealt_player_set", props);

--- a/src/ui/components/Checklist.setup.test.tsx
+++ b/src/ui/components/Checklist.setup.test.tsx
@@ -67,6 +67,15 @@ import { seedOnboardingDismissed } from "../../test-utils/onboardingSeed";
 beforeEach(() => {
     window.localStorage.clear();
     seedOnboardingDismissed();
+    // M6 PR-A4 flipped the setup-wizard flag default to ON, swapping
+    // the live setup surface from `<Checklist inSetup>` to
+    // `<SetupWizard>`. These tests pin the legacy Checklist setup
+    // rendering — opt them out of the wizard explicitly so we keep
+    // testing the legacy path until PR-B removes it.
+    window.localStorage.setItem(
+        "effect-clue.flag.setup-wizard.v1",
+        "0",
+    );
     window.history.replaceState(null, "", "/");
 });
 

--- a/src/ui/setup/SetupStepPanel.tsx
+++ b/src/ui/setup/SetupStepPanel.tsx
@@ -107,9 +107,9 @@ export function SetupStepPanel({
                         )}
                     </span>
                     <div className="flex min-w-0 flex-col">
-                        <h2 className="m-0 text-[15px] font-semibold leading-tight">
+                        <h3 className="m-0 text-[15px] font-semibold leading-tight">
                             {title}
-                        </h2>
+                        </h3>
                         <span className="text-[11px] uppercase tracking-wide text-muted">
                             {t("stepCounter", {
                                 step: stepNumber,

--- a/src/ui/setup/SetupWizard.tsx
+++ b/src/ui/setup/SetupWizard.tsx
@@ -3,7 +3,13 @@
 import { useTranslations } from "next-intl";
 import { useEffect, useMemo, useState } from "react";
 import { startSetup } from "../../analytics/gameSession";
-import { gameSetupStarted } from "../../analytics/events";
+import {
+    gameSetupStarted,
+    setupWizardCompleted,
+    setupWizardStepAdvanced,
+    setupWizardStepReentered,
+    setupWizardStepSkipped,
+} from "../../analytics/events";
 import { useConfirm } from "../hooks/useConfirm";
 import { useClue } from "../state";
 import { useSetupWizardFocus } from "./SetupWizardFocusContext";
@@ -128,6 +134,20 @@ export function SetupWizard() {
         setCompleted(nextCompleted);
         const remaining = steps.find(id => !nextCompleted.has(id));
         setFocusedStep(remaining ?? null);
+        setupWizardStepAdvanced({ step: currentId });
+    };
+
+    const skip = (currentId: WizardStepId) => {
+        // Same flow as `advance` (one less event, different signal).
+        // The accordion treats "Skip" and "Next" identically — both
+        // mark the step complete and move on; the analytics
+        // distinction lets us see which steps users actually fill in.
+        const nextCompleted = new Set(completed);
+        nextCompleted.add(currentId);
+        setCompleted(nextCompleted);
+        const remaining = steps.find(id => !nextCompleted.has(id));
+        setFocusedStep(remaining ?? null);
+        setupWizardStepSkipped({ step: currentId });
     };
 
     const reEnter = (id: WizardStepId) => {
@@ -144,6 +164,7 @@ export function SetupWizard() {
         nextCompleted.delete(id);
         setCompleted(nextCompleted);
         setFocusedStep(id);
+        setupWizardStepReentered({ step: id });
     };
 
     // Required visible steps (subset that block "Start playing"):
@@ -177,6 +198,7 @@ export function SetupWizard() {
             startSetup();
             gameSetupStarted();
         }
+        setupWizardCompleted();
         dispatch({ type: "setUiMode", mode: "checklist" });
     };
 
@@ -192,9 +214,9 @@ export function SetupWizard() {
     return (
         <div className="mx-auto flex w-full max-w-[720px] flex-col gap-4">
             <header className="flex flex-col gap-1">
-                <h1 className="m-0 text-[24px] font-semibold tracking-tight">
+                <h2 className="m-0 text-[24px] font-semibold tracking-tight">
                     {t("heading")}
-                </h1>
+                </h2>
                 <p className="m-0 text-[14px] text-muted">
                     {t("subheading")}
                 </p>
@@ -240,7 +262,7 @@ export function SetupWizard() {
                                 stepNumber={stepNumber}
                                 totalSteps={totalSteps}
                                 onAdvance={() => advance(id)}
-                                onSkip={() => advance(id)}
+                                onSkip={() => skip(id)}
                                 onClickToEdit={() => reEnter(id)}
                             />
                         );
@@ -253,7 +275,7 @@ export function SetupWizard() {
                                 stepNumber={stepNumber}
                                 totalSteps={totalSteps}
                                 onAdvance={() => advance(id)}
-                                onSkip={() => advance(id)}
+                                onSkip={() => skip(id)}
                                 onClickToEdit={() => reEnter(id)}
                             />
                         );
@@ -271,7 +293,7 @@ export function SetupWizard() {
                                 totalSteps={totalSteps}
                                 selfPlayerId={state.selfPlayerId}
                                 onAdvance={() => advance(id)}
-                                onSkip={() => advance(id)}
+                                onSkip={() => skip(id)}
                                 onClickToEdit={() => reEnter(id)}
                             />
                         );
@@ -284,7 +306,7 @@ export function SetupWizard() {
                                 stepNumber={stepNumber}
                                 totalSteps={totalSteps}
                                 onAdvance={() => advance(id)}
-                                onSkip={() => advance(id)}
+                                onSkip={() => skip(id)}
                                 onClickToEdit={() => reEnter(id)}
                             />
                         );
@@ -307,6 +329,7 @@ export function SetupWizard() {
                     onClick={startPlaying}
                     disabled={!ctaEnabled}
                     data-tour-anchor="setup-start-playing"
+                    data-setup-cta=""
                 >
                     {ctaLabel}
                 </button>

--- a/src/ui/setup/featureFlag.ts
+++ b/src/ui/setup/featureFlag.ts
@@ -3,22 +3,22 @@
 import { useEffect, useState } from "react";
 
 /**
- * Feature flag for the M6 setup wizard. Off by default — the
- * `<Checklist inSetup>` legacy path keeps rendering. The flag exists
- * as a code-organization aid so PR-A2/A3 can ship the wizard plumbing
- * without exposing it; PR-A4 flips the default once the wizard is
- * complete.
+ * Feature flag for the M6 setup wizard. **On by default** as of PR-A4
+ * — the wizard is the live setup surface for everyone. The legacy
+ * `<Checklist inSetup>` path remains in the codebase and is gated
+ * behind the same flag set to `"0"`, both for explicit opt-out and
+ * to give us a runtime fallback during the rollout window before the
+ * legacy path is removed in PR-B.
  *
- * Two override channels for local development before that happens:
+ * Override channels:
  *
- * - **localStorage:** `effect-clue.flag.setup-wizard.v1 = "1"` enables;
- *   `"0"` disables. Set this in DevTools and reload to test the wizard.
- *   The localStorage value wins over the default — useful for the
- *   "pause for me to test" workflow during PR-A2.
- *
- * - **Module default:** `WIZARD_DEFAULT_ENABLED` constant. Flipping it
- *   to `true` enables the wizard for everyone with no localStorage
- *   override. PR-A4 flips this.
+ * - **localStorage:** `effect-clue.flag.setup-wizard.v1 = "0"`
+ *   disables (forces the legacy Checklist path); `"1"` enables.
+ *   Useful for users who hit a wizard regression and need to fall
+ *   back temporarily.
+ * - **Module default:** `WIZARD_DEFAULT_ENABLED` constant. PR-B
+ *   removes the legacy path entirely; this constant goes away with
+ *   the legacy code.
  *
  * The hook is SSR-safe — returns `WIZARD_DEFAULT_ENABLED` on the
  * server and the first client render, then re-renders to pick up the
@@ -30,7 +30,7 @@ const STORAGE_KEY = "effect-clue.flag.setup-wizard.v1";
 const ENABLED_VALUE = "1";
 const DISABLED_VALUE = "0";
 
-const WIZARD_DEFAULT_ENABLED = false;
+const WIZARD_DEFAULT_ENABLED = true;
 
 function readFlag(): boolean {
     if (typeof window === "undefined") return WIZARD_DEFAULT_ENABLED;

--- a/src/ui/setup/shared/PlayerColumnCardList.tsx
+++ b/src/ui/setup/shared/PlayerColumnCardList.tsx
@@ -28,9 +28,20 @@ import { useClue } from "../../state";
 interface Props {
     readonly player: Player;
     readonly heading?: string;
+    /**
+     * Optional `data-tour-anchor` for the very first checkbox row.
+     * Used by the M6 setup tour's "Mark your cards" step to spotlight
+     * the first row when the column lives in step 5 (My cards). Other
+     * mounts (step 6, M8 my-hand panel) leave this undefined.
+     */
+    readonly firstRowTourAnchor?: string;
 }
 
-export function PlayerColumnCardList({ player, heading }: Props) {
+export function PlayerColumnCardList({
+    player,
+    heading,
+    firstRowTourAnchor,
+}: Props) {
     const tSetup = useTranslations("setup");
     const { state, dispatch } = useClue();
     const setup = state.setup;
@@ -64,6 +75,12 @@ export function PlayerColumnCardList({ player, heading }: Props) {
 
     const heading_ = heading ?? String(player);
 
+    // Stable identity of the very first card across all categories.
+    // Tagged with `firstRowTourAnchor` (when provided) so the setup
+    // tour's "Mark your cards" step can spotlight a single row rather
+    // than the whole column.
+    const firstCardId = setup.categories[0]?.cards[0]?.id;
+
     return (
         <div className="flex min-w-0 flex-col gap-2 rounded border border-border/40 p-3">
             <h3 className="m-0 truncate text-[14px] font-semibold">
@@ -81,10 +98,19 @@ export function PlayerColumnCardList({ player, heading }: Props) {
                         <ul className="m-0 flex list-none flex-col gap-1 p-0">
                             {category.cards.map(entry => {
                                 const owned = ownedSet.has(entry.id);
+                                const isFirst =
+                                    firstRowTourAnchor !== undefined &&
+                                    entry.id === firstCardId;
                                 return (
                                     <li
                                         key={String(entry.id)}
                                         className="flex items-center gap-2"
+                                        {...(isFirst
+                                            ? {
+                                                  "data-tour-anchor":
+                                                      firstRowTourAnchor,
+                                              }
+                                            : {})}
                                     >
                                         <label className="flex w-full cursor-pointer items-center gap-2 rounded px-1 py-0.5 hover:bg-hover">
                                             <input

--- a/src/ui/setup/shared/PlayerListReorder.tsx
+++ b/src/ui/setup/shared/PlayerListReorder.tsx
@@ -17,6 +17,10 @@ const REORDER_AXIS_Y = "y" as const;
 // not a translatable string.
 const DRAG_HANDLE_GLYPH = "⋮⋮";
 
+// Tour anchor shared with the M6 setup tour's "Players in turn order"
+// step.
+const PLAYERS_LIST_TOUR_ANCHOR = "setup-step-players-list" as const;
+
 /**
  * Drag-to-reorder list of players, plus inline name + remove
  * controls per row and explicit up/down arrow buttons for keyboard
@@ -63,6 +67,7 @@ export function PlayerListReorder() {
                     setDraft(next);
                 }}
                 className="m-0 flex list-none flex-col gap-2 p-0"
+                data-tour-anchor={PLAYERS_LIST_TOUR_ANCHOR}
             >
                 {draft.map((player, i) => (
                     <Reorder.Item

--- a/src/ui/setup/steps/SetupStepCardPack.tsx
+++ b/src/ui/setup/steps/SetupStepCardPack.tsx
@@ -17,6 +17,8 @@ import {
 import type { StepPanelState } from "../SetupStepPanel";
 
 const STEP_ID = "cardPack" as const;
+// Tour anchor shared with the M6 setup tour's "Card pack" step.
+const PILLS_TOUR_ANCHOR = "setup-step-cardpack-pills" as const;
 
 interface Props {
     readonly state: StepPanelState;
@@ -135,7 +137,10 @@ export function SetupStepCardPack({
         >
             <p className="m-0 text-[13px] text-muted">{t("helperText")}</p>
 
-            <div className="flex flex-wrap gap-2">
+            <div
+                className="flex flex-wrap gap-2"
+                data-tour-anchor={PILLS_TOUR_ANCHOR}
+            >
                 {pills.map(pill => (
                     <button
                         key={pill.id}

--- a/src/ui/setup/steps/SetupStepHandSizes.tsx
+++ b/src/ui/setup/steps/SetupStepHandSizes.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from "next-intl";
 import { useState } from "react";
+import { setupFirstDealtPlayerSet } from "../../../analytics/events";
 import { allCardIds, caseFileSize } from "../../../logic/CardSet";
 import type { Player } from "../../../logic/GameObjects";
 import { useClue } from "../../state";
@@ -191,12 +192,13 @@ function AdjustDealing() {
                         type="radio"
                         name="first-dealt"
                         checked={firstDealt === null}
-                        onChange={() =>
+                        onChange={() => {
                             dispatch({
                                 type: "setFirstDealtPlayer",
                                 player: null,
-                            })
-                        }
+                            });
+                            setupFirstDealtPlayerSet({ auto: true });
+                        }}
                     />
                     {t("firstDealtAuto")}
                 </label>
@@ -209,12 +211,13 @@ function AdjustDealing() {
                             type="radio"
                             name="first-dealt"
                             checked={firstDealt === player}
-                            onChange={() =>
+                            onChange={() => {
                                 dispatch({
                                     type: "setFirstDealtPlayer",
                                     player,
-                                })
-                            }
+                                });
+                                setupFirstDealtPlayerSet({ auto: false });
+                            }}
                         />
                         {String(player)}
                     </label>

--- a/src/ui/setup/steps/SetupStepIdentity.tsx
+++ b/src/ui/setup/steps/SetupStepIdentity.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import { setupSelfPlayerSet } from "../../../analytics/events";
 import { useClue } from "../../state";
 import { SetupStepPanel } from "../SetupStepPanel";
 import { VALID } from "../wizardSteps";
@@ -60,6 +61,7 @@ export function SetupStepIdentity({
             onSkip={() => {
                 if (selfPlayerId !== null) {
                     dispatch({ type: "setSelfPlayer", player: null });
+                    setupSelfPlayerSet({ cleared: true });
                 }
                 onSkip();
             }}
@@ -86,12 +88,16 @@ export function SetupStepIdentity({
                                         : "border-border bg-bg text-fg hover:bg-hover"
                                 }`}
                                 aria-pressed={active}
-                                onClick={() =>
+                                onClick={() => {
+                                    const next = active ? null : player;
                                     dispatch({
                                         type: "setSelfPlayer",
-                                        player: active ? null : player,
-                                    })
-                                }
+                                        player: next,
+                                    });
+                                    setupSelfPlayerSet({
+                                        cleared: next === null,
+                                    });
+                                }}
                             >
                                 {String(player)}
                             </button>

--- a/src/ui/setup/steps/SetupStepMyCards.tsx
+++ b/src/ui/setup/steps/SetupStepMyCards.tsx
@@ -10,6 +10,11 @@ import type { StepPanelState } from "../SetupStepPanel";
 
 const STEP_ID = "myCards" as const;
 
+// Tour anchor shared with `tours.ts` setup step 4 ("Mark your cards").
+// Pulled to module scope so the i18next/no-literal-string lint treats
+// it as a wire identifier, not user copy.
+const FIRST_ROW_TOUR_ANCHOR = "setup-step-mycards-firstrow" as const;
+
 interface Props {
     readonly state: StepPanelState;
     readonly stepNumber: number;
@@ -67,6 +72,7 @@ export function SetupStepMyCards({
             <PlayerColumnCardList
                 player={selfPlayerId}
                 heading={t("yourHand")}
+                firstRowTourAnchor={FIRST_ROW_TOUR_ANCHOR}
             />
         </SetupStepPanel>
     );

--- a/src/ui/tour/TourPopover.test.tsx
+++ b/src/ui/tour/TourPopover.test.tsx
@@ -104,7 +104,7 @@ describe("TourPopover — anchor lookup", () => {
         render(
             <Harness
                 anchors={[
-                    { testId: "card-pack", anchorAttr: "setup-card-pack" },
+                    { testId: "card-pack", anchorAttr: "setup-wizard-shell" },
                 ]}
             >
                 {c => {
@@ -116,13 +116,13 @@ describe("TourPopover — anchor lookup", () => {
         );
         act(() => api.startTour("setup"));
         // Title and body keys for setup tour step 0
-        // (`setup.cardPack.title` / `setup.cardPack.body`) — the
+        // (`setup.welcome.title` / `setup.welcome.body`) — the
         // next-intl mock returns the key itself.
         expect(
-            screen.getByText("setup.cardPack.title"),
+            screen.getByText("setup.welcome.title"),
         ).toBeInTheDocument();
         expect(
-            screen.getByText("setup.cardPack.body"),
+            screen.getByText("setup.welcome.body"),
         ).toBeInTheDocument();
     });
 
@@ -196,7 +196,7 @@ describe("TourPopover — anchor lookup", () => {
         render(
             <Harness
                 anchors={[
-                    { testId: "card-pack", anchorAttr: "setup-card-pack" },
+                    { testId: "card-pack", anchorAttr: "setup-wizard-shell" },
                 ]}
             >
                 {c => {
@@ -230,7 +230,7 @@ describe("TourPopover — anchor lookup", () => {
         // to a fixed viewport position and still shows the copy.
         expect(() => act(() => api.startTour("setup"))).not.toThrow();
         expect(
-            screen.getByText("setup.cardPack.title"),
+            screen.getByText("setup.welcome.title"),
         ).toBeInTheDocument();
     });
 });
@@ -249,7 +249,7 @@ describe("TourPopover — M20 interaction rules", () => {
         render(
             <Harness
                 anchors={[
-                    { testId: "card-pack", anchorAttr: "setup-card-pack" },
+                    { testId: "card-pack", anchorAttr: "setup-wizard-shell" },
                 ]}
             >
                 {c => {
@@ -295,7 +295,7 @@ describe("TourPopover — M20 interaction rules", () => {
                         <button
                             type="button"
                             data-testid="anchor"
-                            data-tour-anchor="setup-card-pack"
+                            data-tour-anchor="setup-wizard-shell"
                             onClick={onAnchorClick}
                         >
                             click me
@@ -332,7 +332,7 @@ describe("TourPopover — M20 interaction rules", () => {
         render(
             <Harness
                 anchors={[
-                    { testId: "card-pack", anchorAttr: "setup-card-pack" },
+                    { testId: "card-pack", anchorAttr: "setup-wizard-shell" },
                 ]}
             >
                 {c => {
@@ -369,7 +369,7 @@ describe("TourPopover — veil isolation", () => {
         render(
             <Harness
                 anchors={[
-                    { testId: "card-pack", anchorAttr: "setup-card-pack" },
+                    { testId: "card-pack", anchorAttr: "setup-wizard-shell" },
                 ]}
             >
                 {c => {
@@ -402,7 +402,7 @@ describe("TourPopover — veil isolation", () => {
                     anchors={[
                         {
                             testId: "card-pack",
-                            anchorAttr: "setup-card-pack",
+                            anchorAttr: "setup-wizard-shell",
                         },
                     ]}
                 >
@@ -445,7 +445,7 @@ describe("TourPopover — veil isolation", () => {
                     anchors={[
                         {
                             testId: "card-pack",
-                            anchorAttr: "setup-card-pack",
+                            anchorAttr: "setup-wizard-shell",
                         },
                     ]}
                 >
@@ -487,7 +487,7 @@ describe("TourPopover — veil isolation", () => {
         render(
             <Harness
                 anchors={[
-                    { testId: "card-pack", anchorAttr: "setup-card-pack" },
+                    { testId: "card-pack", anchorAttr: "setup-wizard-shell" },
                 ]}
             >
                 {c => {
@@ -528,7 +528,7 @@ describe("TourPopover — veil isolation", () => {
         render(
             <Harness
                 anchors={[
-                    { testId: "card-pack", anchorAttr: "setup-card-pack" },
+                    { testId: "card-pack", anchorAttr: "setup-wizard-shell" },
                 ]}
             >
                 {c => {
@@ -574,7 +574,7 @@ describe("TourPopover — veil isolation", () => {
         render(
             <Harness
                 anchors={[
-                    { testId: "card-pack", anchorAttr: "setup-card-pack" },
+                    { testId: "card-pack", anchorAttr: "setup-wizard-shell" },
                     { testId: "sticky", stickyLeft: true },
                 ]}
             >
@@ -627,7 +627,7 @@ describe("TourPopover — veil isolation", () => {
         render(
             <Harness
                 anchors={[
-                    { testId: "card-pack", anchorAttr: "setup-card-pack" },
+                    { testId: "card-pack", anchorAttr: "setup-wizard-shell" },
                     { testId: "sticky", stickyLeft: true },
                 ]}
             >
@@ -679,7 +679,7 @@ describe("TourPopover — veil isolation", () => {
         render(
             <Harness
                 anchors={[
-                    { testId: "card-pack", anchorAttr: "setup-card-pack" },
+                    { testId: "card-pack", anchorAttr: "setup-wizard-shell" },
                     { testId: "sticky", stickyLeft: true },
                 ]}
             >

--- a/src/ui/tour/TourProvider.test.tsx
+++ b/src/ui/tour/TourProvider.test.tsx
@@ -97,10 +97,11 @@ describe("TourProvider — persistence on close", () => {
     test("completion: clicking Next past the last step writes lastDismissedAt", () => {
         const api = mount();
         act(() => api.current().startTour("setup"));
-        // Setup has 6 steps. Click Next 6 times: steps 0→1, 1→2,
-        // 2→3, 3→4, 4→5, then the 6th call past the last step
-        // triggers the completion path.
-        for (let i = 0; i < 6; i++) {
+        // PR-A4: setup tour has 5 steps (welcome → cardpack → players
+        // → mycards → overflow). Click Next 5 times: steps 0→1, 1→2,
+        // 2→3, 3→4, then the 5th call past the last step triggers the
+        // completion path.
+        for (let i = 0; i < 5; i++) {
             act(() => api.current().nextStep());
         }
         expect(api.current().activeScreen).toBeUndefined();
@@ -180,16 +181,16 @@ describe("TourProvider — viewport filter", () => {
         expect(api2.current().steps?.length).toBe(6);
     });
 
-    test("setup tour has the same 6 steps at both breakpoints (no viewport-locked steps)", () => {
+    test("setup tour has the same 5 steps at both breakpoints (no viewport-locked steps)", () => {
         stubMatchMedia(true);
         const api = mount();
         act(() => api.current().startTour("setup"));
-        expect(api.current().steps?.length).toBe(6);
+        expect(api.current().steps?.length).toBe(5);
 
         stubMatchMedia(false);
         const api2 = mount();
         act(() => api2.current().startTour("setup"));
-        expect(api2.current().steps?.length).toBe(6);
+        expect(api2.current().steps?.length).toBe(5);
     });
 
     test("isLastStep is true on the final step of checklistSuggest", () => {
@@ -229,7 +230,7 @@ describe("TourProvider — analytics events", () => {
             event: "tour_started",
             props: {
                 screenKey: "setup",
-                stepCount: 6,
+                stepCount: 5,
                 reengaged: false,
                 daysSinceLastDismissal: null,
             },
@@ -239,8 +240,8 @@ describe("TourProvider — analytics events", () => {
             props: {
                 screenKey: "setup",
                 stepIndex: 0,
-                stepId: "setup-card-pack",
-                totalSteps: 6,
+                stepId: "setup-wizard-shell",
+                totalSteps: 5,
                 isFirstStep: true,
                 isLastStep: false,
             },
@@ -262,7 +263,7 @@ describe("TourProvider — analytics events", () => {
             props: {
                 screenKey: "setup",
                 stepIndex: 1,
-                stepId: "setup-player-column",
+                stepId: "setup-step-cardpack-pills",
                 isFirstStep: false,
                 isLastStep: false,
             },
@@ -274,16 +275,16 @@ describe("TourProvider — analytics events", () => {
         const api = mount();
         act(() => api.current().startTour("setup"));
         captureCalls.length = 0;
-        for (let i = 0; i < 6; i++) {
+        for (let i = 0; i < 5; i++) {
             act(() => api.current().nextStep());
         }
-        // 5 advances + 5 step_views (steps 1..5) + 1 completion.
+        // 4 advances + 4 step_views (steps 1..4) + 1 completion.
         const last = captureCalls[captureCalls.length - 1];
         expect(last?.event).toBe("tour_completed");
         expect(last).toMatchObject({
             props: {
                 screenKey: "setup",
-                totalSteps: 6,
+                totalSteps: 5,
                 $set: { tour_setup_status: "completed" },
             },
         });

--- a/src/ui/tour/tours.test.ts
+++ b/src/ui/tour/tours.test.ts
@@ -41,33 +41,29 @@ const findStep = (
 };
 
 describe("TOURS — setup tour", () => {
-    test("has 6 steps in declaration order", () => {
+    test("walks the M6 wizard in 5 steps", () => {
+        // PR-A4 reworked the setup tour for the wizard: welcome → card
+        // pack → players → my cards → overflow. The deeper "hand sizes"
+        // and "start playing" steps from the legacy setup-mode Checklist
+        // are gone (the wizard's accordion already exposes everything;
+        // re-touring it would be repetitive).
         expect(TOURS.setup.map(s => s.anchor)).toEqual([
-            "setup-card-pack",
-            "setup-player-column",
-            "setup-hand-size",
-            "setup-known-cell",
+            "setup-wizard-shell",
+            "setup-step-cardpack-pills",
+            "setup-step-players-list",
+            "setup-step-mycards-firstrow",
             "overflow-menu",
-            "setup-start-playing",
         ]);
     });
 
-    test("setup-known-cell uses popoverAnchor + sideByViewport", () => {
-        const step = findStep(TOURS.setup, "setup-known-cell");
-        // Spotlight covers all body cells; popover anchors to the
-        // header so it doesn't pin against an 800-px-tall column.
-        expect(step.popoverAnchor).toBe("setup-known-cell-header");
-        // Desktop: popover sits to the RIGHT (column visible).
-        // Mobile: side: bottom; column too narrow horizontally for
-        // a side popover.
-        expect(step.sideByViewport?.desktop).toEqual({
-            side: "right",
-            align: "start",
-        });
-        expect(step.sideByViewport?.mobile).toEqual({
-            side: "bottom",
-            align: "center",
-        });
+    test("mycards step auto-skips when its anchor is missing (selfPlayerId === null)", () => {
+        // The wizard hides step 5 from the accordion entirely when
+        // identity is unset; the anchor isn't mounted, so tours.ts'
+        // missing-anchor auto-skip kicks in. Pin the step exists with
+        // the anchor name we expect; the auto-skip is exercised by
+        // TourPopover's own behavior tests.
+        const step = findStep(TOURS.setup, "setup-step-mycards-firstrow");
+        expect(step.titleKey).toBe("setup.knownCard.title");
     });
 
     test("overflow-menu uses popoverAnchorPriority + sideByViewport", () => {
@@ -82,11 +78,6 @@ describe("TOURS — setup tour", () => {
         expect(step.sideByViewport?.mobile.side).toBe("top");
     });
 
-    test("setup-start-playing keeps the popover below the near-top CTA", () => {
-        const step = findStep(TOURS.setup, "setup-start-playing");
-        expect(step.side).toBe("bottom");
-        expect(step.align).toBe("end");
-    });
 });
 
 describe("TOURS — checklistSuggest tour", () => {

--- a/src/ui/tour/tours.ts
+++ b/src/ui/tour/tours.ts
@@ -185,71 +185,48 @@ export interface TourStep {
 export const TOURS: Record<ScreenKey, ReadonlyArray<TourStep>> = {
     setup: [
         {
-            anchor: "setup-card-pack",
+            // High-level welcome — point at the entire wizard so the
+            // user takes in the accordion shape before drilling down.
+            anchor: "setup-wizard-shell",
+            titleKey: "setup.welcome.title",
+            bodyKey: "setup.welcome.body",
+            side: "bottom",
+            align: "start",
+        },
+        {
+            // Card pack — pill row inside step 1's panel. Mounted only
+            // while step 1 is in `editing` state; auto-skips otherwise.
+            anchor: "setup-step-cardpack-pills",
             titleKey: "setup.cardPack.title",
             bodyKey: "setup.cardPack.body",
             side: "bottom",
             align: "start",
         },
         {
-            anchor: "setup-player-column",
+            // Players in turn order — Reorder.Group inside step 2.
+            anchor: "setup-step-players-list",
             titleKey: "setup.players.title",
             bodyKey: "setup.players.body",
             side: "bottom",
             align: "start",
         },
         {
-            anchor: "setup-hand-size",
-            titleKey: "setup.handSize.title",
-            bodyKey: "setup.handSize.body",
-            side: "bottom",
-            align: "center",
-        },
-        {
-            // Spotlight unions every cell in the first player column
-            // (header + body cells). Popover anchors to the column
-            // HEADER only — pinning to the full column would put the
-            // popover off-screen on narrow viewports because Radix
-            // tries to anchor against a tall rect.
-            anchor: "setup-known-cell",
-            popoverAnchor: "setup-known-cell-header",
+            // Mark your cards — first checkbox row inside step 5. Auto-
+            // skips when `selfPlayerId === null` (the step is hidden
+            // entirely from the accordion in that case, so the anchor
+            // isn't mounted; tours.ts auto-skips missing anchors).
+            anchor: "setup-step-mycards-firstrow",
             titleKey: "setup.knownCard.title",
             bodyKey: "setup.knownCard.body",
-            // Per-viewport positioning:
-            //   - desktop: sit to the RIGHT of the column header so
-            //     the entire column stays visible. The setup table
-            //     is wide enough on desktop that there's room.
-            //   - mobile: sit BELOW the header (popover hangs into
-            //     the column body, covering the top 2-3 rows). Side
-            //     "right" doesn't fit on mobile because the column
-            //     pushes near the right edge.
             side: "bottom",
-            align: "center",
-            sideByViewport: {
-                desktop: { side: "right", align: "start" },
-                mobile: { side: "bottom", align: "center" },
-            },
+            align: "start",
         },
         {
+            // Come back later — overflow menu (existing anchor +
+            // forceOpen wiring still applies).
             anchor: "overflow-menu",
             titleKey: "setup.overflow.title",
             bodyKey: "setup.overflow.body",
-            // The trigger is in DOM order before the portaled menu
-            // content; `last-visible` resolves to the OPEN dropdown
-            // when it's present (which it is during this step, via
-            // forceOpen). The popover lands beside the dropdown,
-            // leaving both the trigger AND the menu items unobscured.
-            //
-            // The popover is too wide (~360px) to fit in the gap on
-            // either SIDE of the menu on mobile (where the menu fills
-            // most of the right column), so the side flips per
-            // viewport:
-            //   - desktop: menu opens DOWN from a TOP-right trigger;
-            //     plenty of room to the LEFT → side:"left".
-            //   - mobile: menu opens UP from a BOTTOM-right trigger;
-            //     plenty of room ABOVE → side:"top", align:"end" so
-            //     the popover hugs the menu's right edge and stays
-            //     in-viewport on a 375 px viewport.
             popoverAnchorPriority: "last-visible",
             side: "left",
             align: "start",
@@ -257,18 +234,6 @@ export const TOURS: Record<ScreenKey, ReadonlyArray<TourStep>> = {
                 mobile: { side: "top", align: "end" },
                 desktop: { side: "left", align: "start" },
             },
-        },
-        {
-            anchor: "setup-start-playing",
-            titleKey: "setup.start.title",
-            bodyKey: "setup.start.body",
-            // This CTA sits near the top of Setup. Keeping the
-            // popover below the button avoids top-edge clipping when
-            // the tour scrolls back up from a deeper table step,
-            // especially on mobile where the header consumes a
-            // meaningful chunk of the viewport.
-            side: "bottom",
-            align: "end",
         },
     ],
     checklistSuggest: [


### PR DESCRIPTION
## Summary

The keystone of the M6 rollout. Flips the setup-wizard feature flag default to ON, making the M6 wizard the live setup surface for everyone for the first time. The legacy `<Checklist inSetup>` path stays in the codebase (gated behind the same flag set to `\"0\"`) so users hitting a regression have a one-line localStorage opt-out, and PR-B can remove it once the rollout is watched.

Also reworks the setup tour to walk the new accordion at a high level, adds analytics events for wizard step transitions, and tightens heading hierarchy.

## What's in this PR

- **Feature flag default flipped** to `true` in `src/ui/setup/featureFlag.ts`. Existing localStorage opt-in / opt-out semantics still apply for users who want to override.
- **Setup tour reworked** to 5 steps walking the wizard: welcome (whole accordion) → card pack → players in turn order → mark your cards → come back later via overflow menu. Legacy hand-sizes / start-playing steps retired — the accordion already exposes everything.
- **`data-tour-anchor` attributes** added on the wizard's card-pack pills, players list, and the first My-cards row so the tour can spotlight them. Anchors auto-skip when their step isn't visible (myCards is hidden when `selfPlayerId === null`).
- **Wizard analytics** wired in `src/analytics/events.ts`:
  - `setup_wizard_step_advanced { step }`
  - `setup_wizard_step_skipped { step }`
  - `setup_wizard_step_reentered { step }` (clicking a complete step's summary)
  - `setup_wizard_completed`
  - `setup_self_player_set { cleared }`
  - `setup_first_dealt_player_set { auto }`
- **i18n keys** under `onboarding.setup.*` repointed to the new copy. `welcome` is new; `cardPack`, `players`, `knownCard`, `overflow` pivot to wizard-friendly wording. Orphan `handSize` and `start` keys retired.
- **Heading hierarchy** tightened — wizard title is now `<h2>` (page header is `<h1>`) and step-panel titles are `<h3>`. Avoids doubled-up `<h1>` reads.
- **`data-setup-cta=\"\"`** added to the wizard's \"Start playing\" button so existing flow tests that key off `[data-setup-cta]` find it on both code paths.

## Test fallout

All tests green. Required updates:

- `Checklist.setup.test.tsx` opts into the legacy path explicitly via `localStorage.setItem(\"effect-clue.flag.setup-wizard.v1\", \"0\")` in `beforeEach`. PR-B retires the file along with the legacy code.
- Tour tests updated for the 5-step structure: anchors, step count assertions, analytics-event step ids.

## Funnel impact

Per CLAUDE.md → Observability and analytics, the onboarding funnel (`game_setup_started → player_added → cards_dealt → game_started`) keeps the same shape — `gameSetupStarted` and `gameStarted` are still emitted at the same boundaries. The new wizard-step events are additive signals for the funnel-step-by-step view in PostHog. **The PostHog UI funnel definition needs no edits**, though we should add a separate \"Wizard completion funnel\" once we have data. Document in PR description; the user / dashboard owner picks up.

## Test plan

- [x] Pre-commit checks green (typecheck, lint, test, knip, i18n:check) — 1344 tests passing
- [x] Browser preview verifies the wizard renders by default (no localStorage flag set), with all 6 steps
- [x] No console errors
- [x] Legacy path still rendered when user opts out (`localStorage.setItem(\"effect-clue.flag.setup-wizard.v1\", \"0\")`)
- [ ] Walk the new setup tour at desktop and mobile in the Vercel preview — manual verification per CLAUDE.md → Tour-popover verification

## Follow-ups

- **PR-B** — pure subtraction of `<Checklist inSetup>` branches (~1500 lines removed) once the rollout is watched. Removes the feature flag entirely.
- **Customize sub-flow** still missing DnD reorder + save-as-pack (deferred from PR-A3); separate follow-up before PR-B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)