### PR TITLE
Fix MyCardsModal chrome to match standard modal pattern

### DIFF
--- a/src/ui/components/ModalStack.tsx
+++ b/src/ui/components/ModalStack.tsx
@@ -67,10 +67,22 @@ interface ModalEntry {
      *  `Dialog.Title` (visually hidden — modal bodies render their own
      *  visible heading). */
     readonly title: string;
+    /** Optional sticky header pinned to the top of the modal, outside
+     *  the scrollable content region. Use this for modals whose body
+     *  scrolls and whose title / close-X should remain visible during
+     *  scroll. Modals whose content always fits in the viewport can
+     *  keep rendering their title inline in `content` instead — both
+     *  patterns are supported. */
+    readonly header?: ReactNode;
     /** The modal body. Must NOT wrap itself in another `Dialog.Root` /
      *  `Dialog.Content` — the shell provides those. Rendered inside a
      *  scrollable region so content overflowing the viewport scrolls
-     *  while `footer` stays pinned. */
+     *  while `header` / `footer` stay pinned. The shell resets the
+     *  page-level sticky offset CSS variables (`--header-offset`,
+     *  `--contradiction-banner-offset`) to 0 on the scrolling body so
+     *  any sticky `<thead>` / sticky first column inside `content`
+     *  (e.g. `CardSelectionGrid`) pins at the modal's scroll-container
+     *  top instead of where the page header would otherwise sit. */
     readonly content: ReactNode;
     /** Optional sticky footer pinned to the bottom of the modal,
      *  outside the scrollable content region. Modals with action
@@ -324,12 +336,18 @@ function DialogShellInternal({
 
                         Layout: the motion.div is a flex column that
                         fills the Dialog.Content's `max-h-[calc(100dvh-2rem)]`.
-                        `content` lives inside a `flex-1 min-h-0
-                        overflow-y-auto` body so it scrolls when too
-                        tall to fit. `footer`, when provided, sits in a
-                        `shrink-0` band below and stays pinned. Modals
-                        without a footer still scroll the same way —
-                        the body fills the whole modal height. */}
+                        `header` (optional) and `footer` (optional)
+                        sit in `shrink-0` bands at the top and bottom
+                        and stay pinned. `content` lives inside a
+                        `flex-1 min-h-0 overflow-y-auto` body so it
+                        scrolls when too tall to fit. The scroll body
+                        resets `--header-offset` /
+                        `--contradiction-banner-offset` to 0 so any
+                        sticky descendant (e.g. a
+                        `CardSelectionGrid`'s sticky `<thead>`) pins
+                        at the modal's scroll-container top rather
+                        than at the page-header offset its `top:` calc
+                        normally inherits from the page. */}
                     <AnimatePresence
                         mode={PRESENCE_WAIT_MODE}
                         custom={direction}
