### PR TITLE
Label deduction chain steps as Known observation or Hypothesis

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -259,8 +259,9 @@
     "reasons": {
         "suggestionHeadline": "Suggestion #{number}",
         "initial-known-card": {
-            "headline": "Given",
-            "detail": "You marked that {cellPlayer} {value, select, Y {owns} other {doesn't own}} {cellCard}."
+            "headlineObservation": "{count, plural, one {Known observation} other {Known observations}}",
+            "headlineHypothesis": "{count, plural, one {Hypothesis} other {Hypotheses}}",
+            "detail": "You marked that {cellPlayer} {value, select, Y {owns} other {doesn't own}} {cardList}."
         },
         "initial-hand-size": {
             "headline": "Given",

--- a/src/logic/Provenance.test.ts
+++ b/src/logic/Provenance.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from "vitest";
-import { MutableHashMap, Result } from "effect";
+import { HashMap, MutableHashMap, Result } from "effect";
 import { CLASSIC_SETUP_3P } from "./GameSetup";
 import { CaseFileOwner, Player, PlayerOwner } from "./GameObjects";
 import { Cell, emptyKnowledge, N, setCell, setHandSize, Y } from "./Knowledge";
+import { KnownCard } from "./InitialKnowledge";
 import {
     CardOwnership,
     CaseFileCategory,
@@ -11,6 +12,7 @@ import {
     DisjointGroupsHandLock,
     FailedAccusation,
     FailedAccusationPairwiseNarrowing,
+    InitialKnownCard,
     NonRefuters,
     PlayerHand,
     type Provenance,
@@ -236,6 +238,63 @@ const baseReason = (
 
 describe("describeReason", () => {
     const cell = Cell(PlayerOwner(A), KNIFE);
+
+    test("InitialKnownCard with cell in knownCards → source: observation", () => {
+        const desc = describeReason(
+            baseReason(InitialKnownCard()),
+            cell,
+            setup,
+            [],
+            [],
+            [KnownCard({ player: A, card: KNIFE })],
+            HashMap.empty(),
+        );
+        expect(desc.kind).toBe("initial-known-card");
+        if (desc.kind !== "initial-known-card") throw new Error("unreachable");
+        expect(desc.params.source).toBe("observation");
+    });
+
+    test("InitialKnownCard with cell in hypotheses → source: hypothesis", () => {
+        const desc = describeReason(
+            baseReason(InitialKnownCard(), N),
+            cell,
+            setup,
+            [],
+            [],
+            [],
+            HashMap.fromIterable([[cell, N] as const]),
+        );
+        if (desc.kind !== "initial-known-card") throw new Error("unreachable");
+        expect(desc.params.source).toBe("hypothesis");
+    });
+
+    test("InitialKnownCard in both → hypothesis wins (foldHypothesesInto overwrites)", () => {
+        const desc = describeReason(
+            baseReason(InitialKnownCard()),
+            cell,
+            setup,
+            [],
+            [],
+            [KnownCard({ player: A, card: KNIFE })],
+            HashMap.fromIterable([[cell, Y] as const]),
+        );
+        if (desc.kind !== "initial-known-card") throw new Error("unreachable");
+        expect(desc.params.source).toBe("hypothesis");
+    });
+
+    test("InitialKnownCard with no matching sources → defaults to observation", () => {
+        const desc = describeReason(
+            baseReason(InitialKnownCard()),
+            cell,
+            setup,
+            [],
+            [],
+            [],
+            HashMap.empty(),
+        );
+        if (desc.kind !== "initial-known-card") throw new Error("unreachable");
+        expect(desc.params.source).toBe("observation");
+    });
 
     test("CardOwnership → `card-ownership` with resolved card name", () => {
         const desc = describeReason(

--- a/src/logic/Provenance.ts
+++ b/src/logic/Provenance.ts
@@ -13,6 +13,8 @@ import {
 } from "./GameSetup";
 import { Accusation, accusationCards } from "./Accusation";
 import { Suggestion, suggestionCards } from "./Suggestion";
+import { KnownCard } from "./InitialKnowledge";
+import type { HypothesisMap } from "./Hypothesis";
 import {
     getAccusations,
     getCardSet,
@@ -91,7 +93,7 @@ export type ReasonKind =
     | FailedAccusationImpl
     | FailedAccusationPairwiseNarrowingImpl;
 
-const InitialKnownCard = (): ReasonKind => new InitialKnownCardImpl();
+export const InitialKnownCard = (): ReasonKind => new InitialKnownCardImpl();
 // InitialHandSize is declared in the ReasonKind union but not yet
 // emitted by any rule — kept for future hand-size-driven deductions.
 export const CardOwnership = (params: { readonly card: Card }): ReasonKind =>
@@ -185,7 +187,7 @@ export type Tracer = (record: SetCellRecord) => void;
  * Dedup uses a HashSet keyed on Cell directly (structural Equal), so
  * no hash-surrogate string is needed.
  */
-interface ChainEntry {
+export interface ChainEntry {
     readonly cell: Cell;
     readonly reason: Reason;
 }
@@ -239,10 +241,26 @@ interface CellParams {
     readonly value: CellValue;
 }
 
+/**
+ * Distinguishes the two ways a cell can land in `initial.checklist` —
+ * either the user marked it as a real-life observation (`observation`)
+ * or it's an active hypothesis being explored (`hypothesis`). Read at
+ * popover-render time by cross-checking the cell against the
+ * `knownCards` array and the `hypotheses` map; the value here drives
+ * the per-step label ("Known observation" vs "Hypothesis").
+ *
+ * If both sources hold, hypothesis wins — `foldHypothesesInto`
+ * overwrites the real value, so the deducer ran on the hypothesis
+ * value and the chain's `value` matches.
+ */
+export type InitialKnownCardSource = "observation" | "hypothesis";
+
 export type ReasonDescription =
     | {
           readonly kind: "initial-known-card";
-          readonly params: CellParams;
+          readonly params: CellParams & {
+              readonly source: InitialKnownCardSource;
+          };
       }
     | {
           readonly kind: "initial-hand-size";
@@ -325,17 +343,30 @@ export const describeReason = (
     setup: GameSetup,
     suggestions: ReadonlyArray<Suggestion>,
     accusations: ReadonlyArray<Accusation> = [],
+    knownCards: ReadonlyArray<KnownCard> = [],
+    hypotheses: HypothesisMap = HashMap.empty(),
 ): ReasonDescription => {
     const base: CellParams = {
         cellPlayer: ownerLabel(cell.owner),
         cellCard: cardName(setup, cell.card),
         value: reason.value,
     };
+    const classifyInitialKnownCard = (): InitialKnownCardSource => {
+        if (HashMap.has(hypotheses, cell)) return "hypothesis";
+        if (cell.owner._tag === "Player") {
+            const player = cell.owner.player;
+            const matchKnown = knownCards.some(
+                kc => kc.player === player && kc.card === cell.card,
+            );
+            if (matchKnown) return "observation";
+        }
+        return "observation";
+    };
     return Match.value(reason.kind).pipe(
         Match.tagsExhaustive({
             InitialKnownCard: (): ReasonDescription => ({
                 kind: "initial-known-card",
-                params: base,
+                params: { ...base, source: classifyInitialKnownCard() },
             }),
             InitialHandSize: (): ReasonDescription => ({
                 kind: "initial-hand-size",

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -5,6 +5,7 @@ import {
     displayFor,
     statusFor,
     type CellDisplay,
+    type HypothesisMap,
     type HypothesisStatus,
     type HypothesisValue,
 } from "../../logic/Hypothesis";
@@ -55,8 +56,10 @@ import {
 } from "../../logic/Knowledge";
 import { footnotesForCell } from "../../logic/Footnotes";
 import {
+    type ChainEntry,
     chainFor,
     describeReason,
+    type InitialKnownCardSource,
     Provenance,
     ReasonDescription,
 } from "../../logic/Provenance";
@@ -961,6 +964,8 @@ export function Checklist() {
             setup,
             owner: popoverCell.owner,
             card: popoverCell.card,
+            knownCards: state.knownCards,
+            hypotheses,
             tDeduce: t,
             tReasons,
         });
@@ -1908,13 +1913,16 @@ export function Checklist() {
 /**
  * Resolve a single `ReasonDescription` (from `describeReason`) into
  * `{ headline, detail }` strings via the "reasons" i18n namespace.
+ *
+ * `initial-known-card` is not handled here — those entries flow through
+ * `groupChainEntries` → `resolveInitialRunCopy` so consecutive runs
+ * (same owner, source, value) consolidate into a single line.
  */
 const resolveReasonCopy = (
-    desc: ReasonDescription,
+    desc: Exclude<ReasonDescription, { kind: "initial-known-card" }>,
     tReasons: ReturnType<typeof useTranslations<"reasons">>,
 ): { readonly headline: string; readonly detail: string } => {
     switch (desc.kind) {
-        case "initial-known-card":
         case "initial-hand-size":
             return {
                 headline: tReasons(`${desc.kind}.headline`),
@@ -2067,6 +2075,108 @@ interface CellWhy {
     readonly chainText: string | undefined;
 }
 
+/**
+ * One displayed line in the Deductions chain. Either a single non-initial
+ * reason (rendered as-is), or a `consolidated` run of consecutive
+ * `initial-known-card` entries sharing (owner, source, value).
+ *
+ * The run shape mirrors the `player-hand` Rule-1 dependsOn shape — when
+ * the user marks an entire hand as Y, those Y cells fan into a single
+ * downstream rule, and listing each as its own "Given:" line is noise.
+ * Grouping by (owner, source, value) keeps unrelated givens distinct.
+ */
+type ChainStep =
+    | { readonly kind: "single"; readonly entry: ChainEntry }
+    | {
+          readonly kind: "initial-run";
+          readonly source: InitialKnownCardSource;
+          readonly cellPlayer: string;
+          readonly value: CellValue;
+          readonly cardNames: ReadonlyArray<string>;
+      };
+
+const groupChainEntries = (
+    chain: ReadonlyArray<ChainEntry>,
+    describe: (entry: ChainEntry) => ReasonDescription,
+): ReadonlyArray<ChainStep> => {
+    const steps: ChainStep[] = [];
+    let run:
+        | {
+              source: InitialKnownCardSource;
+              owner: Owner;
+              cellPlayer: string;
+              value: CellValue;
+              cardNames: string[];
+          }
+        | null = null;
+    const flush = () => {
+        if (run === null) return;
+        steps.push({
+            kind: "initial-run",
+            source: run.source,
+            cellPlayer: run.cellPlayer,
+            value: run.value,
+            cardNames: run.cardNames,
+        });
+        run = null;
+    };
+    for (const entry of chain) {
+        const desc = describe(entry);
+        if (desc.kind === "initial-known-card") {
+            const source = desc.params.source;
+            const owner = entry.cell.owner;
+            const value = entry.reason.value;
+            const cardName = desc.params.cellCard;
+            if (
+                run !== null &&
+                run.source === source &&
+                Equal.equals(run.owner, owner) &&
+                run.value === value
+            ) {
+                run.cardNames.push(cardName);
+            } else {
+                flush();
+                run = {
+                    source,
+                    owner,
+                    cellPlayer: desc.params.cellPlayer,
+                    value,
+                    cardNames: [cardName],
+                };
+            }
+        } else {
+            flush();
+            steps.push({ kind: "single", entry });
+        }
+    }
+    flush();
+    return steps;
+};
+
+const LIST_FORMAT = new Intl.ListFormat("en", {
+    style: "long",
+    type: "conjunction",
+});
+
+const resolveInitialRunCopy = (
+    step: Extract<ChainStep, { kind: "initial-run" }>,
+    tReasons: ReturnType<typeof useTranslations<"reasons">>,
+): { readonly headline: string; readonly detail: string } => {
+    const count = step.cardNames.length;
+    const headline = tReasons(
+        step.source === "hypothesis"
+            ? "initial-known-card.headlineHypothesis"
+            : "initial-known-card.headlineObservation",
+        { count },
+    );
+    const detail = tReasons("initial-known-card.detail", {
+        cellPlayer: step.cellPlayer,
+        value: step.value,
+        cardList: LIST_FORMAT.format(step.cardNames),
+    });
+    return { headline, detail };
+};
+
 const buildCellWhy = (args: {
     provenance: Provenance | undefined;
     suggestions: ReadonlyArray<Suggestion>;
@@ -2074,6 +2184,8 @@ const buildCellWhy = (args: {
     setup: ReturnType<typeof useClue>["state"]["setup"];
     owner: Owner;
     card: Card;
+    knownCards: ReadonlyArray<KnownCard>;
+    hypotheses: HypothesisMap;
     tDeduce: ReturnType<typeof useTranslations<"deduce">>;
     tReasons: ReturnType<typeof useTranslations<"reasons">>;
 }): CellWhy => {
@@ -2084,6 +2196,8 @@ const buildCellWhy = (args: {
         setup,
         owner,
         card,
+        knownCards,
+        hypotheses,
         tDeduce,
         tReasons,
     } = args;
@@ -2091,19 +2205,41 @@ const buildCellWhy = (args: {
     const chain = provenance
         ? chainFor(provenance, Cell(owner, card))
         : [];
-    const chainLines: string[] = chain.map(({ cell: entryCell, reason }, i) => {
-        const desc = describeReason(
-            reason,
-            entryCell,
+    const describe = (entry: ChainEntry): ReasonDescription =>
+        describeReason(
+            entry.reason,
+            entry.cell,
             setup,
             suggestions,
             accusations,
+            knownCards,
+            hypotheses,
         );
+    const steps = groupChainEntries(chain, describe);
+    const chainLines: string[] = steps.map((step, i) => {
+        if (step.kind === "initial-run") {
+            const { headline, detail } = resolveInitialRunCopy(step, tReasons);
+            return tDeduce("whyLine", {
+                index: i + 1,
+                headline,
+                iter: "none",
+                detail,
+            });
+        }
+        const desc = describe(step.entry);
+        if (desc.kind === "initial-known-card") {
+            // groupChainEntries always emits initial-known-card entries
+            // as initial-run steps; this branch is unreachable.
+            throw new Error("unreachable: initial-known-card outside run");
+        }
         const { headline, detail } = resolveReasonCopy(desc, tReasons);
         return tDeduce("whyLine", {
             index: i + 1,
             headline,
-            iter: reason.iteration > 0 ? reason.iteration : "none",
+            iter:
+                step.entry.reason.iteration > 0
+                    ? step.entry.reason.iteration
+                    : "none",
             detail,
         });
     });


### PR DESCRIPTION
## Summary

The cell popover's **Deductions** section previously prefixed every chain step from `initial.checklist` with `Given:` — regardless of whether the underlying cell was a real observation the user entered or a speculative hypothesis they're exploring. Two issues that fixes:

1. **No epistemic distinction at the step level.** A derived cell driven by hypotheses still read as a chain of "Given: ..." lines. The preamble ("Based on your active hypotheses.") hinted at this but every individual step still claimed to be "given".
2. **Repetitive single-fact lines** when several `InitialKnownCard` cells fed the same downstream rule — classically `player-hand` Rule 1, where the chain enumerated every hand-card the user marked, one per line.

### What the chain looks like now

**Hypothesis-driven derived cell (was 3 separate "Given:" lines + 1 rule line):**

> 1. **Hypotheses:** You marked that Player 4 doesn't own Lead pipe and Mrs. White.
> 2. Suggestion #1 (iter 1): Player 4 refuted Player 1's suggestion #1 (Dining room, Lead pipe, Mrs. White); the other two were ruled out, so Player 4 must own Dining room.

**Hand-full deduction (was 5 separate "Given:" lines + 1 rule line):**

> 1. **Known observations:** You marked that Player 1 owns Miss Scarlet, Mr. Green, Rope, Conservatory, and Lounge.
> 2. Hand size (iter 1): Player 1's hand is a fixed size and already full, so Player 1 can't also hold Col. Mustard.

Singleton runs stay one line with the new singular label (`Known observation:` / `Hypothesis:`). Mixed observation + hypothesis runs split into two lines so the source distinction stays intact.

## Commits

- **Distinguish "Known observation" vs "Hypothesis" in deduction chains**
  - `ReasonDescription.initial-known-card` carries a new `InitialKnownCardSource` discriminator (`"observation" | "hypothesis"`).
  - `describeReason` now takes `knownCards` + `hypotheses` and classifies each `InitialKnownCard` reason. Hypothesis wins precedence — it matches what `foldHypothesesInto` actually wrote into the joint knowledge.
  - `Checklist.tsx` adds a `groupChainEntries` pass that walks the chain and either emits single steps (existing copy) or `initial-run` groups (new consolidated copy). Grouping key is `(owner, source, value)`, which matches the `player-hand` Rule-1 `dependsOn: yCells` shape exactly and won't fuse unrelated "Given" lines.
  - Runs render via a new `resolveInitialRunCopy` helper using ICU plurals so "Known observation" / "Hypothesis" pluralize correctly.
  - `messages/en.json` swaps the old `headline: "Given"` key for `headlineObservation` + `headlineHypothesis` (both plural-aware) and rewrites `detail` to take a `cardList` (formatted via `Intl.ListFormat`).
  - New `describeReason` test cases pin the source-classification behavior (knownCards → observation, hypotheses → hypothesis, both → hypothesis wins, neither → defaults to observation).

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` (1393 passed)
- [x] `pnpm knip`
- [x] `pnpm i18n:check`
- [x] Manual verification in `next-dev`:
  - Player 1 hand (5 observations) → click Col. Mustard cell → one "Known observations:" line listing all five cards.
  - Player 4 two N hypotheses + suggestion → click Dining room cell → "Based on your active hypotheses." preamble + one "Hypotheses:" line listing both cards + the suggestion-driven conclusion.
  - Single observation → click derived cell → "Known observation:" singular headline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)