### PR TITLE
Account modal: tour on first signed-in open + return-here-after-OAuth

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -687,6 +687,28 @@
                 "title": "My card packs",
                 "body": "Save custom decks here and share them with friends. Each saved pack syncs across your devices when you're signed in."
             }
+        },
+        "account": {
+            "myCardPacks": {
+                "title": "Your saved card packs live here",
+                "body": "Custom decks sync to your account, so you can pick them up on any device once you sign in."
+            },
+            "syncNow": {
+                "title": "Sync your packs",
+                "body": "Tap Sync now to push local changes up and pull updates from your other devices."
+            },
+            "sharePack": {
+                "title": "Share a pack with a friend",
+                "body": "Send any pack to a friend — they get to use it in their own games."
+            },
+            "renamePack": {
+                "title": "Rename a pack",
+                "body": "Edit a pack's name to keep your library organized."
+            },
+            "deletePack": {
+                "title": "Remove a pack",
+                "body": "Delete a pack you no longer need. The change syncs to your other signed-in devices too."
+            }
         }
     }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -693,21 +693,9 @@
                 "title": "Your saved card packs live here",
                 "body": "Custom decks sync to your account, so you can pick them up on any device once you sign in."
             },
-            "syncNow": {
-                "title": "Sync your packs",
-                "body": "Tap Sync now to push local changes up and pull updates from your other devices."
-            },
-            "sharePack": {
-                "title": "Share a pack with a friend",
-                "body": "Send any pack to a friend — they get to use it in their own games."
-            },
-            "renamePack": {
-                "title": "Rename a pack",
-                "body": "Edit a pack's name to keep your library organized."
-            },
-            "deletePack": {
-                "title": "Remove a pack",
-                "body": "Delete a pack you no longer need. The change syncs to your other signed-in devices too."
+            "packActions": {
+                "title": "What you can do with each pack",
+                "body": "Share a pack with a friend, rename it to keep your library organized, or delete one you don't need anymore."
             }
         }
     }

--- a/src/ui/account/AccountModal.test.tsx
+++ b/src/ui/account/AccountModal.test.tsx
@@ -60,6 +60,27 @@ vi.mock("../share/ShareProvider", () => ({
         children,
 }));
 
+// AccountModal's account-tour gate effect calls `useTour()` +
+// `useStartupCoordinator()` on mount. The shared `Wrappers` in this
+// file doesn't wrap with TourProvider / StartupCoordinatorProvider,
+// so mock both — these tests don't exercise the tour gate path
+// (covered separately). The gate effect bails when `activeScreen`
+// is undefined-but-something OR `phase` is one of the bail values;
+// returning `activeScreen: "account"` here keeps the gate's "no
+// other tour active" check from firing the tour during tests.
+const startTourMock = vi.fn();
+const dismissTourMock = vi.fn();
+vi.mock("../tour/TourProvider", () => ({
+    useTour: () => ({
+        startTour: startTourMock,
+        dismissTour: dismissTourMock,
+        activeScreen: "account" as const,
+    }),
+}));
+vi.mock("../onboarding/StartupCoordinator", () => ({
+    useStartupCoordinator: () => ({ phase: "done" as const }),
+}));
+
 import * as React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { DateTime } from "effect";

--- a/src/ui/account/AccountModal.tsx
+++ b/src/ui/account/AccountModal.tsx
@@ -65,6 +65,7 @@ import { useCardPackActions } from "../components/cardPackActions";
 import { AccountAvatar } from "./AccountAvatar";
 import { authClient } from "./authClient";
 import { DevSignInForm } from "./DevSignInForm";
+import { savePendingAccountModalIntent } from "./pendingAccountModal";
 
 const ACCOUNT_TOUR_SCREEN_KEY = "account" as const;
 // Module-scope so the `i18next/no-literal-string` lint rule reads