@@ -353,6 +371,11 @@ function DialogShellInternal({
                                 transition={transition}
                                 className="flex max-h-[calc(100dvh-2rem)] flex-col"
                             >
+                                {top.header !== undefined && (
+                                    <div className="relative z-[40] shrink-0">
+                                        {top.header}
+                                    </div>
+                                )}
                                 {/* `relative z-0` makes the body wrapper
                                     its own stacking context — any
                                     `z-index` on `top.content`'s
@@ -360,7 +383,8 @@ function DialogShellInternal({
                                     context, so high-z body elements
                                     (e.g. a `CardSelectionGrid`'s
                                     sticky-left column at z-30) can't
-                                    paint over the footer slot below.
+                                    paint over the header / footer
+                                    slots above and below.
 
                                     Paired with `z-[40]` on the footer
                                     slot: footer wins against any
@@ -368,7 +392,14 @@ function DialogShellInternal({
                                     common stacking ladder used inside
                                     cards / grids tops out at 39 so 40
                                     is a comfortable buffer. */}
-                                <div className="relative z-0 min-h-0 flex-1 overflow-y-auto">
+                                <div
+                                    className="relative z-0 min-h-0 flex-1 overflow-y-auto"
+                                    style={{
+                                        ["--header-offset" as never]: "0px",
+                                        ["--contradiction-banner-offset" as never]:
+                                            "0px",
+                                    }}
+                                >
                                     {top.content}
                                 </div>
                                 {top.footer !== undefined && (

--- a/src/ui/components/MyCardsModal.test.tsx
+++ b/src/ui/components/MyCardsModal.test.tsx
@@ -108,5 +108,91 @@ describe("MyCardsModal — opens from null state B", () => {
         // Other players are NOT included as columns.
         expect(dialog?.textContent ?? "").not.toContain("Bob");
         expect(dialog?.textContent ?? "").not.toContain("Cho");
+
+        // Modal chrome matches the standard pattern: a visible
+        // Dialog.Title, an X close button in the header, and a Done
+        // CTA with the standard primary-button styling in a padded
+        // footer band.
+        const title = dialog?.querySelector("h2, [id^='radix-']");
+        expect(dialog?.textContent).toContain("myHand.modalTitle");
+        const closeButton =
+            dialog?.querySelector<HTMLButtonElement>(
+                "button[aria-label='common.close']",
+            );
+        expect(closeButton).not.toBeNull();
+        const doneButton = Array.from(
+            dialog?.querySelectorAll<HTMLButtonElement>("button") ?? [],
+        ).find((b) => b.textContent === "myHand.modalDone");
+        expect(doneButton).toBeDefined();
+        expect(doneButton?.className).toContain("tap-target");
+        expect(doneButton?.className).toContain("text-tap");
+        expect(doneButton?.className).toContain("border-accent");
+        expect(doneButton?.className).toContain("bg-accent");
+        // Compact variant must NOT be present.
+        expect(doneButton?.className).not.toContain("tap-target-compact");
+
+        // Suppress unused-var lint on the optional title handle.
+        void title;
+    });
+
+    test("clicking Done closes the modal", async () => {
+        const session = {
+            version: 9,
+            setup: {
+                players: ["Alice", "Bob", "Cho"],
+                categories: [
+                    {
+                        id: "category-suspects",
+                        name: "Suspect",
+                        cards: [
+                            { id: "card-miss-scarlet", name: "Miss Scarlet" },
+                        ],
+                    },
+                ],
+            },
+            hands: [],
+            handSizes: [],
+            suggestions: [],
+            accusations: [],
+            hypotheses: [],
+            pendingSuggestion: null,
+            selfPlayerId: "Alice",
+            firstDealtPlayerId: null,
+        };
+        window.localStorage.setItem(
+            "effect-clue.session.v9",
+            JSON.stringify(session),
+        );
+        const user = userEvent.setup();
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+
+        const openButton = await waitFor(() => {
+            const found = document.querySelector<HTMLButtonElement>(
+                "[data-tour-anchor~='my-cards-add-button']",
+            );
+            if (!found) throw new Error("Select-cards button not mounted");
+            return found;
+        });
+        await user.click(openButton);
+
+        await waitFor(() => {
+            if (!document.querySelector("[role='dialog']")) {
+                throw new Error("dialog not mounted");
+            }
+        });
+
+        const doneButton = Array.from(
+            document.querySelectorAll<HTMLButtonElement>(
+                "[role='dialog'] button",
+            ),
+        ).find((b) => b.textContent === "myHand.modalDone");
+        if (!doneButton) throw new Error("Done button not mounted");
+        await user.click(doneButton);
+
+        await waitFor(() => {
+            if (document.querySelector("[role='dialog']")) {
+                throw new Error("dialog still mounted after Done");
+            }
+        });
     });
 });

--- a/src/ui/components/MyCardsModal.tsx
+++ b/src/ui/components/MyCardsModal.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import * as Dialog from "@radix-ui/react-dialog";
 import { useTranslations } from "next-intl";
 import { useCallback, useMemo } from "react";
 import type { Player } from "../../logic/GameObjects";
 import { CardSelectionGrid } from "../setup/shared/CardSelectionGrid";
 import { useCardSelectionGridProps } from "../setup/shared/useCardSelectionGridProps";
 import { useClue } from "../state";
+import { XIcon } from "./Icons";
 import { useModalStack } from "./ModalStack";
 
 const MODAL_ID = "my-cards-modal";
@@ -19,6 +21,13 @@ const MODAL_ID = "my-cards-modal";
  *
  * The grid dispatches `addKnownCard` / `removeKnownCard` on each tick,
  * so there is no "commit" step — the Done button just pops the modal.
+ *
+ * Uses the `header` / `content` / `footer` slots of `ModalStack` so
+ * the title strip and the Done CTA stay pinned while the grid
+ * scrolls. The shell also resets the page-level sticky offset CSS
+ * variables to 0 on the scrolling body so the grid's sticky `<thead>`
+ * (`Player N` / `Identified X of Y in hand`) pins at the top of the
+ * modal's body instead of where the page header would sit.
  */
 function MyCardsModalBody() {
     const t = useTranslations("myHand");
@@ -33,36 +42,66 @@ function MyCardsModalBody() {
     if (selfPlayerId === null) {
         // Defensive: the modal opener gates on selfPlayerId !== null,
         // but a state change between open and render could land here.
-        return <p className="m-0 text-[1rem] text-muted">{t("nullStateAPrompt")}</p>;
+        return (
+            <p className="m-0 px-5 pt-3 pb-3 text-[1rem] text-muted">
+                {t("nullStateAPrompt")}
+            </p>
+        );
     }
 
-    return <CardSelectionGrid players={players} {...gridProps} />;
+    return (
+        <div className="px-5 pt-3 pb-3">
+            <CardSelectionGrid players={players} {...gridProps} />
+        </div>
+    );
 }
 
 /**
  * Hook returning an opener for the My Cards modal. Consumers call
  * `open()` from null state B's button; the modal pushes onto the
- * shared `ModalStack` with a sticky Done footer.
+ * shared `ModalStack` with pinned header (title + close X) and
+ * pinned footer (Done CTA).
  */
 export function useOpenMyCardsModal(): () => void {
     const { push, pop } = useModalStack();
     const t = useTranslations("myHand");
+    const tCommon = useTranslations("common");
     return useCallback(() => {
+        const title = t("modalTitle");
         push({
             id: MODAL_ID,
-            title: t("modalTitle"),
-            content: <MyCardsModalBody />,
-            footer: (
-                <div className="flex justify-end">
+            title,
+            header: (
+                <div className="flex items-start justify-between gap-3 px-5 pt-5 pb-3">
+                    <Dialog.Title className="m-0 font-display text-[1.25rem] text-accent">
+                        {title}
+                    </Dialog.Title>
                     <button
                         type="button"
-                        className="tap-target-compact text-tap-compact cursor-pointer rounded-[var(--radius)] border border-accent bg-accent px-3 text-white hover:bg-accent-hover"
+                        aria-label={tCommon("close")}
                         onClick={() => pop()}
+                        className="-mt-1 -mr-1 cursor-pointer rounded-[var(--radius)] border-none bg-transparent p-1 text-[#2a1f12] hover:bg-hover"
+                    >
+                        <XIcon size={18} />
+                    </button>
+                </div>
+            ),
+            content: <MyCardsModalBody />,
+            footer: (
+                <div className="flex items-center justify-end gap-2 bg-panel px-5 pt-4 pb-5">
+                    <button
+                        type="button"
+                        onClick={() => pop()}
+                        className={
+                            "tap-target text-tap cursor-pointer rounded-[var(--radius)] " +
+                            "border-2 border-accent bg-accent font-semibold text-white " +
+                            "hover:bg-accent-hover"
+                        }
                     >
                         {t("modalDone")}
                     </button>
                 </div>
             ),
         });
-    }, [push, pop, t]);
+    }, [push, pop, t, tCommon]);
 }


### PR DESCRIPTION
The "Cards in your hand" modal had three rough edges visible on
mobile: no visible title above the grid, the sticky "Player N"
header pinned ~70 px below the modal's natural top (leaving a gap
where scrolled-out rows showed through), and a Done button flush
against the right edge in the compact tap-target size.

Restructure the body to match SplashModal / StaleGameModal /
InstallPromptModal — a header band with Dialog.Title + X close, a
scrollable body, and a padded footer band with the standard
primary-button styling. Drop the ModalStack `footer:` slot in favor
of the inline action band the other modals use.

The CardSelectionGrid's sticky `<thead>` uses page-level CSS
variables (`--header-offset`, `--contradiction-banner-offset`) for
its `top:` calc — correct when the grid lives in the page's scroll
container during setup, but wrong inside a modal. Reset both to 0px
on the modal body wrapper so the cascade resolves the thead's
sticky offset to 0, pinning it at the modal's scroll-container top.
The grid itself is unchanged; the wizard's existing behavior keeps
its page-level offsets.