### PR TITLE
Game phase state machine + global Play CTA + wizard edit mode

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -121,12 +121,18 @@
         "startPlaying": "Start playing →{shortcut}",
         "continuePlaying": "Continue playing →{shortcut}"
     },
+    "playCta": {
+        "startPlaying": "Start playing{shortcut}",
+        "continuePlaying": "Continue playing{shortcut}",
+        "ariaLabel": "Open the play view"
+    },
     "setupWizard": {
         "heading": "Set up your game",
         "subheading": "Walk through each step in order. You can come back to anything by clicking it.",
         "stepCounter": "Step {step} of {total}",
         "next": "Next",
         "skip": "Skip",
+        "done": "Done",
         "newGame": "Start over",
         "cardPack": {
             "title": "Pick a card pack",

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -898,6 +898,18 @@ export const setupSelfPlayerSet = (props: {
     cleared: boolean;
 }): void => capture("setup_self_player_set", props);
 
+/**
+ * The global "Start playing" / "Continue playing" button in the
+ * chrome (Toolbar on desktop, BottomNav on mobile setup). Fires on
+ * click — the user wants to leave the Setup page for Play. The
+ * `phase` discriminates "first time" vs "returning" so the funnel
+ * can separate the two journeys.
+ */
+export const playCtaClicked = (props: {
+    readonly phase: "setupCompleted" | "gameStarted";
+    readonly variant: "toolbar" | "bottomNav";
+}): void => capture("play_cta_clicked", props);
+
 export const setupFirstDealtPlayerSet = (props: {
     auto: boolean;
 }): void => capture("setup_first_dealt_player_set", props);

--- a/src/logic/GameLifecycleState.ts
+++ b/src/logic/GameLifecycleState.ts
@@ -30,6 +30,16 @@ const PersistedGameLifecycleSchema = Schema.Struct({
     createdAt: Schema.optional(Schema.String),
     lastModifiedAt: Schema.optional(Schema.String),
     lastSnoozedAt: Schema.optional(Schema.String),
+    /**
+     * Set the first time the user clicks "Start playing" on the
+     * wizard's last step (or otherwise completes the linear setup
+     * walkthrough). Drives the wizard's flow → edit mode flip: a
+     * brand-new user gets the guided walkthrough; a returning user
+     * who already completed it once gets the spot-check edit page
+     * with the global Play CTA. Reset by `markGameCreated` on
+     * `newGame` so the next session starts in flow mode again.
+     */
+    setupWalkthroughDoneAt: Schema.optional(Schema.String),
 });
 
 const decodeUnknown = Schema.decodeUnknownResult(
@@ -38,11 +48,19 @@ const decodeUnknown = Schema.decodeUnknownResult(
 const encode = Schema.encodeSync(PersistedGameLifecycleSchema);
 
 const STORAGE_KEY = "effect-clue.gameLifecycle.v1";
+/**
+ * Event name dispatched on `window` whenever lifecycle state is
+ * written from within the same tab. React subscribers
+ * (`useSetupWalkthroughDone`) re-read storage on the event so a
+ * walkthrough-completion flip propagates without a full re-render.
+ */
+export const WALKTHROUGH_EVENT = "effect-clue.gameLifecycle.changed";
 
 interface GameLifecycleState {
     readonly createdAt?: DateTime.Utc;
     readonly lastModifiedAt?: DateTime.Utc;
     readonly lastSnoozedAt?: DateTime.Utc;
+    readonly setupWalkthroughDoneAt?: DateTime.Utc;
 }
 
 export const STALE_GAME_THRESHOLD_STARTED: Duration.Duration = Duration.days(3);
@@ -80,6 +98,10 @@ export const loadGameLifecycleState = (): GameLifecycleState => {
             const parsed = parseIso(decoded.success.lastSnoozedAt);
             if (parsed !== undefined) out.lastSnoozedAt = parsed;
         }
+        if (decoded.success.setupWalkthroughDoneAt !== undefined) {
+            const parsed = parseIso(decoded.success.setupWalkthroughDoneAt);
+            if (parsed !== undefined) out.setupWalkthroughDoneAt = parsed;
+        }
         return out;
     } catch {
         return {};
@@ -103,11 +125,13 @@ const writeMerged = (
         const createdAt = pickField("createdAt");
         const lastModifiedAt = pickField("lastModifiedAt");
         const lastSnoozedAt = pickField("lastSnoozedAt");
+        const setupWalkthroughDoneAt = pickField("setupWalkthroughDoneAt");
         const merged: {
             version: 1;
             createdAt?: string;
             lastModifiedAt?: string;
             lastSnoozedAt?: string;
+            setupWalkthroughDoneAt?: string;
         } = { version: 1 };
         if (createdAt !== undefined) {
             merged.createdAt = formatIso(createdAt);
@@ -118,18 +142,31 @@ const writeMerged = (
         if (lastSnoozedAt !== undefined) {
             merged.lastSnoozedAt = formatIso(lastSnoozedAt);
         }
+        if (setupWalkthroughDoneAt !== undefined) {
+            merged.setupWalkthroughDoneAt = formatIso(setupWalkthroughDoneAt);
+        }
         const encoded = encode(merged);
         window.localStorage.setItem(STORAGE_KEY, JSON.stringify(encoded));
+        // Tell React-side subscribers (useSetupWalkthroughDone) the
+        // flag may have changed. Storage events don't fire in the
+        // same tab on writes, so we dispatch a synthetic event.
+        try {
+            window.dispatchEvent(new CustomEvent(WALKTHROUGH_EVENT));
+        } catch {
+            // ignored — fallback to next React render
+        }
     } catch {
         // Quota exceeded, private mode, etc. — non-fatal.
     }
 };
 
-/** Stamp the moment a fresh game came into being. Resets snooze too. */
+/** Stamp the moment a fresh game came into being. Resets snooze
+ * AND the setup-walkthrough flag — a new game should re-run the
+ * first-time-through wizard. */
 export const markGameCreated = (now: DateTime.Utc): void =>
     writeMerged(
         { createdAt: now, lastModifiedAt: now },
-        { clear: ["lastSnoozedAt"] },
+        { clear: ["lastSnoozedAt", "setupWalkthroughDoneAt"] },
     );
 
 /** Bump the touched timestamp without changing creation or snooze. */
@@ -139,6 +176,15 @@ export const markGameTouched = (now: DateTime.Utc): void =>
 /** Record that the user just dismissed the stale-game prompt. */
 export const markStaleGameSnoozed = (now: DateTime.Utc): void =>
     writeMerged({ lastSnoozedAt: now });
+
+/**
+ * Record that the user finished the setup walkthrough (clicked the
+ * wizard's last-step "Start playing" button). The next time they
+ * visit Setup the wizard renders in spot-check edit mode, and the
+ * global Play CTA in the chrome becomes visible.
+ */
+export const markSetupWalkthroughDone = (now: DateTime.Utc): void =>
+    writeMerged({ setupWalkthroughDoneAt: now });
 
 /** Wipe lifecycle state — used after `newGame` followed by markGameCreated. */
 export const clearGameLifecycle = (): void => {

--- a/src/logic/GamePhase.test.ts
+++ b/src/logic/GamePhase.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, test } from "vitest";
+import type {
+    ClueState,
+    DraftAccusation,
+    DraftSuggestion,
+} from "./ClueState";
+import {
+    CARD_SETS,
+    CLASSIC_SETUP_3P,
+    DEFAULT_SETUP,
+    GameSetup,
+} from "./GameSetup";
+import { Player } from "./GameObjects";
+import {
+    getGamePhase,
+    hasCardInformation,
+    phaseAtLeast,
+} from "./GamePhase";
+import { emptyHypotheses } from "./Hypothesis";
+import { KnownCard } from "./InitialKnowledge";
+import { newSuggestionId } from "./Suggestion";
+import { newAccusationId } from "./Accusation";
+import { cardByName } from "./test-utils/CardByName";
+
+// Base state: matches state.tsx's `initialState`. Every test starts
+// from this and mutates only the fields it cares about. Phase: "new".
+const baseState: ClueState = {
+    setup: DEFAULT_SETUP,
+    handSizes: [],
+    knownCards: [],
+    suggestions: [],
+    accusations: [],
+    uiMode: "setup",
+    hypotheses: emptyHypotheses,
+    hypothesisOrder: [],
+    pendingSuggestion: null,
+    selfPlayerId: null,
+    firstDealtPlayerId: null,
+    dismissedInsights: new Map(),
+};
+
+// Fixture state with a card pack + 3 players + every player's hand
+// size set — the minimum bar for "setupCompleted".
+const setupCompletedSetup = CLASSIC_SETUP_3P;
+const [SC_P1, SC_P2, SC_P3] = setupCompletedSetup.players;
+const setupCompletedState: ClueState = {
+    ...baseState,
+    setup: setupCompletedSetup,
+    handSizes: [
+        [SC_P1!, 6],
+        [SC_P2!, 6],
+        [SC_P3!, 6],
+    ],
+};
+
+const PLUM = cardByName(setupCompletedSetup, "Prof. Plum");
+const PIPE = cardByName(setupCompletedSetup, "Lead pipe");
+const STUDY = cardByName(setupCompletedSetup, "Study");
+
+const draftSuggestion = (suggester: Player): DraftSuggestion => ({
+    id: newSuggestionId(),
+    suggester,
+    cards: [PLUM, PIPE, STUDY],
+    nonRefuters: [],
+});
+
+const draftAccusation = (accuser: Player): DraftAccusation => ({
+    id: newAccusationId(),
+    accuser,
+    cards: [PLUM, PIPE, STUDY],
+});
+
+describe("getGamePhase", () => {
+    test("returns 'new' on a fresh default state", () => {
+        expect(getGamePhase(baseState)).toBe("new");
+    });
+
+    test("returns 'dirty' when a non-default player roster is entered", () => {
+        const state: ClueState = {
+            ...baseState,
+            setup: GameSetup({
+                players: [Player("Alice"), Player("Bob")],
+                categories: DEFAULT_SETUP.categories,
+            }),
+        };
+        expect(getGamePhase(state)).toBe("dirty");
+    });
+
+    test("returns 'dirty' when selfPlayerId is set on default roster", () => {
+        const state: ClueState = {
+            ...baseState,
+            selfPlayerId: DEFAULT_SETUP.players[0]!,
+        };
+        expect(getGamePhase(state)).toBe("dirty");
+    });
+
+    test("returns 'dirty' when handSizes are partial (only one player)", () => {
+        // Card pack is default (categories present), default roster has
+        // ≥2 players, so the only thing preventing setupCompleted is the
+        // partial handSizes set. Phase falls back to dirty because the
+        // handSizes-only-for-one-player is a user touch.
+        const state: ClueState = {
+            ...baseState,
+            handSizes: [[DEFAULT_SETUP.players[0]!, 5]],
+        };
+        expect(getGamePhase(state)).toBe("dirty");
+    });
+
+    test("returns 'setupCompleted' once card pack + ≥2 players + all hand sizes are set", () => {
+        expect(getGamePhase(setupCompletedState)).toBe("setupCompleted");
+    });
+
+    test("returns 'setupCompleted' even when knownCards alone exist (knownCards don't count as gameStarted)", () => {
+        const stateWithKnownCards: ClueState = {
+            ...setupCompletedState,
+            knownCards: [KnownCard({ player: SC_P1!, card: PLUM })],
+        };
+        expect(getGamePhase(stateWithKnownCards)).toBe("setupCompleted");
+    });
+
+    test("returns 'gameStarted' on the first logged suggestion", () => {
+        const stateWithSuggestion: ClueState = {
+            ...setupCompletedState,
+            suggestions: [draftSuggestion(SC_P1!)],
+        };
+        expect(getGamePhase(stateWithSuggestion)).toBe("gameStarted");
+    });
+
+    test("returns 'gameStarted' on a logged accusation even with no suggestions", () => {
+        const stateWithAccusation: ClueState = {
+            ...setupCompletedState,
+            accusations: [draftAccusation(SC_P1!)],
+        };
+        expect(getGamePhase(stateWithAccusation)).toBe("gameStarted");
+    });
+
+    test("returns 'dirty' when the user picked a non-default pack but hasn't set hand sizes", () => {
+        const alternativePack = CARD_SETS.find(
+            (cs) => cs.id !== CARD_SETS[0]?.id,
+        );
+        if (alternativePack === undefined) {
+            // No alternate pack defined; skip.
+            return;
+        }
+        const state: ClueState = {
+            ...baseState,
+            setup: GameSetup({
+                cardSet: alternativePack.cardSet,
+                playerSet: DEFAULT_SETUP.playerSet,
+            }),
+        };
+        expect(getGamePhase(state)).toBe("dirty");
+    });
+});
+
+describe("phaseAtLeast", () => {
+    test("orders phases correctly", () => {
+        expect(phaseAtLeast("gameStarted", "setupCompleted")).toBe(true);
+        expect(phaseAtLeast("setupCompleted", "setupCompleted")).toBe(true);
+        expect(phaseAtLeast("dirty", "setupCompleted")).toBe(false);
+        expect(phaseAtLeast("new", "dirty")).toBe(false);
+        expect(phaseAtLeast("dirty", "new")).toBe(true);
+        expect(phaseAtLeast("gameStarted", "new")).toBe(true);
+    });
+});
+
+describe("hasCardInformation", () => {
+    test("false on a pristine state", () => {
+        expect(hasCardInformation(baseState)).toBe(false);
+    });
+
+    test("true when knownCards exist (the key distinction from gameStarted)", () => {
+        const state: ClueState = {
+            ...setupCompletedState,
+            knownCards: [KnownCard({ player: SC_P1!, card: PLUM })],
+        };
+        expect(hasCardInformation(state)).toBe(true);
+        // knownCards alone DON'T elevate the phase to gameStarted, but
+        // DO count as engagement.
+        expect(getGamePhase(state)).toBe("setupCompleted");
+    });
+
+    test("true when suggestions exist", () => {
+        const state: ClueState = {
+            ...setupCompletedState,
+            suggestions: [draftSuggestion(SC_P1!)],
+        };
+        expect(hasCardInformation(state)).toBe(true);
+    });
+
+    test("matches the legacy inline check (suggestions ∪ accusations ∪ knownCards)", () => {
+        const stateOnlyKnown: ClueState = {
+            ...setupCompletedState,
+            knownCards: [KnownCard({ player: SC_P1!, card: PLUM })],
+        };
+        const stateOnlySugg: ClueState = {
+            ...setupCompletedState,
+            suggestions: [draftSuggestion(SC_P1!)],
+        };
+        const stateOnlyAccu: ClueState = {
+            ...setupCompletedState,
+            accusations: [draftAccusation(SC_P1!)],
+        };
+        expect(hasCardInformation(stateOnlyKnown)).toBe(true);
+        expect(hasCardInformation(stateOnlySugg)).toBe(true);
+        expect(hasCardInformation(stateOnlyAccu)).toBe(true);
+        expect(hasCardInformation(baseState)).toBe(false);
+    });
+});

--- a/src/logic/GamePhase.ts
+++ b/src/logic/GamePhase.ts
@@ -1,0 +1,128 @@
+/**
+ * Mutually-exclusive game phases derived from {@link ClueState}. The
+ * single source of truth for "where is the user in the lifecycle of
+ * this game?" — consolidates the four scattered inline checks the
+ * codebase used to inline at every call site:
+ *
+ * - the wizard's `hasGameProgress` flip-the-CTA-label rule
+ * - state.tsx's `gameStartedRef` for smart-landing focus
+ * - Clue.tsx's `gameStarted` for tour eligibility
+ * - useStaleGameGate's `gameStarted` for the idle-threshold pick
+ *
+ * Plus the wizard's `hasGameData()` brand-new-user-redirect helper.
+ *
+ * The phase ordering is forward-only during normal play; `newGame`
+ * resets to `"new"`.
+ *
+ *   new ──► dirty ──► setupCompleted ──► gameStarted
+ *                                            │
+ *                                  newGame action
+ *                                            ▼
+ *                                          new
+ */
+import { DEFAULT_SETUP } from "./GameSetup";
+import type { ClueState } from "./ClueState";
+
+export type GamePhase = "new" | "dirty" | "setupCompleted" | "gameStarted";
+
+const PHASE_ORDER: Record<GamePhase, number> = {
+    new: 0,
+    dirty: 1,
+    setupCompleted: 2,
+    gameStarted: 3,
+};
+
+/**
+ * `true` when `phase` is at least `threshold` in the lifecycle
+ * ordering. Reads naturally at call sites:
+ * `phaseAtLeast(phase, "setupCompleted")` ≈ "the game is at least
+ * setup-completed."
+ */
+export const phaseAtLeast = (
+    phase: GamePhase,
+    threshold: GamePhase,
+): boolean => PHASE_ORDER[phase] >= PHASE_ORDER[threshold];
+
+/**
+ * Broader engagement check — "the user has touched any concrete card
+ * information." True iff knownCards OR suggestions OR accusations
+ * exist. Different from `getGamePhase(state) === "gameStarted"`
+ * because knownCards entry counts here but not as gameStarted.
+ *
+ * Consumed by the stale-game gate (idle-threshold pick), tour
+ * eligibility (StartupCoordinator's `gameStarted` input), and
+ * smart-landing focus on ⌘H. These surfaces want "any engagement,"
+ * not strictly "the user has played a suggestion" — keeping the
+ * helper separate lets the phase model stay crisp without forcing
+ * those consumers to migrate their semantics.
+ */
+export const hasCardInformation = (state: ClueState): boolean =>
+    state.knownCards.length > 0
+    || state.suggestions.length > 0
+    || state.accusations.length > 0;
+
+/**
+ * `true` when at least one suggestion or accusation has been logged
+ * — the strict "the user has played" signal. The wizard's CTA flips
+ * its label on this; the phase machine elevates to `gameStarted`
+ * on this.
+ */
+const hasGameProgress = (state: ClueState): boolean =>
+    state.suggestions.length > 0 || state.accusations.length > 0;
+
+/**
+ * `true` when the minimum data needed to play exists: a card pack is
+ * chosen, at least two players are entered, and every player has a
+ * hand-size entry. Sum-of-hand-sizes is intentionally not enforced
+ * — wizardSteps's validation treats sum mismatch as a `warning`,
+ * not `blocked`, and we want the phase to honor the same threshold.
+ *
+ * `knownCards` / `selfPlayerId` aren't required either — both are
+ * skippable in the wizard; the user can play without them.
+ */
+const hasMinimumSetup = (state: ClueState): boolean => {
+    if (state.setup.categories.length === 0) return false;
+    const players = state.setup.players;
+    if (players.length < 2) return false;
+    const handSizePlayers = new Set(state.handSizes.map(([p]) => p));
+    return players.every((p) => handSizePlayers.has(p));
+};
+
+/**
+ * `true` when any user-touched state exists. Mirrors the legacy
+ * `hasGameData()` semantics — the brand-new-user redirect needs a
+ * very permissive "is there anything to preserve?" check that
+ * includes player-roster customisation, pack swaps, identity, and
+ * first-dealt-player edits.
+ */
+const hasAnyData = (state: ClueState): boolean => {
+    if (state.knownCards.length > 0) return true;
+    if (state.handSizes.length > 0) return true;
+    if (state.suggestions.length > 0) return true;
+    if (state.accusations.length > 0) return true;
+    if (state.selfPlayerId !== null) return true;
+    if (state.firstDealtPlayerId !== null) return true;
+    const players = state.setup.players;
+    if (players.length !== DEFAULT_SETUP.players.length) return true;
+    for (let i = 0; i < players.length; i++) {
+        if (players[i] !== DEFAULT_SETUP.players[i]) return true;
+    }
+    const categories = state.setup.categories;
+    if (categories.length !== DEFAULT_SETUP.categories.length) return true;
+    for (let i = 0; i < categories.length; i++) {
+        if (categories[i] !== DEFAULT_SETUP.categories[i]) return true;
+    }
+    return false;
+};
+
+/**
+ * Pure derivation: which phase is this game in? Guarded match where
+ * the first satisfied condition wins (most-progressed match), so the
+ * result is well-defined for every `ClueState`.
+ */
+export const getGamePhase = (state: ClueState): GamePhase => {
+    if (hasGameProgress(state)) return "gameStarted";
+    if (hasMinimumSetup(state)) return "setupCompleted";
+    if (hasAnyData(state)) return "dirty";
+    return "new";
+};

--- a/src/ui/Clue.flow.test.tsx
+++ b/src/ui/Clue.flow.test.tsx
@@ -196,16 +196,23 @@ describe("Clue — full user-journey umbrella", () => {
         await user.click(stickyByText("next")); // players → identity
         await user.click(stickyByText("skip")); // identity skipped
         await user.click(stickyByText("next")); // handSizes → knownCards
-        await user.click(stickyByText("next")); // knownCards → inviteOtherPlayers
+        // After the handSizes commit (driven by Next), the game phase
+        // becomes setupCompleted and the wizard transitions to spot-
+        // check edit mode. The per-step Next is replaced by Done,
+        // and the canonical "go play" affordance lives in the chrome
+        // (PlayCTAButton, `data-tour-anchor="play-cta"`).
         await waitFor(() => {
             expect(
-                document.querySelector("[data-setup-cta]"),
+                document.querySelector("[data-tour-anchor='play-cta']"),
             ).toBeInTheDocument();
         });
 
-        // 2. Clicking Start Playing flips the URL to checklist view.
-        const cta = document.querySelector<HTMLElement>("[data-setup-cta]");
-        if (!cta) throw new Error("Start Playing CTA missing");
+        // 2. Clicking the global Play CTA flips the URL to the
+        //    checklist view.
+        const cta = document.querySelector<HTMLElement>(
+            "[data-tour-anchor='play-cta']",
+        );
+        if (!cta) throw new Error("Play CTA missing");
         await user.click(cta);
         await waitFor(() => {
             expect(window.location.search).toContain("view=checklist");

--- a/src/ui/Clue.flow.test.tsx
+++ b/src/ui/Clue.flow.test.tsx
@@ -196,23 +196,26 @@ describe("Clue — full user-journey umbrella", () => {
         await user.click(stickyByText("next")); // players → identity
         await user.click(stickyByText("skip")); // identity skipped
         await user.click(stickyByText("next")); // handSizes → knownCards
-        // After the handSizes commit (driven by Next), the game phase
-        // becomes setupCompleted and the wizard transitions to spot-
-        // check edit mode. The per-step Next is replaced by Done,
-        // and the canonical "go play" affordance lives in the chrome
-        // (PlayCTAButton, `data-tour-anchor="play-cta"`).
+        await user.click(stickyByText("next")); // knownCards → inviteOtherPlayers
+        // The walkthrough flag is not yet set — the global Play CTA
+        // stays hidden during the first-time flow. The wizard's
+        // last-step `data-setup-cta` button is the only way to leave
+        // setup.
+        expect(
+            document.querySelector("[data-tour-anchor='play-cta']"),
+        ).toBeNull();
         await waitFor(() => {
             expect(
-                document.querySelector("[data-tour-anchor='play-cta']"),
+                document.querySelector("[data-setup-cta]"),
             ).toBeInTheDocument();
         });
 
-        // 2. Clicking the global Play CTA flips the URL to the
-        //    checklist view.
-        const cta = document.querySelector<HTMLElement>(
-            "[data-tour-anchor='play-cta']",
-        );
-        if (!cta) throw new Error("Play CTA missing");
+        // 2. Clicking the wizard's last-step Start Playing CTA flips
+        //    the URL to the checklist view AND sets the walkthrough-
+        //    done flag so future visits to Setup will surface the
+        //    global Play CTA.
+        const cta = document.querySelector<HTMLElement>("[data-setup-cta]");
+        if (!cta) throw new Error("Wizard Start Playing CTA missing");
         await user.click(cta);
         await waitFor(() => {
             expect(window.location.search).toContain("view=checklist");

--- a/src/ui/Clue.tsx
+++ b/src/ui/Clue.tsx
@@ -41,6 +41,7 @@ import {
     saveTourVisited,
 } from "./tour/TourState";
 import { TelemetryRuntime } from "../observability/runtime";
+import { hasCardInformation } from "../logic/GamePhase";
 import { DateTime } from "effect";
 import {
     pickFirstEligibleScreenKey,
@@ -179,12 +180,11 @@ function CoordinatedShell({
 }) {
     const { hydrated, state, dispatch } = useClue();
     const activeScreen = screenKeyForUiMode(state.uiMode);
-    // Whether the hydrated game has any progress. Drives the
-    // staleGame slot's threshold choice in the coordinator.
-    const gameStarted =
-        state.knownCards.length > 0
-        || state.suggestions.length > 0
-        || state.accusations.length > 0;
+    // Whether the hydrated game has any concrete card engagement.
+    // Drives the staleGame slot's threshold choice (3-day vs 1-day)
+    // in the coordinator — broader than `phase === "gameStarted"`
+    // because knownCards entry alone counts here.
+    const gameStarted = hasCardInformation(state);
     // Translate the coordinator's precedence-redirect request back
     // into a `setUiMode` dispatch. The coordinator only fires this
     // when the highest-priority eligible tour belongs to a screen

--- a/src/ui/components/BottomNav.tsx
+++ b/src/ui/components/BottomNav.tsx
@@ -20,6 +20,7 @@ import { ExternalLinkIcon } from "./Icons";
 import { useInstallPromptContext } from "./InstallPromptProvider";
 import type { InstallPromptTrigger } from "../../analytics/events";
 import { OverflowMenu } from "./OverflowMenu";
+import { PlayCTAButton } from "./PlayCTAButton";
 import { useToolbarActions } from "./Toolbar";
 
 const TRIGGER_MENU: InstallPromptTrigger = "menu";

--- a/src/ui/components/BottomNav.tsx
+++ b/src/ui/components/BottomNav.tsx
@@ -101,11 +101,16 @@ export function BottomNav() {
                     </LayoutGroup>
                 )}
                 {setupMode && (
-                    // Spacer that pushes the overflow trigger to the
-                    // right edge — matches the visual rhythm of the
-                    // Checklist / Suggest tabs taking the left side
-                    // when not in setup mode.
-                    <li className="flex-1" aria-hidden />
+                    // Setup-mode chrome: when phase ≥ setupCompleted
+                    // the PlayCTAButton renders a centered "Start /
+                    // Continue playing" primary CTA in the row to
+                    // the left of the overflow menu. When phase
+                    // < setupCompleted the button renders an empty
+                    // <li flex-1> spacer instead so the overflow
+                    // stays right-aligned and the row keeps its
+                    // ~56px height (the wizard's sticky-footer
+                    // offset depends on that).
+                    <PlayCTAButton variant="bottomNav" />
                 )}
                 <BottomOverflowMenu
                     setupActive={setupMode}

--- a/src/ui/components/PlayCTAButton.test.tsx
+++ b/src/ui/components/PlayCTAButton.test.tsx
@@ -51,6 +51,13 @@ vi.mock("../hooks/useHasKeyboard", () => ({
 
 beforeEach(() => {
     window.localStorage.clear();
+    // The ClueProvider mirrors uiMode to `?view=…` on each
+    // dispatch; without resetting the URL between tests, the
+    // previous test's "setUiMode('checklist')" click would leak
+    // into the next mount's hydration (viewParam = "checklist"),
+    // and PlayCTA's setup-mode-only visibility gate would then
+    // fail because uiMode isn't "setup" on mount.
+    window.history.replaceState(null, "", "/");
     captureCalls.length = 0;
     hasKeyboardOverride = true;
     // The PlayCTAButton is gated on BOTH phase ≥ setupCompleted AND
@@ -255,6 +262,32 @@ describe("PlayCTAButton — toolbar variant", () => {
         seedSetupCompleted(dispatch());
         const button = screen.getByRole("button");
         expect(button.getAttribute("data-tour-anchor")).toBe("play-cta");
+    });
+
+    test("hides on Play views (uiMode = checklist or suggest), even at gameStarted phase", () => {
+        // The CTA's purpose is the Setup → Play handoff. On the
+        // Checklist or Suggest views the user is already in Play,
+        // so the button is redundant. Verify it hides when uiMode
+        // flips to checklist OR suggest, regardless of phase.
+        const { container, dispatch } = mountToolbar();
+        seedGameStarted(dispatch());
+        // Sanity: visible on setup.
+        expect(container.querySelector("button")).not.toBeNull();
+        // Flip to checklist → button hides.
+        act(() => {
+            dispatch()({ type: "setUiMode", mode: "checklist" });
+        });
+        expect(container.querySelector("button")).toBeNull();
+        // Flip to suggest → still hidden.
+        act(() => {
+            dispatch()({ type: "setUiMode", mode: "suggest" });
+        });
+        expect(container.querySelector("button")).toBeNull();
+        // Back to setup → reappears.
+        act(() => {
+            dispatch()({ type: "setUiMode", mode: "setup" });
+        });
+        expect(container.querySelector("button")).not.toBeNull();
     });
 });
 

--- a/src/ui/components/PlayCTAButton.test.tsx
+++ b/src/ui/components/PlayCTAButton.test.tsx
@@ -53,6 +53,26 @@ beforeEach(() => {
     window.localStorage.clear();
     captureCalls.length = 0;
     hasKeyboardOverride = true;
+    // The PlayCTAButton is gated on BOTH phase ≥ setupCompleted AND
+    // the per-game "user completed the wizard walkthrough" flag in
+    // GameLifecycleState. The tests below verify visibility from a
+    // walkthrough-already-done state; seed the flag at the start so
+    // every "should render" test sees the button. The two "renders
+    // empty spacer" tests that exercise the hidden-state spacer
+    // path explicitly clear it inside the test.
+    // Also seed `createdAt` so the ClueProvider hydration effect
+    // doesn't backfill via markGameCreated, which would clear the
+    // walkthroughDoneAt flag we're trying to set up.
+    const now = new Date().toISOString();
+    window.localStorage.setItem(
+        "effect-clue.gameLifecycle.v1",
+        JSON.stringify({
+            version: 1,
+            createdAt: now,
+            lastModifiedAt: now,
+            setupWalkthroughDoneAt: now,
+        }),
+    );
 });
 
 afterEach(() => {
@@ -170,6 +190,19 @@ describe("PlayCTAButton — toolbar variant", () => {
         expect(container.querySelector("button")).toBeNull();
     });
 
+    test("renders nothing when phase ≥ setupCompleted but the walkthrough hasn't been completed yet (first-time flow)", () => {
+        // Clear the walkthrough-done flag seeded in beforeEach so the
+        // composite visibility gate fails. Phase is brought to
+        // setupCompleted via the dispatch harness.
+        window.localStorage.setItem(
+            "effect-clue.gameLifecycle.v1",
+            JSON.stringify({ version: 1 }),
+        );
+        const { container, dispatch } = mountToolbar();
+        seedSetupCompleted(dispatch());
+        expect(container.querySelector("button")).toBeNull();
+    });
+
     test("renders 'Start playing' when phase becomes setupCompleted", () => {
         const { dispatch } = mountToolbar();
         seedSetupCompleted(dispatch());
@@ -227,12 +260,36 @@ describe("PlayCTAButton — toolbar variant", () => {
 
 describe("PlayCTAButton — bottomNav variant", () => {
     test("renders empty <li> spacer in phase 'new' to preserve the BottomNav grid", () => {
+        // Clear the walkthrough flag — phase 'new' is below the gate
+        // either way, but we want this test to assert the spacer
+        // path regardless of the gate state.
+        window.localStorage.setItem(
+            "effect-clue.gameLifecycle.v1",
+            JSON.stringify({ version: 1 }),
+        );
         const { container } = mountBottomNav();
         const list = container.querySelector("[data-testid='bottom-nav-list']");
         const li = list?.querySelector("li");
         expect(li).not.toBeNull();
         expect(li?.querySelector("button")).toBeNull();
         // Spacer has the spacer testid.
+        expect(li?.getAttribute("data-testid")).toBe("play-cta-spacer");
+    });
+
+    test("renders empty <li> spacer when phase = setupCompleted but the walkthrough hasn't been completed yet", () => {
+        // Without the walkthrough flag, the global Play CTA stays
+        // hidden so the first-time wizard CTA is the only path. The
+        // spacer keeps the BottomNav's grid balanced.
+        window.localStorage.setItem(
+            "effect-clue.gameLifecycle.v1",
+            JSON.stringify({ version: 1 }),
+        );
+        const { container, dispatch } = mountBottomNav();
+        seedSetupCompleted(dispatch());
+        const list = container.querySelector("[data-testid='bottom-nav-list']");
+        const li = list?.querySelector("li");
+        expect(li).not.toBeNull();
+        expect(li?.querySelector("button")).toBeNull();
         expect(li?.getAttribute("data-testid")).toBe("play-cta-spacer");
     });
 

--- a/src/ui/components/PlayCTAButton.test.tsx
+++ b/src/ui/components/PlayCTAButton.test.tsx
@@ -1,0 +1,262 @@
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import type { DraftSuggestion } from "../../logic/ClueState";
+import { CLASSIC_SETUP_3P } from "../../logic/GameSetup";
+import { newSuggestionId } from "../../logic/Suggestion";
+import { cardByName } from "../../logic/test-utils/CardByName";
+import { ClueProvider, useClue } from "../state";
+import { TestQueryClientProvider } from "../../test-utils/queryClient";
+import { PlayCTAButton } from "./PlayCTAButton";
+
+// PostHog event capture spy. Mirrors the pattern from SplashModal.test.tsx
+// so the `playCtaClicked` analytics call is asserted on click.
+const captureCalls: Array<{
+    event: string;
+    props: Record<string, unknown> | undefined;
+}> = [];
+
+vi.mock("../../analytics/posthog", () => ({
+    posthog: {
+        __loaded: true,
+        capture: (event: string, props?: Record<string, unknown>) => {
+            captureCalls.push({ event, props });
+        },
+    },
+}));
+
+// Light i18n shim — preserves namespace + key so assertions can match
+// on string fragments.
+vi.mock("next-intl", () => ({
+    useTranslations: (ns?: string) => (key: string, vars?: Record<string, string>) => {
+        const base = ns ? `${ns}.${key}` : key;
+        // Interpolate {shortcut} so the keyboard-suffix assertions can
+        // distinguish "with" / "without" shortcut.
+        if (vars && "shortcut" in vars) {
+            return `${base}${vars["shortcut"] ?? ""}`;
+        }
+        return base;
+    },
+}));
+
+// useHasKeyboard reads navigator userAgent + various heuristics. Mock
+// it directly so tests can toggle the keyboard-present / touch-only
+// branches without juggling jsdom userAgent.
+let hasKeyboardOverride = true;
+vi.mock("../hooks/useHasKeyboard", () => ({
+    useHasKeyboard: () => hasKeyboardOverride,
+}));
+
+beforeEach(() => {
+    window.localStorage.clear();
+    captureCalls.length = 0;
+    hasKeyboardOverride = true;
+});
+
+afterEach(() => {
+    // Reset the keyboard hook for any leftover renders.
+    hasKeyboardOverride = true;
+});
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+    <TestQueryClientProvider>
+        <ClueProvider>{children}</ClueProvider>
+    </TestQueryClientProvider>
+);
+
+/**
+ * Test harness that exposes the ClueProvider's `dispatch` while
+ * rendering the PlayCTAButton inside the same provider. Tests seed
+ * state by calling `dispatchRef.current` inside `act` blocks.
+ */
+function Harness({
+    variant,
+    onReady,
+}: {
+    readonly variant: "toolbar" | "bottomNav";
+    readonly onReady: (
+        dispatch: ReturnType<typeof useClue>["dispatch"],
+    ) => void;
+}) {
+    const { dispatch } = useClue();
+    // Latch the dispatch on first render so tests can drive it. React
+    // re-renders won't change identity within a single ClueProvider
+    // instance.
+    onReady(dispatch);
+    if (variant === "bottomNav") {
+        return (
+            <ul data-testid="bottom-nav-list">
+                <PlayCTAButton variant="bottomNav" />
+            </ul>
+        );
+    }
+    return <PlayCTAButton variant="toolbar" />;
+}
+
+const mountToolbar = () => {
+    let dispatchRef: ReturnType<typeof useClue>["dispatch"] | null = null;
+    const onReady = (
+        d: ReturnType<typeof useClue>["dispatch"],
+    ) => {
+        dispatchRef = d;
+    };
+    const utils = render(
+        <Harness variant="toolbar" onReady={onReady} />,
+        { wrapper },
+    );
+    return { ...utils, dispatch: () => dispatchRef! };
+};
+
+const mountBottomNav = () => {
+    let dispatchRef: ReturnType<typeof useClue>["dispatch"] | null = null;
+    const onReady = (
+        d: ReturnType<typeof useClue>["dispatch"],
+    ) => {
+        dispatchRef = d;
+    };
+    const utils = render(
+        <Harness variant="bottomNav" onReady={onReady} />,
+        { wrapper },
+    );
+    return { ...utils, dispatch: () => dispatchRef! };
+};
+
+/**
+ * Drive state into `setupCompleted`: load Classic 3-player setup and
+ * set hand sizes for all three players.
+ */
+const seedSetupCompleted = (
+    dispatch: ReturnType<typeof useClue>["dispatch"],
+) => {
+    act(() => {
+        dispatch({ type: "setSetup", setup: CLASSIC_SETUP_3P });
+    });
+    for (const p of CLASSIC_SETUP_3P.players) {
+        act(() => {
+            dispatch({ type: "setHandSize", player: p, size: 6 });
+        });
+    }
+};
+
+/**
+ * Drive state into `gameStarted` by adding a suggestion to a
+ * setupCompleted state.
+ */
+const seedGameStarted = (
+    dispatch: ReturnType<typeof useClue>["dispatch"],
+) => {
+    seedSetupCompleted(dispatch);
+    const suggester = CLASSIC_SETUP_3P.players[0]!;
+    const suggestion: DraftSuggestion = {
+        id: newSuggestionId(),
+        suggester,
+        cards: [
+            cardByName(CLASSIC_SETUP_3P, "Prof. Plum"),
+            cardByName(CLASSIC_SETUP_3P, "Lead pipe"),
+            cardByName(CLASSIC_SETUP_3P, "Study"),
+        ],
+        nonRefuters: [],
+    };
+    act(() => {
+        dispatch({ type: "addSuggestion", suggestion });
+    });
+};
+
+describe("PlayCTAButton — toolbar variant", () => {
+    test("renders nothing in phase 'new'", () => {
+        const { container } = mountToolbar();
+        expect(container.querySelector("button")).toBeNull();
+    });
+
+    test("renders 'Start playing' when phase becomes setupCompleted", () => {
+        const { dispatch } = mountToolbar();
+        seedSetupCompleted(dispatch());
+        const button = screen.getByRole("button");
+        // i18n shim returns "playCta.startPlaying" + shortcut suffix.
+        expect(button.textContent).toContain("playCta.startPlaying");
+    });
+
+    test("renders 'Continue playing' once a suggestion is logged", () => {
+        const { dispatch } = mountToolbar();
+        seedGameStarted(dispatch());
+        const button = screen.getByRole("button");
+        expect(button.textContent).toContain("playCta.continuePlaying");
+    });
+
+    test("renders shortcut suffix when keyboard is present", () => {
+        hasKeyboardOverride = true;
+        const { dispatch } = mountToolbar();
+        seedSetupCompleted(dispatch());
+        const button = screen.getByRole("button");
+        // shortcutSuffix produces " (⌘J)" — match the parens.
+        expect(button.textContent).toMatch(/\(.*J\)/);
+    });
+
+    test("hides shortcut suffix on touch-only devices", () => {
+        hasKeyboardOverride = false;
+        const { dispatch } = mountToolbar();
+        seedSetupCompleted(dispatch());
+        const button = screen.getByRole("button");
+        expect(button.textContent).not.toMatch(/\(.*\)/);
+    });
+
+    test("clicking dispatches setUiMode('checklist') and emits play_cta_clicked", async () => {
+        const user = userEvent.setup();
+        const { dispatch } = mountToolbar();
+        seedSetupCompleted(dispatch());
+        const button = screen.getByRole("button");
+        await user.click(button);
+        // PostHog spy receives the typed event with the right props.
+        const playCta = captureCalls.find((c) => c.event === "play_cta_clicked");
+        expect(playCta).toBeDefined();
+        expect(playCta?.props).toMatchObject({
+            phase: "setupCompleted",
+            variant: "toolbar",
+        });
+    });
+
+    test("carries the data-tour-anchor='play-cta' attribute", () => {
+        const { dispatch } = mountToolbar();
+        seedSetupCompleted(dispatch());
+        const button = screen.getByRole("button");
+        expect(button.getAttribute("data-tour-anchor")).toBe("play-cta");
+    });
+});
+
+describe("PlayCTAButton — bottomNav variant", () => {
+    test("renders empty <li> spacer in phase 'new' to preserve the BottomNav grid", () => {
+        const { container } = mountBottomNav();
+        const list = container.querySelector("[data-testid='bottom-nav-list']");
+        const li = list?.querySelector("li");
+        expect(li).not.toBeNull();
+        expect(li?.querySelector("button")).toBeNull();
+        // Spacer has the spacer testid.
+        expect(li?.getAttribute("data-testid")).toBe("play-cta-spacer");
+    });
+
+    test("renders an <li> with a button when phase is setupCompleted", () => {
+        const { dispatch, container } = mountBottomNav();
+        seedSetupCompleted(dispatch());
+        const list = container.querySelector("[data-testid='bottom-nav-list']");
+        const li = list?.querySelector("li");
+        expect(li).not.toBeNull();
+        const button = li?.querySelector("button");
+        expect(button).not.toBeNull();
+        expect(button?.textContent).toContain("playCta.startPlaying");
+    });
+
+    test("emits play_cta_clicked with variant='bottomNav'", async () => {
+        const user = userEvent.setup();
+        const { dispatch } = mountBottomNav();
+        seedGameStarted(dispatch());
+        const button = screen.getByRole("button");
+        await user.click(button);
+        const playCta = captureCalls.find((c) => c.event === "play_cta_clicked");
+        expect(playCta?.props).toMatchObject({
+            phase: "gameStarted",
+            variant: "bottomNav",
+        });
+    });
+});

--- a/src/ui/components/PlayCTAButton.tsx
+++ b/src/ui/components/PlayCTAButton.tsx
@@ -16,6 +16,7 @@ const VARIANT_BOTTOM_NAV = "bottomNav" as const;
 // lint rule from flagging these as user copy.
 const PHASE_GAME_STARTED: GamePhase = "gameStarted";
 const PHASE_SETUP_COMPLETED: GamePhase = "setupCompleted";
+const UI_MODE_SETUP = "setup" as const;
 // i18n keys (not user copy — the lint rule flags the bare literal).
 // eslint-disable-next-line i18next/no-literal-string -- i18n key, not user copy
 const I18N_KEY_CONTINUE = "continuePlaying" as const;
@@ -50,11 +51,16 @@ export function PlayCTAButton({
 }) {
     const phase = useGamePhase();
     const walkthroughDone = useSetupWalkthroughDone();
-    const { dispatch } = useClue();
+    const { state, dispatch } = useClue();
     const t = useTranslations("playCta");
     const hasKeyboard = useHasKeyboard();
 
-    // Visibility composes BOTH signals:
+    // Visibility composes three signals:
+    //  - uiMode === "setup": this CTA's whole purpose is "go play
+    //    from the Setup page." On the Checklist or Suggest views
+    //    the user is already in Play, so the button is redundant
+    //    (and on desktop, where both panes are always visible, also
+    //    pointless).
     //  - phase ≥ setupCompleted: the user has enough data to play.
     //  - walkthroughDone: the user has finished the first-time
     //    walkthrough at least once (the wizard's last-step "Start
@@ -64,7 +70,9 @@ export function PlayCTAButton({
     //    the global chrome button. We want the wizard's CTA to be
     //    the only path during the first-time flow.
     const visible =
-        phaseAtLeast(phase, PHASE_SETUP_COMPLETED) && walkthroughDone;
+        state.uiMode === UI_MODE_SETUP
+        && phaseAtLeast(phase, PHASE_SETUP_COMPLETED)
+        && walkthroughDone;
 
     if (!visible) {
         return variant === VARIANT_BOTTOM_NAV

--- a/src/ui/components/PlayCTAButton.tsx
+++ b/src/ui/components/PlayCTAButton.tsx
@@ -2,7 +2,7 @@
 
 import { useTranslations } from "next-intl";
 import { playCtaClicked } from "../../analytics/events";
-import { phaseAtLeast } from "../../logic/GamePhase";
+import { phaseAtLeast, type GamePhase } from "../../logic/GamePhase";
 import { useGamePhase } from "../hooks/useGamePhase";
 import { useHasKeyboard } from "../hooks/useHasKeyboard";
 import { shortcutSuffix } from "../keyMap";
@@ -11,7 +11,17 @@ import { useClue } from "../state";
 const VARIANT_TOOLBAR = "toolbar" as const;
 const VARIANT_BOTTOM_NAV = "bottomNav" as const;
 
-export type PlayCTAButtonVariant = typeof VARIANT_TOOLBAR | typeof VARIANT_BOTTOM_NAV;
+// Module-scope discriminators — keep the i18next/no-literal-string
+// lint rule from flagging these as user copy.
+const PHASE_GAME_STARTED: GamePhase = "gameStarted";
+const PHASE_SETUP_COMPLETED: GamePhase = "setupCompleted";
+// i18n keys (not user copy — the lint rule flags the bare literal).
+// eslint-disable-next-line i18next/no-literal-string -- i18n key, not user copy
+const I18N_KEY_CONTINUE = "continuePlaying" as const;
+// eslint-disable-next-line i18next/no-literal-string -- i18n key, not user copy
+const I18N_KEY_START = "startPlaying" as const;
+
+type PlayCTAButtonVariant = typeof VARIANT_TOOLBAR | typeof VARIANT_BOTTOM_NAV;
 
 /**
  * Global "Start playing" / "Continue playing" affordance. Appears
@@ -42,7 +52,7 @@ export function PlayCTAButton({
     const t = useTranslations("playCta");
     const hasKeyboard = useHasKeyboard();
 
-    const visible = phaseAtLeast(phase, "setupCompleted");
+    const visible = phaseAtLeast(phase, PHASE_SETUP_COMPLETED);
 
     if (!visible) {
         return variant === VARIANT_BOTTOM_NAV
@@ -57,13 +67,13 @@ export function PlayCTAButton({
     }
 
     // `phase` is `setupCompleted | gameStarted` here (the visibility
-    // gate filters out `new | dirty`). Narrowing in TS isn't worth
-    // the runtime cast; spelling it as a literal union prop is
-    // clearer.
+    // gate filters out `new | dirty`). Pin the narrower discriminator
+    // through the module-scope constants so the i18next/no-literal
+    // lint reads "gameStarted" / "setupCompleted" as identifiers.
     const labelPhase: "setupCompleted" | "gameStarted" =
-        phase === "gameStarted" ? "gameStarted" : "setupCompleted";
+        phase === PHASE_GAME_STARTED ? "gameStarted" : "setupCompleted"; // eslint-disable-line i18next/no-literal-string -- analytics discriminator
     const labelKey =
-        labelPhase === "gameStarted" ? "continuePlaying" : "startPlaying";
+        labelPhase === PHASE_GAME_STARTED ? I18N_KEY_CONTINUE : I18N_KEY_START;
     const label = t(labelKey, {
         shortcut: shortcutSuffix("global.gotoChecklist", hasKeyboard),
     });

--- a/src/ui/components/PlayCTAButton.tsx
+++ b/src/ui/components/PlayCTAButton.tsx
@@ -5,6 +5,7 @@ import { playCtaClicked } from "../../analytics/events";
 import { phaseAtLeast, type GamePhase } from "../../logic/GamePhase";
 import { useGamePhase } from "../hooks/useGamePhase";
 import { useHasKeyboard } from "../hooks/useHasKeyboard";
+import { useSetupWalkthroughDone } from "../hooks/useSetupWalkthroughDone";
 import { shortcutSuffix } from "../keyMap";
 import { useClue } from "../state";
 
@@ -48,11 +49,22 @@ export function PlayCTAButton({
     readonly variant: PlayCTAButtonVariant;
 }) {
     const phase = useGamePhase();
+    const walkthroughDone = useSetupWalkthroughDone();
     const { dispatch } = useClue();
     const t = useTranslations("playCta");
     const hasKeyboard = useHasKeyboard();
 
-    const visible = phaseAtLeast(phase, PHASE_SETUP_COMPLETED);
+    // Visibility composes BOTH signals:
+    //  - phase ≥ setupCompleted: the user has enough data to play.
+    //  - walkthroughDone: the user has finished the first-time
+    //    walkthrough at least once (the wizard's last-step "Start
+    //    playing" button has been clicked for this game). Without
+    //    this, a brand-new user mid-walk would see two competing
+    //    Start-playing affordances: the wizard's per-step CTA AND
+    //    the global chrome button. We want the wizard's CTA to be
+    //    the only path during the first-time flow.
+    const visible =
+        phaseAtLeast(phase, PHASE_SETUP_COMPLETED) && walkthroughDone;
 
     if (!visible) {
         return variant === VARIANT_BOTTOM_NAV

--- a/src/ui/components/PlayCTAButton.tsx
+++ b/src/ui/components/PlayCTAButton.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { playCtaClicked } from "../../analytics/events";
+import { phaseAtLeast } from "../../logic/GamePhase";
+import { useGamePhase } from "../hooks/useGamePhase";
+import { useHasKeyboard } from "../hooks/useHasKeyboard";
+import { shortcutSuffix } from "../keyMap";
+import { useClue } from "../state";
+
+const VARIANT_TOOLBAR = "toolbar" as const;
+const VARIANT_BOTTOM_NAV = "bottomNav" as const;
+
+export type PlayCTAButtonVariant = typeof VARIANT_TOOLBAR | typeof VARIANT_BOTTOM_NAV;
+
+/**
+ * Global "Start playing" / "Continue playing" affordance. Appears
+ * next to the overflow menu — in the desktop Toolbar and in the
+ * mobile BottomNav's setup-mode slot.
+ *
+ * - Hidden when phase < setupCompleted (the user can't usefully
+ *   "start playing" until the minimum data is there).
+ * - Label flips between "Start playing" (setupCompleted) and
+ *   "Continue playing" (gameStarted).
+ * - Shortcut suffix `(⌘J)` appears on devices that have a keyboard.
+ * - Clicking dispatches `setUiMode("checklist")` — equivalent to
+ *   pressing ⌘J.
+ *
+ * The `bottomNav` variant always renders an `<li className="flex-1">`
+ * slot so the BottomNav's `[flex-1][⋯]` shape stays balanced even
+ * when the button is hidden — the slot is just an empty spacer in
+ * that case. The `toolbar` variant returns `null` when hidden; the
+ * parent's `gap-3` flex collapses cleanly.
+ */
+export function PlayCTAButton({
+    variant,
+}: {
+    readonly variant: PlayCTAButtonVariant;
+}) {
+    const phase = useGamePhase();
+    const { dispatch } = useClue();
+    const t = useTranslations("playCta");
+    const hasKeyboard = useHasKeyboard();
+
+    const visible = phaseAtLeast(phase, "setupCompleted");
+
+    if (!visible) {
+        return variant === VARIANT_BOTTOM_NAV
+            ? (
+                <li
+                    className="flex-1"
+                    aria-hidden
+                    data-testid="play-cta-spacer"
+                />
+            )
+            : null;
+    }
+
+    // `phase` is `setupCompleted | gameStarted` here (the visibility
+    // gate filters out `new | dirty`). Narrowing in TS isn't worth
+    // the runtime cast; spelling it as a literal union prop is
+    // clearer.
+    const labelPhase: "setupCompleted" | "gameStarted" =
+        phase === "gameStarted" ? "gameStarted" : "setupCompleted";
+    const labelKey =
+        labelPhase === "gameStarted" ? "continuePlaying" : "startPlaying";
+    const label = t(labelKey, {
+        shortcut: shortcutSuffix("global.gotoChecklist", hasKeyboard),
+    });
+    const ariaLabel = t("ariaLabel");
+
+    const onClick = () => {
+        playCtaClicked({ phase: labelPhase, variant });
+        dispatch({ type: "setUiMode", mode: "checklist" });
+    };
+
+    if (variant === VARIANT_TOOLBAR) {
+        return (
+            <button
+                type="button"
+                aria-label={ariaLabel}
+                data-tour-anchor="play-cta"
+                onClick={onClick}
+                className={
+                    "tap-target-compact text-tap-compact rounded-[var(--radius)] " +
+                    "border-none bg-accent font-semibold text-white " +
+                    "cursor-pointer hover:bg-accent-hover " +
+                    "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent " +
+                    "focus-visible:ring-offset-1 focus-visible:ring-offset-bg " +
+                    "inline-flex items-center justify-center"
+                }
+            >
+                {label}
+            </button>
+        );
+    }
+
+    return (
+        <li className="flex-1">
+            <button
+                type="button"
+                aria-label={ariaLabel}
+                data-tour-anchor="play-cta"
+                onClick={onClick}
+                className={
+                    "flex h-12 w-full cursor-pointer items-center justify-center " +
+                    "rounded-[var(--radius)] border-0 bg-accent px-3 " +
+                    "text-[1rem] font-semibold text-white " +
+                    "hover:bg-accent-hover " +
+                    "focus:outline-none focus-visible:ring-2 focus-visible:ring-accent " +
+                    "focus-visible:ring-offset-1 focus-visible:ring-offset-bg"
+                }
+            >
+                {label}
+            </button>
+        </li>
+    );
+}

--- a/src/ui/components/Toolbar.tsx
+++ b/src/ui/components/Toolbar.tsx
@@ -22,6 +22,7 @@ import { ExternalLinkIcon, RedoIcon, UndoIcon } from "./Icons";
 import { useInstallPromptContext } from "./InstallPromptProvider";
 import type { InstallPromptTrigger } from "../../analytics/events";
 import { OverflowMenu } from "./OverflowMenu";
+import { PlayCTAButton } from "./PlayCTAButton";
 import { Tooltip } from "./Tooltip";
 
 // Module-scope discriminator values, exempt from the i18next literal
@@ -166,6 +167,7 @@ export function Toolbar() {
                     {t("redo", { shortcut: shortcutSuffix("global.redo", hasKeyboard) })}
                 </button>
             </Tooltip>
+            <PlayCTAButton variant="toolbar" />
             <OverflowMenu
                 triggerClassName={`${buttonClass} inline-flex items-center justify-center`}
                 triggerLabel={tNav("more")}

--- a/src/ui/hooks/useGamePhase.ts
+++ b/src/ui/hooks/useGamePhase.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { getGamePhase, type GamePhase } from "../../logic/GamePhase";
+import { useClue } from "../state";
+
+/**
+ * Hook over the central game-phase state machine. Returns one of
+ * `"new" | "dirty" | "setupCompleted" | "gameStarted"` derived
+ * synchronously from the live `ClueState`. Cheap — `getGamePhase` is
+ * a handful of length checks, no memoisation needed.
+ *
+ * See {@link getGamePhase} for the phase semantics.
+ */
+export function useGamePhase(): GamePhase {
+    const { state } = useClue();
+    return getGamePhase(state);
+}

--- a/src/ui/hooks/useSetupWalkthroughDone.ts
+++ b/src/ui/hooks/useSetupWalkthroughDone.ts
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+    loadGameLifecycleState,
+    WALKTHROUGH_EVENT,
+} from "../../logic/GameLifecycleState";
+
+/**
+ * Reactive view over the per-game "user has finished the setup
+ * walkthrough at least once" flag. Drives the wizard's flow → edit
+ * mode flip and the global Play CTA's visibility:
+ *
+ * - First time through: `false`. Wizard runs in linear flow; chrome
+ *   shows no Play CTA. The user reaches the wizard's last step
+ *   (`inviteOtherPlayers`) and uses its in-card "Start playing"
+ *   button to enter Play. That click writes the flag.
+ * - Every visit after that: `true`. Wizard is in spot-check edit
+ *   mode; the global PlayCTAButton is visible in the chrome.
+ *
+ * Resets to `false` on `newGame` (handled by
+ * `markGameCreated`'s `clear` list).
+ *
+ * Reads localStorage on mount and on every `WALKTHROUGH_EVENT`
+ * dispatched by `writeMerged` — same-tab writes (the common case)
+ * propagate via the synthetic event; cross-tab writes propagate via
+ * the native `storage` event.
+ */
+export function useSetupWalkthroughDone(): boolean {
+    const [doneAt, setDoneAt] = useState(
+        () => loadGameLifecycleState().setupWalkthroughDoneAt,
+    );
+    useEffect(() => {
+        const refresh = () => {
+            setDoneAt(loadGameLifecycleState().setupWalkthroughDoneAt);
+        };
+        window.addEventListener(WALKTHROUGH_EVENT, refresh);
+        window.addEventListener("storage", refresh);
+        return () => {
+            window.removeEventListener(WALKTHROUGH_EVENT, refresh);
+            window.removeEventListener("storage", refresh);
+        };
+    }, []);
+    return doneAt !== undefined;
+}

--- a/src/ui/hooks/useStaleGameGate.tsx
+++ b/src/ui/hooks/useStaleGameGate.tsx
@@ -23,6 +23,7 @@ import {
     loadGameLifecycleState,
     markStaleGameSnoozed,
 } from "../../logic/GameLifecycleState";
+import { hasCardInformation } from "../../logic/GamePhase";
 import { useStartupCoordinator } from "../onboarding/StartupCoordinator";
 import { useClue } from "../state";
 import {
@@ -48,10 +49,11 @@ export function useStaleGameGate(): UseStaleGameGateValue {
 
     const open = phase === SLOT_STALE_GAME;
 
-    const gameStarted =
-        state.knownCards.length > 0
-        || state.suggestions.length > 0
-        || state.accusations.length > 0;
+    // Broader than `phase === "gameStarted"` — the stale-game gate
+    // wants to count any concrete card engagement (knownCards alone)
+    // when picking between the 3-day "started" and 1-day "unstarted"
+    // idle thresholds. See {@link hasCardInformation}.
+    const gameStarted = hasCardInformation(state);
 
     // Snapshot the lifecycle timestamps + "now" once per open. Memoize
     // on `open` so the modal's body copy doesn't re-stringify each

--- a/src/ui/setup/SetupStepPanel.tsx
+++ b/src/ui/setup/SetupStepPanel.tsx
@@ -9,9 +9,25 @@ import type { StepValidation, WizardStepId } from "./wizardSteps";
 
 export type StepPanelState = "pending" | "editing" | "complete";
 
+/**
+ * Wizard's overall mode, derived from the central game-phase
+ * machine. Drives whether closed steps are openable and whether the
+ * "pending" treatment dims them.
+ *
+ * - `"flow"`: first-time setup. Steps walked in canonical order;
+ *   pending steps below the focused one are locked (greyed, header
+ *   non-interactive). Footer shows "Skip" / "Next" (or "Start
+ *   playing" on the last step).
+ * - `"edit"`: spot-check edit. Every step is openable independently;
+ *   "pending" reads as "closed without data" with no dim. Footer
+ *   shows a single "Done" that collapses the focused step.
+ */
+export type WizardMode = "flow" | "edit";
+
 interface Props {
     readonly stepId: WizardStepId;
     readonly state: StepPanelState;
+    readonly wizardMode: WizardMode;
     readonly stepNumber: number;
     readonly totalSteps: number;
     readonly title: string;
@@ -73,6 +89,7 @@ interface Props {
 export function SetupStepPanel({
     stepId,
     state,
+    wizardMode,
     stepNumber,
     totalSteps,
     title,
@@ -96,12 +113,23 @@ export function SetupStepPanel({
     const isPending = state === "pending";
     const isEditing = state === "editing";
     const isComplete = state === "complete";
+    const isEditMode = wizardMode === "edit";
 
-    const headerTextClass = isPending
-        ? "text-muted opacity-60"
-        : "text-fg";
+    // Dim the header only in flow mode's "pending" treatment.
+    // Edit mode renders every closed step at full opacity — they're
+    // all equally accessible, dimming would mis-signal "locked."
+    const headerTextClass =
+        isPending && !isEditMode ? "text-muted opacity-60" : "text-fg";
 
-    const headerClickable = isComplete && onClickToEdit !== undefined;
+    // Header click semantics:
+    //   flow mode  — only completed steps are re-enterable.
+    //   edit mode  — every non-editing step is openable. Pending
+    //               (closed-without-data) steps included; the
+    //               accordion's `reEnter` handler is symmetric on
+    //               state, so the shell's existing code path works.
+    const headerClickable =
+        onClickToEdit !== undefined
+        && (isEditMode ? !isEditing : isComplete);
 
     return (
         <section

--- a/src/ui/setup/SetupWizard.test.tsx
+++ b/src/ui/setup/SetupWizard.test.tsx
@@ -198,27 +198,31 @@ describe("SetupWizard — accordion shell", () => {
         expect(skip).not.toBeDisabled();
     });
 
-    test("Start playing CTA appears on the last step and is enabled with defaults", async () => {
+    test("Play CTA appears once minimum setup is complete (mid-flow mode flip to edit)", async () => {
         const user = userEvent.setup();
         render(<Clue />, { wrapper: TestQueryClientProvider });
         await waitForWizard();
-        // Click Next through every step to reach the last one. With
-        // selfPlayerId null on a fresh mount, visible steps are:
-        // cardPack → players → identity → handSizes → knownCards →
-        // inviteOtherPlayers.
-        // We hit Skip on identity to skip past it (avoids setting
-        // selfPlayerId, keeping myCards hidden).
+        // Click Next through every step until handSizes is filled
+        // (committing placeholder defaults via beforeAdvance). At
+        // that point the game phase becomes "setupCompleted" and the
+        // wizard transitions out of forced-flow into spot-check edit
+        // mode — the per-step Next button is replaced by a single
+        // Done button, and the global PlayCTAButton (which lives in
+        // the chrome) becomes visible.
         await user.click(stickyNext()); // cardPack → players
         await user.click(stickyNext()); // players → identity
         await user.click(stickySkip()); // identity → handSizes
-        await user.click(stickyNext()); // handSizes → knownCards
-        await user.click(stickyNext()); // knownCards → inviteOtherPlayers
-        // We're now on the last step. The Next button's label is
-        // "Start playing" or "Continue playing" and `data-setup-cta`
-        // is set.
+        await user.click(stickyNext()); // handSizes → knownCards (commits handSizes via beforeAdvance, flips to edit mode)
+
+        // After the handSizes commit, the global PlayCTAButton renders
+        // with `data-tour-anchor="play-cta"`. It carries the play view
+        // affordance that the wizard's old last-step button used to
+        // carry. In edit mode the per-step `setup-start-playing`
+        // attribute never appears anywhere — `play-cta` is the
+        // canonical "go play now" affordance.
         await waitFor(() => {
             const cta = document.querySelector(
-                '[data-tour-anchor="setup-start-playing"]',
+                '[data-tour-anchor="play-cta"]',
             ) as HTMLButtonElement | null;
             expect(cta).not.toBeNull();
             expect(cta).not.toBeDisabled();

--- a/src/ui/setup/SetupWizard.test.tsx
+++ b/src/ui/setup/SetupWizard.test.tsx
@@ -198,31 +198,30 @@ describe("SetupWizard — accordion shell", () => {
         expect(skip).not.toBeDisabled();
     });
 
-    test("Play CTA appears once minimum setup is complete (mid-flow mode flip to edit)", async () => {
+    test("first-time flow lands the user on the wizard's last-step 'Start playing' CTA — no global Play CTA visible mid-flow", async () => {
         const user = userEvent.setup();
         render(<Clue />, { wrapper: TestQueryClientProvider });
         await waitForWizard();
-        // Click Next through every step until handSizes is filled
-        // (committing placeholder defaults via beforeAdvance). At
-        // that point the game phase becomes "setupCompleted" and the
-        // wizard transitions out of forced-flow into spot-check edit
-        // mode — the per-step Next button is replaced by a single
-        // Done button, and the global PlayCTAButton (which lives in
-        // the chrome) becomes visible.
+        // Walk every step. The wizard's `inviteOtherPlayers` step
+        // (last in the visible order with selfPlayerId null) carries
+        // the final `data-tour-anchor="setup-start-playing"` CTA;
+        // that's the only path out of first-time setup. The global
+        // PlayCTAButton stays hidden during this walkthrough — the
+        // walkthrough-done flag (in GameLifecycleState) hasn't been
+        // set yet, so the chrome's CTA is gated off.
         await user.click(stickyNext()); // cardPack → players
         await user.click(stickyNext()); // players → identity
         await user.click(stickySkip()); // identity → handSizes
-        await user.click(stickyNext()); // handSizes → knownCards (commits handSizes via beforeAdvance, flips to edit mode)
-
-        // After the handSizes commit, the global PlayCTAButton renders
-        // with `data-tour-anchor="play-cta"`. It carries the play view
-        // affordance that the wizard's old last-step button used to
-        // carry. In edit mode the per-step `setup-start-playing`
-        // attribute never appears anywhere — `play-cta` is the
-        // canonical "go play now" affordance.
+        await user.click(stickyNext()); // handSizes → knownCards
+        await user.click(stickyNext()); // knownCards → inviteOtherPlayers
+        // No global PlayCTA at any point in the walkthrough.
+        expect(
+            document.querySelector('[data-tour-anchor="play-cta"]'),
+        ).toBeNull();
+        // The wizard's last-step CTA is what the user clicks.
         await waitFor(() => {
             const cta = document.querySelector(
-                '[data-tour-anchor="play-cta"]',
+                '[data-tour-anchor="setup-start-playing"]',
             ) as HTMLButtonElement | null;
             expect(cta).not.toBeNull();
             expect(cta).not.toBeDisabled();

--- a/src/ui/setup/SetupWizard.tsx
+++ b/src/ui/setup/SetupWizard.tsx
@@ -16,9 +16,11 @@ import {
 import type { ClueState } from "../../logic/ClueState";
 import { cardSetEquals } from "../../logic/CardSet";
 import { CARD_SETS, newGameSetup } from "../../logic/GameSetup";
-import { getGamePhase } from "../../logic/GamePhase";
+import { getGamePhase, phaseAtLeast } from "../../logic/GamePhase";
 import { useConfirm } from "../hooks/useConfirm";
+import { useGamePhase } from "../hooks/useGamePhase";
 import { useClue } from "../state";
+import { useTour } from "../tour/TourProvider";
 import { useSetupWizardFocus } from "./SetupWizardFocusContext";
 import { SetupStepCardPack } from "./steps/SetupStepCardPack";
 import { SetupStepHandSizes } from "./steps/SetupStepHandSizes";
@@ -28,13 +30,14 @@ import { SetupStepKnownCards } from "./steps/SetupStepKnownCards";
 import { SetupStepMyCards } from "./steps/SetupStepMyCards";
 import { SetupStepPlayers } from "./steps/SetupStepPlayers";
 import {
+    isStepDataComplete,
     stepIsSkippable,
     stepValidationLevel,
     visibleSteps,
     type StepValidationLevel,
     type WizardStepId,
 } from "./wizardSteps";
-import type { StepPanelState } from "./SetupStepPanel";
+import type { StepPanelState, WizardMode } from "./SetupStepPanel";
 
 // Default Classic deck — used to detect "deck has not been touched."
 const CLASSIC_CARD_SET = CARD_SETS[0]!.cardSet;
@@ -83,6 +86,31 @@ function hasDestructiveState(state: ClueState): boolean {
 const STEP_EDITING: StepPanelState = "editing";
 const STEP_COMPLETE: StepPanelState = "complete";
 const STEP_PENDING: StepPanelState = "pending";
+const WIZARD_MODE_FLOW: WizardMode = "flow";
+const WIZARD_MODE_EDIT: WizardMode = "edit";
+// Phase discriminator used in this file's phaseAtLeast checks. Kept
+// to module scope so the lint rule reads it as an identifier.
+const PHASE_SETUP_COMPLETED = "setupCompleted" as const;
+const PHASE_NEW = "new" as const;
+const PHASE_GAME_STARTED = "gameStarted" as const;
+
+/**
+ * Tour anchors that live INSIDE a wizard step's expanded body, mapped
+ * to the wizard step that must be open for the anchor to be in the
+ * DOM. The wizard reads this table on tour-step transitions and
+ * expands the required step as a pre-condition (per AGENTS.md
+ * "Tour steps must set up the UI to their expected pre-condition").
+ *
+ * The two entries today come from the `sharing` tour
+ * ([src/ui/tour/tours.ts]). If a future tour anchors at another
+ * in-step element, add it here and verify in the next-dev preview.
+ */
+const TOUR_ANCHOR_REQUIRES_WIZARD_STEP: Readonly<
+    Record<string, WizardStepId>
+> = {
+    "setup-share-pack-pill": "cardPack",
+    "setup-invite-player": "inviteOtherPlayers",
+};
 
 /**
  * M6 setup wizard — accordion of step panels rendered when the
@@ -117,7 +145,7 @@ export function SetupWizard() {
     const t = useTranslations("setupWizard");
     const tSetup = useTranslations("setup");
     const tToolbar = useTranslations("toolbar");
-    const { state, dispatch } = useClue();
+    const { state, dispatch, hydrated } = useClue();
     const confirm = useConfirm();
     const focus = useSetupWizardFocus();
 
@@ -136,14 +164,26 @@ export function SetupWizard() {
         () => new Set(),
     );
 
-    // Initial focused step: the focus-context hint (programmatic
-    // jumps from a future "edit this step" affordance), else the
-    // first canonical step. Always starts on cardPack on a normal
-    // mount.
+    // Initial focused step. Three regimes:
+    //   1. Explicit focus-hint (programmatic jump from an "edit this
+    //      step" affordance somewhere else) — honor it if visible.
+    //   2. Edit-mode mount (phase ≥ setupCompleted on first render):
+    //      open NO step by default. The user picks what to edit; we
+    //      don't want to open `cardPack` unannounced for a returning
+    //      mid-game user navigating to Setup.
+    //   3. Flow-mode mount (phase < setupCompleted): legacy "land on
+    //      step 1" so first-time setup feels guided.
+    //
+    // Read phase directly off state (no hook — useState initializers
+    // don't re-run on prop change anyway, and we want the value as
+    // of mount).
     const [focusedStep, setFocusedStep] = useState<WizardStepId | null>(
         () => {
             const hinted = focus?.consumeFocusHint() ?? null;
             if (hinted !== null && steps.includes(hinted)) return hinted;
+            if (phaseAtLeast(getGamePhase(state), PHASE_SETUP_COMPLETED)) {
+                return null;
+            }
             return steps[0] ?? null;
         },
     );
@@ -168,8 +208,109 @@ export function SetupWizard() {
         );
     }, [steps]);
 
+    // When phase transitions to "new" while the wizard is still
+    // mounted (e.g. user clicked "New game" in the overflow menu
+    // while already in Setup mode, or "Start over" → confirm from
+    // the wizard's own footer), snap the local nav state back to
+    // step 1. The legacy reliance on a "newGame remounts the
+    // wizard" effect was wishful — uiMode is already "setup", so
+    // the wizard never unmounts/remounts on that dispatch. Driving
+    // the reset off the phase machine handles every entry path with
+    // one effect.
+    //
+    // Deps are kept to `[phase]` (the only signal we react to);
+    // `steps` is captured via a ref so reducer ticks that produce
+    // new state objects don't re-fire this effect spuriously. See
+    // AGENTS.md "Effect deps in tour-driven entry effects."
+    const phase = useGamePhase();
+    const prevPhaseRef = useRef(phase);
+    const stepsRefForPhaseReset = useRef(steps);
+    useEffect(() => {
+        stepsRefForPhaseReset.current = steps;
+    }, [steps]);
+    useEffect(() => {
+        const prev = prevPhaseRef.current;
+        prevPhaseRef.current = phase;
+        if (phase !== PHASE_NEW) return;
+        if (prev === PHASE_NEW) return;
+        setCompleted(new Set());
+        setFocusedStep(stepsRefForPhaseReset.current[0] ?? null);
+    }, [phase]);
+
+    // Wizard mode = "edit" once the user has enough data to play.
+    // Drives per-step click-to-open + dim, the sticky footer's
+    // primary action ("Done" vs Skip/Next), and the per-step
+    // "complete" badge logic below.
+    const wizardMode: WizardMode = phaseAtLeast(phase, PHASE_SETUP_COMPLETED)
+        ? WIZARD_MODE_EDIT
+        : WIZARD_MODE_FLOW;
+
+    // Hydration-aware initial-focused-step correction. The useState
+    // initializer above evaluates phase off the pre-hydration state
+    // (always "new"), so a user returning to a setupCompleted+ game
+    // would otherwise land on the cardPack step "editing" — wrong for
+    // edit mode, which wants no step open by default. Once hydration
+    // completes, snap focusedStep to null IF (a) we're now in edit
+    // mode AND (b) focusedStep is still the default `steps[0]` (the
+    // user hasn't already picked another step in the time between
+    // useState and the hydrated effect). Runs once on the hydration
+    // edge.
+    const correctedForHydratedEditModeRef = useRef(false);
+    useEffect(() => {
+        if (!hydrated) return;
+        if (correctedForHydratedEditModeRef.current) return;
+        correctedForHydratedEditModeRef.current = true;
+        if (!phaseAtLeast(phase, PHASE_SETUP_COMPLETED)) return;
+        setFocusedStep((prev) =>
+            prev === (stepsRefForPhaseReset.current[0] ?? null) ? null : prev,
+        );
+    }, [hydrated, phase]);
+
+    // Tour pre-condition effect. Some tour steps (today: the sharing
+    // tour's `setup-share-pack-pill` and `setup-invite-player`)
+    // anchor at DOM nodes that live INSIDE an expanded wizard step's
+    // body. In edit mode the wizard's default `focusedStep` is null
+    // (no step open), so those anchors aren't in the DOM when the
+    // tour fires — the popover would have nothing to point at.
+    //
+    // Per AGENTS.md "Tour steps must set up the UI to their expected
+    // pre-condition," each step's entry should arrange the UI for
+    // its anchor. We do that here from the consuming component (the
+    // wizard) by mapping known tour anchors → the wizard step they
+    // require, and expanding that step when the tour enters one.
+    //
+    // `steps` is captured via a ref so the effect's deps stay at
+    // just `[currentStepAnchor]` — reducer ticks that produce new
+    // state objects don't re-fire and overwrite the user's chosen
+    // open step.
+    const { currentStep } = useTour();
+    const currentStepAnchor = currentStep?.anchor;
+    const stepsRefForTour = useRef(steps);
+    useEffect(() => {
+        stepsRefForTour.current = steps;
+    }, [steps]);
+    useEffect(() => {
+        if (currentStepAnchor === undefined) return;
+        const required = TOUR_ANCHOR_REQUIRES_WIZARD_STEP[currentStepAnchor];
+        if (required === undefined) return;
+        if (!stepsRefForTour.current.includes(required)) return;
+        setFocusedStep((prev) => (prev === required ? prev : required));
+    }, [currentStepAnchor]);
+
     const stepStateFor = (id: WizardStepId): StepPanelState => {
         if (id === focusedStep) return STEP_EDITING;
+        // Edit mode: the "completed" check derives from data presence,
+        // not the local advance/skip-tracked `completed` set. That
+        // way a returning user (who never walked the wizard linearly)
+        // still sees check marks on the steps they have data for.
+        // `pending` here is just "closed without data" — the panel
+        // reads `wizardMode === "edit"` and renders it without the
+        // dim/locked treatment.
+        if (wizardMode === WIZARD_MODE_EDIT) {
+            return isStepDataComplete(id, state)
+                ? STEP_COMPLETE
+                : STEP_PENDING;
+        }
         if (completed.has(id)) return STEP_COMPLETE;
         return STEP_PENDING;
     };
@@ -381,7 +522,7 @@ export function SetupWizard() {
         (focusedSkippable || focusedValidationLevel !== "blocked");
     const nextEnabled =
         focusedStep !== null && focusedValidationLevel !== "blocked";
-    const hasGameProgress = getGamePhase(state) === "gameStarted";
+    const hasGameProgress = getGamePhase(state) === PHASE_GAME_STARTED;
     const startPlayingLabel = hasGameProgress
         ? tSetup("continuePlaying", { shortcut: "" })
         : tSetup("startPlaying", { shortcut: "" });
@@ -423,6 +564,19 @@ export function SetupWizard() {
         dispatch({ type: "setUiMode", mode: "checklist" });
     };
 
+    // Edit-mode footer action: collapse the open step. Per-input
+    // changes already committed via dispatch; "Done" is a pure UI
+    // close. Flush any beforeAdvance hook the step registered (e.g.
+    // hand-sizes commits placeholder defaults) so the user's implicit
+    // "accept default" is captured. beforeSkip is intentionally NOT
+    // fired — edit mode has no skip semantics.
+    const onClickDone = () => {
+        if (focusedStep === null) return;
+        beforeAdvanceRef.current?.();
+        beforeAdvanceRef.current = null;
+        setFocusedStep(null);
+    };
+
     /**
      * "Start over" branches on whether anything destructive would be
      * lost. With a fresh wizard mount (default deck, default roster,
@@ -445,8 +599,12 @@ export function SetupWizard() {
         });
         if (!ok) return;
         dispatch({ type: "newGame" });
-        // newGame remounts the wizard via state reset; the fresh
-        // mount lands on step 1 via the initial-state logic above.
+        // The newGame action resets phase to "new"; the phase-
+        // transition effect above catches that and resets
+        // focusedStep + completed back to step 1. (This path runs
+        // while uiMode is already "setup", so the wizard does NOT
+        // unmount/remount — the effect is what actually performs
+        // the reset.)
     };
 
     /**
@@ -498,26 +656,42 @@ export function SetupWizard() {
                 {t("newGame")}
             </button>
             <div className="ml-auto flex items-center gap-2">
-                <button
-                    type="button"
-                    className="tap-target-compact text-tap-compact cursor-pointer rounded border border-border bg-control hover:bg-hover disabled:cursor-not-allowed disabled:opacity-50"
-                    onClick={onClickSkip}
-                    disabled={!skipEnabled}
-                >
-                    {t("skip")}
-                </button>
-                <button
-                    type="button"
-                    className="tap-target text-tap cursor-pointer rounded border-none bg-accent font-semibold text-white hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
-                    onClick={onClickNext}
-                    disabled={!nextEnabled}
-                    data-tour-anchor={
-                        isLastStep ? "setup-start-playing" : undefined
-                    }
-                    data-setup-cta={isLastStep ? "" : undefined}
-                >
-                    {isLastStep ? startPlayingLabel : t("next")}
-                </button>
+                {wizardMode === WIZARD_MODE_FLOW ? (
+                    <>
+                        <button
+                            type="button"
+                            className="tap-target-compact text-tap-compact cursor-pointer rounded border border-border bg-control hover:bg-hover disabled:cursor-not-allowed disabled:opacity-50"
+                            onClick={onClickSkip}
+                            disabled={!skipEnabled}
+                        >
+                            {t("skip")}
+                        </button>
+                        <button
+                            type="button"
+                            className="tap-target text-tap cursor-pointer rounded border-none bg-accent font-semibold text-white hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-50"
+                            onClick={onClickNext}
+                            disabled={!nextEnabled}
+                            data-tour-anchor={
+                                isLastStep ? "setup-start-playing" : undefined
+                            }
+                            data-setup-cta={isLastStep ? "" : undefined}
+                        >
+                            {isLastStep ? startPlayingLabel : t("next")}
+                        </button>
+                    </>
+                ) : (
+                    // Edit mode: single "Done" CTA. Collapses the
+                    // open step; no advance, no skip. The global
+                    // PlayCTAButton in the chrome carries the "go
+                    // play" affordance instead.
+                    <button
+                        type="button"
+                        className="tap-target text-tap cursor-pointer rounded border-none bg-accent font-semibold text-white hover:bg-accent-hover"
+                        onClick={onClickDone}
+                    >
+                        {t("done")}
+                    </button>
+                )}
             </div>
         </div>
     );
@@ -549,6 +723,7 @@ export function SetupWizard() {
                             <SetupStepCardPack
                                 key={id}
                                 state={panelState}
+                                wizardMode={wizardMode}
                                 stepNumber={stepNumber}
                                 totalSteps={totalSteps}
                                 onClickToEdit={() => reEnter(id)}
@@ -562,6 +737,7 @@ export function SetupWizard() {
                             <SetupStepPlayers
                                 key={id}
                                 state={panelState}
+                                wizardMode={wizardMode}
                                 stepNumber={stepNumber}
                                 totalSteps={totalSteps}
                                 onClickToEdit={() => reEnter(id)}
@@ -575,6 +751,7 @@ export function SetupWizard() {
                             <SetupStepIdentity
                                 key={id}
                                 state={panelState}
+                                wizardMode={wizardMode}
                                 stepNumber={stepNumber}
                                 totalSteps={totalSteps}
                                 onClickToEdit={() => reEnter(id)}
@@ -589,6 +766,7 @@ export function SetupWizard() {
                             <SetupStepHandSizes
                                 key={id}
                                 state={panelState}
+                                wizardMode={wizardMode}
                                 stepNumber={stepNumber}
                                 totalSteps={totalSteps}
                                 onClickToEdit={() => reEnter(id)}
@@ -609,6 +787,7 @@ export function SetupWizard() {
                             <SetupStepMyCards
                                 key={id}
                                 state={panelState}
+                                wizardMode={wizardMode}
                                 stepNumber={stepNumber}
                                 totalSteps={totalSteps}
                                 selfPlayerId={state.selfPlayerId}
@@ -623,6 +802,7 @@ export function SetupWizard() {
                             <SetupStepKnownCards
                                 key={id}
                                 state={panelState}
+                                wizardMode={wizardMode}
                                 stepNumber={stepNumber}
                                 totalSteps={totalSteps}
                                 onClickToEdit={() => reEnter(id)}
@@ -636,6 +816,7 @@ export function SetupWizard() {
                             <SetupStepInviteOtherPlayers
                                 key={id}
                                 state={panelState}
+                                wizardMode={wizardMode}
                                 stepNumber={stepNumber}
                                 totalSteps={totalSteps}
                                 onClickToEdit={() => reEnter(id)}

--- a/src/ui/setup/SetupWizard.tsx
+++ b/src/ui/setup/SetupWizard.tsx
@@ -16,6 +16,7 @@ import {
 import type { ClueState } from "../../logic/ClueState";
 import { cardSetEquals } from "../../logic/CardSet";
 import { CARD_SETS, newGameSetup } from "../../logic/GameSetup";
+import { getGamePhase } from "../../logic/GamePhase";
 import { useConfirm } from "../hooks/useConfirm";
 import { useClue } from "../state";
 import { useSetupWizardFocus } from "./SetupWizardFocusContext";
@@ -380,8 +381,7 @@ export function SetupWizard() {
         (focusedSkippable || focusedValidationLevel !== "blocked");
     const nextEnabled =
         focusedStep !== null && focusedValidationLevel !== "blocked";
-    const hasGameProgress =
-        state.suggestions.length > 0 || state.accusations.length > 0;
+    const hasGameProgress = getGamePhase(state) === "gameStarted";
     const startPlayingLabel = hasGameProgress
         ? tSetup("continuePlaying", { shortcut: "" })
         : tSetup("startPlaying", { shortcut: "" });

--- a/src/ui/setup/SetupWizard.tsx
+++ b/src/ui/setup/SetupWizard.tsx
@@ -19,8 +19,14 @@ import { CARD_SETS, newGameSetup } from "../../logic/GameSetup";
 import { getGamePhase, phaseAtLeast } from "../../logic/GamePhase";
 import { useConfirm } from "../hooks/useConfirm";
 import { useGamePhase } from "../hooks/useGamePhase";
+import { useSetupWalkthroughDone } from "../hooks/useSetupWalkthroughDone";
 import { useClue } from "../state";
 import { useTour } from "../tour/TourProvider";
+import {
+    loadGameLifecycleState,
+    markSetupWalkthroughDone,
+} from "../../logic/GameLifecycleState";
+import { DateTime } from "effect";
 import { useSetupWizardFocus } from "./SetupWizardFocusContext";
 import { SetupStepCardPack } from "./steps/SetupStepCardPack";
 import { SetupStepHandSizes } from "./steps/SetupStepHandSizes";
@@ -167,21 +173,28 @@ export function SetupWizard() {
     // Initial focused step. Three regimes:
     //   1. Explicit focus-hint (programmatic jump from an "edit this
     //      step" affordance somewhere else) — honor it if visible.
-    //   2. Edit-mode mount (phase ≥ setupCompleted on first render):
-    //      open NO step by default. The user picks what to edit; we
-    //      don't want to open `cardPack` unannounced for a returning
-    //      mid-game user navigating to Setup.
-    //   3. Flow-mode mount (phase < setupCompleted): legacy "land on
-    //      step 1" so first-time setup feels guided.
+    //   2. Edit-mode mount (phase ≥ setupCompleted AND the user has
+    //      already finished the walkthrough for this game): open NO
+    //      step by default. The user picks what to edit.
+    //   3. Otherwise (flow mode — first-time walkthrough): legacy
+    //      "land on step 1" so first-time setup feels guided.
     //
-    // Read phase directly off state (no hook — useState initializers
-    // don't re-run on prop change anyway, and we want the value as
-    // of mount).
+    // Read phase + walkthrough flag directly (useState initializers
+    // don't re-run on prop change; we want the value at mount).
     const [focusedStep, setFocusedStep] = useState<WizardStepId | null>(
         () => {
             const hinted = focus?.consumeFocusHint() ?? null;
             if (hinted !== null && steps.includes(hinted)) return hinted;
-            if (phaseAtLeast(getGamePhase(state), PHASE_SETUP_COMPLETED)) {
+            const phaseAtMount = getGamePhase(state);
+            // `loadGameLifecycleState` already guards SSR (returns
+            // `{}` when window is undefined), so no extra check
+            // needed here.
+            const walkthroughDoneAtMount =
+                loadGameLifecycleState().setupWalkthroughDoneAt !== undefined;
+            if (
+                phaseAtLeast(phaseAtMount, PHASE_SETUP_COMPLETED)
+                && walkthroughDoneAtMount
+            ) {
                 return null;
             }
             return steps[0] ?? null;
@@ -237,13 +250,24 @@ export function SetupWizard() {
         setFocusedStep(stepsRefForPhaseReset.current[0] ?? null);
     }, [phase]);
 
-    // Wizard mode = "edit" once the user has enough data to play.
-    // Drives per-step click-to-open + dim, the sticky footer's
-    // primary action ("Done" vs Skip/Next), and the per-step
-    // "complete" badge logic below.
-    const wizardMode: WizardMode = phaseAtLeast(phase, PHASE_SETUP_COMPLETED)
-        ? WIZARD_MODE_EDIT
-        : WIZARD_MODE_FLOW;
+    // Wizard mode = "edit" once the user has:
+    //   1. enough data to play (phase ≥ setupCompleted) AND
+    //   2. finished the linear walkthrough at least once for this
+    //      game (clicked Start playing on the wizard's last step,
+    //      recorded as `setupWalkthroughDoneAt` on the lifecycle
+    //      stamp). Resets on `newGame`.
+    //
+    // The double gate keeps the first-time experience strictly
+    // linear: even after the user committed handSizes mid-walk
+    // (which flips phase to setupCompleted), the wizard stays in
+    // flow mode until they reach `inviteOtherPlayers` and click its
+    // in-card Start playing button. Without #2, the global Play CTA
+    // would appear mid-flow and compete with the wizard's flow CTA.
+    const walkthroughDone = useSetupWalkthroughDone();
+    const wizardMode: WizardMode =
+        phaseAtLeast(phase, PHASE_SETUP_COMPLETED) && walkthroughDone
+            ? WIZARD_MODE_EDIT
+            : WIZARD_MODE_FLOW;
 
     // Hydration-aware initial-focused-step correction. The useState
     // initializer above evaluates phase off the pre-hydration state
@@ -251,20 +275,22 @@ export function SetupWizard() {
     // would otherwise land on the cardPack step "editing" — wrong for
     // edit mode, which wants no step open by default. Once hydration
     // completes, snap focusedStep to null IF (a) we're now in edit
-    // mode AND (b) focusedStep is still the default `steps[0]` (the
-    // user hasn't already picked another step in the time between
-    // useState and the hydrated effect). Runs once on the hydration
-    // edge.
+    // mode (phase ≥ setupCompleted AND the user has already finished
+    // the walkthrough for this game) AND (b) focusedStep is still
+    // the default `steps[0]` (the user hasn't already picked another
+    // step in the time between useState and the hydrated effect).
+    // Runs once on the hydration edge.
     const correctedForHydratedEditModeRef = useRef(false);
     useEffect(() => {
         if (!hydrated) return;
         if (correctedForHydratedEditModeRef.current) return;
         correctedForHydratedEditModeRef.current = true;
         if (!phaseAtLeast(phase, PHASE_SETUP_COMPLETED)) return;
+        if (!walkthroughDone) return;
         setFocusedStep((prev) =>
             prev === (stepsRefForPhaseReset.current[0] ?? null) ? null : prev,
         );
-    }, [hydrated, phase]);
+    }, [hydrated, phase, walkthroughDone]);
 
     // Tour pre-condition effect. Some tour steps (today: the sharing
     // tour's `setup-share-pack-pill` and `setup-invite-player`)
@@ -561,6 +587,12 @@ export function SetupWizard() {
             gameSetupStarted();
         }
         setupWizardCompleted();
+        // Persist "this game's setup walkthrough is done." Next time
+        // the wizard mounts (e.g. user navigates back from Play), it
+        // renders in spot-check edit mode and the global PlayCTA
+        // becomes visible. Cleared on `newGame` via
+        // `markGameCreated`'s clear list.
+        markSetupWalkthroughDone(DateTime.nowUnsafe());
         dispatch({ type: "setUiMode", mode: "checklist" });
     };
 

--- a/src/ui/setup/steps/SetupStepCardPack.tsx
+++ b/src/ui/setup/steps/SetupStepCardPack.tsx
@@ -37,7 +37,7 @@ import {
     type StepValidation,
     type WizardStepId,
 } from "../wizardSteps";
-import type { StepPanelState } from "../SetupStepPanel";
+import type { StepPanelState, WizardMode } from "../SetupStepPanel";
 
 const STEP_ID = "cardPack" as const;
 // Tour anchor shared with the M6 setup tour's "Card pack" step.
@@ -90,6 +90,7 @@ const totalCardsIn = (cardSet: CardSet): number =>
 
 interface Props {
     readonly state: StepPanelState;
+    readonly wizardMode: WizardMode;
     readonly stepNumber: number;
     readonly totalSteps: number;
     readonly onClickToEdit: () => void;
@@ -126,6 +127,7 @@ interface Props {
  */
 export function SetupStepCardPack({
     state,
+    wizardMode,
     stepNumber,
     totalSteps,
     onClickToEdit,
@@ -390,6 +392,7 @@ export function SetupStepCardPack({
         <SetupStepPanel
             stepId={STEP_ID}
             state={state}
+            wizardMode={wizardMode}
             stepNumber={stepNumber}
             totalSteps={totalSteps}
             title={t("title")}

--- a/src/ui/setup/steps/SetupStepHandSizes.tsx
+++ b/src/ui/setup/steps/SetupStepHandSizes.tsx
@@ -14,12 +14,13 @@ import {
     type StepValidation,
     type WizardStepId,
 } from "../wizardSteps";
-import type { StepPanelState } from "../SetupStepPanel";
+import type { StepPanelState, WizardMode } from "../SetupStepPanel";
 
 const STEP_ID = "handSizes" as const;
 
 interface Props {
     readonly state: StepPanelState;
+    readonly wizardMode: WizardMode;
     readonly stepNumber: number;
     readonly totalSteps: number;
     readonly onClickToEdit: () => void;
@@ -59,6 +60,7 @@ interface Props {
  */
 export function SetupStepHandSizes({
     state,
+    wizardMode,
     stepNumber,
     totalSteps,
     onClickToEdit,
@@ -153,6 +155,7 @@ export function SetupStepHandSizes({
         <SetupStepPanel
             stepId={STEP_ID}
             state={state}
+            wizardMode={wizardMode}
             stepNumber={stepNumber}
             totalSteps={totalSteps}
             title={t("title")}

--- a/src/ui/setup/steps/SetupStepIdentity.tsx
+++ b/src/ui/setup/steps/SetupStepIdentity.tsx
@@ -6,12 +6,13 @@ import { setupSelfPlayerSet } from "../../../analytics/events";
 import { useClue } from "../../state";
 import { SetupStepPanel } from "../SetupStepPanel";
 import { VALID, type WizardStepId } from "../wizardSteps";
-import type { StepPanelState } from "../SetupStepPanel";
+import type { StepPanelState, WizardMode } from "../SetupStepPanel";
 
 const STEP_ID = "identity" as const;
 
 interface Props {
     readonly state: StepPanelState;
+    readonly wizardMode: WizardMode;
     readonly stepNumber: number;
     readonly totalSteps: number;
     readonly onClickToEdit: () => void;
@@ -43,6 +44,7 @@ interface Props {
  */
 export function SetupStepIdentity({
     state,
+    wizardMode,
     stepNumber,
     totalSteps,
     onClickToEdit,
@@ -81,6 +83,7 @@ export function SetupStepIdentity({
         <SetupStepPanel
             stepId={STEP_ID}
             state={state}
+            wizardMode={wizardMode}
             stepNumber={stepNumber}
             totalSteps={totalSteps}
             title={t("title")}

--- a/src/ui/setup/steps/SetupStepInviteOtherPlayers.tsx
+++ b/src/ui/setup/steps/SetupStepInviteOtherPlayers.tsx
@@ -3,13 +3,14 @@
 import { useTranslations } from "next-intl";
 import { SetupStepPanel } from "../SetupStepPanel";
 import { VALID, type WizardStepId } from "../wizardSteps";
-import type { StepPanelState } from "../SetupStepPanel";
+import type { StepPanelState, WizardMode } from "../SetupStepPanel";
 import { useShareContext } from "../../share/ShareProvider";
 
 const STEP_ID = "inviteOtherPlayers" as const;
 
 interface Props {
     readonly state: StepPanelState;
+    readonly wizardMode: WizardMode;
     readonly stepNumber: number;
     readonly totalSteps: number;
     readonly onClickToEdit: () => void;
@@ -33,6 +34,7 @@ interface Props {
  */
 export function SetupStepInviteOtherPlayers({
     state,
+    wizardMode,
     stepNumber,
     totalSteps,
     onClickToEdit,
@@ -45,6 +47,7 @@ export function SetupStepInviteOtherPlayers({
         <SetupStepPanel
             stepId={STEP_ID}
             state={state}
+            wizardMode={wizardMode}
             stepNumber={stepNumber}
             totalSteps={totalSteps}
             title={t("title")}

--- a/src/ui/setup/steps/SetupStepKnownCards.tsx
+++ b/src/ui/setup/steps/SetupStepKnownCards.tsx
@@ -8,12 +8,13 @@ import { ChevronLeftIcon, ChevronRightIcon } from "../../components/Icons";
 import { PlayerColumnCardList } from "../shared/PlayerColumnCardList";
 import { SetupStepPanel } from "../SetupStepPanel";
 import { VALID, type WizardStepId } from "../wizardSteps";
-import type { StepPanelState } from "../SetupStepPanel";
+import type { StepPanelState, WizardMode } from "../SetupStepPanel";
 
 const STEP_ID = "knownCards" as const;
 
 interface Props {
     readonly state: StepPanelState;
+    readonly wizardMode: WizardMode;
     readonly stepNumber: number;
     readonly totalSteps: number;
     readonly onClickToEdit: () => void;
@@ -41,6 +42,7 @@ interface Props {
  */
 export function SetupStepKnownCards({
     state,
+    wizardMode,
     stepNumber,
     totalSteps,
     onClickToEdit,
@@ -76,6 +78,7 @@ export function SetupStepKnownCards({
             <SetupStepPanel
                 stepId={STEP_ID}
                 state={state}
+                wizardMode={wizardMode}
                 stepNumber={stepNumber}
                 totalSteps={totalSteps}
                 title={t("title")}
@@ -98,6 +101,7 @@ export function SetupStepKnownCards({
         <SetupStepPanel
             stepId={STEP_ID}
             state={state}
+            wizardMode={wizardMode}
             stepNumber={stepNumber}
             totalSteps={totalSteps}
             title={t("title")}

--- a/src/ui/setup/steps/SetupStepMyCards.tsx
+++ b/src/ui/setup/steps/SetupStepMyCards.tsx
@@ -6,7 +6,7 @@ import { useClue } from "../../state";
 import { PlayerColumnCardList } from "../shared/PlayerColumnCardList";
 import { SetupStepPanel } from "../SetupStepPanel";
 import { VALID, type WizardStepId } from "../wizardSteps";
-import type { StepPanelState } from "../SetupStepPanel";
+import type { StepPanelState, WizardMode } from "../SetupStepPanel";
 
 const STEP_ID = "myCards" as const;
 
@@ -17,6 +17,7 @@ const FIRST_ROW_TOUR_ANCHOR = "setup-step-mycards-firstrow" as const;
 
 interface Props {
     readonly state: StepPanelState;
+    readonly wizardMode: WizardMode;
     readonly stepNumber: number;
     readonly totalSteps: number;
     readonly selfPlayerId: Player;
@@ -40,6 +41,7 @@ interface Props {
  */
 export function SetupStepMyCards({
     state,
+    wizardMode,
     stepNumber,
     totalSteps,
     selfPlayerId,
@@ -61,6 +63,7 @@ export function SetupStepMyCards({
         <SetupStepPanel
             stepId={STEP_ID}
             state={state}
+            wizardMode={wizardMode}
             stepNumber={stepNumber}
             totalSteps={totalSteps}
             title={t("title")}

--- a/src/ui/setup/steps/SetupStepPlayers.tsx
+++ b/src/ui/setup/steps/SetupStepPlayers.tsx
@@ -10,13 +10,14 @@ import {
     type StepValidation,
     type WizardStepId,
 } from "../wizardSteps";
-import type { StepPanelState } from "../SetupStepPanel";
+import type { StepPanelState, WizardMode } from "../SetupStepPanel";
 
 // Step id discriminator hoisted so it isn't flagged as user copy.
 const STEP_ID = "players" as const;
 
 interface Props {
     readonly state: StepPanelState;
+    readonly wizardMode: WizardMode;
     readonly stepNumber: number;
     readonly totalSteps: number;
     readonly onClickToEdit: () => void;
@@ -41,6 +42,7 @@ interface Props {
  */
 export function SetupStepPlayers({
     state,
+    wizardMode,
     stepNumber,
     totalSteps,
     onClickToEdit,
@@ -68,6 +70,7 @@ export function SetupStepPlayers({
         <SetupStepPanel
             stepId={STEP_ID}
             state={state}
+            wizardMode={wizardMode}
             stepNumber={stepNumber}
             totalSteps={totalSteps}
             title={t("title")}

--- a/src/ui/state.tsx
+++ b/src/ui/state.tsx
@@ -35,6 +35,11 @@ import {
     type CardPackUsage,
     recordCardPackUse,
 } from "../logic/CardPackUsage";
+import {
+    getGamePhase,
+    hasCardInformation,
+    phaseAtLeast,
+} from "../logic/GamePhase";
 import { cardPackUsageQueryKey } from "../data/cardPackUsage";
 import { Equal, HashMap } from "effect";
 import {
@@ -1088,11 +1093,12 @@ export function ClueProvider({ children }: { children: ReactNode }) {
     }, [state.uiMode]);
     const gameStartedRef = useRef(false);
     useEffect(() => {
-        gameStartedRef.current =
-            state.knownCards.length > 0
-            || state.suggestions.length > 0
-            || state.accusations.length > 0;
-    }, [state.knownCards, state.suggestions, state.accusations]);
+        // Broader than `phase === "gameStarted"` — smart-landing on
+        // ⌘H wants to bias toward "user has touched concrete card
+        // info," including knownCards-only entry. See
+        // {@link hasCardInformation}.
+        gameStartedRef.current = hasCardInformation(state);
+    }, [state]);
 
     // Keyboard bindings wired via the central keyMap module. Each
     // useGlobalShortcut installs one window keydown listener that only
@@ -1616,23 +1622,16 @@ export function ClueProvider({ children }: { children: ReactNode }) {
         state.suggestions.length,
     ]);
 
-    const hasGameData = useCallback((): boolean => {
-        if (state.knownCards.length > 0) return true;
-        if (state.handSizes.length > 0) return true;
-        if (state.suggestions.length > 0) return true;
-        if (state.accusations.length > 0) return true;
-        // M6: a user who only set their identity has expressed intent
-        // ("I'm Alice in this game") that the brand-new-user redirect
-        // shouldn't override. Same for first-dealt-player.
-        if (state.selfPlayerId !== null) return true;
-        if (state.firstDealtPlayerId !== null) return true;
-        const players = state.setup.players;
-        if (players.length !== DEFAULT_SETUP.players.length) return true;
-        for (let i = 0; i < players.length; i++) {
-            if (players[i] !== DEFAULT_SETUP.players[i]) return true;
-        }
-        return false;
-    }, [state]);
+    // Brand-new-user redirect gate. True iff the game has any user
+    // touch at all — any phase above `"new"`. The phase machine's
+    // `"dirty"` predicate covers knownCards / handSizes / suggestions
+    // / accusations / selfPlayerId / firstDealtPlayerId / non-default
+    // roster / non-default deck; one of those triggering is what we
+    // want here.
+    const hasGameData = useCallback(
+        (): boolean => phaseAtLeast(getGamePhase(state), "dirty"),
+        [state],
+    );
 
     const value: ClueContextValue = useMemo(
         () => ({


### PR DESCRIPTION
## Summary (user-facing)

Setup gains a clear two-mode behavior, and the chrome gets a global play affordance that's strict about when it appears.

**First-time setup is a guided walkthrough.** On a brand-new game, the wizard walks the user through every step in order. The only way out of setup is the wizard's own last-step "Start playing →" card on the **Invite other players** step. The global chrome's CTA stays hidden the whole time — even after the user commits hand sizes mid-walk and the game technically has enough data to play. This keeps the first-time experience strictly linear.

**Once the user finishes that first walkthrough**, the Setup page becomes a spot-check edit page:

- Every step is openable on its own. The "pending" lock and the dimmed treatment are gone — closed steps without data still read as fully accessible.
- The open step's footer is a single "Done" button that just collapses the panel. No more "Next" / "Skip" / "Start playing →" inside the wizard.
- The global "Start playing" / "Continue playing" button appears in the chrome (desktop Toolbar; mobile BottomNav, centered to the left of the overflow menu). The label flips Start → Continue once a suggestion or accusation has been logged. The keyboard shortcut **⌘J** is shown on devices that have a keyboard.

**The global Play CTA is strictly Setup-page-only.** On Checklist or Suggest views it doesn't appear at all (those views are already in Play).

**"New game" reliably rewinds.** Whether the user clicks "New game" from the overflow menu, presses ⌘⇧⌫, or hits "Start over → confirm" from inside the wizard, the wizard snaps back to step 1 and the global CTA disappears. (The previous code relied on a remount that didn't actually happen when the wizard was already mounted in Setup mode.)

**The sharing tour keeps working in edit mode.** The tour's per-pack share button and "Invite a player" link live inside step bodies that aren't open by default in edit mode. When the tour advances onto one of those anchors, the wizard expands the right step as a pre-condition (per the new AGENTS.md "tour steps must set up the UI" rule).

## Test plan
- [ ] Brand-new game (clear localStorage, load `/play?view=setup`): walk every step, confirm no global CTA at any point. Click the wizard's last-step "Start playing →" → land on Checklist.
- [ ] Return to Setup (⌘H or overflow → Game setup): wizard is in edit mode (footer: `[Start over] [Done]`), global CTA visible.
- [ ] Press ⌘J / ⌘K from Setup: navigates to Checklist / Suggest, global CTA hides on both. Press ⌘H back to Setup: CTA reappears.
- [ ] Click "New game" (overflow menu) → Confirm: wizard rewinds to step 1, footer is back to `[Start over] [Skip] [Next]`, global CTA hidden.
- [ ] Sharing tour: seed dismissals for `setup` and `checklistSuggest`, return to Setup. Tour fires; first step's "share pack" anchor finds its target (wizard auto-expands the cardPack step); second step's "Invite a player" anchor finds its target (wizard auto-expands inviteOtherPlayers).
- [ ] Mobile (375×812): same walks. Mobile Play views keep the existing `[Checklist][Suggest][⋯]` tabs. Mobile Setup BottomNav row shows the centered Play CTA to the left of the overflow menu (or an empty spacer before the walkthrough completes).

## Technical commit log

- **`081abb7` WIP: GamePhase + refactor + PlayCTAButton + i18n** — adds `src/logic/GamePhase.ts` with `getGamePhase(state)` (mutually-exclusive `new | dirty | setupCompleted | gameStarted`), `phaseAtLeast`, and a broader `hasCardInformation` helper for stale-game / tour-eligibility / smart-landing surfaces. Refactors the four scattered inline `gameStarted` checks (state.tsx, Clue.tsx, useStaleGameGate.tsx, SetupWizard.tsx) plus the wizard's `hasGameProgress` and the brand-new-user redirect's `hasGameData` to route through the consolidated helpers. Adds `useGamePhase` hook and `PlayCTAButton` component (Toolbar + BottomNav variants, `data-tour-anchor="play-cta"`, ⌘J shortcut hint via `shortcutSuffix`, `playCtaClicked` analytics event). Wires the button into `Toolbar.tsx` (between Redo and overflow) and `BottomNav.tsx` (replaces the setup-mode spacer). Adds the `playCta` i18n namespace.

- **`ce8addf` Wizard spot-check edit mode + tour pre-condition + New-game reset** — adds `wizardMode: "flow" | "edit"` prop through `SetupStepPanel` and the seven step components; edit mode drops the pending-lock + dimmed header and renders Done in place of Skip/Next. Adds `onClickDone`, `TOUR_ANCHOR_REQUIRES_WIZARD_STEP` map + entry effect (handles the sharing tour's `setup-share-pack-pill` and `setup-invite-player` anchors per AGENTS.md), and a phase-transition effect that resets `focusedStep` to step 1 when phase drops to `"new"` while the wizard is mounted (fixes the bug where the misleading "newGame remounts the wizard" comment claimed). Hydration-aware correction of the initial focused step. Adds `setupWizard.done` i18n key.

- **`7cccdcf` Gate global Play CTA on first-time walkthrough completion** — adds `setupWalkthroughDoneAt` field to `effect-clue.gameLifecycle.v1`, set by `markSetupWalkthroughDone` (called from `onClickStartPlaying`) and cleared by `markGameCreated`'s clear list. Same-tab writes dispatch a `WALKTHROUGH_EVENT` so `useSetupWalkthroughDone` (the new reactive hook) re-reads storage without waiting for an unrelated re-render. `PlayCTAButton` and `SetupWizard.wizardMode` both compose `phase ≥ setupCompleted && walkthroughDone`. Tests seed `createdAt` alongside the walkthrough flag so the hydration backfill doesn't clobber it.

- **`1e10713` Restrict global Play CTA to the Setup page** — extends the visibility gate with `state.uiMode === "setup"`. New test case walks uiMode through setup → checklist → suggest → setup and asserts the button hides on the Play views and reappears on Setup. `beforeEach` now resets `window.history` between tests (the ClueProvider mirrors uiMode to `?view=…`, so prior tests' clicks would leak into subsequent mounts' hydration without the reset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)