### PR TITLE
Setup wizard: scroll up when a tall step's heading is offscreen

### DIFF
--- a/src/ui/setup/SetupWizard.tsx
+++ b/src/ui/setup/SetupWizard.tsx
@@ -346,27 +346,34 @@ export function SetupWizard() {
             // unit-test environment doesn't throw — the scroll is
             // verified manually in the next-dev preview.
             if (typeof body.scrollTo !== "function") return;
-            // Only scroll if the newly-focused step's top edge sits
-            // in the bottom 20% of the viewport (or below it). When
-            // the step is already comfortably in view, scrolling
-            // every advance reads as jumpy — everything shifts while
-            // the user is still mid-interaction. Leaving scroll alone
-            // keeps the user's reading position stable.
-            const viewportTop = el.getBoundingClientRect().top;
-            const viewportHeight = window.innerHeight;
-            if (viewportTop <= viewportHeight * 0.8) return;
-            // The page header is `position: sticky` and its measured
+            // The page header is `position: fixed` and its measured
             // height is published as `--header-offset` on `:root` by
-            // a ResizeObserver in `Clue.tsx`. Reading it ensures the
-            // scrolled-to heading isn't hidden behind the sticky
-            // header on either breakpoint. Add a small extra gap
-            // (16px) so a sliver of the previous step's bottom is
-            // still visible — confirms forward progress.
+            // a ResizeObserver in `Clue.tsx`. Reading it lets us both
+            // (a) detect when the focused step's heading is hidden
+            // above the visible area, and (b) land the heading just
+            // below the header when we do scroll. The extra 16px gap
+            // leaves a sliver of context above the heading.
             const rootStyle = window.getComputedStyle(
                 document.documentElement,
             );
             const headerOffset =
                 parseFloat(rootStyle.getPropertyValue("--header-offset")) || 0;
+            const viewportTop = el.getBoundingClientRect().top;
+            const viewportHeight = window.innerHeight;
+            // Scroll DOWN when the step's top sits in the bottom 20%
+            // of the viewport (or below it) — the heading is too far
+            // down to be a comfortable starting point. Scroll UP when
+            // the step's top is hidden behind the sticky page header
+            // (top < headerOffset), which happens when a tall step
+            // expands from a scrolled-down position: the previous
+            // step collapses, the new step's body fills the viewport
+            // but its heading is offscreen above. Otherwise the
+            // heading is already comfortably in view — leaving the
+            // scroll alone keeps the user's reading position stable.
+            const isBelowBottomThreshold =
+                viewportTop > viewportHeight * 0.8;
+            const isAboveStickyHeader = viewportTop < headerOffset;
+            if (!isBelowBottomThreshold && !isAboveStickyHeader) return;
             const top = viewportTop + body.scrollTop;
             body.scrollTo({
                 top: Math.max(0, top - headerOffset - 16),


### PR DESCRIPTION
## What changes for the user

In Game Setup, when you advance from "What cards do you have?" to "Do you know any other player's cards?", the wizard now scrolls **up** so the new step's heading lands just below the sticky page header. Previously, because the `knownCards` step is so tall, the previous step collapsing left you looking at the *middle* of the new step with its heading hidden offscreen above — no obvious cue what step you were on now.

The scroll-on-advance effect was one-sided: it already scrolled **down** when the new step's top sat in the bottom 20% of the viewport, but had no matching case for "the new step's top is above the visible area." This PR adds the symmetric branch so navigation between any two steps lands the heading in a comfortable starting position — regardless of whether the new step needs the page to move down (short → next short, etc.) or up (long step expanding after a scrolled-down position).

## Technical log

- **`Setup wizard: scroll up when a tall step's heading is offscreen`** — In `src/ui/setup/SetupWizard.tsx`'s scroll-on-focus effect, move the `--header-offset` lookup above the gate and extend the gate from `if (viewportTop <= viewportHeight * 0.8) return;` to a two-sided check: scroll down on `viewportTop > viewportHeight * 0.8`, scroll up on `viewportTop < headerOffset`, otherwise no-op. The existing target formula (`viewportTop + body.scrollTop - headerOffset - 16`) works for both directions because `body.scrollTo` takes an absolute position — a negative `viewportTop` (heading offscreen above) maps to a smaller `body.scrollTop` and the page scrolls up.

## Test plan

- [ ] In `next-dev` preview, advance through to `myCards`, scroll until its body fills the viewport, click Next. The page should smooth-scroll **up** so the `knownCards` heading lands just below the page header.
- [ ] No regression on the existing scroll-down case (e.g. `cardPack` → `players` from the top of the page).
- [ ] No scroll when the new step's heading is already comfortably in view (between `headerOffset` and `viewportHeight * 0.8`).
- [ ] Back navigation also scrolls up when the previous step's heading is now hidden.
- [ ] With OS-level reduced motion, the upward scroll is instant.
- [ ] Repeat at both desktop (1280×800) and mobile (375×812) breakpoints.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJhvYiY4JqxcNvicDr1TVz)_