@@ -258,6 +259,15 @@ export function AccountModal() {
     };
 
     const onGoogleSignIn = async (): Promise<void> => {
+        // Mark the OAuth round-trip as "started from the Account
+        // modal." `AccountProvider`'s mount-time consumer reads this
+        // back after Better Auth redirects the user here, then opens
+        // the modal again so the user lands exactly where they were
+        // before the sign-in flow. Written even on failure — the
+        // consumer checks freshness + clears the marker either way,
+        // so a stale entry from a cancelled OAuth flow doesn't
+        // resurface on the next page load.
+        savePendingAccountModalIntent();
         signInStarted({ provider: PROVIDER_GOOGLE, from: SIGN_IN_FROM_MENU });
         const result = await authClient.signIn.social({
             provider: PROVIDER_GOOGLE,

--- a/src/ui/account/AccountModal.tsx
+++ b/src/ui/account/AccountModal.tsx
@@ -193,24 +193,23 @@ export function AccountModal() {
     const activeScreenRef = useRef(activeScreen);
     activeScreenRef.current = activeScreen;
     const firedRef = useRef(false);
-    // Reads `activeScreen` and `phase` via refs so they don't end up
-    // as effect deps that would re-fire the gate on unrelated state
-    // changes (the `FirstSuggestionTourGate` reads them directly
-    // because its trigger event IS a reducer-derived value; ours is
-    // simply "modal mount").
-    const phaseRef = useRef(phase);
-    phaseRef.current = phase;
+    // Read `activeScreen` and `startTour` via refs so dep-array
+    // churn (their identity changes when a tour starts) doesn't
+    // re-fire the gate. `phase` IS in the dep array though — when
+    // the StartupCoordinator advances from "boot" → "done" after
+    // the modal has already mounted, the gate needs to re-evaluate
+    // so the tour can fire. Same pattern as
+    // `FirstSuggestionTourGate` in `Clue.tsx`.
     const startTourRef = useRef(startTour);
     startTourRef.current = startTour;
     useEffect(() => {
         if (isAnon) return;
         if (activeScreenRef.current !== undefined) return;
         if (firedRef.current) return;
-        const currentPhase = phaseRef.current;
         if (
-            currentPhase === "boot"
-            || currentPhase === "splash"
-            || currentPhase === "install"
+            phase === "boot"
+            || phase === "splash"
+            || phase === "install"
         ) {
             return;
         }
@@ -227,7 +226,7 @@ export function AccountModal() {
         startTourRef.current(ACCOUNT_TOUR_SCREEN_KEY);
         saveTourVisited(ACCOUNT_TOUR_SCREEN_KEY, now);
         saveTourDismissed(ACCOUNT_TOUR_SCREEN_KEY, now);
-    }, [isAnon]);
+    }, [isAnon, phase]);
     // Cleanup: when AccountModal unmounts (X / Esc / `pop()`), if
     // the tour is still active on `account`, dismiss it. Read both
     // `activeScreen` and `dismissTour` via refs so this effect mounts
@@ -350,7 +349,6 @@ export function AccountModal() {
                                             type="button"
                                             onClick={() => void handleSyncNow()}
                                             disabled={isSyncing}
-                                            data-tour-anchor="account-sync-now"
                                             className="inline-flex cursor-pointer items-center gap-1.5 rounded-[var(--radius)] border border-border bg-white px-2 py-1 text-[1rem] text-muted transition-colors duration-200 ease-out hover:bg-hover hover:text-accent disabled:cursor-not-allowed"
                                         >
                                             <RefreshIcon
@@ -388,12 +386,17 @@ export function AccountModal() {
                                                 const hasPending =
                                                     pack.unsyncedSince !==
                                                     undefined;
-                                                // Tour anchors emit on the FIRST row only — same
-                                                // pattern as `checklist-cell` on (0,0). Empty-state
-                                                // users (no packs) see steps 3-5 auto-skip via the
-                                                // tour driver's missing-anchor path; users with
-                                                // packs always have a first row to anchor against.
-                                                const isFirst = i === 0;
+                                                // Tour anchor emits on the FIRST row's action
+                                                // buttons only — same pattern as `checklist-cell`
+                                                // on (0,0). All three buttons share the same
+                                                // `account-pack-actions` token so the tour's
+                                                // spotlight unions them into one cohesive callout
+                                                // ("you can share, rename, or delete a pack").
+                                                // Empty-state users (no rows) see the step
+                                                // auto-skip via the missing-anchor path.
+                                                const tourAnchor = i === 0
+                                                    ? "account-pack-actions"
+                                                    : undefined;
                                                 return (
                                                 <li
                                                     key={pack.id}
@@ -436,10 +439,11 @@ export function AccountModal() {
                                                         onClick={() =>
                                                             sharePack(pack)
                                                         }
-                                                        {...(isFirst
+                                                        {...(tourAnchor !==
+                                                        undefined
                                                             ? {
                                                                   "data-tour-anchor":
-                                                                      "account-pack-share",
+                                                                      tourAnchor,
                                                               }
                                                             : {})}
                                                         className="inline-flex cursor-pointer items-center border-l border-border px-2.5 py-1.5 text-muted transition-colors duration-200 ease-out hover:bg-hover hover:text-accent"
@@ -453,10 +457,11 @@ export function AccountModal() {
                                                         onClick={() =>
                                                             void renamePack(pack)
                                                         }
-                                                        {...(isFirst
+                                                        {...(tourAnchor !==
+                                                        undefined
                                                             ? {
                                                                   "data-tour-anchor":
-                                                                      "account-pack-rename",
+                                                                      tourAnchor,
                                                               }
                                                             : {})}
                                                         className="inline-flex cursor-pointer items-center border-l border-border px-2.5 py-1.5 text-muted transition-colors duration-200 ease-out hover:bg-hover hover:text-accent"
@@ -470,10 +475,11 @@ export function AccountModal() {
                                                         onClick={() =>
                                                             void deletePack(pack)
                                                         }
-                                                        {...(isFirst
+                                                        {...(tourAnchor !==
+                                                        undefined
                                                             ? {
                                                                   "data-tour-anchor":
-                                                                      "account-pack-delete",
+                                                                      tourAnchor,
                                                               }
                                                             : {})}
                                                         className="inline-flex cursor-pointer items-center border-l border-border px-2.5 py-1.5 text-muted transition-colors duration-200 ease-out hover:bg-hover hover:text-danger"

--- a/src/ui/account/AccountModal.tsx
+++ b/src/ui/account/AccountModal.tsx
@@ -20,11 +20,13 @@ import { DateTime } from "effect";
 import { useTranslations } from "next-intl";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
 import {
     type SignInFromContext,
     signInFailed,
     signInStarted,
 } from "../../analytics/events";
+import { TelemetryRuntime } from "../../observability/runtime";
 import {
     getMyCardPacks,
     type PersistedCardPack,
@@ -39,6 +41,17 @@ import { decodeServerPack } from "../../data/serverPackCodec";
 import type { CardSet } from "../../logic/CardSet";
 import type { CustomCardSet } from "../../logic/CustomCardSets";
 import { useSession } from "../hooks/useSession";
+import { useStartupCoordinator } from "../onboarding/StartupCoordinator";
+import { useTour } from "../tour/TourProvider";
+import {
+    computeShouldShowTour,
+    TOUR_RE_ENGAGE_DURATION,
+} from "../tour/useTourGate";
+import {
+    loadTourState,
+    saveTourDismissed,
+    saveTourVisited,
+} from "../tour/TourState";
 import {
     CardStackIcon,
     PencilIcon,
@@ -52,6 +65,11 @@ import { useCardPackActions } from "../components/cardPackActions";
 import { AccountAvatar } from "./AccountAvatar";
 import { authClient } from "./authClient";
 import { DevSignInForm } from "./DevSignInForm";
+
+const ACCOUNT_TOUR_SCREEN_KEY = "account" as const;
+// Module-scope so the `i18next/no-literal-string` lint rule reads
+// this as a wire-format discriminator, not user copy.
+const TOUR_DISMISS_VIA_CLOSE = "close" as const;
 
 export const ACCOUNT_MODAL_ID = "account" as const;
 export const ACCOUNT_MODAL_MAX_WIDTH = "min(92vw,440px)" as const;
@@ -152,6 +170,81 @@ export function AccountModal() {
     const isInFlight = useIsSyncingCardPacks();
     const isSyncing = isInFlight || myCardPacks.isFetching;
 
+    // Event-triggered tour for the My card packs section. Fires on
+    // signed-in modal mount, gated by the standard 4-week dormancy
+    // (`computeShouldShowTour` against `effect-clue.tour.account.v1`).
+    // Matches the `FirstSuggestionTourGate` pattern in `Clue.tsx`:
+    // - Reads the gate FRESH on mount (not at component-render
+    //   snapshot) so a "Restart tour" wipe takes effect immediately.
+    // - Guards against overlapping with any other active tour.
+    // - Writes BOTH `lastVisitedAt` and `lastDismissedAt` on fire so
+    //   the gate locks for the next 4 weeks.
+    // - `firedRef` suppresses StrictMode double-mount re-fires.
+    //
+    // Cleanup-on-unmount: if the user closes the modal mid-walk (X
+    // button or Esc), dismiss the tour too — its anchors all live
+    // inside the modal, so leaving the tour active after the modal
+    // unmounts would render the popover against missing elements.
+    // `activeScreenRef` keeps the cleanup pointing at the latest
+    // value without re-installing the effect.
+    const { startTour, dismissTour, activeScreen } = useTour();
+    const { phase } = useStartupCoordinator();
+    const activeScreenRef = useRef(activeScreen);
+    activeScreenRef.current = activeScreen;
+    const firedRef = useRef(false);
+    // Reads `activeScreen` and `phase` via refs so they don't end up
+    // as effect deps that would re-fire the gate on unrelated state
+    // changes (the `FirstSuggestionTourGate` reads them directly
+    // because its trigger event IS a reducer-derived value; ours is
+    // simply "modal mount").
+    const phaseRef = useRef(phase);
+    phaseRef.current = phase;
+    const startTourRef = useRef(startTour);
+    startTourRef.current = startTour;
+    useEffect(() => {
+        if (isAnon) return;
+        if (activeScreenRef.current !== undefined) return;
+        if (firedRef.current) return;
+        const currentPhase = phaseRef.current;
+        if (
+            currentPhase === "boot"
+            || currentPhase === "splash"
+            || currentPhase === "install"
+        ) {
+            return;
+        }
+        const now = DateTime.nowUnsafe();
+        const shouldShow = TelemetryRuntime.runSync(
+            computeShouldShowTour(
+                loadTourState(ACCOUNT_TOUR_SCREEN_KEY),
+                now,
+                TOUR_RE_ENGAGE_DURATION,
+            ),
+        );
+        if (!shouldShow) return;
+        firedRef.current = true;
+        startTourRef.current(ACCOUNT_TOUR_SCREEN_KEY);
+        saveTourVisited(ACCOUNT_TOUR_SCREEN_KEY, now);
+        saveTourDismissed(ACCOUNT_TOUR_SCREEN_KEY, now);
+    }, [isAnon]);
+    // Cleanup: when AccountModal unmounts (X / Esc / `pop()`), if
+    // the tour is still active on `account`, dismiss it. Read both
+    // `activeScreen` and `dismissTour` via refs so this effect mounts
+    // exactly once — `dismissTour`'s identity changes when
+    // `activeScreen` changes (the TourProvider's useCallback chain
+    // depends on it), and a re-running cleanup effect would fire
+    // dismissTour on every step transition, dismissing the tour
+    // prematurely.
+    const dismissTourRef = useRef(dismissTour);
+    dismissTourRef.current = dismissTour;
+    useEffect(() => {
+        return () => {
+            if (activeScreenRef.current === ACCOUNT_TOUR_SCREEN_KEY) {
+                dismissTourRef.current(TOUR_DISMISS_VIA_CLOSE);
+            }
+        };
+    }, []);
+
     const handleSyncNow = async (): Promise<void> => {
         await flushPendingChanges();
         await queryClient.invalidateQueries({
@@ -235,7 +328,10 @@ export function AccountModal() {
                                         </div>
                                     </div>
                                 </div>
-                                <section className="rounded-[var(--radius)] border border-border bg-white px-3 py-2">
+                                <section
+                                    data-tour-anchor="account-my-card-packs"
+                                    className="rounded-[var(--radius)] border border-border bg-white px-3 py-2"
+                                >
                                     <div className="flex items-center justify-between gap-2">
                                         <h3 className="m-0 text-[1.125rem] font-semibold text-accent">
                                             {t("myCardPacksTitle")}
@@ -244,6 +340,7 @@ export function AccountModal() {
                                             type="button"
                                             onClick={() => void handleSyncNow()}
                                             disabled={isSyncing}
+                                            data-tour-anchor="account-sync-now"
                                             className="inline-flex cursor-pointer items-center gap-1.5 rounded-[var(--radius)] border border-border bg-white px-2 py-1 text-[1rem] text-muted transition-colors duration-200 ease-out hover:bg-hover hover:text-accent disabled:cursor-not-allowed"
                                         >
                                             <RefreshIcon
@@ -277,10 +374,16 @@ export function AccountModal() {
                                         </div>
                                     ) : (
                                         <ul className="m-0 mt-2 flex list-none flex-col gap-1 p-0 text-[1rem]">
-                                            {packs.map((pack) => {
+                                            {packs.map((pack, i) => {
                                                 const hasPending =
                                                     pack.unsyncedSince !==
                                                     undefined;
+                                                // Tour anchors emit on the FIRST row only — same
+                                                // pattern as `checklist-cell` on (0,0). Empty-state
+                                                // users (no packs) see steps 3-5 auto-skip via the
+                                                // tour driver's missing-anchor path; users with
+                                                // packs always have a first row to anchor against.
+                                                const isFirst = i === 0;
                                                 return (
                                                 <li
                                                     key={pack.id}
@@ -323,6 +426,12 @@ export function AccountModal() {
                                                         onClick={() =>
                                                             sharePack(pack)
                                                         }
+                                                        {...(isFirst
+                                                            ? {
+                                                                  "data-tour-anchor":
+                                                                      "account-pack-share",
+                                                              }
+                                                            : {})}
                                                         className="inline-flex cursor-pointer items-center border-l border-border px-2.5 py-1.5 text-muted transition-colors duration-200 ease-out hover:bg-hover hover:text-accent"
                                                         title={t("sharePackTitle", { label: pack.label })}
                                                         aria-label={t("sharePackAria", { label: pack.label })}
@@ -334,6 +443,12 @@ export function AccountModal() {
                                                         onClick={() =>
                                                             void renamePack(pack)
                                                         }
+                                                        {...(isFirst
+                                                            ? {
+                                                                  "data-tour-anchor":
+                                                                      "account-pack-rename",
+                                                              }
+                                                            : {})}
                                                         className="inline-flex cursor-pointer items-center border-l border-border px-2.5 py-1.5 text-muted transition-colors duration-200 ease-out hover:bg-hover hover:text-accent"
                                                         title={t("renamePackTitle", { label: pack.label })}
                                                         aria-label={t("renamePackAria", { label: pack.label })}
@@ -345,6 +460,12 @@ export function AccountModal() {
                                                         onClick={() =>
                                                             void deletePack(pack)
                                                         }
+                                                        {...(isFirst
+                                                            ? {
+                                                                  "data-tour-anchor":
+                                                                      "account-pack-delete",
+                                                              }
+                                                            : {})}
                                                         className="inline-flex cursor-pointer items-center border-l border-border px-2.5 py-1.5 text-muted transition-colors duration-200 ease-out hover:bg-hover hover:text-danger"
                                                         title={t("deletePackTitle", { label: pack.label })}
                                                         aria-label={t("deletePackAria", { label: pack.label })}

--- a/src/ui/account/AccountProvider.tsx
+++ b/src/ui/account/AccountProvider.tsx
@@ -18,6 +18,7 @@ import {
     createContext,
     useCallback,
     useContext,
+    useEffect,
     useMemo,
     useRef,
     type ReactNode,
@@ -50,6 +51,7 @@ import {
     LOGOUT_WARNING_MODAL_ID,
     LogoutWarningModalContent,
 } from "./LogoutWarningModal";
+import { consumePendingAccountModalIntent } from "./pendingAccountModal";
 
 const ACCOUNT_TOUR_SCREEN_KEY = "account" as const;
 
@@ -268,6 +270,43 @@ export function AccountProvider({
             });
         });
     }, [performCommitSignOut, showLogoutWarning]);
+
+    // Re-open the Account modal after a Google OAuth round-trip.
+    // `AccountModal.onGoogleSignIn` writes a sessionStorage marker
+    // before kicking off the redirect; after Better Auth lands the
+    // user back here, the SPA mounts fresh and this effect reads +
+    // clears the marker. When it was present AND the user is now
+    // signed in, we call `openModal()` so the user lands exactly
+    // where they were before sign-in.
+    //
+    // Gating:
+    //   - `session.isPending` — wait for Better Auth to finish
+    //     fetching the session from the cookie set during the OAuth
+    //     callback. Reading too early shows the anonymous state and
+    //     the modal would open with the sign-in CTA, defeating the
+    //     point.
+    //   - `!isAnonymous` — if OAuth failed silently or the user
+    //     was downgraded back to anonymous somehow, don't re-open
+    //     a sign-in CTA on top of them.
+    //   - `consumedRef` — fire at most once per mount, since the
+    //     marker has already been cleared from storage by the
+    //     consume call.
+    //
+    // The marker has a 10-minute freshness window (see
+    // `pendingAccountModal.ts`), so an old marker from an
+    // abandoned earlier flow can't surface days later.
+    const consumedRef = useRef(false);
+    const openModalRef = useRef(openModal);
+    openModalRef.current = openModal;
+    useEffect(() => {
+        if (consumedRef.current) return;
+        if (session.isPending) return;
+        const user = session.data?.user;
+        if (!user || user.isAnonymous) return;
+        if (!consumePendingAccountModalIntent()) return;
+        consumedRef.current = true;
+        openModalRef.current();
+    }, [session.isPending, session.data]);
 
     const value = useMemo<AccountContextValue>(
         () => ({ openModal, requestSignOut }),

--- a/src/ui/account/AccountProvider.tsx
+++ b/src/ui/account/AccountProvider.tsx
@@ -22,6 +22,7 @@ import {
     useRef,
     type ReactNode,
 } from "react";
+import { DateTime } from "effect";
 import { useTranslations } from "next-intl";
 import { signOut as signOutEvent } from "../../analytics/events";
 import {
@@ -31,8 +32,14 @@ import {
     type FlushReason,
     type UnsyncedSummary,
 } from "../../data/cardPacksSync";
+import { TelemetryRuntime } from "../../observability/runtime";
 import { useModalStack } from "../components/ModalStack";
 import { useSession } from "../hooks/useSession";
+import { loadTourState } from "../tour/TourState";
+import {
+    computeShouldShowTour,
+    TOUR_RE_ENGAGE_DURATION,
+} from "../tour/useTourGate";
 import {
     ACCOUNT_MODAL_ID,
     ACCOUNT_MODAL_MAX_WIDTH,
@@ -43,6 +50,8 @@ import {
     LOGOUT_WARNING_MODAL_ID,
     LogoutWarningModalContent,
 } from "./LogoutWarningModal";
+
+const ACCOUNT_TOUR_SCREEN_KEY = "account" as const;
 
 interface AccountContextValue {
     /** Open the modal. Idempotent; calling while open re-pushes the
@@ -105,13 +114,38 @@ export function AccountProvider({
     const logoutStateRef = useRef<LogoutModalState | null>(null);
 
     const openModal = useCallback(() => {
+        // Ghost-click guard for the My card packs walkthrough. When
+        // the account tour will fire on this open (gate is fresh and
+        // the user is signed in — `AccountModal`'s mount effect does
+        // the actual fire), push the modal with backdrop close
+        // disabled. iOS Safari can fire a synthetic "ghost click" up
+        // to ~300 ms after a tap that ended on `touchend`, and that
+        // click can land on the backdrop and dismiss the modal out
+        // from under the walkthrough. Esc + the X button stay
+        // enabled — those are deliberate exits.
+        //
+        // We don't need to also guard signed-out opens (no walk
+        // there) or already-dismissed-gate opens (no walk either),
+        // so cheap to check inline. The gate read here mirrors the
+        // one inside AccountModal — both reads should agree.
+        const willFireTour =
+            session.data?.user
+            && !session.data.user.isAnonymous
+            && TelemetryRuntime.runSync(
+                computeShouldShowTour(
+                    loadTourState(ACCOUNT_TOUR_SCREEN_KEY),
+                    DateTime.nowUnsafe(),
+                    TOUR_RE_ENGAGE_DURATION,
+                ),
+            );
         push({
             id: ACCOUNT_MODAL_ID,
             title: tAccount("titleSignedIn"),
             maxWidth: ACCOUNT_MODAL_MAX_WIDTH,
             content: <AccountModal />,
+            ...(willFireTour ? { dismissOnOutsideClick: false } : {}),
         });
-    }, [push, tAccount]);
+    }, [push, tAccount, session]);
     const closeAccountModal = useCallback(() => {
         popTo(ACCOUNT_MODAL_ID);
     }, [popTo]);

--- a/src/ui/account/pendingAccountModal.test.ts
+++ b/src/ui/account/pendingAccountModal.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for the "re-open the Account modal after OAuth"
+ * sessionStorage handle. Mirrors `pendingImport.test.ts` in shape.
+ *
+ * The interesting edges are around `consumePendingAccountModalIntent`:
+ *   - It must return `true` only when there's a fresh entry.
+ *   - It must ALWAYS clear the entry from storage (even on parse
+ *     failure / expiry / wrong shape), so a corrupt or stale marker
+ *     can't accumulate or trigger a surprise auto-open later.
+ *   - Save tolerates `sessionStorage.setItem` throwing — graceful
+ *     degradation, not a hard failure.
+ */
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+    consumePendingAccountModalIntent,
+    savePendingAccountModalIntent,
+} from "./pendingAccountModal";
+
+const KEY = "effect-clue.pending-account-modal.v1";
+
+beforeEach(() => {
+    sessionStorage.clear();
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("savePendingAccountModalIntent", () => {
+    test("writes a JSON-encoded entry with a timestamp", () => {
+        const before = Date.now();
+        savePendingAccountModalIntent();
+        const after = Date.now();
+        const raw = sessionStorage.getItem(KEY);
+        expect(raw).not.toBeNull();
+        const parsed = JSON.parse(raw!);
+        expect(parsed).toMatchObject({ t: expect.any(Number) });
+        expect(parsed.t).toBeGreaterThanOrEqual(before);
+        expect(parsed.t).toBeLessThanOrEqual(after);
+    });
+
+    test("swallows storage errors so OAuth can still proceed", () => {
+        const spy = vi
+            .spyOn(Storage.prototype, "setItem")
+            .mockImplementation(() => {
+                throw new Error("quota exceeded");
+            });
+        expect(() => savePendingAccountModalIntent()).not.toThrow();
+        expect(spy).toHaveBeenCalled();
+    });
+});
+
+describe("consumePendingAccountModalIntent", () => {
+    test("returns false + leaves storage clean when there's no entry", () => {
+        expect(consumePendingAccountModalIntent()).toBe(false);
+        expect(sessionStorage.getItem(KEY)).toBeNull();
+    });
+
+    test("returns true for a fresh entry", () => {
+        savePendingAccountModalIntent();
+        expect(consumePendingAccountModalIntent()).toBe(true);
+    });
+
+    test("clears the entry from storage after a successful consume", () => {
+        savePendingAccountModalIntent();
+        consumePendingAccountModalIntent();
+        expect(sessionStorage.getItem(KEY)).toBeNull();
+    });
+
+    test("returns false + clears storage when the entry has expired (> 10 min)", () => {
+        // Hand-craft an old entry — `Date.now() - 11 minutes`.
+        const elevenMinAgo = Date.now() - 11 * 60 * 1000;
+        sessionStorage.setItem(KEY, JSON.stringify({ t: elevenMinAgo }));
+        expect(consumePendingAccountModalIntent()).toBe(false);
+        // Always-clear policy: expired entries are removed too.
+        expect(sessionStorage.getItem(KEY)).toBeNull();
+    });
+
+    test("accepts an entry just under the 10-minute window", () => {
+        const justUnder = Date.now() - 9 * 60 * 1000;
+        sessionStorage.setItem(KEY, JSON.stringify({ t: justUnder }));
+        expect(consumePendingAccountModalIntent()).toBe(true);
+    });
+
+    test("returns false + clears storage on a future-dated entry (clock skew defense)", () => {
+        sessionStorage.setItem(
+            KEY,
+            JSON.stringify({ t: Date.now() + 5_000 }),
+        );
+        expect(consumePendingAccountModalIntent()).toBe(false);
+        expect(sessionStorage.getItem(KEY)).toBeNull();
+    });
+
+    test("returns false + clears storage when the entry isn't valid JSON", () => {
+        sessionStorage.setItem(KEY, "this is not json {");
+        expect(consumePendingAccountModalIntent()).toBe(false);
+        expect(sessionStorage.getItem(KEY)).toBeNull();
+    });
+
+    test("returns false + clears storage when the entry has the wrong shape", () => {
+        sessionStorage.setItem(KEY, JSON.stringify({ wrong: "shape" }));
+        expect(consumePendingAccountModalIntent()).toBe(false);
+        expect(sessionStorage.getItem(KEY)).toBeNull();
+    });
+
+    test("is single-use — a second consume after a successful one returns false", () => {
+        savePendingAccountModalIntent();
+        expect(consumePendingAccountModalIntent()).toBe(true);
+        expect(consumePendingAccountModalIntent()).toBe(false);
+    });
+});

--- a/src/ui/account/pendingAccountModal.ts
+++ b/src/ui/account/pendingAccountModal.ts
@@ -1,0 +1,92 @@
+/**
+ * SessionStorage handle for the "re-open the Account modal after
+ * OAuth" intent. Mirrors `pendingImport.ts` on the share-receive
+ * side.
+ *
+ * The Account modal's anonymous render path kicks off Better Auth's
+ * social sign-in via `authClient.signIn.social({ provider, callbackURL })`.
+ * After Google redirects the user back, the SPA mounts fresh — the
+ * modal is GONE because the stack didn't survive the navigation.
+ * Without help, the user lands on the underlying page (Setup or
+ * Checklist), signed in but with no visible feedback that the click
+ * they made before redirect did anything.
+ *
+ * The fix is the same pattern share-import uses:
+ *
+ *   1. Before kicking off OAuth, `savePendingAccountModalIntent()`
+ *      writes a timestamped marker.
+ *   2. After OAuth lands the user back, `AccountProvider`'s mount
+ *      effect waits for the session to settle (and for the user to
+ *      be non-anonymous), then `consumePendingAccountModalIntent()`
+ *      reads + clears the marker. If it was present and fresh, the
+ *      provider calls `openModal()` automatically — the user lands
+ *      back exactly where they were before sign-in.
+ *
+ * Malicious-URL safety: nothing on the page can write this
+ * sessionStorage entry without the user's own click on the in-modal
+ * "Sign in with Google" button. A drive-by URL gets no auto-open.
+ * The freshness window keeps a leftover marker from an abandoned
+ * earlier sign-in from re-firing days later.
+ */
+import { Duration } from "effect";
+
+const PENDING_ACCOUNT_MODAL_KEY = "effect-clue.pending-account-modal.v1";
+
+/**
+ * OAuth round-trips are normally a few seconds; ten minutes covers
+ * password-manager + 2FA + slow network without being so generous
+ * that a stale marker from an earlier flow can resurface days later.
+ */
+const MAX_AGE = Duration.minutes(10);
+
+interface PendingAccountModalIntent {
+    /**
+     * Epoch millis at the moment of save. Stored as a number so the
+     * sessionStorage JSON round-trip is lossless. Compared via
+     * `Date.now()` against `MAX_AGE` (in millis) at consume time.
+     */
+    readonly t: number;
+}
+
+const isPendingIntent = (raw: unknown): raw is PendingAccountModalIntent => {
+    if (typeof raw !== "object" || raw === null) return false;
+    const r = raw as Record<string, unknown>;
+    return typeof r["t"] === "number";
+};
+
+export const savePendingAccountModalIntent = (): void => {
+    try {
+        const intent: PendingAccountModalIntent = { t: Date.now() };
+        sessionStorage.setItem(
+            PENDING_ACCOUNT_MODAL_KEY,
+            JSON.stringify(intent),
+        );
+    } catch {
+        // Non-fatal: OAuth still proceeds. Worst case the user lands
+        // back signed in but has to click ⋯ → Account themselves —
+        // graceful degradation, not a hard failure.
+    }
+};
+
+/**
+ * Read + remove the intent. Returns `true` only when an entry was
+ * present AND was saved within `MAX_AGE` of now. Always clears the
+ * entry from storage (even on mismatch / expiry / parse failure) so
+ * stale intents never accumulate.
+ */
+export const consumePendingAccountModalIntent = (): boolean => {
+    let parsed: unknown = null;
+    try {
+        const raw = sessionStorage.getItem(PENDING_ACCOUNT_MODAL_KEY);
+        if (raw === null) return false;
+        sessionStorage.removeItem(PENDING_ACCOUNT_MODAL_KEY);
+        parsed = JSON.parse(raw);
+    } catch {
+        return false;
+    }
+    if (!isPendingIntent(parsed)) return false;
+    const ageMillis = Date.now() - parsed.t;
+    if (ageMillis < 0) return false;
+    if (ageMillis > Duration.toMillis(MAX_AGE)) return false;
+    return true;
+};

--- a/src/ui/tour/tours.test.ts
+++ b/src/ui/tour/tours.test.ts
@@ -378,17 +378,15 @@ describe("TOUR_PREREQUISITES", () => {
 });
 
 describe("TOURS — account tour (event-triggered, My card packs modal)", () => {
-    test("has five steps in declaration order", () => {
-        // Section intro → Sync now → Share / Rename / Delete on the
-        // first pack row. Per-row anchors live on the FIRST row only;
-        // empty-state users see the auto-skip path (steps 3-5
-        // silently drop because their anchors aren't mounted).
+    test("has two steps in declaration order: intro → pack actions", () => {
+        // Sync now is deliberately NOT called out — syncing is
+        // automatic and the button is just a manual fail-safe.
+        // Share / Rename / Delete are folded into one combined
+        // "actions you can take" step so the user gets the full
+        // mental model without three separate popovers.
         expect(TOURS.account.map(s => s.anchor)).toEqual([
             "account-my-card-packs",
-            "account-sync-now",
-            "account-pack-share",
-            "account-pack-rename",
-            "account-pack-delete",
+            "account-pack-actions",
         ]);
     });
 
@@ -404,7 +402,7 @@ describe("TOURS — account tour (event-triggered, My card packs modal)", () => 
     });
 
     test("titleKey + bodyKey point at onboarding.account.* keys", () => {
-        const tags = ["myCardPacks", "syncNow", "sharePack", "renamePack", "deletePack"];
+        const tags = ["myCardPacks", "packActions"];
         TOURS.account.forEach((step, i) => {
             const tag = tags[i]!;
             expect(step.titleKey).toBe(`account.${tag}.title`);

--- a/src/ui/tour/tours.test.ts
+++ b/src/ui/tour/tours.test.ts
@@ -377,11 +377,49 @@ describe("TOUR_PREREQUISITES", () => {
     });
 });
 
-describe("TOURS — placeholder tours", () => {
-    test("account is reserved (empty step list)", () => {
-        expect(TOURS.account).toEqual([]);
+describe("TOURS — account tour (event-triggered, My card packs modal)", () => {
+    test("has five steps in declaration order", () => {
+        // Section intro → Sync now → Share / Rename / Delete on the
+        // first pack row. Per-row anchors live on the FIRST row only;
+        // empty-state users see the auto-skip path (steps 3-5
+        // silently drop because their anchors aren't mounted).
+        expect(TOURS.account.map(s => s.anchor)).toEqual([
+            "account-my-card-packs",
+            "account-sync-now",
+            "account-pack-share",
+            "account-pack-rename",
+            "account-pack-delete",
+        ]);
     });
 
+    test("closing step uses 'gotIt' finish label", () => {
+        const last = TOURS.account[TOURS.account.length - 1]!;
+        expect(last.finishLabelKey).toBe("gotIt");
+    });
+
+    test("no step is advance-on-click — passive Next-button callouts only", () => {
+        for (const step of TOURS.account) {
+            expect(step.advanceOn).toBeUndefined();
+        }
+    });
+
+    test("titleKey + bodyKey point at onboarding.account.* keys", () => {
+        const tags = ["myCardPacks", "syncNow", "sharePack", "renamePack", "deletePack"];
+        TOURS.account.forEach((step, i) => {
+            const tag = tags[i]!;
+            expect(step.titleKey).toBe(`account.${tag}.title`);
+            expect(step.bodyKey).toBe(`account.${tag}.body`);
+        });
+    });
+});
+
+describe("TOUR_PREREQUISITES (account)", () => {
+    test("account tour has no prerequisites (event-triggered, like firstSuggestion)", () => {
+        expect(TOUR_PREREQUISITES.account).toBeUndefined();
+    });
+});
+
+describe("TOURS — placeholder tours", () => {
     test("shareImport is reserved (empty step list)", () => {
         expect(TOURS.shareImport).toEqual([]);
     });

--- a/src/ui/tour/tours.ts
+++ b/src/ui/tour/tours.ts
@@ -734,22 +734,21 @@ export const TOURS: Record<ScreenKey, ReadonlyArray<TourStep>> = {
      * mount = "modal just opened"), then locks for 4 weeks via the
      * standard `lastDismissedAt` gate.
      *
-     * Walks five callouts inside the modal:
+     * Two passive Next-button callouts:
      *   1. Intro on the My card packs section header.
-     *   2. Sync now button — push local changes / pull remote ones.
-     *   3-5. The Share / Rename / Delete actions on the first pack
-     *        row. These rely on a pack existing; empty-state users
-     *        see the auto-skip path (steps 3-5 silently drop because
-     *        their anchors aren't mounted).
+     *   2. The per-row action group (Share / Rename / Delete) on the
+     *      first pack row — one combined callout that lists all three
+     *      actions instead of stepping through them individually. The
+     *      "Sync now" button is deliberately NOT called out: syncing
+     *      is automatic and the button is just a manual fail-safe,
+     *      so a tour step would over-explain.
      *
-     * All five steps are passive Next-button callouts — no
-     * advance-on-click — so the native-DOM-listener gotcha for
-     * touch advance-on-click doesn't apply. The modal stays open
-     * across all five steps via `AccountProvider`'s
-     * `dismissOnOutsideClick: false` push when the gate is fresh,
-     * which is the modal analog of `tourKeepsCellOpen` in
-     * Checklist.tsx — it prevents iOS ghost clicks on the backdrop
-     * from collapsing the modal out from under the walkthrough.
+     * Empty-state users (no packs) see step 2 auto-skip — they get
+     * the 1-step intro. The modal stays open across both steps via
+     * `AccountProvider`'s `dismissOnOutsideClick: false` push (the
+     * modal analog of `tourKeepsCellOpen` in Checklist.tsx —
+     * prevents iOS ghost clicks on the backdrop from collapsing the
+     * modal out from under the walkthrough).
      */
     account: [
         {
@@ -761,35 +760,14 @@ export const TOURS: Record<ScreenKey, ReadonlyArray<TourStep>> = {
             align: "center",
         },
         {
-            // Sync now button in the section header.
-            anchor: "account-sync-now",
-            titleKey: "account.syncNow.title",
-            bodyKey: "account.syncNow.body",
-            side: "bottom",
-            align: "end",
-        },
-        {
-            // Share on the first pack row. Auto-skips for empty-state
-            // users (no rows = no anchor).
-            anchor: "account-pack-share",
-            titleKey: "account.sharePack.title",
-            bodyKey: "account.sharePack.body",
-            side: "bottom",
-            align: "end",
-        },
-        {
-            // Rename on the first pack row.
-            anchor: "account-pack-rename",
-            titleKey: "account.renamePack.title",
-            bodyKey: "account.renamePack.body",
-            side: "bottom",
-            align: "end",
-        },
-        {
-            // Delete on the first pack row. Wrap-up CTA.
-            anchor: "account-pack-delete",
-            titleKey: "account.deletePack.title",
-            bodyKey: "account.deletePack.body",
+            // Combined action group on the first pack row. The
+            // `account-pack-actions` token is on Share / Rename /
+            // Delete buttons of the first row, so the spotlight
+            // unions all three into one cohesive callout. Auto-skips
+            // for empty-state users (no rows = no anchor).
+            anchor: "account-pack-actions",
+            titleKey: "account.packActions.title",
+            bodyKey: "account.packActions.body",
             side: "bottom",
             align: "end",
             finishLabelKey: "gotIt",

--- a/src/ui/tour/tours.ts
+++ b/src/ui/tour/tours.ts
@@ -261,6 +261,12 @@ export interface TourStep {
  * - `sharing`: three callouts for share affordances inside the
  *   overflow menu (invite a player, transfer to another device, my
  *   card packs).
+ * - `account`: walks the My card packs section of the Account modal.
+ *   Event-triggered like `firstSuggestion` — fires on signed-in
+ *   modal mount, gated by the same 4-week dormancy. The modal is
+ *   pushed with `dismissOnOutsideClick: false` when the gate is
+ *   fresh so a backdrop tap (or iOS ghost click) can't drop the
+ *   modal out from under the walkthrough.
  *
  * Every step blocks page interaction by default — the dim veil
  * absorbs clicks and the keyboard isolator swallows non-Esc keys.
@@ -268,7 +274,7 @@ export interface TourStep {
  * use `advanceOn` to whitelist that one element; the rest of the
  * page stays blocked.
  *
- * `account` and `shareImport` remain reserved placeholders.
+ * `shareImport` remains a reserved placeholder.
  */
 export const TOURS: Record<ScreenKey, ReadonlyArray<TourStep>> = {
     setup: [
@@ -721,8 +727,74 @@ export const TOURS: Record<ScreenKey, ReadonlyArray<TourStep>> = {
             finishLabelKey: "gotIt",
         },
     ],
-    // Reserved for M7 / M9 — no content yet.
-    account: [],
+    /**
+     * Event-triggered tour for the My Card Packs section of the
+     * Account modal. Fires the first time a signed-in user opens the
+     * modal (the trigger lives in `AccountModal.tsx` itself — modal
+     * mount = "modal just opened"), then locks for 4 weeks via the
+     * standard `lastDismissedAt` gate.
+     *
+     * Walks five callouts inside the modal:
+     *   1. Intro on the My card packs section header.
+     *   2. Sync now button — push local changes / pull remote ones.
+     *   3-5. The Share / Rename / Delete actions on the first pack
+     *        row. These rely on a pack existing; empty-state users
+     *        see the auto-skip path (steps 3-5 silently drop because
+     *        their anchors aren't mounted).
+     *
+     * All five steps are passive Next-button callouts — no
+     * advance-on-click — so the native-DOM-listener gotcha for
+     * touch advance-on-click doesn't apply. The modal stays open
+     * across all five steps via `AccountProvider`'s
+     * `dismissOnOutsideClick: false` push when the gate is fresh,
+     * which is the modal analog of `tourKeepsCellOpen` in
+     * Checklist.tsx — it prevents iOS ghost clicks on the backdrop
+     * from collapsing the modal out from under the walkthrough.
+     */
+    account: [
+        {
+            // Intro — spotlights the whole My card packs section.
+            anchor: "account-my-card-packs",
+            titleKey: "account.myCardPacks.title",
+            bodyKey: "account.myCardPacks.body",
+            side: "bottom",
+            align: "center",
+        },
+        {
+            // Sync now button in the section header.
+            anchor: "account-sync-now",
+            titleKey: "account.syncNow.title",
+            bodyKey: "account.syncNow.body",
+            side: "bottom",
+            align: "end",
+        },
+        {
+            // Share on the first pack row. Auto-skips for empty-state
+            // users (no rows = no anchor).
+            anchor: "account-pack-share",
+            titleKey: "account.sharePack.title",
+            bodyKey: "account.sharePack.body",
+            side: "bottom",
+            align: "end",
+        },
+        {
+            // Rename on the first pack row.
+            anchor: "account-pack-rename",
+            titleKey: "account.renamePack.title",
+            bodyKey: "account.renamePack.body",
+            side: "bottom",
+            align: "end",
+        },
+        {
+            // Delete on the first pack row. Wrap-up CTA.
+            anchor: "account-pack-delete",
+            titleKey: "account.deletePack.title",
+            bodyKey: "account.deletePack.body",
+            side: "bottom",
+            align: "end",
+            finishLabelKey: "gotIt",
+        },
+    ],
     shareImport: [],
 };
 


### PR DESCRIPTION
## Behavior changes

### Tour walks the My card packs section on first signed-in open

The first time a signed-in user opens the Account modal, a short two-step walkthrough fires:

1. Intro on the **My card packs** section.
2. A combined callout on the first pack row's action buttons — **Share / Rename / Delete** — explaining what you can do with each pack.

The tour locks for 4 weeks via the standard `lastDismissedAt` gate (same cadence as `firstSuggestion`). The **Sync now** button is intentionally NOT called out — syncing is automatic and the button is a manual fail-safe. Empty-state users (no saved packs) see the action-row step auto-skip via the tour driver's missing-anchor path, so they get a 1-step intro.

### Ghost-click guard while the tour is up

When the tour will fire on a given modal open, `AccountProvider.openModal` pushes the modal with `dismissOnOutsideClick: false`. iOS Safari can fire a synthetic ghost click ~300 ms after a tap; without the guard, that click can land on the backdrop and drop the modal out from under the walkthrough. Esc + the X button stay enabled — those are deliberate exits.

### Google OAuth round-trip brings the user back to the modal

Before this PR, signing in via the Account modal's Google CTA kicked off an OAuth redirect, and Better Auth landed the user back on the same page — signed in, but with the Account modal gone. No visible feedback that the sign-in click did anything; the user had to re-open ⋯ → Account themselves to see their newly-synced packs (and the My card packs tour wouldn't fire because the modal never re-opened).

The fix mirrors `pendingImport.ts`'s pattern from the share-receive flow:

- `AccountModal.onGoogleSignIn` writes a sessionStorage marker (`effect-clue.pending-account-modal.v1`, 10-minute freshness window) immediately before kicking off `authClient.signIn.social`.
- `AccountProvider` mounts a consume effect that waits for the session to settle, confirms the user is non-anonymous, then consumes the marker. When present + fresh, it calls `openModal()` so the user lands exactly where they were before the redirect.

The auto-opened modal then satisfies the tour's trigger condition, so the tour fires for them on the same page load.

## Gotchas codified during this PR

- **`dismissTour` identity churn.** `dismissTour` from `useTour()` recreates when `activeScreen` flips. A cleanup-on-unmount effect with `[dismissTour]` deps re-runs on the first tour transition and fires the cleanup mid-walk. Fix: stash `dismissTour` in a ref and depend on the empty array so the cleanup runs exactly once at unmount.
- **Gate-fire dep array needs `phase`.** When `AccountModal` mounted before the `StartupCoordinator` finished its phase machine, the fire effect bailed on `phase === "boot"` and never re-fired. Added `phase` to the deps so the coordinator's transition to `"done"` re-evaluates the gate — same pattern as `FirstSuggestionTourGate` in `Clue.tsx`.

## Commits in this PR

- `99a02db` — Account tour: walk My card packs the first time the modal opens. Five-step tour, gate-fire on modal mount, cleanup on unmount, conditional `dismissOnOutsideClick: false` push for the ghost-click guard.
- `be1a1dd` — Account: re-open the modal after Google OAuth lands the user back. New `pendingAccountModal.ts` (sessionStorage marker, 10-min freshness), 11 unit tests covering save / consume / freshness / single-use / parse failures. Save in `onGoogleSignIn`, consume in `AccountProvider`.
- `044d7f0` — Account tour: trim to 2 steps (drop Sync now, fold actions into one). Drops the Sync now callout (automatic sync; button is a fail-safe). Folds Share / Rename / Delete into one combined ring via a shared `account-pack-actions` data-tour-anchor token on the first row's three buttons. Includes the `phase` dep-array fix.

## Test plan

- [x] Pre-commit green: typecheck / lint / test (1415) / knip / i18n:check.
- [x] Verified in `next-dev` preview at desktop (1280×800) and mobile (375×812): both tour steps render fully on-screen, "1 of 2" → "2 of 2" → "Got it" sequence works.
- [x] Backdrop click during tour: modal stays open, tour stays on its current step.
- [x] After tour locks: re-opening the modal does NOT re-fire it (4-week dormancy via `lastDismissedAt`).
- [x] OAuth round-trip simulation (set marker + reload): modal auto-opens, marker cleared. Without marker: modal stays closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)