### PR TITLE
Dedupe custom card packs by id at every boundary

### DIFF
--- a/src/data/cardPacksSync.test.tsx
+++ b/src/data/cardPacksSync.test.tsx
@@ -206,4 +206,80 @@ describe("reconcileCardPacks", () => {
         expect(result.packs[0]?.unsyncedSince).toBeDefined();
         expect(result.packs[0]?.id).toBe("local-1");
     });
+
+    // The dedupe pass at the end of `reconcileCardPacks` exists because
+    // localStorage state was observed with multiple entries sharing one
+    // server-minted id (e.g. three packs all stamped
+    // `q7xao88qw0hobmp43aa5s0r8`, all labelled "Sync test (PENDING)").
+    // The server-side schema rules out the matching shape on disk
+    // (`card_packs.id` is `PRIMARY KEY`, `(owner_id, client_generated_id)`
+    // is `UNIQUE` — verified live), so the corruption is purely local.
+    // Phase 1 and Phase 3 both leak dupes from corrupt input; the
+    // collapse-to-first-occurrence step at the end is the chokepoint.
+    describe("dedupe — defensive against pre-corrupted local state", () => {
+        test("collapses local-only siblings sharing one id (Phase 3)", () => {
+            const result = reconcileCardPacks(
+                [
+                    localPack("dup-1", "Office", "Rope"),
+                    localPack("dup-1", "Office", "Pipe"),
+                    localPack("dup-1", "Office", "Knife"),
+                ],
+                [],
+            );
+            expect(result.packs).toHaveLength(1);
+            expect(result.packs[0]?.id).toBe("dup-1");
+            // First occurrence wins.
+            expect(
+                cardSetEquals(result.packs[0]!.cardSet, makeCardSet("Rope")),
+            ).toBe(true);
+        });
+
+        test("collapses Phase-1 siblings that all match one server pack", () => {
+            // Two locals with the same id both pair-match the server's
+            // `clientGeneratedId`. Without the dedupe, Phase 1 would
+            // emit two merged entries with `id: server-1`.
+            const result = reconcileCardPacks(
+                [
+                    localPack("client-1", "Office", "Rope"),
+                    localPack("client-1", "Office", "Pipe"),
+                ],
+                [serverPack("server-1", "client-1", "Office", "Rope")],
+            );
+            expect(result.packs).toHaveLength(1);
+            expect(result.packs[0]?.id).toBe("server-1");
+        });
+
+        test(
+            "collapses a Phase-1 server-paired entry against a stale " +
+                "Phase-3 sibling sharing the post-swap id",
+            () => {
+                // Real-world shape: localStorage has both the freshly-
+                // synced pack (id swapped to `server-1`) AND a stale
+                // sibling that still carries `server-1` from a prior
+                // sync round. Phase 1 pair-matches `client-1` and emits
+                // a server-paired entry first; Phase 3 then tries to
+                // pass through the stale sibling. Dedupe drops the
+                // sibling so the server-paired entry — the one with
+                // `lastSyncedSnapshot` populated — survives.
+                const result = reconcileCardPacks(
+                    [
+                        localPack("client-1", "Office", "Rope"),
+                        localPack("server-1", "Office (stale)", "Pipe"),
+                    ],
+                    [
+                        serverPack(
+                            "server-1",
+                            "client-1",
+                            "Office",
+                            "Rope",
+                        ),
+                    ],
+                );
+                expect(result.packs).toHaveLength(1);
+                expect(result.packs[0]?.id).toBe("server-1");
+                expect(result.packs[0]?.lastSyncedSnapshot).toBeDefined();
+                expect(result.packs[0]?.label).toBe("Office");
+            },
+        );
+    });
 });

--- a/src/data/cardPacksSync.tsx
+++ b/src/data/cardPacksSync.tsx
@@ -221,7 +221,46 @@ export const reconcileCardPacks = (
         merged.push(localPack);
     }
 
