### PR TITLE
Explanation panel header: reserve space for the close button

### DIFF
--- a/src/ui/components/CellExplanationRow.tsx
+++ b/src/ui/components/CellExplanationRow.tsx
@@ -431,7 +431,7 @@ export function CellExplanationRow({
     return (
         <div className="flex flex-col">
             <div className="relative px-4 py-2">
-                <h3 className="m-0 text-center text-[1.25rem] uppercase tracking-[0.05em] text-accent">
+                <h3 className="m-0 px-9 text-center text-[1.25rem] uppercase tracking-[0.05em] text-accent">
                     {t("cellHeading", {
                         owner: ownerLabel(cell.owner),
                         card: cardLabel,


### PR DESCRIPTION
Long player/card combinations like "PLAYER 4 / CANDLESTICK" were
visually overlapping the absolute-positioned X close button in the
explanation panel header, leaving the button half-hidden behind the
title text.

The X button sits at `right-2 w-7` (36px from the parent's outer right
edge), but the centered `<h3>` extended to the parent's content edge
(16px in), giving the title a 20px overlap zone with the button. Adding
`px-9` to the `<h3>` reserves 36px on each side, pushing the title's
text boundary 16px clear of the button while keeping it visually
centered between symmetric gutters.