### PR TITLE
Mobile: same-row cell tap opens new cell directly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -210,7 +210,7 @@ Resize the preview between viewports as you go — many of these regress on one 
 
 - Tap-to-dismiss on the parchment outside the open cell + explanation row works.
 - Touch-scrolling anywhere on the page does NOT dismiss the row. The dismissal effect listens for `click` (not `pointerdown`); a `click` only fires after a tap that didn't move significantly, so a drag/scroll never produces one. If you change the listener back to `pointerdown` to "fix" some other problem, scrolling the page with the row open will dismiss it again — that's the regression to avoid.
-- Tapping a different cell while one is open closes the old row and opens the new one (capture-phase outer + bubble-phase cell `onClick`, batched together so React lands on the new cell). On touch, the existing two-tap protocol still applies: tapping a different cell closes the open row but doesn't open the new one until the second tap.
+- Tapping a different cell while one is open closes the old row and opens the new one (capture-phase outer + bubble-phase cell `onClick`, batched together so React lands on the new cell). On touch, the two-tap protocol applies for CROSS-ROW navigation only: tapping a cell on a different row (different `card`) closes the open row but doesn't open the new one until the second tap. Tapping a cell in the SAME ROW as the open one (same `card`, different owner column) opens the new cell directly with a single tap — the row is already in context, so the second-tap dismiss gate would be pure friction.
 
 **Open-cell outline + related-cell highlight (`Checklist.tsx` + `globals.css`):**
 

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -1504,17 +1504,46 @@ export function Checklist() {
                                                         ) {
                                                             // Tap on a
                                                             // different cell
-                                                            // while a row
-                                                            // is open →
-                                                            // close. Browser
-                                                            // focus moves to
-                                                            // thisCell during
-                                                            // the click; the
-                                                            // next tap is the
-                                                            // second tap that
+                                                            // while a row is
+                                                            // open.
+                                                            //
+                                                            // SAME-ROW shortcut:
+                                                            // if the new cell
+                                                            // shares the open
+                                                            // cell's card
+                                                            // (same row in the
+                                                            // grid), treat the
+                                                            // tap as a direct
+                                                            // cell-swap. The
+                                                            // explanation row
+                                                            // is already open
+                                                            // on this row;
+                                                            // dismissing only
+                                                            // to require a
+                                                            // second tap on
+                                                            // the next column
+                                                            // is friction
+                                                            // without payoff.
+                                                            //
+                                                            // DIFFERENT-ROW:
+                                                            // close the open
+                                                            // row and let
+                                                            // browser focus
+                                                            // move to thisCell
+                                                            // during the
+                                                            // click; the next
+                                                            // tap is the
+                                                            // second tap of
+                                                            // the two-tap
+                                                            // protocol that
                                                             // opens it.
+                                                            const sameRow =
+                                                                popoverCellRef.current.card ===
+                                                                thisCell.card;
                                                             setExpandedCell(
-                                                                null,
+                                                                sameRow
+                                                                    ? thisCell
+                                                                    : null,
                                                             );
                                                             return;
                                                         }


### PR DESCRIPTION
## Summary

On touch devices, tapping a different cell while an explanation row is already open now opens the new cell directly *if* it's in the same row (same card, different owner column). Cross-row taps keep the existing two-tap behavior — the first tap dismisses the open row, the second tap opens the new cell.

**Why**: when the user is already focused on a row's explanation, swapping to another column on that row is a tight, contextual action — needing a dismiss + second tap is friction without payoff. Cross-row navigation legitimately deserves the dismiss-as-confirmation step.

Mouse and keyboard paths are unchanged — they already single-action toggle to whatever cell is clicked, regardless of row.

## Implementation

In the cell's `onClick` in `Checklist.tsx`, the touch-protocol branch for "tap on a different cell while a row is open" now checks `popoverCellRef.current.card === thisCell.card`. If same row, `setExpandedCell(thisCell)`; otherwise `setExpandedCell(null)` (existing close behavior). The capture-phase outside-click handler still fires `setExpandedCell(null)` ahead of the cell's onClick; React batches the two setState calls so the net result is `thisCell` for same-row and `null` for cross-row.

`AGENTS.md`'s "Cell-explanation row dismissal" note is rewritten in place to reflect the new same-row shortcut.

## Test plan

- [x] `pnpm typecheck` ✓
- [x] `pnpm lint` ✓
- [x] `pnpm test` — 1315 / 1315 ✓
- [x] `pnpm knip` ✓
- [x] `pnpm i18n:check` ✓
- [ ] Mobile (375×812) browser walkthrough:
  - Open Player 1 / Miss Scarlet's cell. Tap Player 2 / Miss Scarlet (same row). The explanation panel should switch to Player 2 / Miss Scarlet without an intermediate dismiss.
  - Open Player 1 / Miss Scarlet's cell. Tap Player 1 / Col. Mustard (different row). The explanation panel should dismiss; tap Player 1 / Col. Mustard again to open it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)