### PR TITLE
My Cards polish: inline banner, bold cards, no layout shift, animated caret, icon badge

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -229,10 +229,10 @@
         "panelCloseAriaLabel": "Close my cards"
     },
     "refuteHint": {
-        "canRefute": "You can refute this suggestion with: {cards}",
+        "canRefute": "You can refute this suggestion with: <bold>{cards}</bold>",
         "canRefuteTeaser": "You can refute this suggestion with…",
         "cannotRefute": "You cannot refute this suggestion.",
-        "selfSuggesting": "You are suggesting from your hand: {cards}",
+        "selfSuggesting": "You are suggesting from your hand: <bold>{cards}</bold>",
         "selfSuggestingTeaser": "You are suggesting from your hand…",
         "revealHintMouse": "(click to reveal)",
         "revealHintTouch": "(tap to reveal)",

--- a/src/ui/components/Icons.tsx
+++ b/src/ui/components/Icons.tsx
@@ -515,26 +515,33 @@ export function ChevronDownIcon({ className, size = 16 }: IconProps) {
     );
 }
 
-/** Up-pointing chevron — the inverse of `ChevronDownIcon` for the
- *  "this section is currently collapsed, click to expand" state. */
-export function ChevronUpIcon({ className, size = 16 }: IconProps) {
+/**
+ * "Mini-FAB" badge that wraps `HandOfCardsIcon` in a filled
+ * accent-colored circle with white strokes — the same look as the
+ * mobile FAB button but inline and non-interactive. Used in any
+ * "collapsed entry point" surface (the desktop section header, the
+ * mobile open-panel header, the stacked teaser bar) so the My Cards
+ * affordance reads in the same visual language as the FAB.
+ *
+ * Default size is `28px` — fits the h3 line-height without growing
+ * the header row. Bump `size` for taller contexts.
+ */
+export function HandOfCardsBadge({
+    className,
+    size = 28,
+}: IconProps) {
+    const iconSize = Math.round(size * 0.6);
     return (
-        <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width={size}
-            height={size}
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
+        <span
             aria-hidden="true"
-            focusable="false"
-            className={className}
+            className={
+                "inline-flex shrink-0 items-center justify-center rounded-full bg-accent text-white " +
+                (className ?? "")
+            }
+            style={{ width: size, height: size }}
         >
-            <polyline points="6 15 12 9 18 15" />
-        </svg>
+            <HandOfCardsIcon size={iconSize} />
+        </span>
     );
 }
 

--- a/src/ui/components/MyCardsFAB.tsx
+++ b/src/ui/components/MyCardsFAB.tsx
@@ -15,7 +15,7 @@ import {
     MY_CARDS_SURFACE_FAB,
 } from "../../analytics/events";
 import { T_STANDARD, useReducedTransition } from "../motion";
-import { ChevronDownIcon, HandOfCardsIcon } from "./Icons";
+import { ChevronDownIcon, HandOfCardsBadge, HandOfCardsIcon } from "./Icons";
 import { MyHandPanelBody } from "./MyHandPanel";
 import {
     SuggestionBanner,
@@ -333,10 +333,7 @@ export function MyCardsFAB() {
                     >
                         <header className="flex items-center justify-between gap-2">
                             <h3 className="m-0 flex items-center gap-2 font-sans! text-[1.125rem] font-bold uppercase tracking-wide text-accent">
-                                <HandOfCardsIcon
-                                    size={20}
-                                    className="text-accent"
-                                />
+                                <HandOfCardsBadge size={28} />
                                 {t("title")}
                             </h3>
                             <button

--- a/src/ui/components/MyHandPanel.test.tsx
+++ b/src/ui/components/MyHandPanel.test.tsx
@@ -6,8 +6,25 @@ vi.mock("next-intl", () => {
             const full = ns ? `${ns}.${key}` : key;
             return values ? `${full}:${JSON.stringify(values)}` : full;
         };
-        (t as unknown as { rich: unknown }).rich = (key: string): string =>
-            ns ? `${ns}.${key}` : key;
+        (t as unknown as { rich: unknown }).rich = (
+            key: string,
+            values?: Record<string, unknown>,
+        ): unknown => {
+            const full = ns ? `${ns}.${key}` : key;
+            if (values === undefined) return full;
+            // For rich-text calls, build a React-node array including
+            // each named value so textContent assertions can match on
+            // card names even when wrapped in tag callbacks.
+            const out: Array<unknown> = [`${full}:`];
+            for (const [chunkName, val] of Object.entries(values)) {
+                if (typeof val === "function") {
+                    out.push((val as () => unknown)());
+                } else {
+                    out.push(`[${chunkName}=${String(val)}]`);
+                }
+            }
+            return out;
+        };
         return t;
     };
     return {

--- a/src/ui/components/MyHandPanel.tsx
+++ b/src/ui/components/MyHandPanel.tsx
@@ -12,7 +12,7 @@ import { categoryName } from "../../logic/CardSet";
 import type { Card, CardCategory } from "../../logic/GameObjects";
 import { T_STANDARD, useReducedTransition } from "../motion";
 import { useClue } from "../state";
-import { ChevronDownIcon, ChevronUpIcon, HandOfCardsIcon } from "./Icons";
+import { ChevronDownIcon, HandOfCardsBadge } from "./Icons";
 import { useOpenMyCardsModal } from "./MyCardsModal";
 import {
     SuggestionBanner,
@@ -115,7 +115,7 @@ export function MyHandPanel() {
         >
             <header className="flex items-center justify-between gap-2">
                 <h3 className="m-0 flex shrink-0 items-center gap-2 font-sans! text-[1.125rem] font-bold uppercase tracking-wide text-accent">
-                    <HandOfCardsIcon size={20} className="text-accent" />
+                    <HandOfCardsBadge size={28} />
                     {t("title")}
                 </h3>
                 {/* Banner sits INLINE in the header row so its
@@ -141,11 +141,26 @@ export function MyHandPanel() {
                     }
                     onClick={toggle}
                 >
-                    {collapsed ? (
+                    {/* Animate the chevron rotation — one icon (down-
+                        pointing at rest), rotated 180° when the
+                        section is expanded. Uses motion.span +
+                        `transform: rotate(…)` so the rotation
+                        interpolates smoothly; a plain `rotate-0` /
+                        `rotate-180` toggle wouldn't animate
+                        cross-browser because `rotate: 0deg` computes
+                        to `none` and isn't interpolatable. */}
+                    <span
+                        aria-hidden
+                        className="flex motion-reduce:transition-none"
+                        style={{
+                            transform: collapsed
+                                ? "rotate(0deg)"
+                                : "rotate(180deg)",
+                            transition: "transform 200ms cubic-bezier(0.22, 1, 0.36, 1)",
+                        }}
+                    >
                         <ChevronDownIcon size={18} />
-                    ) : (
-                        <ChevronUpIcon size={18} />
-                    )}
+                    </span>
                 </button>
             </header>
             <motion.div

--- a/src/ui/components/MyHandPanel.tsx
+++ b/src/ui/components/MyHandPanel.tsx
@@ -114,13 +114,25 @@ export function MyHandPanel() {
             className="contain-inline-size rounded border border-border/40 bg-panel/60 px-3 py-2 shadow-[0_1px_3px_rgba(0,0,0,0.05)]"
         >
             <header className="flex items-center justify-between gap-2">
-                <h3 className="m-0 flex items-center gap-2 font-sans! text-[1.125rem] font-bold uppercase tracking-wide text-accent">
+                <h3 className="m-0 flex shrink-0 items-center gap-2 font-sans! text-[1.125rem] font-bold uppercase tracking-wide text-accent">
                     <HandOfCardsIcon size={20} className="text-accent" />
                     {t("title")}
                 </h3>
+                {/* Banner sits INLINE in the header row so its
+                    arrival (e.g. when a draft starts during a
+                    suggestion-log interaction) doesn't grow the
+                    section and shift everything below. When the
+                    banner has no content `:empty:hidden` removes the
+                    wrapper from layout entirely, keeping the header
+                    visually balanced (title left, chevron right). */}
+                <BannerSlot
+                    collapsed={collapsed}
+                    paused={isHovered}
+                    onTap={expandFromBanner}
+                />
                 <button
                     type="button"
-                    className="tap-icon flex cursor-pointer items-center justify-center rounded border border-border bg-control text-fg hover:bg-hover"
+                    className="tap-icon flex shrink-0 cursor-pointer items-center justify-center rounded border border-border bg-control text-fg hover:bg-hover"
                     aria-expanded={!collapsed}
                     aria-label={
                         collapsed
@@ -136,16 +148,6 @@ export function MyHandPanel() {
                     )}
                 </button>
             </header>
-            {/* Banner sits outside the collapsible wrapper so it stays
-                visible in banner-only mode. In the collapsed state it
-                runs in teaser form (cards hidden behind a "click to
-                reveal" hint); tapping the banner is the implicit
-                expand affordance. */}
-            <BannerSlot
-                collapsed={collapsed}
-                paused={isHovered}
-                onTap={expandFromBanner}
-            />
             <motion.div
                 data-my-hand-panel-body=""
                 initial={false}
@@ -178,10 +180,13 @@ export function MyHandPanel() {
 }
 
 /**
- * Banner wrapper that handles the teaser display + tap-to-expand
- * affordance for the collapsed-but-banner-visible mode. Outside the
- * `MyHandPanel` body wrapper so the banner stays put when the body
- * animates collapsed.
+ * Banner wrapper that sits inline in the header row. When the section
+ * is collapsed and the banner has content, the wrapper is a tap
+ * target — clicking expands the section. When expanded, the banner
+ * is purely informational. When `SuggestionBanner` returns `null`
+ * (no draft / no overlap), the wrapper has no children and Tailwind's
+ * `empty:hidden` drops it from layout so the header collapses back
+ * to title + chevron at the row's edges.
  */
 function BannerSlot({
     collapsed,
@@ -192,35 +197,32 @@ function BannerSlot({
     readonly paused: boolean;
     readonly onTap: () => void;
 }) {
-    if (collapsed) {
-        return (
-            <div
-                role="button"
-                tabIndex={0}
-                onClick={onTap}
-                onKeyDown={e => {
-                    if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        onTap();
-                    }
-                }}
-                className="mt-1.5 cursor-pointer"
-            >
-                <SuggestionBanner
-                    teaser
-                    paused={paused}
-                    surface={MY_CARDS_SURFACE_SECTION}
-                    expanded={false}
-                />
-            </div>
-        );
-    }
+    const clickable = collapsed;
     return (
-        <div className="mt-1.5">
+        <div
+            role={clickable ? "button" : undefined}
+            tabIndex={clickable ? 0 : undefined}
+            onClick={clickable ? onTap : undefined}
+            onKeyDown={
+                clickable
+                    ? e => {
+                          if (e.key === "Enter" || e.key === " ") {
+                              e.preventDefault();
+                              onTap();
+                          }
+                      }
+                    : undefined
+            }
+            className={
+                "min-w-0 flex-1 empty:hidden" +
+                (clickable ? " cursor-pointer" : "")
+            }
+        >
             <SuggestionBanner
+                teaser={collapsed}
                 paused={paused}
                 surface={MY_CARDS_SURFACE_SECTION}
-                expanded
+                expanded={!collapsed}
             />
         </div>
     );

--- a/src/ui/components/SuggestionBanner.test.tsx
+++ b/src/ui/components/SuggestionBanner.test.tsx
@@ -6,17 +6,39 @@ import { KnownCard } from "../../logic/InitialKnowledge";
 import { cardByName } from "../../logic/test-utils/CardByName";
 import type { PendingSuggestionDraft } from "../../logic/ClueState";
 
-// next-intl mock — echoes back `${namespace}.${key}:${values}` so we can
-// assert which template + arguments the banner picked.
+// next-intl mock — echoes back `${namespace}.${key}:${values}` for `t()`,
+// and for `t.rich()` returns a React-node array that includes the
+// key + every value/tag-callback so tests can assert on textContent
+// regardless of whether the call site uses interpolation or rich tags.
 vi.mock("next-intl", () => ({
-    useTranslations: (ns?: string) =>
-        Object.assign(
-            (key: string, values?: Record<string, unknown>) => {
-                const full = ns ? `${ns}.${key}` : key;
-                return values ? `${full}:${JSON.stringify(values)}` : full;
-            },
-            { rich: (key: string) => (ns ? `${ns}.${key}` : key) },
-        ),
+    useTranslations: (ns?: string) => {
+        const t = (key: string, values?: Record<string, unknown>) => {
+            const full = ns ? `${ns}.${key}` : key;
+            return values ? `${full}:${JSON.stringify(values)}` : full;
+        };
+        (t as unknown as { rich: unknown }).rich = (
+            key: string,
+            values?: Record<string, unknown>,
+        ): unknown => {
+            const full = ns ? `${ns}.${key}` : key;
+            if (values === undefined) return full;
+            const out: Array<unknown> = [`${full}:`];
+            for (const [chunkName, val] of Object.entries(values)) {
+                if (typeof val === "function") {
+                    // Tag callback — invoke with no chunks. The
+                    // wrapping element (e.g. <strong/>) still
+                    // renders, so its contents are absent here but
+                    // the value-based version above already includes
+                    // the readable text via `[chunkName=value]`.
+                    out.push((val as () => unknown)());
+                } else {
+                    out.push(`[${chunkName}=${String(val)}]`);
+                }
+            }
+            return out;
+        };
+        return t;
+    },
 }));
 
 const A = Player("Anisha");

--- a/src/ui/components/SuggestionBanner.tsx
+++ b/src/ui/components/SuggestionBanner.tsx
@@ -195,7 +195,10 @@ export function SuggestionBanner({
         const names = intersection.map(c => cardName(setup.cardSet, c));
         return (
             <Banner kind={kind} paused={paused} variant={variant}>
-                {t("selfSuggesting", { cards: names.join(t("join")) })}
+                {t.rich("selfSuggesting", {
+                    cards: names.join(t("join")),
+                    bold: boldChunks,
+                })}
             </Banner>
         );
     }
@@ -212,7 +215,10 @@ export function SuggestionBanner({
         const names = intersection.map(c => cardName(setup.cardSet, c));
         return (
             <Banner kind={kind} paused={paused} variant={variant}>
-                {t("canRefute", { cards: names.join(t("join")) })}
+                {t.rich("canRefute", {
+                    cards: names.join(t("join")),
+                    bold: boldChunks,
+                })}
             </Banner>
         );
     }
@@ -375,4 +381,13 @@ function Banner({
 
 function RevealHint({ label }: { readonly label: string }) {
     return <span className="ml-1.5 text-muted">{label}</span>;
+}
+
+// Tag callback for `t.rich` — wraps the card-name listing inside a
+// `<strong>` so the names visually stand out from the surrounding
+// sentence ("You can refute this suggestion with: **Miss Scarlet,
+// Knife**"). Defined as a module-level constant so the function
+// identity stays stable across renders.
+function boldChunks(chunks: React.ReactNode): React.ReactNode {
+    return <strong>{chunks}</strong>;
 }

--- a/src/ui/components/SuggestionBanner.tsx
+++ b/src/ui/components/SuggestionBanner.tsx
@@ -12,7 +12,7 @@ import { cardName } from "../../logic/CardSet";
 import type { Card } from "../../logic/GameObjects";
 import { useHasKeyboard } from "../hooks/useHasKeyboard";
 import { useClue } from "../state";
-import { HandOfCardsIcon } from "./Icons";
+import { HandOfCardsBadge } from "./Icons";
 
 // Banner-kind tags used as a `data-banner-kind` attribute for tests
 // and CSS hooks. Hoisted into named constants so the literal values
@@ -355,10 +355,7 @@ function Banner({
                     bounceClass
                 }
             >
-                <HandOfCardsIcon
-                    size={22}
-                    className="shrink-0 text-accent"
-                />
+                <HandOfCardsBadge size={32} />
                 <span className="min-w-0 flex-1">{children}</span>
             </p>
         );


### PR DESCRIPTION
## Summary

Follow-up to #207 with two commits' worth of UI polish on the My Cards section.

**Banner & layout (ab4a904)**
- **Bold the card names** in the refute / self-suggesting banner: "You can refute this suggestion with: **Miss Scarlet, Knife**". Implemented via `t.rich` with a `<bold>` tag in the i18n value.
- **Banner is inline in the header row.** `BannerSlot` lives between the "Your cards" title and the chevron button (`flex-1 min-w-0 empty:hidden`). When the banner has no content the wrapper drops from layout; when content arrives, it slots in without growing the section.
- **Header is now perfectly vertically centered in the collapsed state** — the always-present 6px banner-slot top margin that biased the header upward is gone since the banner moved inline.
- **No page shift when the banner appears.** Previously a draft kicking off mid-interaction with the suggestion log pushed everything below the section down. Now the banner slots into the existing header row; the section's height doesn't change.

Bonus: the chevron-toggle animation has nothing un-animated alongside it any more, so the body wrapper's smooth tween is the entire visible transition.

**Caret rotation & icon badge (f9bfc33)**
- **Animate the chevron's rotation.** One down-pointing chevron that rotates 180° when the section is expanded, via inline `transform: rotate(…)` + `transition: transform 200ms cubic-bezier(…)`. Smoother than the previous icon swap and reads as a single physical element moving. `motion-reduce:transition-none` retires the animation under `prefers-reduced-motion`.
- **FAB-style icon badge** for the hand-of-cards icon in every "collapsed entry point" surface — the desktop section header, the mobile open-panel header, and the mobile stacked teaser bar. All three get the same red-circle + white-strokes treatment the floating FAB uses, tying the surface vocabulary together. New `HandOfCardsBadge` component in `Icons.tsx` wraps `HandOfCardsIcon` in a `rounded-full bg-accent text-white` container. The unused `ChevronUpIcon` export is removed.

## Test plan

- [ ] Walk the populated section on desktop — chip row shows category pills (SUSPECT/Miss Scarlet, WEAPON/Knife, ROOM/Library); h3 has a small red circle with white hand-of-cards strokes next to "Your cards".
- [ ] Start a suggestion draft as another player; fill a card in your hand — banner appears **inline in the header row** between "Your cards" and the chevron, **with the card name(s) in bold**. The Suggestion Log column below the section doesn't move.
- [ ] Collapse the section — banner stays in the header row in teaser form, header still vertically centered, clicking the banner expands.
- [ ] Toggle the chevron a few times — the caret **rotates smoothly** between down (collapsed) and up (expanded), no longer an instant icon swap. Body wrapper's height tween is also smooth, no pop-in.
- [ ] Self as suggester with overlap → "You are suggesting from your hand: **Miss Scarlet**" (cards bolded).
- [ ] Mobile: the FAB itself is unchanged. The open panel's header shows the same red-circle badge next to "Your cards". The stacked teaser bar shows the badge on its left.

## Commits

- `ab4a904` — banner inline, bold card names, no layout shift, removed body-wrapper borders.
- `f9bfc33` — animated chevron rotation, FAB-style icon badge in all collapsed-entry-point surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)