### PR TITLE
Lighten secondary button color and soften its hover

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -21,14 +21,15 @@
     --color-bg: #e8dcb8;
     /* Cream panel — for card/section fills. */
     --color-panel: #f7f0dc;
-    /* Warm tan for interactive controls (buttons, pills, draggable
-     * rows, status badges). Reads as a classic dossier-tan layer —
-     * a few shades darker and noticeably more tan than the parchment
-     * page background, but lighter than the deeper honey-gold the
-     * palette experimented with previously. Hover (--color-hover) is
-     * darker so press-down feels like the surface sinking, the
-     * convention users expect. */
-    --color-control: #dac796;
+    /* Soft warm cream for interactive controls (buttons, pills,
+     * draggable rows, status badges). Sits between --color-panel and
+     * --color-bg so a control reads as visibly active on either
+     * surface, while staying clearly less white than the toolbar's
+     * pure-white pills (Undo / Redo / overflow) — those remain the
+     * lightest treatment in the system. Hover (--color-hover) jumps
+     * to a much darker tan so press-down feels like the surface
+     * sinking, the convention users expect. */
+    --color-control: #efe5c2;
     /* Aged-paper edge, warm taupe-brown. */
     --color-border: #cbb68c;
     /* Faded ink for secondary text. Darkened from #6d5a3f for WCAG

--- a/app/globals.css
+++ b/app/globals.css
@@ -42,9 +42,18 @@
     --color-row-header: #e5d9b8;
     /* Dossier manila for the case-file header strip. */
     --color-case-file-bg: #ead9b0;
-    /* Press-down hover tint for `--color-control`. Darker than control
-     * by ~10% lightness, keeping the "sink in on hover" direction. */
+    /* Press-down hover tint shared by every `hover:bg-hover` site that
+     * isn't a secondary button — transparent close-X buttons, modal
+     * Cancel buttons, overflow-menu items, the toolbar's white pills.
+     * Darker than --color-control so the hover reads as a clear
+     * surface change. */
     --color-hover: #c2a96b;
+    /* Press-down hover tint specifically for secondary buttons
+     * (`bg-control`). Lands a single step darker than the new
+     * lighter --color-control so the hover feels like a soft
+     * "sink in" rather than the dramatic jump to --color-hover.
+     * Equivalent to the previous --color-control value. */
+    --color-control-hover: #dac796;
     /* Alternating "striped" row fill for dense tables. */
     --color-row-alt: #ede0c1;
 