-    return { packs: merged, idMap, countPulled };
+    // Defensive dedupe — see comment block in `dedupePacksById` below.
+    return { packs: dedupePacksById(merged), idMap, countPulled };
+};
+
+/**
+ * Collapse the merged output to one entry per `id`, keeping the first
+ * occurrence. Stable: preserves input order.
+ *
+ * Why we apply dedupe at the merge output (not just inside each
+ * Phase): localStorage has been observed in the wild with multiple
+ * entries sharing one id (see the docblock on `dedupePacksById` in
+ * `src/logic/CustomCardSets.ts` for the full rationale and the
+ * read / write / reconcile triangulation). When the input is dirty:
+ *
+ *   - Phase 1's loop (client-id pair matches) doesn't `continue` when
+ *     `localPack.id` is already in `handledLocalIds`, so two local
+ *     packs sharing one id both push merged entries with the matching
+ *     server pack's id.
+ *   - Phase 3 (local-only passthrough) doesn't check whether a
+ *     `localPack.id` has already been emitted by an earlier iteration,
+ *     so corrupt sibling entries flow through untouched.
+ *
+ * Rather than chasing every Phase that could leak a dup, we collapse
+ * at the output. Phase 1's server-paired entries land in `merged`
+ * before Phase 3's stale local copies, so on collision the
+ * server-paired entry (with `lastSyncedSnapshot` populated) wins —
+ * which is the right answer for syncing back into the canonical
+ * library.
+ */
+const dedupePacksById = (
+    packs: ReadonlyArray<CustomCardSet>,
+): ReadonlyArray<CustomCardSet> => {
+    const seen = new Set<string>();
+    const out: Array<CustomCardSet> = [];
+    for (const pack of packs) {
+        if (seen.has(pack.id)) continue;
+        seen.add(pack.id);
+        out.push(pack);
+    }
+    return out;
 };
 
 // ── Server-snapshot application ─────────────────────────────────────────────

--- a/src/logic/CustomCardSets.test.ts
+++ b/src/logic/CustomCardSets.test.ts
@@ -70,6 +70,46 @@ describe("loadCustomCardSets", () => {
         );
         expect(loadCustomCardSets()).toEqual([]);
     });
+
+    // Read-side dedupe — see `dedupePacksById` in `CustomCardSets.ts`
+    // for the full backstory. The matching read of corrupt on-disk
+    // state must not produce duplicates, since `useCustomCardPacks`
+    // seeds React Query's `initialData` with `loadCustomCardSets()`
+    // and any duplicates would reach `<SetupStepCardPack>` on first
+    // render, before reconcile / writeAll can clean up.
+    test("dedupes by id when the on-disk blob has duplicate ids", () => {
+        const baseCategory = {
+            id: "cat-w",
+            name: "Weapon",
+            cards: [{ id: "card-knife", name: "Knife" }],
+        };
+        window.localStorage.setItem(
+            STORAGE_KEY,
+            JSON.stringify({
+                version: 1,
+                presets: [
+                    {
+                        id: "q7xao88qw0hobmp43aa5s0r8",
+                        label: "Sync test (PENDING)",
+                        categories: [baseCategory],
+                    },
+                    {
+                        id: "q7xao88qw0hobmp43aa5s0r8",
+                        label: "Sync test (PENDING)",
+                        categories: [baseCategory],
+                    },
+                    {
+                        id: "q7xao88qw0hobmp43aa5s0r8",
+                        label: "Sync test (PENDING)",
+                        categories: [baseCategory],
+                    },
+                ],
+            }),
+        );
+        const loaded = loadCustomCardSets();
+        expect(loaded).toHaveLength(1);
+        expect(loaded[0]?.id).toBe("q7xao88qw0hobmp43aa5s0r8");
+    });
 });
 
 describe("saveCustomCardSet + loadCustomCardSets", () => {
@@ -267,6 +307,57 @@ describe("replaceCustomCardSets metadata round-trip", () => {
             ),
         );
         expect(loaded[0]?.lastSyncedSnapshot?.label).toBe("Office");
+    });
+});
+
+// Belt-and-suspenders for the same dedupe invariant
+// `reconcileCardPacks` enforces in memory: localStorage state has
+// been observed with multiple entries sharing one server-minted id
+// (e.g. three rows all stamped `q7xao88qw0hobmp43aa5s0r8`,
+// "Sync test (PENDING)"), which the server-side schema rules out
+// (`card_packs.id` PK + `(owner_id, client_generated_id)` UNIQUE,
+// verified live). Provenance unclear; symptom is React's "Encountered
+// two children with the same key" warning in `<SetupStepCardPack>`'s
+// pill row + a silently-dropped pack. Cleaning up at the localStorage
+// write boundary means any path that flushes packs (reconcile,
+// markPackSynced, replaceCustomCardSets) self-heals the on-disk blob.
+describe("writeAll dedupe — collapses ids on persist", () => {
+    beforeEach(() => window.localStorage.clear());
+
+    test(
+        "replaceCustomCardSets keeps the first occurrence when ids collide",
+        () => {
+            replaceCustomCardSets([
+                {
+                    id: "server-1",
+                    label: "Office",
+                    cardSet: makePack(),
+                },
+                {
+                    id: "server-1",
+                    label: "Office (stale)",
+                    cardSet: makePack(),
+                },
+                {
+                    id: "server-1",
+                    label: "Office (stale 2)",
+                    cardSet: makePack(),
+                },
+            ]);
+            const loaded = loadCustomCardSets();
+            expect(loaded).toHaveLength(1);
+            expect(loaded[0]?.label).toBe("Office");
+        },
+    );
+
+    test("non-colliding ids round-trip unchanged", () => {
+        replaceCustomCardSets([
+            { id: "a", label: "A", cardSet: makePack() },
+            { id: "b", label: "B", cardSet: makePack() },
+            { id: "c", label: "C", cardSet: makePack() },
+        ]);
+        const loaded = loadCustomCardSets();
+        expect(loaded.map(p => p.id)).toEqual(["a", "b", "c"]);
     });
 });
 

