### PR TITLE
M7: setup summary panel in play mode

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -192,6 +192,63 @@
             "paginator": "{current} of {total} · {player}"
         }
     },
+    "setupSummary": {
+        "heading": "Game setup",
+        "toggleExpand": "Show setup",
+        "toggleCollapse": "Hide setup",
+        "cardPack": {
+            "label": "Card pack",
+            "summary": "{categories} {categories, plural, one {category} other {categories}} · {cards} cards",
+            "summaryEmpty": "No deck yet",
+            "edit": "Change deck"
+        },
+        "players": {
+            "label": "Players",
+            "summary": "{count} {count, plural, one {player} other {players}}",
+            "summaryEmpty": "No players yet",
+            "renameTitle": "Rename {player}",
+            "renameAria": "Rename {player}",
+            "renameInputLabel": "Player name",
+            "renameSave": "Save",
+            "renameCancel": "Cancel",
+            "addOrRemove": "Add or remove players"
+        },
+        "identity": {
+            "label": "You",
+            "summary": "Playing as {player}",
+            "summaryUnset": "Identity not set",
+            "setSelf": "Set yourself",
+            "popoverTitle": "Who are you?",
+            "popoverHint": "Pick yourself to enable My Cards and refute hints. You can clear this anytime.",
+            "clearOption": "(not set)",
+            "noPlayersHint": "Add some players first."
+        },
+        "handSizes": {
+            "label": "Hand sizes",
+            "summary": "{total} cards dealt across all players",
+            "summaryPartial": "Hand sizes incomplete",
+            "summaryNoPlayers": "No players yet",
+            "editTitle": "Edit hand size for {player}",
+            "editAria": "Edit hand size for {player}",
+            "popoverTitle": "Hand size",
+            "popoverInputLabel": "{player}'s hand",
+            "save": "Save",
+            "cancel": "Cancel",
+            "mismatch": "Total dealt: {total} · expected {expected}"
+        },
+        "myCards": {
+            "label": "My cards",
+            "summary": "{count} {count, plural, one {card} other {cards}} marked",
+            "summaryEmpty": "No cards marked yet",
+            "edit": "Edit my cards"
+        },
+        "knownCards": {
+            "label": "Known other cards",
+            "summary": "{count} {count, plural, one {card} other {cards}} marked across other players",
+            "summaryEmpty": "No other-player cards marked",
+            "edit": "Edit known cards"
+        }
+    },
     "deduce": {
         "title": "Deduction grid",
         "caseFileProgress": "Case file · {percent}% solved",

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -864,3 +864,20 @@ export const setupSelfPlayerSet = (props: {
 export const setupFirstDealtPlayerSet = (props: {
     auto: boolean;
 }): void => capture("setup_first_dealt_player_set", props);
+
+// ── Setup summary (M7) ────────────────────────────────────────────────────
+// Read-at-a-glance summary panel that lives above the play-mode grid.
+// Inline popover edits cover small fields; "jump to wizard step" sends
+// the user back into the wizard with a focus hint.
+type SetupSummaryField =
+    | "playerName"
+    | "handSize"
+    | "selfPlayer";
+
+export const setupSummaryInlineEdit = (props: {
+    field: SetupSummaryField;
+}): void => capture("setup_summary_inline_edit", props);
+
+export const setupSummaryJumpedToWizard = (props: {
+    step: WizardStep;
+}): void => capture("setup_summary_jumped_to_wizard", props);

--- a/src/ui/components/PlayLayout.tsx
+++ b/src/ui/components/PlayLayout.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef } from "react";
 import { useIsDesktop } from "../hooks/useIsDesktop";
 import { T_STANDARD, useReducedTransition } from "../motion";
 import { Checklist } from "./Checklist";
+import { SetupSummary } from "./SetupSummary";
 import { SuggestionLogPanel } from "./SuggestionLogPanel";
 
 // Non user-facing literals.
@@ -53,7 +54,16 @@ const slideVariants: Variants = {
  */
 export function PlayLayout({ mode }: { readonly mode: PlayMode }) {
     const isDesktop = useIsDesktop();
-    return isDesktop ? <DesktopPlayLayout /> : <MobilePlayLayout mode={mode} />;
+    return (
+        <div className="flex min-w-0 flex-col gap-4">
+            <SetupSummary />
+            {isDesktop ? (
+                <DesktopPlayLayout />
+            ) : (
+                <MobilePlayLayout mode={mode} />
+            )}
+        </div>
+    );
 }
 
 function DesktopPlayLayout() {

--- a/src/ui/components/SetupSummary.test.tsx
+++ b/src/ui/components/SetupSummary.test.tsx
@@ -1,0 +1,252 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("next-intl", () => {
+    const useTranslations = (ns?: string) => {
+        const t = (key: string, values?: Record<string, unknown>): string => {
+            const full = ns ? `${ns}.${key}` : key;
+            return values ? `${full}:${JSON.stringify(values)}` : full;
+        };
+        (t as unknown as { rich: unknown }).rich = (key: string): string =>
+            ns ? `${ns}.${key}` : key;
+        return t;
+    };
+    return {
+        useTranslations,
+        useLocale: () => "en",
+    };
+});
+
+import { render, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Clue } from "../Clue";
+import { TestQueryClientProvider } from "../../test-utils/queryClient";
+import { seedOnboardingDismissed } from "../../test-utils/onboardingSeed";
+
+beforeEach(() => {
+    window.localStorage.clear();
+    seedOnboardingDismissed();
+    window.history.replaceState(null, "", "/?view=checklist");
+});
+
+const findSummary = (): HTMLElement | null =>
+    document.querySelector("[data-setup-summary]");
+
+const waitForSummary = async (): Promise<HTMLElement> => {
+    await waitFor(() => {
+        expect(findSummary()).toBeInTheDocument();
+    });
+    return findSummary() as HTMLElement;
+};
+
+describe("SetupSummary — visibility", () => {
+    test("mounts above the play layout in checklist mode", async () => {
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        await waitForSummary();
+    });
+
+    test("does NOT mount in setup mode (only in play mode)", async () => {
+        window.history.replaceState(null, "", "/?view=setup");
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        // Wait for setup wizard shell to render then ensure the
+        // summary panel is absent from the page.
+        await waitFor(() => {
+            expect(
+                document.querySelector('[data-tour-anchor="setup-wizard-shell"]'),
+            ).toBeInTheDocument();
+        });
+        expect(findSummary()).toBeNull();
+    });
+
+    test("hides the My cards row when selfPlayerId is null", async () => {
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        const summary = await waitForSummary();
+        expect(
+            within(summary).queryByText(/setupSummary\.myCards\.label/),
+        ).toBeNull();
+    });
+});
+
+describe("SetupSummary — rows", () => {
+    test("Card pack row shows category + card count for the default Classic deck", async () => {
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        const summary = await waitForSummary();
+        // Classic deck has 3 categories and 21 cards (6+6+9). The
+        // values get JSON-stringified by the test t() shim.
+        expect(
+            within(summary).getByText(
+                /setupSummary\.cardPack\.summary:\{"categories":3,"cards":21\}/,
+            ),
+        ).toBeInTheDocument();
+    });
+
+    test("Players row shows the count for the default 4-player preset", async () => {
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        const summary = await waitForSummary();
+        expect(
+            within(summary).getByText(
+                /setupSummary\.players\.summary:\{"count":4\}/,
+            ),
+        ).toBeInTheDocument();
+    });
+
+    test("Identity row reads as 'unset' on a fresh game", async () => {
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        const summary = await waitForSummary();
+        expect(
+            within(summary).getByText(/setupSummary\.identity\.summaryUnset/),
+        ).toBeInTheDocument();
+    });
+});
+
+describe("SetupSummary — collapse toggle", () => {
+    test("clicking the toggle hides the rows and persists to localStorage", async () => {
+        const user = userEvent.setup();
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        const summary = await waitForSummary();
+
+        // Rows are visible by default.
+        expect(
+            within(summary).getByText(/setupSummary\.cardPack\.label/),
+        ).toBeInTheDocument();
+
+        const toggle = within(summary).getByRole("button", {
+            name: /setupSummary\.toggleCollapse/,
+        });
+        await user.click(toggle);
+
+        await waitFor(() => {
+            expect(
+                within(summary).queryByText(/setupSummary\.cardPack\.label/),
+            ).toBeNull();
+        });
+        expect(
+            window.localStorage.getItem("effect-clue.setup-summary.collapsed.v1"),
+        ).toBe("1");
+    });
+});
+
+describe("SetupSummary — inline identity edit", () => {
+    test("clicking 'Set yourself' opens a popover with player options", async () => {
+        const user = userEvent.setup();
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        const summary = await waitForSummary();
+
+        const setSelf = within(summary).getByRole("button", {
+            name: /setupSummary\.identity\.setSelf/,
+        });
+        await user.click(setSelf);
+
+        // The Radix popover content is portaled — search at document
+        // scope. Player 1 from the default preset should appear as a
+        // radio.
+        await waitFor(() => {
+            const radios = document.querySelectorAll('[role="radio"]');
+            expect(radios.length).toBeGreaterThan(0);
+        });
+    });
+
+    test("picking a player updates the identity row summary", async () => {
+        const user = userEvent.setup();
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        const summary = await waitForSummary();
+
+        const setSelf = within(summary).getByRole("button", {
+            name: /setupSummary\.identity\.setSelf/,
+        });
+        await user.click(setSelf);
+
+        // Player 1 radio in the popover.
+        const player1Radio = await waitFor(() => {
+            const r = Array.from(
+                document.querySelectorAll('[role="radio"]'),
+            ).find(el => el.textContent === "Player 1");
+            if (!r) throw new Error("Player 1 radio not found");
+            return r as HTMLElement;
+        });
+        await user.click(player1Radio);
+
+        // Identity row summary should now be the "summary" key with
+        // Player 1 in the values payload (not summaryUnset).
+        await waitFor(() => {
+            expect(
+                within(summary).getByText(
+                    /setupSummary\.identity\.summary:\{"player":"Player 1"\}/,
+                ),
+            ).toBeInTheDocument();
+        });
+    });
+
+    test("setting identity reveals the My cards row", async () => {
+        const user = userEvent.setup();
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        const summary = await waitForSummary();
+
+        // Self is unset → no My cards row.
+        expect(
+            within(summary).queryByText(/setupSummary\.myCards\.label/),
+        ).toBeNull();
+
+        const setSelf = within(summary).getByRole("button", {
+            name: /setupSummary\.identity\.setSelf/,
+        });
+        await user.click(setSelf);
+
+        const player1Radio = await waitFor(() => {
+            const r = Array.from(
+                document.querySelectorAll('[role="radio"]'),
+            ).find(el => el.textContent === "Player 1");
+            if (!r) throw new Error("Player 1 radio not found");
+            return r as HTMLElement;
+        });
+        await user.click(player1Radio);
+
+        await waitFor(() => {
+            expect(
+                within(summary).getByText(/setupSummary\.myCards\.label/),
+            ).toBeInTheDocument();
+        });
+    });
+});
+
+describe("SetupSummary — jump to wizard", () => {
+    test("'Change deck' switches the UI to setup mode", async () => {
+        const user = userEvent.setup();
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        const summary = await waitForSummary();
+
+        const changeDeck = within(summary).getByRole("button", {
+            name: /setupSummary\.cardPack\.edit/,
+        });
+        await user.click(changeDeck);
+
+        // After dispatch, the wizard mounts. The summary may still
+        // briefly co-exist depending on AnimatePresence timing in
+        // jsdom; the contract under test is "wizard appears."
+        await waitFor(() => {
+            expect(
+                document.querySelector(
+                    '[data-tour-anchor="setup-wizard-shell"]',
+                ),
+            ).toBeInTheDocument();
+        });
+    });
+
+    test("'Add or remove' on the players row opens the wizard", async () => {
+        const user = userEvent.setup();
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        const summary = await waitForSummary();
+
+        const addOrRemove = within(summary).getByRole("button", {
+            name: /setupSummary\.players\.addOrRemove/,
+        });
+        await user.click(addOrRemove);
+
+        await waitFor(() => {
+            expect(
+                document.querySelector(
+                    '[data-tour-anchor="setup-wizard-shell"]',
+                ),
+            ).toBeInTheDocument();
+        });
+    });
+});

--- a/src/ui/components/SetupSummary.tsx
+++ b/src/ui/components/SetupSummary.tsx
@@ -1,0 +1,639 @@
+"use client";
+
+import * as RadixPopover from "@radix-ui/react-popover";
+import { useTranslations } from "next-intl";
+import { useId, useMemo, useRef, useState } from "react";
+import {
+    setupSelfPlayerSet,
+    setupSummaryInlineEdit,
+    setupSummaryJumpedToWizard,
+} from "../../analytics/events";
+import { allCardIds, caseFileSize } from "../../logic/CardSet";
+import {
+    disambiguateName,
+    type GameSetup,
+} from "../../logic/GameSetup";
+import { Player, type Player as PlayerId } from "../../logic/GameObjects";
+import { useClue } from "../state";
+import { useSetupWizardFocus } from "../setup/SetupWizardFocusContext";
+import type { WizardStepId } from "../setup/wizardSteps";
+
+// Module-scope discriminators: both the analytics field tag and the
+// WizardStepId values. Hoisted so the i18next/no-literal-string lint
+// treats them as identifiers, not user-facing copy.
+const FIELD_PLAYER_NAME = "playerName" as const;
+const FIELD_HAND_SIZE = "handSize" as const;
+const FIELD_SELF_PLAYER = "selfPlayer" as const;
+
+const STEP_CARD_PACK: WizardStepId = "cardPack";
+const STEP_PLAYERS: WizardStepId = "players";
+const STEP_MY_CARDS: WizardStepId = "myCards";
+const STEP_KNOWN_CARDS: WizardStepId = "knownCards";
+
+const STORAGE_KEY = "effect-clue.setup-summary.collapsed.v1";
+
+/**
+ * Read-at-a-glance summary of the current game's setup, mounted above
+ * the play-mode grid. Lets the user tweak small things inline (rename
+ * a player, fix a hand size, set themselves) without leaving the play
+ * view, and offers "jump to wizard step" buttons for structural
+ * changes (add/remove a player, swap the deck, edit my-cards).
+ *
+ * The component is intentionally compact: a heading + collapse toggle,
+ * one row per setup concern. Inline edits use Radix popovers anchored
+ * to the row's value/edit button. Jump buttons set a focus hint via
+ * `useSetupWizardFocus()` and dispatch `setUiMode("setup")`; the
+ * wizard reads the hint on mount and lands the user on the right
+ * step.
+ *
+ * Hides the "My cards" row entirely when `selfPlayerId === null` —
+ * per the M6 plan's 0i decision, identity-gated UI is hidden, not
+ * shown with apologetic empty-state copy. The identity row is still
+ * visible (and offers a "Set yourself" CTA) since it IS the
+ * discoverable path back to setting identity.
+ */
+export function SetupSummary() {
+    const t = useTranslations("setupSummary");
+    const { state } = useClue();
+    const [collapsed, setCollapsed] = useState<boolean>(() => {
+        if (typeof window === "undefined") return false;
+        try {
+            return window.localStorage.getItem(STORAGE_KEY) === "1";
+        } catch {
+            return false;
+        }
+    });
+
+    const toggle = () => {
+        setCollapsed(prev => {
+            const next = !prev;
+            try {
+                window.localStorage.setItem(STORAGE_KEY, next ? "1" : "0");
+            } catch {
+                // Quota / private mode — non-fatal.
+            }
+            return next;
+        });
+    };
+
+    const showMyCards = state.selfPlayerId !== null;
+
+    return (
+        <section
+            aria-label={t("heading")}
+            data-setup-summary=""
+            // contain-inline-size: stops the wrapped chip rows below
+            // from propagating their no-wrap intrinsic size up into
+            // `<main>`'s `min-w-max` sizing — same pattern as
+            // SuggestionLogPanel uses on its pill row (CLAUDE.md →
+            // "Mobile Suggest pane fits the viewport").
+            className="contain-inline-size rounded border border-border/40 bg-panel/60 px-3 py-2 text-[13px]"
+        >
+            <header className="flex items-center justify-between gap-2">
+                <h2 className="m-0 text-[14px] font-semibold tracking-tight">
+                    {t("heading")}
+                </h2>
+                <button
+                    type="button"
+                    className="cursor-pointer rounded border border-border bg-bg px-2 py-0.5 text-[12px] hover:bg-hover"
+                    aria-expanded={!collapsed}
+                    onClick={toggle}
+                >
+                    {collapsed ? t("toggleExpand") : t("toggleCollapse")}
+                </button>
+            </header>
+            {!collapsed && (
+                <ul className="m-0 mt-2 flex list-none flex-col gap-1 p-0">
+                    <CardPackRow />
+                    <PlayersRow />
+                    <IdentityRow />
+                    <HandSizesRow />
+                    {showMyCards && <MyCardsRow />}
+                    <KnownCardsRow />
+                </ul>
+            )}
+        </section>
+    );
+}
+
+/**
+ * Hook that wires a "jump to wizard step" click. Sets the focus hint
+ * (so the wizard expands the requested step on mount) and dispatches
+ * `setUiMode("setup")`. Falls back to a plain mode switch when the
+ * provider isn't available.
+ */
+function useJumpToWizardStep(): (step: WizardStepId) => void {
+    const { dispatch } = useClue();
+    const focus = useSetupWizardFocus();
+    return (step: WizardStepId) => {
+        focus?.setFocusOnNextMount(step);
+        setupSummaryJumpedToWizard({ step });
+        dispatch({ type: "setUiMode", mode: "setup" });
+    };
+}
+
+// ── Rows ────────────────────────────────────────────────────────────────
+
+function Row({
+    label,
+    children,
+}: {
+    readonly label: string;
+    readonly children: React.ReactNode;
+}) {
+    return (
+        <li className="flex min-w-0 flex-wrap items-center justify-between gap-x-3 gap-y-1 py-0.5">
+            <span className="shrink-0 text-[12px] uppercase tracking-wide text-muted">
+                {label}
+            </span>
+            <div className="flex min-w-0 flex-1 flex-wrap items-center justify-end gap-2">
+                {children}
+            </div>
+        </li>
+    );
+}
+
+function CardPackRow() {
+    const t = useTranslations("setupSummary.cardPack");
+    const jump = useJumpToWizardStep();
+    const { state } = useClue();
+    const setup = state.setup;
+    const cardCount = setup.categories.reduce(
+        (acc, c) => acc + c.cards.length,
+        0,
+    );
+    const summary =
+        setup.categories.length === 0
+            ? t("summaryEmpty")
+            : t("summary", {
+                  categories: setup.categories.length,
+                  cards: cardCount,
+              });
+
+    return (
+        <Row label={t("label")}>
+            <span className="truncate text-[13px]">{summary}</span>
+            <button
+                type="button"
+                className="cursor-pointer rounded border border-border bg-bg px-2 py-0.5 text-[12px] hover:bg-hover"
+                onClick={() => jump(STEP_CARD_PACK)}
+            >
+                {t("edit")}
+            </button>
+        </Row>
+    );
+}
+
+function PlayersRow() {
+    const t = useTranslations("setupSummary.players");
+    const jump = useJumpToWizardStep();
+    const { state } = useClue();
+    const players = state.setup.players;
+    const summary =
+        players.length === 0
+            ? t("summaryEmpty")
+            : t("summary", { count: players.length });
+
+    return (
+        <Row label={t("label")}>
+            <span className="text-[13px] text-muted">{summary}</span>
+            <ul className="m-0 flex list-none flex-wrap gap-1.5 p-0">
+                {players.map(player => (
+                    <li key={String(player)}>
+                        <PlayerNameChip player={player} />
+                    </li>
+                ))}
+            </ul>
+            <button
+                type="button"
+                className="shrink-0 cursor-pointer rounded border border-border bg-bg px-2 py-0.5 text-[12px] hover:bg-hover"
+                onClick={() => jump(STEP_PLAYERS)}
+            >
+                {t("addOrRemove")}
+            </button>
+        </Row>
+    );
+}
+
+/**
+ * One player's name rendered as a clickable chip. Clicking opens a
+ * Radix popover with a text input; submit dispatches `renamePlayer`
+ * with disambiguation against the other players' names.
+ */
+function PlayerNameChip({ player }: { readonly player: PlayerId }) {
+    const t = useTranslations("setupSummary.players");
+    const { state, dispatch } = useClue();
+    const inputRef = useRef<HTMLInputElement | null>(null);
+    const inputId = useId();
+
+    const [open, setOpen] = useState(false);
+    const [draft, setDraft] = useState<string>(String(player));
+
+    const onOpenChange = (next: boolean) => {
+        setOpen(next);
+        if (next) {
+            setDraft(String(player));
+        }
+    };
+
+    const submit = () => {
+        const trimmed = draft.trim();
+        if (trimmed.length === 0) {
+            setOpen(false);
+            return;
+        }
+        if (trimmed === String(player)) {
+            setOpen(false);
+            return;
+        }
+        const others = state.setup.players
+            .filter(p => p !== player)
+            .map(p => String(p));
+        const finalName = disambiguateName(trimmed, others);
+        const newName = Player(finalName);
+        dispatch({
+            type: "renamePlayer",
+            oldName: player,
+            newName,
+        });
+        setupSummaryInlineEdit({ field: FIELD_PLAYER_NAME });
+        setOpen(false);
+    };
+
+    return (
+        <RadixPopover.Root open={open} onOpenChange={onOpenChange}>
+            <RadixPopover.Trigger asChild>
+                <button
+                    type="button"
+                    className="cursor-pointer rounded-full border border-border bg-bg px-2.5 py-0.5 text-[12px] hover:bg-hover"
+                    aria-label={t("renameAria", { player: String(player) })}
+                    title={t("renameTitle", { player: String(player) })}
+                >
+                    {String(player)}
+                </button>
+            </RadixPopover.Trigger>
+            <RadixPopover.Portal>
+                <RadixPopover.Content
+                    side="bottom"
+                    align="start"
+                    sideOffset={6}
+                    collisionPadding={8}
+                    onOpenAutoFocus={e => {
+                        e.preventDefault();
+                        inputRef.current?.focus();
+                        inputRef.current?.select();
+                    }}
+                    className="z-[var(--z-popover)] w-[min(90vw,260px)] rounded-[var(--radius)] border border-border bg-panel p-2 shadow-[0_6px_16px_rgba(0,0,0,0.18)] focus:outline-none"
+                >
+                    <form
+                        className="flex flex-col gap-2"
+                        onSubmit={e => {
+                            e.preventDefault();
+                            submit();
+                        }}
+                    >
+                        <label
+                            htmlFor={inputId}
+                            className="text-[12px] text-muted"
+                        >
+                            {t("renameInputLabel")}
+                        </label>
+                        <input
+                            ref={inputRef}
+                            id={inputId}
+                            type="text"
+                            value={draft}
+                            onChange={e => setDraft(e.currentTarget.value)}
+                            className="w-full rounded border border-border bg-white px-2 py-1 text-[13px] focus:border-accent focus:outline-none"
+                        />
+                        <div className="flex items-center justify-end gap-2">
+                            <button
+                                type="button"
+                                onClick={() => setOpen(false)}
+                                className="cursor-pointer rounded border border-border bg-bg px-2 py-0.5 text-[12px] hover:bg-hover"
+                            >
+                                {t("renameCancel")}
+                            </button>
+                            <button
+                                type="submit"
+                                className="cursor-pointer rounded border-none bg-accent px-2 py-0.5 text-[12px] text-white hover:bg-accent-hover"
+                            >
+                                {t("renameSave")}
+                            </button>
+                        </div>
+                    </form>
+                </RadixPopover.Content>
+            </RadixPopover.Portal>
+        </RadixPopover.Root>
+    );
+}
+
+function IdentityRow() {
+    const t = useTranslations("setupSummary.identity");
+    const { state, dispatch } = useClue();
+    const players = state.setup.players;
+    const selfPlayer = state.selfPlayerId;
+    const inputRef = useRef<HTMLDivElement | null>(null);
+    const [open, setOpen] = useState(false);
+
+    const choose = (next: PlayerId | null) => {
+        dispatch({ type: "setSelfPlayer", player: next });
+        setupSelfPlayerSet({ cleared: next === null });
+        setupSummaryInlineEdit({ field: FIELD_SELF_PLAYER });
+        setOpen(false);
+    };
+
+    const summary =
+        selfPlayer === null
+            ? t("summaryUnset")
+            : t("summary", { player: String(selfPlayer) });
+
+    return (
+        <Row label={t("label")}>
+            <span className="text-[13px]">{summary}</span>
+            <RadixPopover.Root open={open} onOpenChange={setOpen}>
+                <RadixPopover.Trigger asChild>
+                    <button
+                        type="button"
+                        className="cursor-pointer rounded border border-border bg-bg px-2 py-0.5 text-[12px] hover:bg-hover"
+                    >
+                        {t("setSelf")}
+                    </button>
+                </RadixPopover.Trigger>
+                <RadixPopover.Portal>
+                    <RadixPopover.Content
+                        ref={inputRef}
+                        side="bottom"
+                        align="end"
+                        sideOffset={6}
+                        collisionPadding={8}
+                        className="z-[var(--z-popover)] w-[min(90vw,280px)] rounded-[var(--radius)] border border-border bg-panel p-3 shadow-[0_6px_16px_rgba(0,0,0,0.18)] focus:outline-none"
+                    >
+                        <div className="flex flex-col gap-2">
+                            <p className="m-0 text-[12px] text-muted">
+                                {t("popoverHint")}
+                            </p>
+                            {players.length === 0 ? (
+                                <p className="m-0 text-[13px] text-muted">
+                                    {t("noPlayersHint")}
+                                </p>
+                            ) : (
+                                <div
+                                    role="radiogroup"
+                                    aria-label={t("popoverTitle")}
+                                    className="flex flex-wrap gap-1.5"
+                                >
+                                    <button
+                                        type="button"
+                                        role="radio"
+                                        aria-checked={selfPlayer === null}
+                                        className={`cursor-pointer rounded-full border px-2.5 py-0.5 text-[12px] ${
+                                            selfPlayer === null
+                                                ? "border-accent bg-accent text-white hover:bg-accent-hover"
+                                                : "border-border bg-bg text-fg hover:bg-hover"
+                                        }`}
+                                        onClick={() => choose(null)}
+                                    >
+                                        {t("clearOption")}
+                                    </button>
+                                    {players.map(player => {
+                                        const active = selfPlayer === player;
+                                        return (
+                                            <button
+                                                key={String(player)}
+                                                type="button"
+                                                role="radio"
+                                                aria-checked={active}
+                                                className={`cursor-pointer rounded-full border px-2.5 py-0.5 text-[12px] ${
+                                                    active
+                                                        ? "border-accent bg-accent text-white hover:bg-accent-hover"
+                                                        : "border-border bg-bg text-fg hover:bg-hover"
+                                                }`}
+                                                onClick={() => choose(player)}
+                                            >
+                                                {String(player)}
+                                            </button>
+                                        );
+                                    })}
+                                </div>
+                            )}
+                        </div>
+                    </RadixPopover.Content>
+                </RadixPopover.Portal>
+            </RadixPopover.Root>
+        </Row>
+    );
+}
+
+function HandSizesRow() {
+    const t = useTranslations("setupSummary.handSizes");
+    const { state } = useClue();
+    const players = state.setup.players;
+    const handSizeMap = useMemo(
+        () => new Map(state.handSizes),
+        [state.handSizes],
+    );
+    const setSizes = players
+        .map(p => handSizeMap.get(p))
+        .filter((n): n is number => typeof n === "number");
+    const allSet = setSizes.length === players.length && players.length > 0;
+    const totalEntered = setSizes.reduce((a, b) => a + b, 0);
+    const expected = totalDealt(state.setup);
+
+    const summary = (() => {
+        if (players.length === 0) return t("summaryNoPlayers");
+        if (!allSet) return t("summaryPartial");
+        return t("summary", { total: totalEntered });
+    })();
+
+    const mismatch =
+        allSet && totalEntered !== expected ? (
+            <span className="text-[12px] text-warning">
+                {t("mismatch", { total: totalEntered, expected })}
+            </span>
+        ) : null;
+
+    return (
+        <Row label={t("label")}>
+            <span className="text-[13px]">{summary}</span>
+            {mismatch}
+            <ul className="m-0 flex list-none flex-wrap gap-1.5 p-0">
+                {players.map(player => (
+                    <li key={String(player)}>
+                        <HandSizeChip player={player} />
+                    </li>
+                ))}
+            </ul>
+        </Row>
+    );
+}
+
+function totalDealt(setup: GameSetup): number {
+    return allCardIds(setup).length - caseFileSize(setup);
+}
+
+function HandSizeChip({ player }: { readonly player: PlayerId }) {
+    const t = useTranslations("setupSummary.handSizes");
+    const { state, dispatch } = useClue();
+    const inputRef = useRef<HTMLInputElement | null>(null);
+    const inputId = useId();
+    const [open, setOpen] = useState(false);
+    const handSizeMap = useMemo(
+        () => new Map(state.handSizes),
+        [state.handSizes],
+    );
+    const current = handSizeMap.get(player);
+    const [draft, setDraft] = useState<string>(
+        current === undefined ? "" : String(current),
+    );
+
+    const onOpenChange = (next: boolean) => {
+        setOpen(next);
+        if (next) {
+            setDraft(current === undefined ? "" : String(current));
+        }
+    };
+
+    const submit = () => {
+        const trimmed = draft.trim();
+        if (trimmed === "") {
+            dispatch({ type: "setHandSize", player, size: undefined });
+            setupSummaryInlineEdit({ field: FIELD_HAND_SIZE });
+            setOpen(false);
+            return;
+        }
+        const n = Number(trimmed);
+        if (!Number.isFinite(n) || n < 0) {
+            return;
+        }
+        dispatch({ type: "setHandSize", player, size: n });
+        setupSummaryInlineEdit({ field: FIELD_HAND_SIZE });
+        setOpen(false);
+    };
+
+    const label =
+        current === undefined ? "—" : String(current);
+
+    return (
+        <RadixPopover.Root open={open} onOpenChange={onOpenChange}>
+            <RadixPopover.Trigger asChild>
+                <button
+                    type="button"
+                    className="cursor-pointer rounded-full border border-border bg-bg px-2 py-0.5 text-[12px] hover:bg-hover"
+                    aria-label={t("editAria", { player: String(player) })}
+                    title={t("editTitle", { player: String(player) })}
+                >
+                    {String(player)}: {label}
+                </button>
+            </RadixPopover.Trigger>
+            <RadixPopover.Portal>
+                <RadixPopover.Content
+                    side="bottom"
+                    align="end"
+                    sideOffset={6}
+                    collisionPadding={8}
+                    onOpenAutoFocus={e => {
+                        e.preventDefault();
+                        inputRef.current?.focus();
+                        inputRef.current?.select();
+                    }}
+                    className="z-[var(--z-popover)] w-[min(90vw,220px)] rounded-[var(--radius)] border border-border bg-panel p-2 shadow-[0_6px_16px_rgba(0,0,0,0.18)] focus:outline-none"
+                >
+                    <form
+                        className="flex flex-col gap-2"
+                        onSubmit={e => {
+                            e.preventDefault();
+                            submit();
+                        }}
+                    >
+                        <label
+                            htmlFor={inputId}
+                            className="text-[12px] text-muted"
+                        >
+                            {t("popoverInputLabel", { player: String(player) })}
+                        </label>
+                        <input
+                            ref={inputRef}
+                            id={inputId}
+                            type="number"
+                            min={0}
+                            value={draft}
+                            onChange={e => setDraft(e.currentTarget.value)}
+                            className="w-full rounded border border-border bg-white px-2 py-1 text-[13px] focus:border-accent focus:outline-none"
+                        />
+                        <div className="flex items-center justify-end gap-2">
+                            <button
+                                type="button"
+                                onClick={() => setOpen(false)}
+                                className="cursor-pointer rounded border border-border bg-bg px-2 py-0.5 text-[12px] hover:bg-hover"
+                            >
+                                {t("cancel")}
+                            </button>
+                            <button
+                                type="submit"
+                                className="cursor-pointer rounded border-none bg-accent px-2 py-0.5 text-[12px] text-white hover:bg-accent-hover"
+                            >
+                                {t("save")}
+                            </button>
+                        </div>
+                    </form>
+                </RadixPopover.Content>
+            </RadixPopover.Portal>
+        </RadixPopover.Root>
+    );
+}
+
+function MyCardsRow() {
+    const t = useTranslations("setupSummary.myCards");
+    const jump = useJumpToWizardStep();
+    const { state } = useClue();
+    const selfPlayer = state.selfPlayerId;
+    const myCount =
+        selfPlayer === null
+            ? 0
+            : state.knownCards.filter(kc => kc.player === selfPlayer).length;
+
+    const summary =
+        myCount === 0 ? t("summaryEmpty") : t("summary", { count: myCount });
+
+    return (
+        <Row label={t("label")}>
+            <span className="text-[13px]">{summary}</span>
+            <button
+                type="button"
+                className="cursor-pointer rounded border border-border bg-bg px-2 py-0.5 text-[12px] hover:bg-hover"
+                onClick={() => jump(STEP_MY_CARDS)}
+            >
+                {t("edit")}
+            </button>
+        </Row>
+    );
+}
+
+function KnownCardsRow() {
+    const t = useTranslations("setupSummary.knownCards");
+    const jump = useJumpToWizardStep();
+    const { state } = useClue();
+    const selfPlayer = state.selfPlayerId;
+    const otherCount = state.knownCards.filter(
+        kc => kc.player !== selfPlayer,
+    ).length;
+
+    const summary =
+        otherCount === 0
+            ? t("summaryEmpty")
+            : t("summary", { count: otherCount });
+
+    return (
+        <Row label={t("label")}>
+            <span className="text-[13px]">{summary}</span>
+            <button
+                type="button"
+                className="cursor-pointer rounded border border-border bg-bg px-2 py-0.5 text-[12px] hover:bg-hover"
+                onClick={() => jump(STEP_KNOWN_CARDS)}
+            >
+                {t("edit")}
+            </button>
+        </Row>
+    );
+}


### PR DESCRIPTION
## Summary
- New "Game setup" summary panel above the play view: read at a glance, edit small fields inline, jump back into the wizard for structural changes.
- Inline popovers cover rename-a-player, fix-a-hand-size, and set-yourself. The "My cards" row is hidden when identity isn't set (per M6 plan's 0i — gated UI is hidden, not shown with apologetic empty-state copy).
- Jump-to-wizard buttons reuse the `<SetupWizardFocusProvider>` scaffolded in M6 PR-A2 — a one-shot focus hint the wizard reads on mount; no separate "edit-one-step" mode.
- Hide/Show toggle persists per-device in localStorage.

## Test plan
- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm knip && pnpm i18n:check` all green (1303 tests, +12 new in `SetupSummary.test.tsx`)
- [x] Browser verification at desktop (1280×800) and mobile (375×812)
  - Renders above grid in both layouts; mobile Suggest pane still satisfies `body.scrollWidth === clientWidth` (added `contain-inline-size` on the section, mirroring `SuggestionLogPanel`)
  - Rename Player 1 → "Alice" inline; chips, hand-size labels, and Checklist column header all update
  - "Set yourself" popover opens with all 4 players + "(not set)" radio; selecting Alice updates the identity row and reveals the "My cards" row
  - Hide/Show toggle persists across reload
  - "Change deck" / "Add or remove" jumps to wizard with the right step expanded
- [x] `checklistSuggest` tour walked at both breakpoints — all popovers fully on-screen, no clipping, no console warnings

## Out of scope
- M8 — My cards panel + refute hint (depends on this groundwork but ships separately)
- M9 — Cell-popover sightings + Deductions overhaul

## Commits
- M7: setup summary panel in play mode — `<SetupSummary>` + 5 row sub-components, popover editors, focus-context wiring, 12 new tests, `setupSummary` i18n namespace, two new analytics events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)