### PR TITLE
Stop sticky first column from chopping cell-detail row content

### DIFF
--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -1056,7 +1056,8 @@ export function Checklist() {
                                         className="relative z-[var(--z-checklist-explain-row)]"
                                     >
                                         <td
-                                            className={`${STICKY_FIRST_COL} bg-panel border-b border-border p-0`}
+                                            // z-0 (not `--z-checklist-sticky-column`) so the sibling td's popup paints on top during horizontal scroll — this cell is intentionally empty.
+                                            className="sticky left-0 z-0 bg-panel border-b border-border p-0"
                                             data-tour-sticky-left=""
                                         />
                                         <td


### PR DESCRIPTION
When the checklist is wider than the viewport and the user scrolls
horizontally with a cell-detail row open, the row's empty sticky-left
first td (at `--z-checklist-sticky-column`, z-30) sat above its sibling
content td (at the row's own z-22), masking ~80px of the popup body —
"DEDUCTIONS" rendered as "TIONS", "HYPOTHESIS" as "ESIS", etc.

Drop that one td to z-0. The cell is intentionally empty (just
`bg-panel`), so it has no content to keep above the popup, and the
sibling now paints on top in document order during horizontal scroll.
The body sticky-column z-index ladder is unchanged everywhere else.