### PR TITLE
Require refreshing PR title and description on every push

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -475,3 +475,15 @@ When I ask you to "rebase on/against latest origin/main" (or "latest remote main
 
 - **Title**: a cohesive, concise summary that covers all commits in the PR.
 - **Description**: lead with the behavior changes from the user's perspective. At the bottom, include a log of the commits with code-oriented technical descriptions of what each one does.
+
+**Refresh the title and description on every push.** Once a PR exists, every time you push new commits to it — whether it's a follow-up fix, a review-comment response, a rebase, an amend, or a brand-new feature stacked on the same branch — re-derive the title and description from the **actual state of the branch**, not from the previous title/description plus a mental delta. The PR's title and body should always describe what's *currently* on the branch, not what was on the branch at the moment the PR was opened.
+
+The mechanical version:
+
+1. After pushing, run `git log --oneline origin/main..HEAD` and `git diff origin/main...HEAD --stat` to see the full set of commits and the cumulative change.
+2. Read the diff and the commit bodies. Don't just skim the latest commit — earlier commits on the branch are equally part of the PR.
+3. Rewrite the title to cover the whole branch cohesively. If the scope of the branch changed (e.g. the original feature plus a tangential fix that came up during review), the title should reflect the new scope, not the original framing.
+4. Rewrite the description from scratch: user-facing behavior changes at the top, commit-by-commit technical log at the bottom (regenerated from `git log`, not edited in place from the previous version).
+5. Update via `mcp__github__update_pull_request` — don't ask the user to do it.
+
+This applies even when the change you just pushed feels small ("just a typo fix"). The cost of re-reading the diff and regenerating the body is a few seconds; the cost of a PR whose description has silently drifted out of sync with the code is a reviewer trusting outdated copy and missing a real change. Always re-derive from the branch, never patch the existing body.


### PR DESCRIPTION
## Summary

Adds a rule to `AGENTS.md` (the shared agent instruction file that `CLAUDE.md` symlinks to) requiring the PR title and description to be regenerated from the actual state of the branch on every push — not patched in place from the previous version.

The new guidance lives in the existing "PR title and description format" section and spells out the mechanical steps: after pushing, run `git log --oneline origin/main..HEAD` + `git diff origin/main...HEAD --stat`, read the diff and commit bodies, rewrite the title to cover the current scope, rewrite the description from scratch (user-facing changes on top, commit-by-commit technical log at the bottom), and update via `mcp__github__update_pull_request`. The rationale is that the cost of regeneration is trivial compared to the cost of a description that has silently drifted out of sync with the code.

## Commits

- `09d834c` Require refreshing PR title and description on every push — extends the "PR title and description format" section in `AGENTS.md` with the refresh-on-every-push rule and a 5-step mechanical recipe.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSejQc7p1mwf2Zb7Rs4MyR)_