### PR TITLE
M8: my cards panel + refute hint

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -200,6 +200,18 @@
             "paginator": "{current} of {total} · {player}"
         }
     },
+    "myHand": {
+        "title": "Your cards",
+        "empty": "Mark your cards in setup to see them here.",
+        "categoryLabel": "{category}:",
+        "toggleHide": "Hide my cards",
+        "toggleShow": "Show my cards"
+    },
+    "refuteHint": {
+        "canRefute": "You can refute with: {cards}",
+        "cannotRefute": "You can't refute this — none of your cards match.",
+        "join": ", "
+    },
     "deduce": {
         "title": "Deduction grid",
         "caseFileProgress": "Case file · {percent}% solved",

--- a/src/ui/components/MyHandPanel.test.tsx
+++ b/src/ui/components/MyHandPanel.test.tsx
@@ -1,0 +1,311 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("next-intl", () => {
+    const useTranslations = (ns?: string) => {
+        const t = (key: string, values?: Record<string, unknown>): string => {
+            const full = ns ? `${ns}.${key}` : key;
+            return values ? `${full}:${JSON.stringify(values)}` : full;
+        };
+        (t as unknown as { rich: unknown }).rich = (key: string): string =>
+            ns ? `${ns}.${key}` : key;
+        return t;
+    };
+    return {
+        useTranslations,
+        useLocale: () => "en",
+    };
+});
+
+import { render, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Clue } from "../Clue";
+import { TestQueryClientProvider } from "../../test-utils/queryClient";
+import { seedOnboardingDismissed } from "../../test-utils/onboardingSeed";
+
+beforeEach(() => {
+    window.localStorage.clear();
+    seedOnboardingDismissed();
+    window.history.replaceState(null, "", "/?view=checklist");
+});
+
+const findMyHand = (): HTMLElement | null =>
+    document.querySelector("[data-my-hand-panel]");
+
+describe("MyHandPanel — visibility", () => {
+    test("does NOT mount when selfPlayerId is null (default state)", async () => {
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        // Wait for play layout to mount
+        await waitFor(() => {
+            expect(document.getElementById("checklist")).toBeInTheDocument();
+        });
+        expect(findMyHand()).toBeNull();
+    });
+
+    test("does NOT mount when self is set but no cards are marked", async () => {
+        // Seed a session with selfPlayerId set but hands empty.
+        const session = {
+            version: 9,
+            setup: {
+                players: ["Alice", "Bob", "Cho"],
+                categories: [
+                    {
+                        id: "category-suspects",
+                        name: "Suspect",
+                        cards: [
+                            { id: "card-miss-scarlet", name: "Miss Scarlet" },
+                        ],
+                    },
+                ],
+            },
+            hands: [],
+            handSizes: [],
+            suggestions: [],
+            accusations: [],
+            hypotheses: [],
+            pendingSuggestion: null,
+            selfPlayerId: "Alice",
+            firstDealtPlayerId: null,
+        };
+        window.localStorage.setItem(
+            "effect-clue.session.v9",
+            JSON.stringify(session),
+        );
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        await waitFor(() => {
+            expect(document.getElementById("checklist")).toBeInTheDocument();
+        });
+        expect(findMyHand()).toBeNull();
+    });
+
+    test("mounts when self is set AND cards are marked", async () => {
+        const session = {
+            version: 9,
+            setup: {
+                players: ["Alice", "Bob", "Cho"],
+                categories: [
+                    {
+                        id: "category-suspects",
+                        name: "Suspect",
+                        cards: [
+                            { id: "card-miss-scarlet", name: "Miss Scarlet" },
+                            { id: "card-col-mustard", name: "Col. Mustard" },
+                        ],
+                    },
+                    {
+                        id: "category-weapons",
+                        name: "Weapon",
+                        cards: [
+                            { id: "card-knife", name: "Knife" },
+                        ],
+                    },
+                ],
+            },
+            hands: [
+                {
+                    player: "Alice",
+                    cards: ["card-miss-scarlet", "card-knife"],
+                },
+            ],
+            handSizes: [],
+            suggestions: [],
+            accusations: [],
+            hypotheses: [],
+            pendingSuggestion: null,
+            selfPlayerId: "Alice",
+            firstDealtPlayerId: null,
+        };
+        window.localStorage.setItem(
+            "effect-clue.session.v9",
+            JSON.stringify(session),
+        );
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        const panel = await waitFor(() => {
+            const found = findMyHand();
+            if (!found) throw new Error("panel not mounted");
+            return found;
+        });
+        // Both cards visible, grouped by category.
+        expect(panel.textContent).toContain("Miss Scarlet");
+        expect(panel.textContent).toContain("Knife");
+        expect(panel.textContent).toContain("Suspect");
+        expect(panel.textContent).toContain("Weapon");
+    });
+});
+
+describe("RefuteHint", () => {
+    const seedSessionWithDraft = (
+        suggestedCards: ReadonlyArray<string>,
+    ): void => {
+        const session = {
+            version: 9,
+            setup: {
+                players: ["Alice", "Bob"],
+                categories: [
+                    {
+                        id: "category-suspects",
+                        name: "Suspect",
+                        cards: [
+                            { id: "card-miss-scarlet", name: "Miss Scarlet" },
+                            { id: "card-col-mustard", name: "Col. Mustard" },
+                        ],
+                    },
+                    {
+                        id: "category-weapons",
+                        name: "Weapon",
+                        cards: [
+                            { id: "card-knife", name: "Knife" },
+                            { id: "card-rope", name: "Rope" },
+                        ],
+                    },
+                    {
+                        id: "category-rooms",
+                        name: "Room",
+                        cards: [
+                            { id: "card-library", name: "Library" },
+                            { id: "card-kitchen", name: "Kitchen" },
+                        ],
+                    },
+                ],
+            },
+            hands: [
+                {
+                    player: "Alice",
+                    cards: [
+                        "card-miss-scarlet",
+                        "card-knife",
+                        "card-library",
+                    ],
+                },
+            ],
+            handSizes: [],
+            suggestions: [],
+            accusations: [],
+            hypotheses: [],
+            pendingSuggestion: {
+                id: "draft-1",
+                suggester: "Bob",
+                cards: suggestedCards,
+                nonRefutersDecided: false,
+                nonRefutersIsNobody: false,
+                nonRefuters: [],
+                refuterDecided: false,
+                refuterIsNobody: false,
+                refuter: null,
+                seenCardDecided: false,
+                seenCardIsNobody: false,
+                seenCard: null,
+            },
+            selfPlayerId: "Alice",
+            firstDealtPlayerId: null,
+        };
+        window.localStorage.setItem(
+            "effect-clue.session.v9",
+            JSON.stringify(session),
+        );
+    };
+
+    test("hides when selfPlayerId is null", async () => {
+        // Default session has selfPlayerId === null.
+        window.history.replaceState(null, "", "/?view=suggest");
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        await waitFor(() => {
+            expect(
+                document.getElementById("prior-suggestions"),
+            ).toBeInTheDocument();
+        });
+        expect(document.querySelector("[data-refute-hint]")).toBeNull();
+    });
+
+    test("'You can refute with' lists intersection cards", async () => {
+        seedSessionWithDraft([
+            "card-miss-scarlet", // in hand
+            "card-rope", // not in hand
+            "card-library", // in hand
+        ]);
+        window.history.replaceState(null, "", "/?view=suggest");
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        const hint = await waitFor(() => {
+            const found = document.querySelector("[data-refute-hint]");
+            if (!found) throw new Error("hint not rendered");
+            return found;
+        });
+        expect(hint.textContent).toContain("Miss Scarlet");
+        expect(hint.textContent).toContain("Library");
+        expect(hint.textContent).not.toContain("Rope");
+    });
+
+    test("'You can't refute' shows when no cards intersect", async () => {
+        seedSessionWithDraft([
+            "card-col-mustard", // not in hand
+            "card-rope", // not in hand
+            "card-kitchen", // not in hand
+        ]);
+        window.history.replaceState(null, "", "/?view=suggest");
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        const hint = await waitFor(() => {
+            const found = document.querySelector("[data-refute-hint]");
+            if (!found) throw new Error("hint not rendered");
+            return found;
+        });
+        expect(hint.textContent).toContain("refuteHint.cannotRefute");
+    });
+});
+
+describe("MyHandPanel — collapse toggle", () => {
+    test("toggle hides the cards and persists to localStorage", async () => {
+        const session = {
+            version: 9,
+            setup: {
+                players: ["Alice", "Bob"],
+                categories: [
+                    {
+                        id: "category-suspects",
+                        name: "Suspect",
+                        cards: [
+                            { id: "card-miss-scarlet", name: "Miss Scarlet" },
+                        ],
+                    },
+                ],
+            },
+            hands: [
+                { player: "Alice", cards: ["card-miss-scarlet"] },
+            ],
+            handSizes: [],
+            suggestions: [],
+            accusations: [],
+            hypotheses: [],
+            pendingSuggestion: null,
+            selfPlayerId: "Alice",
+            firstDealtPlayerId: null,
+        };
+        window.localStorage.setItem(
+            "effect-clue.session.v9",
+            JSON.stringify(session),
+        );
+        const user = userEvent.setup();
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        const panel = await waitFor(() => {
+            const found = findMyHand();
+            if (!found) throw new Error("panel not mounted");
+            return found;
+        });
+
+        // Cards visible by default.
+        expect(panel.textContent).toContain("Miss Scarlet");
+
+        const hideBtn = Array.from(panel.querySelectorAll("button")).find(
+            b => b.textContent === "myHand.toggleHide",
+        );
+        if (!hideBtn) throw new Error("no hide button");
+        await user.click(hideBtn);
+
+        await waitFor(() => {
+            expect(panel.textContent).not.toContain("Miss Scarlet");
+        });
+        expect(
+            window.localStorage.getItem(
+                "effect-clue.my-hand-panel.collapsed.v1",
+            ),
+        ).toBe("1");
+    });
+});

--- a/src/ui/components/MyHandPanel.tsx
+++ b/src/ui/components/MyHandPanel.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useMemo, useState } from "react";
+import { cardName, categoryName } from "../../logic/CardSet";
+import type { Card, CardCategory } from "../../logic/GameObjects";
+import { useClue } from "../state";
+
+const STORAGE_KEY = "effect-clue.my-hand-panel.collapsed.v1";
+
+/**
+ * Persistent "your hand" affordance shown above the play layout when
+ * the user has identified themselves (`selfPlayerId !== null`) and
+ * has marked at least one card as their own. Renders nothing when
+ * either condition is false — per the M6 plan's 0i decision, gated
+ * UI is hidden, not shown with apologetic empty-state copy.
+ *
+ * Cards are grouped by category so the row reads as
+ * "Suspect: Miss Scarlet · Weapon: Knife · Room: Library" — that
+ * keeps the grouping cue users already learned in the checklist.
+ *
+ * Collapse toggle persists across reloads. The panel is intentionally
+ * compact (a single horizontal scroll-free strip with `flex-wrap`)
+ * so it doesn't fight the play view for vertical space.
+ */
+export function MyHandPanel() {
+    const t = useTranslations("myHand");
+    const { state } = useClue();
+    const [collapsed, setCollapsed] = useState<boolean>(() => {
+        if (typeof window === "undefined") return false;
+        try {
+            return window.localStorage.getItem(STORAGE_KEY) === "1";
+        } catch {
+            return false;
+        }
+    });
+
+    const selfPlayer = state.selfPlayerId;
+    const myCards = useMemo<ReadonlyArray<Card>>(() => {
+        if (selfPlayer === null) return [];
+        return state.knownCards
+            .filter(kc => kc.player === selfPlayer)
+            .map(kc => kc.card);
+    }, [state.knownCards, selfPlayer]);
+
+    // Grouped lookup: category id → category name + card names in that
+    // category that the user owns. Iterates the deck order so the
+    // grouping reads in canonical category order.
+    const grouped = useMemo(() => {
+        if (selfPlayer === null || myCards.length === 0) return [];
+        const myCardSet = new Set(myCards);
+        return state.setup.cardSet.categories
+            .map(category => ({
+                id: category.id as CardCategory,
+                label: categoryName(state.setup.cardSet, category.id),
+                cards: category.cards
+                    .filter(entry => myCardSet.has(entry.id))
+                    .map(entry => entry.name),
+            }))
+            .filter(g => g.cards.length > 0);
+    }, [state.setup.cardSet, myCards, selfPlayer]);
+
+    if (selfPlayer === null) return null;
+    if (myCards.length === 0) return null;
+
+    const toggle = () => {
+        setCollapsed(prev => {
+            const next = !prev;
+            try {
+                window.localStorage.setItem(STORAGE_KEY, next ? "1" : "0");
+            } catch {
+                // Quota / private mode — non-fatal.
+            }
+            return next;
+        });
+    };
+
+    return (
+        <section
+            aria-label={t("title")}
+            data-my-hand-panel=""
+            // contain-inline-size: stops the wrapped chip rows from
+            // propagating their no-wrap intrinsic size into
+            // `<main>`'s `min-w-max` calculation on mobile (mirrors
+            // SuggestionLogPanel's pill row pattern).
+            className="contain-inline-size rounded border border-border/40 bg-panel/60 px-3 py-2"
+        >
+            <header className="flex items-center justify-between gap-2">
+                <h2 className="m-0 text-[12px] font-semibold uppercase tracking-wide text-muted">
+                    {t("title")}
+                </h2>
+                <button
+                    type="button"
+                    className="cursor-pointer rounded border border-border bg-bg px-2 py-0.5 text-[12px] hover:bg-hover"
+                    aria-expanded={!collapsed}
+                    onClick={toggle}
+                >
+                    {collapsed ? t("toggleShow") : t("toggleHide")}
+                </button>
+            </header>
+            {!collapsed && (
+                <ul className="m-0 mt-1.5 flex list-none flex-wrap gap-x-3 gap-y-1 p-0">
+                    {grouped.map(group => (
+                        <li
+                            key={String(group.id)}
+                            className="flex items-baseline gap-1.5 text-[13px]"
+                        >
+                            <span className="font-semibold text-muted">
+                                {t("categoryLabel", { category: group.label })}
+                            </span>
+                            <span>{group.cards.join(", ")}</span>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </section>
+    );
+}
+
+/**
+ * Helper used by `RefuteHint` to derive the user's hand. Module-
+ * internal — no other consumer today, and exporting it would invite
+ * call-site drift. Returns the set of card ids in the current
+ * user's hand; empty when identity is unset or no cards are marked.
+ */
+function useMyCards(): ReadonlySet<Card> {
+    const { state } = useClue();
+    return useMemo(() => {
+        if (state.selfPlayerId === null) return new Set();
+        return new Set(
+            state.knownCards
+                .filter(kc => kc.player === state.selfPlayerId)
+                .map(kc => kc.card),
+        );
+    }, [state.knownCards, state.selfPlayerId]);
+}
+
+/**
+ * Inline hint shown beneath the "Add a suggestion" form when the
+ * three suggested cards are filled in. Tells the user whether they
+ * can refute (and with which cards) given their identified hand.
+ *
+ * Visibility rules per the M8 plan:
+ *   - Hidden when `selfPlayerId === null`.
+ *   - Hidden until all three suggested cards are filled in.
+ *   - Empty intersection → "You can't refute this."
+ *   - Non-empty intersection → "You can refute with: X, Y, or Z."
+ *
+ * Reads directly from `useClue` so the form (which is intentionally
+ * decoupled from the reducer — it dispatches via an `onSubmit`
+ * callback) doesn't have to take new props. The hint mounts as a
+ * sibling of the form inside `SuggestionLogPanel`'s AddForm wrapper.
+ */
+export function RefuteHint() {
+    const t = useTranslations("refuteHint");
+    const { state } = useClue();
+    const myCards = useMyCards();
+
+    if (state.selfPlayerId === null) return null;
+    const draft = state.pendingSuggestion;
+    if (draft === null) return null;
+    const filledCards = draft.cards.filter(
+        (c): c is Card => c !== null,
+    );
+    if (filledCards.length !== state.setup.cardSet.categories.length) {
+        return null;
+    }
+
+    const intersect = filledCards.filter(card => myCards.has(card));
+    const setup = state.setup;
+
+    if (intersect.length === 0) {
+        return (
+            <p
+                className="m-0 px-1 py-1 text-[12px] text-muted"
+                data-refute-hint=""
+            >
+                {t("cannotRefute")}
+            </p>
+        );
+    }
+
+    const names = intersect.map(card =>
+        cardName(setup.cardSet, card),
+    );
+    return (
+        <p
+            className="m-0 px-1 py-1 text-[12px] text-fg"
+            data-refute-hint=""
+        >
+            {t("canRefute", {
+                cards: names.join(t("join")),
+            })}
+        </p>
+    );
+}

--- a/src/ui/components/PlayLayout.tsx
+++ b/src/ui/components/PlayLayout.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef } from "react";
 import { useIsDesktop } from "../hooks/useIsDesktop";
 import { T_STANDARD, useReducedTransition } from "../motion";
 import { Checklist } from "./Checklist";
+import { MyHandPanel } from "./MyHandPanel";
 import { SuggestionLogPanel } from "./SuggestionLogPanel";
 
 // Non user-facing literals.
@@ -53,7 +54,16 @@ const slideVariants: Variants = {
  */
 export function PlayLayout({ mode }: { readonly mode: PlayMode }) {
     const isDesktop = useIsDesktop();
-    return isDesktop ? <DesktopPlayLayout /> : <MobilePlayLayout mode={mode} />;
+    return (
+        <div className="flex min-w-0 flex-col gap-3">
+            <MyHandPanel />
+            {isDesktop ? (
+                <DesktopPlayLayout />
+            ) : (
+                <MobilePlayLayout mode={mode} />
+            )}
+        </div>
+    );
 }
 
 function DesktopPlayLayout() {

--- a/src/ui/components/SuggestionLogPanel.tsx
+++ b/src/ui/components/SuggestionLogPanel.tsx
@@ -45,6 +45,7 @@ import { useSelection } from "../SelectionContext";
 import { TrashIcon, XIcon } from "./Icons";
 import { InfoPopover } from "./InfoPopover";
 import { AccusationForm, type AccusationFormHandle } from "./AccusationForm";
+import { RefuteHint } from "./MyHandPanel";
 import {
     SuggestionForm,
     type SuggestionFormHandle,
@@ -304,6 +305,7 @@ function AddSuggestion() {
                                 });
                             }}
                         />
+                        <RefuteHint />
                     </FormSlide>
                 ) : (
                     <FormSlide key="accusation" direction={1}>


### PR DESCRIPTION
## Summary
- Persistent "Your cards" strip above the play view: shows the user's hand grouped by category. Hidden when `selfPlayerId === null` or no cards are marked.
- Inline "You can refute with: X, Y" hint under the suggestion form; tells the user whether their hand intersects with the suggested triple. Empty intersection → "You can't refute this." Hidden when identity isn't set or until all 3 cards are filled.
- Both affordances read `useClue()` directly so the underlying `<SuggestionForm>` keeps its dispatch-via-callback shape.

## Test plan
- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm knip && pnpm i18n:check` all green (1298 tests, +7 new)
- [x] Browser verification at desktop (1280×800)
  - With Player 1 set as self + 3 cards marked: panel renders "Suspect: Miss Scarlet · Weapon: Knife · Room: Library"
  - Hide/Show toggle persists across reload
  - Suggestion with 2 of user's cards → "You can refute with: Miss Scarlet, Library" (Rope correctly excluded)
  - Suggestion with no overlap (Col. Mustard / Rope / Kitchen) → "You can't refute this — none of your cards match."

## Stacked on top of
- [#159](https://github.com/LetsGetIntoIt/effect-clue/pull/159) — M6 follow-ups (drag-to-reorder + save-as-pack)

Once #159 merges, please retarget this PR to `main`. M9 (cell-popover Observations section) will be opened next, stacked on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)