### PR TITLE
Tighten modal body line-height for consistency

### DIFF
--- a/src/ui/account/AccountModal.tsx
+++ b/src/ui/account/AccountModal.tsx
@@ -303,7 +303,7 @@ export function AccountModal() {
                             <XIcon size={18} />
                         </button>
                     </div>
-                    <Dialog.Description className="px-5 pt-3 text-[1rem] leading-relaxed">
+                    <Dialog.Description className="px-5 pt-3 text-[1rem] leading-normal">
                         {isAnon ? t("descriptionSignedOut") : t("descriptionSignedIn")}
                     </Dialog.Description>
                     <div className="px-5 pb-5">

--- a/src/ui/components/InstallPromptModal.tsx
+++ b/src/ui/components/InstallPromptModal.tsx
@@ -114,10 +114,10 @@ function InstallPromptModalContent({
                     <XIcon size={18} />
                 </button>
             </div>
-            <p className="px-5 pt-3 text-[1rem] leading-relaxed">
+            <p className="px-5 pt-3 text-[1rem] leading-normal">
                 {t("description")}
             </p>
-            <ul className="m-0 list-disc px-5 pl-9 pt-3 text-[1rem] leading-relaxed">
+            <ul className="m-0 list-disc px-5 pl-9 pt-3 text-[1rem] leading-normal">
                 <li>{t("benefitOffline")}</li>
                 <li>{t("benefitHomeScreen")}</li>
                 <li>{t("benefitFastLaunch")}</li>

--- a/src/ui/components/StaleGameModal.tsx
+++ b/src/ui/components/StaleGameModal.tsx
@@ -129,7 +129,7 @@ function StaleGameModalContent({
                     <XIcon size={18} />
                 </button>
             </div>
-            <p className="px-5 pt-3 pb-1 text-[1rem] leading-relaxed">
+            <p className="px-5 pt-3 pb-1 text-[1rem] leading-normal">
                 {t(descriptionKey, { humanDuration })}
             </p>
             <div className="mt-4 flex items-center justify-end gap-2 border-t border-border bg-panel px-5 pt-4 pb-5">

--- a/src/ui/hooks/useConfirm.tsx
+++ b/src/ui/hooks/useConfirm.tsx
@@ -118,7 +118,7 @@ function ConfirmModalContent({
                     {confirmTitle}
                 </Dialog.Title>
             )}
-            <p className="m-0 text-[1rem] leading-snug text-[#2a1f12]">
+            <p className="m-0 text-[1rem] leading-normal text-[#2a1f12]">
                 {options.message}
             </p>
             <div className="mt-5 flex flex-wrap justify-end gap-2">

--- a/src/ui/setup/CardPackEditorModal.tsx
+++ b/src/ui/setup/CardPackEditorModal.tsx
@@ -184,7 +184,7 @@ function CardPackEditorModal({
                 </button>
             </div>
             <div className="flex flex-col gap-3 overflow-y-auto px-5 pt-3 pb-2">
-                <p className="m-0 text-[1rem] text-muted">{t("helperText")}</p>
+                <p className="m-0 text-[1rem] leading-normal text-muted">{t("helperText")}</p>
                 <CategoriesEditor
                     draft={draft}
                     setDraft={setDraft}

--- a/src/ui/share/ShareCreateModal.tsx
+++ b/src/ui/share/ShareCreateModal.tsx
@@ -880,7 +880,7 @@ export function ShareCreateModal({
                                     transition={transition}
                                     className="[grid-area:stack] min-w-0"
                                 >
-                                    <Dialog.Description className="px-5 pt-3 text-[1rem] leading-relaxed">
+                                    <Dialog.Description className="px-5 pt-3 text-[1rem] leading-normal">
                                         {t(descriptionKey)}
                                     </Dialog.Description>
                                     {variant === VARIANT_PACK ? (
@@ -1078,7 +1078,7 @@ export function ShareCreateModal({
                                     transition={transition}
                                     className="[grid-area:stack] min-w-0"
                                 >
-                                    <Dialog.Description className="px-5 pt-3 text-[1rem] leading-relaxed">
+                                    <Dialog.Description className="px-5 pt-3 text-[1rem] leading-normal">
                                         {t(SIGN_IN_DESCRIPTION_KEY)}
                                     </Dialog.Description>
                                     <div className="flex flex-col gap-2 px-5 pt-4 pb-2">

--- a/src/ui/share/ShareImportPage.tsx
+++ b/src/ui/share/ShareImportPage.tsx
@@ -898,7 +898,7 @@ export function ShareImportPage({
                         <div className="relative z-0 flex min-h-0 flex-1 flex-col overflow-y-auto pb-4">
                         {snapshot.ownerName !== null ? (
                             <Dialog.Description
-                                className="px-5 pt-3 text-[1rem] leading-relaxed"
+                                className="px-5 pt-3 text-[1rem] leading-normal"
                                 data-share-import-sender
                             >
                                 {t("importSharedBy", {
@@ -907,7 +907,7 @@ export function ShareImportPage({
                             </Dialog.Description>
                         ) : null}
                         {isEmpty ? (
-                            <div className="px-5 pt-3 text-[1rem] leading-relaxed text-muted">
+                            <div className="px-5 pt-3 text-[1rem] leading-normal text-muted">
                                 {t("importEmpty")}
                             </div>
                         ) : (

--- a/src/ui/share/ShareMissingPage.tsx
+++ b/src/ui/share/ShareMissingPage.tsx
@@ -61,7 +61,7 @@ export function ShareMissingPage({
                             <Dialog.Title className="m-0 text-[1.25rem] uppercase tracking-[0.05em] text-accent">
                                 {t("missingTitle")}
                             </Dialog.Title>
-                            <Dialog.Description className="pt-3 text-[1rem] leading-relaxed text-muted">
+                            <Dialog.Description className="pt-3 text-[1rem] leading-normal text-muted">
                                 {t("missingBody")}
                             </Dialog.Description>
                         </div>


### PR DESCRIPTION
## Summary

Modal description copy across the app was inconsistent — 8 modals used `leading-relaxed` (line-height 1.75), 3 used `leading-snug` (1.375), and one had no explicit class. The relaxed setting read too airy on prose like the Invite-a-player description (the trigger for this change).

This standardizes modal body prose on `leading-normal` (1.5), and reserves `leading-snug` for the surfaces that are genuinely information-dense.

### What you'll notice

- The "Invite a player", "Continue on another device", and suggestion-share modal descriptions read tighter (1.5 line-height instead of 1.75).
- Stale-game, install-prompt, account, share-import, share-missing, and confirm dialogs all read at the same tighter line-height for consistency.
- Information-dense surfaces are unchanged on purpose: LogoutWarningModal's lede above its pack-changes list, plus ShareCreateModal's pack-details box and transfer-warning callout, keep their `leading-snug` (1.375) to fit list content into a tight cluster.

### Verification

- Pre-commit set green: typecheck, lint, test (1555 passed), knip, i18n:check.
- Walked the Invite-a-player modal in the `next-dev` preview at both 1280×800 and 375×812 viewports — confirmed computed `line-height: 24px` over `font-size: 16px` (ratio 1.5).
- No console errors.

## Commits

- `Tighten modal body line-height for consistency` — single class swap across 8 files. `leading-relaxed` → `leading-normal` in `ShareCreateModal.tsx` (×2), `StaleGameModal.tsx`, `InstallPromptModal.tsx` (×2 — `<p>` + benefits `<ul>`), `AccountModal.tsx`, `ShareImportPage.tsx` (×2), `ShareMissingPage.tsx`. `leading-snug` → `leading-normal` in `useConfirm.tsx`. Added explicit `leading-normal` to `CardPackEditorModal.tsx`'s helper text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)