--- a/src/ui/components/MyCardsFAB.tsx
+++ b/src/ui/components/MyCardsFAB.tsx
@@ -339,7 +339,7 @@ export function MyCardsFAB() {
                             <button
                                 type="button"
                                 aria-label={t("panelCloseAriaLabel")}
-                                className="tap-icon flex cursor-pointer items-center justify-center rounded border border-border bg-control text-fg hover:bg-hover"
+                                className="tap-icon flex cursor-pointer items-center justify-center rounded border border-border bg-control text-fg hover:bg-control-hover"
                                 onClick={closePanel}
                             >
                                 <ChevronDownIcon size={18} />

--- a/src/ui/components/MyHandPanel.tsx
+++ b/src/ui/components/MyHandPanel.tsx
@@ -132,7 +132,7 @@ export function MyHandPanel() {
                 />
                 <button
                     type="button"
-                    className="tap-icon flex shrink-0 cursor-pointer items-center justify-center rounded border border-border bg-control text-fg hover:bg-hover"
+                    className="tap-icon flex shrink-0 cursor-pointer items-center justify-center rounded border border-border bg-control text-fg hover:bg-control-hover"
                     aria-expanded={!collapsed}
                     aria-label={
                         collapsed
@@ -292,7 +292,7 @@ export function MyHandPanelBody() {
                             <button
                                 key={String(player)}
                                 type="button"
-                                className="tap-target-compact text-tap-compact cursor-pointer rounded-full border border-border bg-control text-fg hover:bg-hover"
+                                className="tap-target-compact text-tap-compact cursor-pointer rounded-full border border-border bg-control text-fg hover:bg-control-hover"
                                 onClick={() => {
                                     dispatch({
                                         type: "setSelfPlayer",

--- a/src/ui/setup/CardPackEditorModal.tsx
+++ b/src/ui/setup/CardPackEditorModal.tsx
@@ -207,7 +207,7 @@ function CardPackEditorModal({
                 />
                 <button
                     type="button"
-                    className="tap-target-compact text-tap-compact self-start cursor-pointer rounded border border-border bg-control hover:bg-hover"
+                    className="tap-target-compact text-tap-compact self-start cursor-pointer rounded border border-border bg-control hover:bg-control-hover"
                     onClick={() =>
                         setDraft(prev => addCategoryToCardSet(prev))
                     }
@@ -218,14 +218,14 @@ function CardPackEditorModal({
             <div className="sticky bottom-0 z-[40] flex flex-wrap items-center justify-end gap-2 border-t border-border/30 bg-panel px-5 py-3">
                 <button
                     type="button"
-                    className="tap-target-compact text-tap-compact cursor-pointer rounded border border-border bg-control hover:bg-hover"
+                    className="tap-target-compact text-tap-compact cursor-pointer rounded border border-border bg-control hover:bg-control-hover"
                     onClick={close}
                 >
                     {t("cancel")}
                 </button>
                 <button
                     type="button"
-                    className="tap-target-compact text-tap-compact cursor-pointer rounded border border-border bg-control hover:bg-hover"
+                    className="tap-target-compact text-tap-compact cursor-pointer rounded border border-border bg-control hover:bg-control-hover"
                     onClick={saveAsNewPack}
                 >
                     {t("saveAsNewPack")}
@@ -346,7 +346,7 @@ function CategoriesEditor({
                     />
                     <button
                         type="button"
-                        className="self-start cursor-pointer rounded border border-border bg-control px-2 py-1 text-[1rem] hover:bg-hover"
+                        className="self-start cursor-pointer rounded border border-border bg-control px-2 py-1 text-[1rem] hover:bg-control-hover"
                         onClick={() =>
                             setDraft(prev =>
                                 addCardToCategoryInCardSet(
@@ -512,7 +512,7 @@ function CategoryHeader({
             {canRemove && (
                 <button
                     type="button"
-                    className="shrink-0 cursor-pointer rounded border border-border bg-control p-1 text-fg hover:bg-hover"
+                    className="shrink-0 cursor-pointer rounded border border-border bg-control p-1 text-fg hover:bg-control-hover"
                     aria-label={t("removeCategoryTitle", {
                         name: category.name,
                     })}
@@ -595,7 +595,7 @@ function CardRow({
             {canRemove && (
                 <button
                     type="button"
-                    className="shrink-0 cursor-pointer rounded border border-border bg-control p-1 text-fg hover:bg-hover"
+                    className="shrink-0 cursor-pointer rounded border border-border bg-control p-1 text-fg hover:bg-control-hover"
                     aria-label={t("removeCardTitle", { name: entry.name })}
                     onClick={onRemove}
                 >

--- a/src/ui/setup/SetupWizard.tsx
+++ b/src/ui/setup/SetupWizard.tsx
@@ -606,7 +606,7 @@ export function SetupWizard() {
             {wizardMode === WIZARD_MODE_FLOW && !isFirstStep ? (
                 <button
                     type="button"
-                    className="tap-target-compact text-tap-compact shrink-0 cursor-pointer rounded border border-border bg-control hover:bg-hover"
+                    className="tap-target-compact text-tap-compact shrink-0 cursor-pointer rounded border border-border bg-control hover:bg-control-hover"
                     onClick={onClickBack}
                 >
                     {tCommon("back")}

--- a/src/ui/setup/shared/PlayerListReorder.tsx
+++ b/src/ui/setup/shared/PlayerListReorder.tsx
@@ -139,7 +139,7 @@ export function PlayerListReorder() {
 
             <button
                 type="button"
-                className="tap-target-compact text-tap-compact self-start cursor-pointer rounded border border-border bg-control hover:bg-hover"
+                className="tap-target-compact text-tap-compact self-start cursor-pointer rounded border border-border bg-control hover:bg-control-hover"
                 onClick={() => dispatch({ type: "addPlayer" })}
             >
                 {tSetup("addPlayerLabel")}

--- a/src/ui/setup/shared/PlayerNameInput.tsx
+++ b/src/ui/setup/shared/PlayerNameInput.tsx
@@ -113,7 +113,7 @@ export function PlayerNameInput({
                 />
                 <button
                     type="button"
-                    className="shrink-0 cursor-pointer rounded border border-border bg-control p-1.5 text-fg hover:bg-hover"
+                    className="shrink-0 cursor-pointer rounded border border-border bg-control p-1.5 text-fg hover:bg-control-hover"
                     aria-label={t("removePlayerTitle", {
                         player: String(player),
                     })}

--- a/src/ui/setup/steps/SetupStepCardPack.tsx
+++ b/src/ui/setup/steps/SetupStepCardPack.tsx
@@ -421,7 +421,7 @@ export function SetupStepCardPack({
                                         "tap-target-compact text-tap-compact cursor-pointer rounded-full border transition-colors duration-200 ease-out " +
                                         (isActive
                                             ? "border-accent bg-accent font-semibold text-white"
-                                            : "border-border bg-control hover:bg-hover")
+                                            : "border-border bg-control hover:bg-control-hover")
                                     }
                                     aria-pressed={isActive}
                                     data-card-pack-active={
@@ -456,7 +456,7 @@ export function SetupStepCardPack({
                     >
                         <button
                             type="button"
-                            className="tap-target-compact text-tap-compact cursor-pointer rounded-full border border-border bg-control hover:bg-hover"
+                            className="tap-target-compact text-tap-compact cursor-pointer rounded-full border border-border bg-control hover:bg-control-hover"
                         >
                             {t("allCardPacks")}
                         </button>
@@ -467,7 +467,7 @@ export function SetupStepCardPack({
             <div className="flex flex-col gap-2">
                 <button
                     type="button"
-                    className="tap-target-compact text-tap-compact self-start cursor-pointer rounded border border-border bg-control hover:bg-hover"
+                    className="tap-target-compact text-tap-compact self-start cursor-pointer rounded border border-border bg-control hover:bg-control-hover"
                     onClick={() => {
                         const customLoaded = loadedCustomPack;
                         // `loadedCustomPack` covers customs; built-in

--- a/src/ui/setup/steps/SetupStepIdentity.tsx
+++ b/src/ui/setup/steps/SetupStepIdentity.tsx
@@ -108,7 +108,7 @@ export function SetupStepIdentity({
                                 className={`tap-target-compact text-tap-compact cursor-pointer rounded-full border transition-colors ${
                                     active
                                         ? "border-accent bg-accent text-white hover:bg-accent-hover"
-                                        : "border-border bg-control text-fg hover:bg-hover"
+                                        : "border-border bg-control text-fg hover:bg-control-hover"
                                 }`}
                                 aria-pressed={active}
                                 onClick={() => {

--- a/src/ui/setup/steps/SetupStepKnownCards.tsx
+++ b/src/ui/setup/steps/SetupStepKnownCards.tsx
@@ -182,7 +182,7 @@ export function SetupStepKnownCards({
                 <div className="flex items-center justify-between gap-2">
                     <button
                         type="button"
-                        className="cursor-pointer rounded border border-border bg-control p-1.5 hover:bg-hover disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-control"
+                        className="cursor-pointer rounded border border-border bg-control p-1.5 hover:bg-control-hover disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-control"
                         disabled={activeIndex === 0}
                         aria-label={t("prevPlayer")}
                         onClick={() =>
@@ -200,7 +200,7 @@ export function SetupStepKnownCards({
                     </span>
                     <button
                         type="button"
-                        className="cursor-pointer rounded border border-border bg-control p-1.5 hover:bg-hover disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-control"
+                        className="cursor-pointer rounded border border-border bg-control p-1.5 hover:bg-control-hover disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-control"
                         disabled={activeIndex >= targets.length - 1}
                         aria-label={t("nextPlayer")}
                         onClick={() =>

--- a/src/ui/share/ShareImportPage.tsx
+++ b/src/ui/share/ShareImportPage.tsx
@@ -1015,7 +1015,7 @@ export function ShareImportPage({
                                                 className={`tap-target-compact text-tap-compact cursor-pointer rounded-full border transition-colors ${
                                                     active
                                                         ? "border-accent bg-accent text-white hover:bg-accent-hover"
-                                                        : "border-border bg-control text-fg hover:bg-hover"
+                                                        : "border-border bg-control text-fg hover:bg-control-hover"
                                                 }`}
                                             >
                                                 {String(player)}


### PR DESCRIPTION
## Summary

The de-facto secondary button treatment (`bg-control border-border hover:bg-hover`) used in 19 places across the app — MyHand collapse caret, MyCards FAB close button, setup wizard pills, card pack editor, player roster controls, share-import page — was a warm tan (#dac796) that read as muted to the point of looking disabled against parchment surfaces.

This PR:

- **Lightens `--color-control`** from #dac796 to a soft warm cream (#efe5c2) that sits between `--color-panel` (#f7f0dc) and `--color-bg` (#e8dcb8). Stays clearly less white than the toolbar's pure-white Undo / Redo / overflow pills (`bg-white`) — those remain the lightest treatment in the system, distinct from the new secondary cream.
- **Adds a dedicated `--color-control-hover`** token (#dac796 — recycled from the previous control color). The secondary buttons now hover one step darker than their resting cream instead of jumping all the way to the shared `--color-hover` (#c2a96b). Other `hover:bg-hover` sites (toolbar pills, modal Cancel buttons, transparent close-X buttons, overflow-menu items) keep the original hover treatment unchanged.

Visually verified in the `next-dev` preview at desktop and mobile: MyHand collapse caret, MyCards FAB, setup wizard pills, and player-selection pills all render with the new cream; toolbar pills still resolve to pure white.

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (1580 tests)
- [x] `pnpm knip` passes
- [x] `pnpm i18n:check` passes
- [x] Verified collapse caret renders `rgb(239, 229, 194)`; toolbar Undo button renders `rgb(255, 255, 255)`
- [x] Verified `--color-control-hover` resolves to `rgb(218, 199, 150)` and the `.hover:bg-control-hover:hover` utility was generated by Tailwind
- [x] Rebased on `origin/main` past `d5d3041` (My Cards polish #208) — conflict in `MyHandPanel.tsx` collapse-button className resolved by keeping upstream's `shrink-0` alongside this branch's `hover:bg-control-hover`

## Commits

- `3b463e4` **Lighten secondary button color so it stops reading as disabled** — single-token change to `--color-control` in `app/globals.css` from `#dac796` to `#efe5c2`, with the doc-comment block above it rewritten cohesively.
- `1f276f1` **Soften secondary-button hover with dedicated --color-control-hover** — adds the new token to `app/globals.css` and routes the 19 secondary-button sites through `hover:bg-control-hover` instead of `hover:bg-hover`. Touches `MyHandPanel.tsx`, `MyCardsFAB.tsx`, `CardPackEditorModal.tsx`, `SetupWizard.tsx`, `PlayerListReorder.tsx`, `PlayerNameInput.tsx`, `SetupStepCardPack.tsx`, `SetupStepIdentity.tsx`, `SetupStepKnownCards.tsx`, and `ShareImportPage.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)