### PR TITLE
Drop pill tap-target sizes on desktop, keep them big for mobile

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -180,6 +180,80 @@
     --z-tour-popover: 90;
 }
 
+/*
+ * Responsive interactive sizing — tap-target tokens.
+ *
+ * Mobile defaults are sized for finger taps (44px primary, 36px
+ * compact). At the existing 800px mobile/desktop split (see
+ * `useIsMobile` in `src/ui/state.tsx` and the `[@media(min-width:
+ * 800px)]:` arbitrary classes throughout TSX), the same tokens
+ * shrink to pointer-friendly densities so buttons, pills, modal
+ * CTAs, and dropdown rows don't waste vertical space on desktop.
+ *
+ * Consumed via the `tap-target`, `tap-target-compact`, `tap-icon`,
+ * `text-tap`, and `text-tap-compact` utilities below — interactive
+ * components apply those classes and inherit the breakpoint-driven
+ * sizing automatically.
+ *
+ * Kept in `:root` rather than `@theme` for the same reason as the
+ * tour palette above: tokens consumed via `var()` rather than via
+ * generated utility names get tree-shaken by v4's scanner if they
+ * live in `@theme`. A plain `:root` block is always emitted.
+ */
+:root {
+    /* Standard tap target — primary buttons, form pills, modal CTAs. */
+    --tap-min: 44px;
+    --tap-pad-x: 16px;
+    --tap-pad-y: 10px;
+    --tap-text: 15px;
+
+    /* Compact target — secondary buttons, setup chips, dropdown rows. */
+    --tap-min-compact: 36px;
+    --tap-pad-x-compact: 12px;
+    --tap-pad-y-compact: 6px;
+    --tap-text-compact: 13px;
+
+    /* Icon-only square button — close X, info circles. */
+    --tap-icon: 44px;
+}
+
+@media (min-width: 800px) {
+    :root {
+        --tap-min: 32px;
+        --tap-pad-x: 12px;
+        --tap-pad-y: 6px;
+        --tap-text: 13px;
+
+        --tap-min-compact: 28px;
+        --tap-pad-x-compact: 10px;
+        --tap-pad-y-compact: 4px;
+        --tap-text-compact: 13px;
+
+        --tap-icon: 32px;
+    }
+}
+
+@utility tap-target {
+    min-height: var(--tap-min);
+    padding-inline: var(--tap-pad-x);
+    padding-block: var(--tap-pad-y);
+}
+@utility tap-target-compact {
+    min-height: var(--tap-min-compact);
+    padding-inline: var(--tap-pad-x-compact);
+    padding-block: var(--tap-pad-y-compact);
+}
+@utility tap-icon {
+    min-height: var(--tap-icon);
+    min-width: var(--tap-icon);
+}
+@utility text-tap {
+    font-size: var(--tap-text);
+}
+@utility text-tap-compact {
+    font-size: var(--tap-text-compact);
+}
+
 html,
 body {
     background: var(--color-bg);

--- a/src/ui/account/AccountModal.tsx
+++ b/src/ui/account/AccountModal.tsx
@@ -219,7 +219,7 @@ export function AccountModal({
                                 <button
                                     type="button"
                                     onClick={() => void onGoogleSignIn()}
-                                    className="mt-4 cursor-pointer rounded-[var(--radius)] border-2 border-accent bg-accent px-4 py-2 text-[14px] font-semibold text-white hover:bg-accent-hover"
+                                    className="tap-target text-tap mt-4 cursor-pointer rounded-[var(--radius)] border-2 border-accent bg-accent font-semibold text-white hover:bg-accent-hover"
                                 >
                                     {t("signInWithGoogle")}
                                 </button>

--- a/src/ui/account/DevSignInForm.tsx
+++ b/src/ui/account/DevSignInForm.tsx
@@ -84,7 +84,7 @@ export function DevSignInForm({ onSignedIn }: DevSignInFormProps) {
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
                     autoComplete="off"
-                    className="rounded border border-border bg-white px-2 py-1 text-[13px]"
+                    className="tap-target-compact text-tap-compact rounded border border-border bg-white"
                 />
             </label>
             {error !== null ? (
@@ -93,7 +93,7 @@ export function DevSignInForm({ onSignedIn }: DevSignInFormProps) {
             <button
                 type="submit"
                 disabled={submitting}
-                className="cursor-pointer rounded-[var(--radius)] border border-border bg-white px-3 py-1.5 text-[13px] hover:bg-hover disabled:cursor-not-allowed disabled:opacity-40"
+                className="tap-target-compact text-tap-compact cursor-pointer rounded-[var(--radius)] border border-border bg-white hover:bg-hover disabled:cursor-not-allowed disabled:opacity-40"
             >
                 {submitting ? "Signing in…" : "Sign in (dev only)"}
             </button>

--- a/src/ui/account/LogoutWarningModal.tsx
+++ b/src/ui/account/LogoutWarningModal.tsx
@@ -160,7 +160,7 @@ export function LogoutWarningModal({
                             <button
                                 type="button"
                                 onClick={onStay}
-                                className="cursor-pointer rounded-[var(--radius)] border border-border bg-transparent px-4 py-2 text-[13px] font-semibold text-[#2a1f12] hover:bg-hover"
+                                className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-transparent font-semibold text-[#2a1f12] hover:bg-hover"
                             >
                                 {t("stayLoggedIn")}
                             </button>
@@ -170,7 +170,7 @@ export function LogoutWarningModal({
                                 type="button"
                                 onClick={onRetry}
                                 disabled={retrying}
-                                className="cursor-pointer rounded-[var(--radius)] border border-border bg-panel px-4 py-2 text-[13px] font-semibold text-[#2a1f12] hover:bg-hover disabled:opacity-60"
+                                className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-panel font-semibold text-[#2a1f12] hover:bg-hover disabled:opacity-60"
                             >
                                 {retrying ? t("tryingAgain") : t("tryAgain")}
                             </button>
@@ -179,7 +179,7 @@ export function LogoutWarningModal({
                             <button
                                 type="button"
                                 onClick={onSignOutAnyway}
-                                className="cursor-pointer rounded-[var(--radius)] border border-accent bg-accent px-4 py-2 text-[13px] font-semibold text-white hover:bg-accent-hover"
+                                className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-accent bg-accent font-semibold text-white hover:bg-accent-hover"
                             >
                                 {t("signOutAnyway")}
                             </button>

--- a/src/ui/components/CardPackPicker.tsx
+++ b/src/ui/components/CardPackPicker.tsx
@@ -205,7 +205,7 @@ export function CardPackPicker({
                                 }}
                                 onKeyDown={onKeyDown}
                                 className={
-                                    "w-full rounded border border-border bg-white px-2 py-1 text-[13px] " +
+                                    "tap-target-compact text-tap-compact w-full rounded border border-border bg-white " +
                                     "focus:border-accent focus:outline-none"
                                 }
                             />
@@ -238,7 +238,7 @@ export function CardPackPicker({
                                                 isActiveMatch ? "true" : undefined
                                             }
                                             className={
-                                                "flex items-stretch justify-between rounded px-2 py-1.5 text-[13px] " +
+                                                "tap-target-compact text-tap-compact flex items-stretch justify-between rounded " +
                                                 (isHighlighted ? "bg-hover " : "") +
                                                 (isActiveMatch
                                                     ? "border-l-2 border-accent text-accent font-semibold"

--- a/src/ui/components/InstallPromptModal.tsx
+++ b/src/ui/components/InstallPromptModal.tsx
@@ -148,7 +148,7 @@ export function InstallPromptModal({
                             ref={notNowRef}
                             type="button"
                             onClick={handleSnooze}
-                            className="cursor-pointer rounded-[var(--radius)] border border-border bg-white px-4 py-2 text-[14px] hover:bg-hover"
+                            className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-white hover:bg-hover"
                         >
                             {t("notNow")}
                         </button>
@@ -156,8 +156,8 @@ export function InstallPromptModal({
                             type="button"
                             onClick={() => void handleInstall()}
                             className={
-                                "inline-flex cursor-pointer items-center gap-2 rounded-[var(--radius)] border-2 border-accent bg-accent " +
-                                "px-4 py-2 text-[14px] font-semibold text-white hover:bg-accent-hover"
+                                "tap-target text-tap inline-flex cursor-pointer items-center gap-2 rounded-[var(--radius)] border-2 border-accent bg-accent " +
+                                "font-semibold text-white hover:bg-accent-hover"
                             }
                         >
                             <span>{t("install")}</span>

--- a/src/ui/components/OverflowMenu.tsx
+++ b/src/ui/components/OverflowMenu.tsx
@@ -219,7 +219,7 @@ function MenuItem({
             onClick={onClick}
             disabled={disabled}
             className={
-                "flex w-full items-center justify-between gap-2 rounded-[var(--radius)] border-none bg-transparent px-3 py-2 text-left text-[13px] " +
+                "tap-target-compact text-tap-compact flex w-full items-center justify-between gap-2 rounded-[var(--radius)] border-none bg-transparent text-left " +
                 (disabled
                     ? "cursor-not-allowed opacity-40 text-inherit"
                     : "cursor-pointer hover:bg-hover " +

--- a/src/ui/components/PillForm.tsx
+++ b/src/ui/components/PillForm.tsx
@@ -316,7 +316,7 @@ export const PillForm = forwardRef<PillFormHandle, PillFormProps>(
                 clearInputsLabel !== undefined);
 
         const submitButtonClass =
-            "min-h-[44px] rounded border-none px-4 py-2.5 text-[15px] " +
+            "tap-target text-tap rounded border-none " +
             (canSubmit
                 ? "cursor-pointer bg-accent text-white"
                 : "cursor-not-allowed bg-unknown-bg text-muted/70");
@@ -333,7 +333,7 @@ export const PillForm = forwardRef<PillFormHandle, PillFormProps>(
                                     type="button"
                                     aria-label={clearInputsLabel}
                                     onClick={onClearInputs}
-                                    className="inline-flex min-h-[44px] min-w-[44px] cursor-pointer items-center justify-center rounded border-none bg-transparent text-muted hover:text-accent"
+                                    className="tap-icon inline-flex cursor-pointer items-center justify-center rounded border-none bg-transparent text-muted hover:text-accent"
                                 >
                                     <XIcon size={18} />
                                 </button>
@@ -376,7 +376,7 @@ export const PillForm = forwardRef<PillFormHandle, PillFormProps>(
                     {onCancel !== undefined && (
                         <button
                             type="button"
-                            className="min-h-[44px] cursor-pointer rounded border border-border bg-white px-4 py-2.5 text-[15px]"
+                            className="tap-target text-tap cursor-pointer rounded border border-border bg-white"
                             onClick={onCancel}
                         >
                             {cancelLabel ?? null}

--- a/src/ui/components/StaleGameModal.tsx
+++ b/src/ui/components/StaleGameModal.tsx
@@ -171,7 +171,7 @@ export function StaleGameModal({
                             ref={keepWorkingRef}
                             type="button"
                             onClick={onKeepWorking}
-                            className="cursor-pointer rounded-[var(--radius)] border border-border bg-white px-4 py-2 text-[14px] hover:bg-hover"
+                            className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-white hover:bg-hover"
                         >
                             {t("keepWorking")}
                         </button>
@@ -179,8 +179,8 @@ export function StaleGameModal({
                             type="button"
                             onClick={onSetupNewGame}
                             className={
-                                "inline-flex cursor-pointer items-center gap-2 rounded-[var(--radius)] border-2 border-accent bg-accent "
-                                + "px-4 py-2 text-[14px] font-semibold text-white hover:bg-accent-hover"
+                                "tap-target text-tap inline-flex cursor-pointer items-center gap-2 rounded-[var(--radius)] border-2 border-accent bg-accent "
+                                + "font-semibold text-white hover:bg-accent-hover"
                             }
                         >
                             <span>{t("setupNew")}</span>

--- a/src/ui/components/SuggestionLogPanel.tsx
+++ b/src/ui/components/SuggestionLogPanel.tsx
@@ -798,7 +798,7 @@ function LogAccusationButton({
         <button
             type="button"
             title={tRecs("accuseNowLogTitle")}
-            className="cursor-pointer rounded border border-accent bg-transparent px-3 py-1 text-[13px] text-accent hover:bg-accent hover:text-white"
+            className="tap-target-compact text-tap-compact cursor-pointer rounded border border-accent bg-transparent text-accent hover:bg-accent hover:text-white"
             onClick={() => {
                 dispatch({
                     type: "addAccusation",
@@ -1706,7 +1706,7 @@ function PriorSuggestionItem({
                                         e.stopPropagation();
                                         enterEdit();
                                     }}
-                                    className="min-h-[44px] cursor-pointer rounded-[var(--radius)] border border-accent bg-transparent px-4 py-2 text-[13px] font-semibold text-accent"
+                                    className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-accent bg-transparent font-semibold text-accent"
                                 >
                                     {t("editAction")}
                                 </button>
@@ -1729,7 +1729,7 @@ function PriorSuggestionItem({
                         exitEdit();
                         refocusRow();
                     }}
-                    className="absolute right-1 top-1 inline-flex min-h-[44px] min-w-[44px] cursor-pointer items-center justify-center rounded border-none bg-transparent text-muted hover:text-accent"
+                    className="tap-icon absolute right-1 top-1 inline-flex cursor-pointer items-center justify-center rounded border-none bg-transparent text-muted hover:text-accent"
                 >
                     <XIcon size={18} />
                 </button>
@@ -1738,7 +1738,7 @@ function PriorSuggestionItem({
                     <button
                         type="button"
                         aria-label={t("removeAction")}
-                        className="absolute right-1 top-1 inline-flex min-h-[44px] min-w-[44px] cursor-pointer items-center justify-center rounded border-none bg-transparent text-muted hover:text-accent"
+                        className="tap-icon absolute right-1 top-1 inline-flex cursor-pointer items-center justify-center rounded border-none bg-transparent text-muted hover:text-accent"
                         onClick={e => {
                             e.stopPropagation();
                             void onRemove();
@@ -2036,7 +2036,7 @@ function PriorAccusationItem({
                                         e.stopPropagation();
                                         enterEdit();
                                     }}
-                                    className="min-h-[44px] cursor-pointer rounded-[var(--radius)] border border-accent bg-transparent px-4 py-2 text-[13px] font-semibold text-accent"
+                                    className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-accent bg-transparent font-semibold text-accent"
                                 >
                                     {t("editAction")}
                                 </button>
@@ -2059,7 +2059,7 @@ function PriorAccusationItem({
                         exitEdit();
                         refocusRow();
                     }}
-                    className="absolute right-1 top-1 inline-flex min-h-[44px] min-w-[44px] cursor-pointer items-center justify-center rounded border-none bg-transparent text-muted hover:text-accent"
+                    className="tap-icon absolute right-1 top-1 inline-flex cursor-pointer items-center justify-center rounded border-none bg-transparent text-muted hover:text-accent"
                 >
                     <XIcon size={18} />
                 </button>
@@ -2068,7 +2068,7 @@ function PriorAccusationItem({
                     <button
                         type="button"
                         aria-label={t("removeAction")}
-                        className="absolute right-1 top-1 inline-flex min-h-[44px] min-w-[44px] cursor-pointer items-center justify-center rounded border-none bg-transparent text-muted hover:text-accent"
+                        className="tap-icon absolute right-1 top-1 inline-flex cursor-pointer items-center justify-center rounded border-none bg-transparent text-muted hover:text-accent"
                         onClick={e => {
                             e.stopPropagation();
                             void onRemove();

--- a/src/ui/components/SuggestionPills.tsx
+++ b/src/ui/components/SuggestionPills.tsx
@@ -230,7 +230,7 @@ export function PillPopover({
             layout
             transition={widthTransition}
             className={
-                "inline-flex min-h-[44px] items-center gap-1.5 rounded-full border px-4 py-2.5 text-[15px] " +
+                "tap-target text-tap inline-flex items-center gap-1.5 rounded-full border " +
                 tone
             }
         >
@@ -529,7 +529,7 @@ export function SingleSelectList<T>({
                         role="option"
                         aria-selected={isSelected}
                         className={
-                            "flex min-h-[44px] cursor-pointer items-center gap-1.5 rounded px-3 py-2.5 text-[15px]" +
+                            "tap-target text-tap flex cursor-pointer items-center gap-1.5 rounded" +
                             (highlighted ? " bg-accent/15" : "") +
                             (row.kind === "nobody"
                                 ? " border-b border-border/60 text-muted"
@@ -706,7 +706,7 @@ export function MultiSelectList({
                     role="option"
                     aria-selected={nobodyChosen}
                     className={
-                        "flex min-h-[44px] cursor-pointer items-center gap-1.5 rounded border-b border-border/60 px-3 py-2.5 text-[15px] text-muted" +
+                        "tap-target text-tap flex cursor-pointer items-center gap-1.5 rounded border-b border-border/60 text-muted" +
                         (focusedIdx === 0 ? " bg-accent/15" : "")
                     }
                     onMouseEnter={() => setFocusedIdx(0)}
@@ -728,7 +728,7 @@ export function MultiSelectList({
                             role="option"
                             aria-selected={checked}
                             className={
-                                "flex min-h-[44px] cursor-pointer items-center gap-1.5 rounded px-3 py-2.5 text-[15px]" +
+                                "tap-target text-tap flex cursor-pointer items-center gap-1.5 rounded" +
                                 (highlighted ? " bg-accent/15" : "")
                             }
                             onMouseEnter={() => setFocusedIdx(rowIdx)}

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -29,8 +29,8 @@ import { Tooltip } from "./Tooltip";
 const TRIGGER_MENU: InstallPromptTrigger = "menu";
 
 const buttonClass =
-    "rounded-[var(--radius)] border border-border bg-white px-3.5 py-1.5 " +
-    "text-[13px] cursor-pointer hover:bg-hover " +
+    "tap-target-compact text-tap-compact rounded-[var(--radius)] border border-border bg-white " +
+    "cursor-pointer hover:bg-hover " +
     "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent " +
     "focus-visible:ring-offset-1 focus-visible:ring-offset-bg";
 

--- a/src/ui/hooks/useConfirm.tsx
+++ b/src/ui/hooks/useConfirm.tsx
@@ -95,7 +95,7 @@ export function ConfirmProvider({ children }: { readonly children: ReactNode }) 
                             <AlertDialog.Cancel asChild>
                                 <button
                                     type="button"
-                                    className="cursor-pointer rounded-[var(--radius)] border border-border bg-transparent px-4 py-2 text-[13px] font-semibold text-[#2a1f12] hover:bg-hover"
+                                    className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-transparent font-semibold text-[#2a1f12] hover:bg-hover"
                                 >
                                     {cancelLabel}
                                 </button>
@@ -105,7 +105,7 @@ export function ConfirmProvider({ children }: { readonly children: ReactNode }) 
                                     type="button"
                                     onClick={() => close(true)}
                                     className={
-                                        "cursor-pointer rounded-[var(--radius)] border px-4 py-2 text-[13px] font-semibold " +
+                                        "tap-target text-tap cursor-pointer rounded-[var(--radius)] border font-semibold " +
                                         (destructive
                                             ? "border-accent bg-accent text-white hover:bg-accent-hover"
                                             : "border-border bg-panel text-[#2a1f12] hover:bg-hover")

--- a/src/ui/hooks/usePrompt.tsx
+++ b/src/ui/hooks/usePrompt.tsx
@@ -123,14 +123,14 @@ export function PromptProvider({ children }: { readonly children: ReactNode }) {
                                     onChange={(e) => setValue(e.target.value)}
                                     placeholder={pending?.placeholder}
                                     maxLength={pending?.maxLength}
-                                    className="mt-1 block w-full min-h-[44px] rounded-[var(--radius)] border border-border bg-white px-3 py-2 text-[14px] text-[#2a1f12] focus:border-accent focus:outline-none"
+                                    className="tap-target text-tap mt-1 block w-full rounded-[var(--radius)] border border-border bg-white text-[#2a1f12] focus:border-accent focus:outline-none"
                                 />
                             </label>
                             <div className="mt-5 flex flex-wrap justify-end gap-2">
                                 <AlertDialog.Cancel asChild>
                                     <button
                                         type="button"
-                                        className="cursor-pointer rounded-[var(--radius)] border border-border bg-transparent px-4 py-2 text-[13px] font-semibold text-[#2a1f12] hover:bg-hover"
+                                        className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-transparent font-semibold text-[#2a1f12] hover:bg-hover"
                                     >
                                         {cancelLabel}
                                     </button>
@@ -139,7 +139,7 @@ export function PromptProvider({ children }: { readonly children: ReactNode }) {
                                     type="submit"
                                     disabled={!canSubmit}
                                     className={
-                                        "cursor-pointer rounded-[var(--radius)] border border-accent bg-accent px-4 py-2 text-[13px] font-semibold text-white hover:bg-accent-hover " +
+                                        "tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-accent bg-accent font-semibold text-white hover:bg-accent-hover " +
                                         "disabled:cursor-not-allowed disabled:border-border disabled:bg-row-alt disabled:text-muted disabled:hover:bg-row-alt"
                                     }
                                 >

--- a/src/ui/setup/SetupWizard.tsx
+++ b/src/ui/setup/SetupWizard.tsx
@@ -470,7 +470,7 @@ export function SetupWizard() {
         >
             <button
                 type="button"
-                className="shrink-0 cursor-pointer rounded border border-border bg-bg px-3 py-1.5 text-[13px] hover:bg-hover"
+                className="tap-target-compact text-tap-compact shrink-0 cursor-pointer rounded border border-border bg-bg hover:bg-hover"
                 onClick={onStartOver}
             >
                 {t("newGame")}
@@ -478,7 +478,7 @@ export function SetupWizard() {
             <div className="ml-auto flex items-center gap-2">
                 <button
                     type="button"
-                    className="cursor-pointer rounded border border-border bg-bg px-3 py-1.5 text-[13px] hover:bg-hover disabled:cursor-not-allowed disabled:opacity-50"
+                    className="tap-target-compact text-tap-compact cursor-pointer rounded border border-border bg-bg hover:bg-hover disabled:cursor-not-allowed disabled:opacity-50"
                     onClick={onClickSkip}
                     disabled={!skipEnabled}
                 >
@@ -486,7 +486,7 @@ export function SetupWizard() {
                 </button>
                 <button
                     type="button"
-                    className="cursor-pointer rounded border-none bg-accent px-4 py-2 text-[14px] font-semibold text-white hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
+                    className="tap-target text-tap cursor-pointer rounded border-none bg-accent font-semibold text-white hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
                     onClick={onClickNext}
                     disabled={!nextEnabled}
                     data-tour-anchor={

--- a/src/ui/setup/shared/PlayerListReorder.tsx
+++ b/src/ui/setup/shared/PlayerListReorder.tsx
@@ -139,7 +139,7 @@ export function PlayerListReorder() {
 
             <button
                 type="button"
-                className="self-start cursor-pointer rounded border border-border bg-bg px-3 py-1.5 text-[13px] hover:bg-hover"
+                className="tap-target-compact text-tap-compact self-start cursor-pointer rounded border border-border bg-bg hover:bg-hover"
                 onClick={() => dispatch({ type: "addPlayer" })}
             >
                 {tSetup("addPlayerLabel")}

--- a/src/ui/setup/steps/SetupStepCardPack.tsx
+++ b/src/ui/setup/steps/SetupStepCardPack.tsx
@@ -383,7 +383,7 @@ export function SetupStepCardPack({
                                 <button
                                     type="button"
                                     className={
-                                        "cursor-pointer rounded-full border px-3 py-1.5 text-[13px] transition-colors duration-200 ease-out " +
+                                        "tap-target-compact text-tap-compact cursor-pointer rounded-full border transition-colors duration-200 ease-out " +
                                         (isActive
                                             ? "border-accent bg-accent font-semibold text-white"
                                             : "border-border bg-bg hover:bg-hover")
@@ -421,7 +421,7 @@ export function SetupStepCardPack({
                     >
                         <button
                             type="button"
-                            className="cursor-pointer rounded-full border border-border bg-bg px-3 py-1.5 text-[13px] hover:bg-hover"
+                            className="tap-target-compact text-tap-compact cursor-pointer rounded-full border border-border bg-bg hover:bg-hover"
                         >
                             {t("allCardPacks")}
                         </button>
@@ -432,7 +432,7 @@ export function SetupStepCardPack({
             <div className="flex flex-col gap-2">
                 <button
                     type="button"
-                    className="self-start cursor-pointer rounded border border-border bg-bg px-3 py-1.5 text-[13px] hover:bg-hover"
+                    className="tap-target-compact text-tap-compact self-start cursor-pointer rounded border border-border bg-bg hover:bg-hover"
                     onClick={() => setShowCustomize(prev => !prev)}
                     aria-expanded={showCustomize}
                 >

--- a/src/ui/setup/steps/SetupStepCardPackCustomize.tsx
+++ b/src/ui/setup/steps/SetupStepCardPackCustomize.tsx
@@ -189,7 +189,7 @@ export function SetupStepCardPackCustomize({
 
             <button
                 type="button"
-                className="self-start cursor-pointer rounded border border-border bg-bg px-2 py-1 text-[12px] hover:bg-hover"
+                className="tap-target-compact text-tap-compact self-start cursor-pointer rounded border border-border bg-bg hover:bg-hover"
                 onClick={() => dispatch({ type: "addCategory" })}
             >
                 {t("addCategory")}
@@ -198,7 +198,7 @@ export function SetupStepCardPackCustomize({
             <div className="flex flex-wrap items-center gap-2 border-t border-border/30 pt-3">
                 <button
                     type="button"
-                    className="cursor-pointer rounded border border-border bg-bg px-3 py-1.5 text-[13px] hover:bg-hover"
+                    className="tap-target-compact text-tap-compact cursor-pointer rounded border border-border bg-bg hover:bg-hover"
                     onClick={saveAsNewPack}
                 >
                     {t("saveAsNewPack")}
@@ -206,7 +206,7 @@ export function SetupStepCardPackCustomize({
                 {loadedCustomPack !== null && (
                     <button
                         type="button"
-                        className="cursor-pointer rounded border-none bg-accent px-3 py-1.5 text-[13px] text-white hover:bg-accent-hover"
+                        className="tap-target-compact text-tap-compact cursor-pointer rounded border-none bg-accent text-white hover:bg-accent-hover"
                         onClick={updateLoadedPack}
                     >
                         {t("updatePack", { label: loadedCustomPack.label })}

--- a/src/ui/setup/steps/SetupStepIdentity.tsx
+++ b/src/ui/setup/steps/SetupStepIdentity.tsx
@@ -105,7 +105,7 @@ export function SetupStepIdentity({
                             <button
                                 key={String(player)}
                                 type="button"
-                                className={`cursor-pointer rounded-full border px-3 py-1.5 text-[13px] transition-colors ${
+                                className={`tap-target-compact text-tap-compact cursor-pointer rounded-full border transition-colors ${
                                     active
                                         ? "border-accent bg-accent text-white hover:bg-accent-hover"
                                         : "border-border bg-bg text-fg hover:bg-hover"

--- a/src/ui/share/ShareCreateModal.tsx
+++ b/src/ui/share/ShareCreateModal.tsx
@@ -1029,7 +1029,7 @@ export function ShareCreateModal({
                                         <button
                                             type="button"
                                             onClick={() => void onGoogleSignIn()}
-                                            className="cursor-pointer rounded-[var(--radius)] border-2 border-accent bg-accent px-4 py-2 text-[14px] font-semibold text-white hover:bg-accent-hover"
+                                            className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border-2 border-accent bg-accent font-semibold text-white hover:bg-accent-hover"
                                         >
                                             {tAccount("signInWithGoogle")}
                                         </button>
@@ -1046,7 +1046,7 @@ export function ShareCreateModal({
                             <button
                                 type="button"
                                 onClick={goBackToToggles}
-                                className="mr-auto cursor-pointer rounded-[var(--radius)] border border-border bg-white px-4 py-2 text-[14px] hover:bg-hover"
+                                className="tap-target text-tap mr-auto cursor-pointer rounded-[var(--radius)] border border-border bg-white hover:bg-hover"
                             >
                                 {tCommon("back")}
                             </button>
@@ -1054,7 +1054,7 @@ export function ShareCreateModal({
                         <button
                             type="button"
                             onClick={close}
-                            className="cursor-pointer rounded-[var(--radius)] border border-border bg-white px-4 py-2 text-[14px] hover:bg-hover"
+                            className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-white hover:bg-hover"
                         >
                             {tCommon("cancel")}
                         </button>
@@ -1063,7 +1063,7 @@ export function ShareCreateModal({
                                 type="button"
                                 onClick={() => void onCreate()}
                                 disabled={submitting}
-                                className="cursor-pointer rounded-[var(--radius)] border-2 border-accent bg-accent px-4 py-2 text-[14px] font-semibold text-white hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-40"
+                                className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border-2 border-accent bg-accent font-semibold text-white hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-40"
                                 data-share-cta
                             >
                                 {ctaLabel}

--- a/src/ui/share/ShareImportPage.tsx
+++ b/src/ui/share/ShareImportPage.tsx
@@ -608,7 +608,7 @@ export function ShareImportPage({
                             <button
                                 type="button"
                                 onClick={() => close(VIA_X)}
-                                className="cursor-pointer rounded-[var(--radius)] border border-border bg-white px-4 py-2 text-[14px] hover:bg-hover"
+                                className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-white hover:bg-hover"
                             >
                                 {tCommon("cancel")}
                             </button>
@@ -617,7 +617,7 @@ export function ShareImportPage({
                                 onClick={() => void onImport()}
                                 disabled={submitting || isEmpty}
                                 data-share-import-cta
-                                className="cursor-pointer rounded-[var(--radius)] border-2 border-accent bg-accent px-4 py-2 text-[14px] font-semibold text-white hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-40"
+                                className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border-2 border-accent bg-accent font-semibold text-white hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-40"
                             >
                                 {submitting
                                     ? t("importing")

--- a/src/ui/share/ShareMissingPage.tsx
+++ b/src/ui/share/ShareMissingPage.tsx
@@ -66,7 +66,7 @@ export function ShareMissingPage({
                             <button
                                 type="button"
                                 onClick={() => router.push(target)}
-                                className="cursor-pointer rounded-[var(--radius)] border-2 border-accent bg-accent px-4 py-2 text-[14px] font-semibold text-white hover:bg-accent-hover"
+                                className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border-2 border-accent bg-accent font-semibold text-white hover:bg-accent-hover"
                                 data-share-missing-cta
                             >
                                 {actionLabel}

--- a/src/ui/tour/TourPopover.tsx
+++ b/src/ui/tour/TourPopover.tsx
@@ -802,7 +802,7 @@ export function TourPopover() {
                                     type="button"
                                     onClick={() => prevStep()}
                                     disabled={stepIndex === 0}
-                                    className="cursor-pointer rounded-[var(--tour-radius)] border border-[var(--color-tour-border)] bg-white px-3 py-1.5 text-[13px] text-[var(--color-tour-accent)] hover:bg-[var(--color-tour-bg-hover)] disabled:cursor-not-allowed disabled:opacity-40"
+                                    className="tap-target-compact text-tap-compact cursor-pointer rounded-[var(--tour-radius)] border border-[var(--color-tour-border)] bg-white text-[var(--color-tour-accent)] hover:bg-[var(--color-tour-bg-hover)] disabled:cursor-not-allowed disabled:opacity-40"
                                 >
                                     {t("back")}
                                 </button>
@@ -810,7 +810,7 @@ export function TourPopover() {
                                     ref={nextButtonRef}
                                     type="button"
                                     onClick={() => nextStep()}
-                                    className="cursor-pointer rounded-[var(--tour-radius)] border-2 border-[var(--color-tour-accent)] bg-[var(--color-tour-accent)] px-3 py-1.5 text-[13px] font-semibold text-white hover:bg-[var(--color-tour-accent-hover)]"
+                                    className="tap-target-compact text-tap-compact cursor-pointer rounded-[var(--tour-radius)] border-2 border-[var(--color-tour-accent)] bg-[var(--color-tour-accent)] font-semibold text-white hover:bg-[var(--color-tour-accent-hover)]"
                                 >
                                     {isLastStep ? t(finishKey) : t("next")}
                                 </button>


### PR DESCRIPTION
## Summary

Pills, modal buttons, setup chips, and toolbar buttons now scale by viewport — finger-friendly 44px on mobile, tighter 32px on desktop — via CSS spacing variables that flip at the existing 800px breakpoint. The biggest visible change is the suggestion form pill row: pills used to be a constant ~44px tall at every viewport, now they shrink to 32px on desktop while keeping 44px on mobile, freeing vertical space in the side panel without sacrificing tap reliability.

Side benefit: consolidates an inconsistency baseline. Buttons previously drifted across `py-1.5` / `py-2` / `py-2.5` / `py-3.5` with text sizes ranging 13/14/15/18px and inconsistent `min-h-[44px]` usage. They now share the same tokens with one source of truth.

## How it works

A new family of `--tap-*` CSS custom properties in `:root` defines mobile sizes; `@media (min-width: 800px) { :root { … } }` overrides them with tighter desktop values. Five Tailwind v4 `@utility` declarations (`tap-target`, `tap-target-compact`, `tap-icon`, `text-tap`, `text-tap-compact`) wire those tokens into single-class utilities. Components opt in by adding the utility class; the breakpoint-driven sizing follows automatically without per-component media queries.

Composition is intentionally narrow — `tap-target` owns only `min-height` + `padding-inline` + `padding-block`. `gap`, `border`, `border-radius`, color, and shape stay at the call site because they vary by content. `text-tap` is a separate one-property utility so callers can override font-size independently.

Tokens live in `:root` rather than `@theme` to dodge Tailwind v4's tree-shaking of var()-only-consumed tokens (the same trap that the tour palette block already documents).

## Migration scope

**`tap-target` + `text-tap` (primary):** SuggestionPills body + popover lists, PillForm submit/cancel, useConfirm, usePrompt, InstallPromptModal, StaleGameModal, AccountModal sign-in, LogoutWarningModal, ShareCreateModal, ShareImportPage, ShareMissingPage, SuggestionLogPanel mobile Edit pill, SetupWizard "Next".

**`tap-target-compact` + `text-tap-compact` (secondary):** Toolbar, OverflowMenu items, SetupWizard Skip / Start over, SetupStepCardPack pills + Customize toggle, SetupStepIdentity player pills, SetupStepCardPackCustomize buttons, PlayerListReorder, CardPackPicker rows + search, DevSignInForm, TourPopover Back/Next, AccuseNow log button.

**`tap-icon` (square icon-only):** PillForm clear-X, SuggestionLogPanel close/trash X buttons.

**Left bespoke (intentional):** Checklist cells (grid-driven), BottomNav (mobile-only by design), SplashModal hero CTA (one-off weight), InfoPopover info circles (visual flow concern; sub-44px deliberate), TourPopover close X (compact to match popover), CardPackPicker/AccountModal inline action icons (share row height via self-stretch).

## Verification

- All five pre-commit checks green: typecheck / lint / test (1296 passed) / knip / i18n:check.
- Manual verification at 1280×800 and 375×812 in the `next-dev` preview: pill row, modals, wizard footer, toolbar, dropdown rows render at expected sizes; resizing across the 800px breakpoint flips smoothly.
- Inspected `getComputedStyle` on a `tap-target` pill: 32×12×6px (desktop) / 44×16×10px (mobile) — variables resolve correctly through `@utility`.
- No tests assert on the changed spacing classes (verified by grep), so the suite stayed green without test edits.

## Known pre-existing issue (not caused by this refactor)

The `setup` tour's first step (anchor: `setup-wizard-shell`) renders its popover off-screen at the top, both before and after this refactor — the wizard accordion is too tall (~700px) to fit a popover above or below at the available viewport heights. Confirmed by stashing the tour-popover change and re-testing — the off-screen position is unchanged. Tracked separately for a follow-up that points the popover at a smaller anchor (e.g. just the wizard intro title).

## Commit log

- `Add --tap-* tokens and tap-target / tap-icon / text-tap utilities` — design system foundation only; no component changes. Lands in its own commit so a future bisect against a visual regression can split "infrastructure landing" from "components migrated".
- `Migrate interactive elements to responsive tap-target sizing` — sweeping migration of 22 files. Mechanical: `min-h-[44px] px-4 py-2.5 text-[15px]` → `tap-target text-tap`; `px-3 py-1.5 text-[13px]` → `tap-target-compact text-tap-compact`; `min-h-[44px] min-w-[44px]` → `tap-icon`. Layout, color, border, and shape classes preserved at call sites.

## Test plan

- [ ] Pre-commit green-check set passes (typecheck, lint, test, knip, i18n:check).
- [ ] Suggest pane on desktop (≥800px): pills are visibly tighter than before, no longer waste vertical space in the side panel.
- [ ] Suggest pane on mobile (<800px): pills are 44px tap-friendly; row wraps cleanly; submit button height matches pills.
- [ ] Confirm modal (e.g. delete a custom card pack): buttons are proportionally sized, not chunky on desktop.
- [ ] Setup wizard at desktop and mobile: card-pack pills scale; Next/Skip/Start over button row consistent.
- [ ] Resize a window across 800px while a modal is open: no layout jump.
- [ ] Force a contradiction; banner appears; sticky header positions still correct.
- [ ] `checklistSuggest` tour Back/Next buttons render at the compact size and stay tappable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)