--- a/src/logic/CustomCardSets.ts
+++ b/src/logic/CustomCardSets.ts
@@ -152,8 +152,60 @@ const encodePersistedCategories = (
     }));
 
 /**
+ * Collapse `packs` to one entry per `id`, preserving input order.
+ *
+ * Why this exists: localStorage state has been observed in the wild
+ * with multiple `CustomCardSet` entries sharing one server-minted id
+ * (e.g. three rows all stamped `q7xao88qw0hobmp43aa5s0r8`, all
+ * labelled "Sync test (PENDING)"). The server-side schema rules out
+ * a matching shape on disk (`card_packs.id` is `PRIMARY KEY`,
+ * `(owner_id, client_generated_id)` is `UNIQUE` — verified against
+ * a live DB with zero collisions), so the corruption is purely
+ * local. Provenance unclear; most likely a stale state from earlier
+ * code paths that have since been cleaned up plus possibly a
+ * hand-edit on the affected user's machine.
+ *
+ * The user-facing symptom is React's "Encountered two children with
+ * the same key" warning in `<SetupStepCardPack>`'s pill row (which
+ * keys on `pack.id`) and one of the duplicates silently disappearing
+ * from the rendered list — so users couldn't reliably select or
+ * delete the affected pack.
+ *
+ * The fix is applied at three boundaries to fully close the loop:
+ *
+ *   - Read (`loadCustomCardSets`): dedupes whatever's on disk
+ *     before returning, so even the very first render against a
+ *     corrupt blob doesn't trip React. `useCustomCardPacks` seeds its
+ *     React Query with `loadCustomCardSets()` as `initialData`, so
+ *     this is the only fix that catches the bug pre-reconcile.
+ *   - Write (`writeAll`): dedupes whatever's about to be persisted,
+ *     so any path that flushes packs (`saveCustomCardSet`,
+ *     `markPackSynced`, `replaceCustomCardSets`, …) self-heals the
+ *     on-disk blob.
+ *   - Reconcile (`reconcileCardPacks` in `src/data/cardPacksSync.tsx`):
+ *     dedupes the merged output of the local-vs-server merge, so
+ *     the in-memory shape we pass to `replaceCustomCardSets` and
+ *     `setQueryData` never has dupes either.
+ */
+const dedupePacksById = (
+    packs: ReadonlyArray<CustomCardSet>,
+): ReadonlyArray<CustomCardSet> => {
+    const seen = new Set<string>();
+    const out: Array<CustomCardSet> = [];
+    for (const pack of packs) {
+        if (seen.has(pack.id)) continue;
+        seen.add(pack.id);
+        out.push(pack);
+    }
+    return out;
+};
+
+/**
  * Read all user-saved card packs from localStorage. Returns an
  * empty array if the key is missing or the payload doesn't decode.
+ *
+ * Returned packs are deduped by id (see `dedupePacksById`) so the
+ * UI never sees collisions even if the on-disk blob is corrupt.
  */
 export const loadCustomCardSets = (): ReadonlyArray<CustomCardSet> => {
     if (typeof window === "undefined") return [];
@@ -162,22 +214,24 @@ export const loadCustomCardSets = (): ReadonlyArray<CustomCardSet> => {
         if (!raw) return [];
         const decoded = decodeUnknown(JSON.parse(raw));
         if (Result.isFailure(decoded)) return [];
-        return decoded.success.presets.map(p => ({
-            id: p.id,
-            label: p.label,
-            cardSet: decodePersistedCategories(p.categories),
-            unsyncedSince: p.unsyncedSince !== undefined
-                ? DateTime.makeUnsafe(p.unsyncedSince)
-                : undefined,
-            lastSyncedSnapshot: p.lastSyncedSnapshot !== undefined
-                ? {
-                    label: p.lastSyncedSnapshot.label,
-                    cardSet: decodePersistedCategories(
-                        p.lastSyncedSnapshot.categories,
-                    ),
-                }
-                : undefined,
-        }));
+        const decodedPacks: ReadonlyArray<CustomCardSet> =
+            decoded.success.presets.map(p => ({
+                id: p.id,
+                label: p.label,
+                cardSet: decodePersistedCategories(p.categories),
+                unsyncedSince: p.unsyncedSince !== undefined
+                    ? DateTime.makeUnsafe(p.unsyncedSince)
+                    : undefined,
+                lastSyncedSnapshot: p.lastSyncedSnapshot !== undefined
+                    ? {
+                        label: p.lastSyncedSnapshot.label,
+                        cardSet: decodePersistedCategories(
+                            p.lastSyncedSnapshot.categories,
+                        ),
+                    }
+                    : undefined,
+            }));
+        return dedupePacksById(decodedPacks);
     } catch {
         return [];
     }
@@ -186,9 +240,10 @@ export const loadCustomCardSets = (): ReadonlyArray<CustomCardSet> => {
 const writeAll = (packs: ReadonlyArray<CustomCardSet>): void => {
     if (typeof window === "undefined") return;
     try {
+        const deduped = dedupePacksById(packs);
         const encoded = encode({
             version: 1,
-            presets: packs.map(p => ({
+            presets: deduped.map(p => ({
                 id: p.id,
                 label: p.label,
                 categories: encodePersistedCategories(p.cardSet),


### PR DESCRIPTION
## Summary

Fixes a React warning on the Setup wizard where the **Pick a card pack** pill row could render multiple sibling pills sharing the same `id`. A user's localStorage was observed with three `CustomCardSet` entries all stamped `q7xao88qw0hobmp43aa5s0r8` (all labelled "Sync test (PENDING)") — React logged "Encountered two children with the same key" on every render and silently dropped one of the duplicates from the rendered list, so the user couldn't reliably select or delete the affected pack.

## What changes for the user

- The pill row no longer shows duplicate sibling pills sharing one `id`, even when localStorage is dirty from a hand-edit or stale state left behind by an earlier code path.
- Existing dirty state self-heals on the next reconcile pass (sign-in pull, focus refetch, reconnect refetch). No manual cleanup needed.

## Why the fix lives in three places

The server-side schema already rules out the matching shape on disk — `card_packs.id` is `PRIMARY KEY` and `(owner_id, client_generated_id)` is `UNIQUE`, both verified live (zero collisions in the affected user's row set). So the corruption is purely localStorage-side. The exact provenance isn't pinned down — most likely earlier-code-path leftovers and/or a hand-edit on the affected user's machine — so this PR doesn't try to chase the originating writer. Instead it adds idempotent dedupe at every boundary that touches the pack list:

| Boundary | File | Why |
|---|---|---|
| Read | `loadCustomCardSets` ([src/logic/CustomCardSets.ts](src/logic/CustomCardSets.ts)) | `useCustomCardPacks` seeds React Query's `initialData` with this. Without read-side dedupe, the very first render against a corrupt blob trips React before reconcile / writeAll can clean up. |
| Write | `writeAll` ([src/logic/CustomCardSets.ts](src/logic/CustomCardSets.ts)) | Every path that flushes packs (`saveCustomCardSet`, `markPackSynced`, `replaceCustomCardSets`, …) self-heals the on-disk blob on the next write. |
| Reconcile | `reconcileCardPacks` ([src/data/cardPacksSync.tsx](src/data/cardPacksSync.tsx)) | Phase 1 (client-id pair matches) and Phase 3 (local-only passthrough) both fail to skip already-emitted entries when the input already has duplicate ids, so without dedupe at the merge output a corrupt local list produces a corrupt merged list. Phase 1's server-paired entries land in `merged` before Phase 3's stale local copies, so on collision the server-paired entry (with `lastSyncedSnapshot` populated) wins — which is the right answer for syncing back into the canonical library. |

The shared helper is named `dedupePacksById` in both modules; the canonical docblock with the full backstory lives in `CustomCardSets.ts`.

## Test plan

- [x] `pnpm typecheck && pnpm lint && pnpm test && pnpm knip && pnpm i18n:check` all green (1309 tests, +6 new)
- [x] Manual verification in `next-dev` preview at desktop:
  - Seeded localStorage with three entries sharing the `q7xao88qw0hobmp43aa5s0r8` id, hard-reloaded `/play?view=setup`, expanded **Pick a card pack**.
  - Pill row rendered 7 unique pills (2 built-in + 5 custom). No React "Encountered two children with the same key" warning in the console.
  - Reconcile cleaned the seeded duplicates from localStorage on the first pull, as expected.

## Commits

- **Dedupe custom card packs by id at every boundary** — adds the shared `dedupePacksById` helper at the read, write, and reconcile boundaries, plus tests covering each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)