### PR TITLE
Standardize modals on shared chrome; press-delay reorder activation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,7 +303,12 @@ If you need a glyph that doesn't fit one of these, add it to `src/ui/components/
 
 ## Modals
 
-Every modal in the app is pushed onto the shared `ModalStack` (`src/ui/components/ModalStack.tsx`) — never as a standalone `<Dialog.Root>`. The shell handles the layout, the pinning, the sticky-offset CSS-variable reset, and the z-index stacking. Consumers supply three opt-in slots and trust the shell.
+Modal chrome (Dialog.Root + Dialog.Content + three-band layout + sticky-offset reset + z-index stacking) is centralized in `src/ui/components/Modal.tsx`. Two surfaces share it:
+
+- **Static modal** (`<Modal>` from `Modal.tsx`) — render directly on a route page when the modal IS the page (e.g. `/share/{id}`), or in any parent that controls `open` with `useState`. No provider needed.
+- **Dynamic stack** (`useModalStack().push(...)` from `ModalStack.tsx`) — push onto a global stack so an inner modal can open another. Internally renders through the same `ModalChrome` + `ModalBands` building blocks as static `Modal`, so visuals are identical.
+
+Pick by the question "does an inner modal of this open another?" — yes → push, no → static. Most modals push, since `useConfirm` / `usePrompt` and downstream alerts compose on top. Route-level standalones (`ShareImportPage`, `ShareMissingPage`) render static.
 
 ### The shape
 
@@ -335,15 +340,16 @@ Standalone landing pages at modal-shaped routes (today: `/share/{id}` — `Share
 
 ### What NOT to do
 
-- **No standalone `<Dialog.Root>` inside the app.** Every modal pushes through `ModalStack`. The exceptions documented above are routes — they still push, they just live at a URL.
+- **No standalone `<Dialog.Root>` inside the app.** Use `<Modal>` (static) or `useModalStack().push(...)` (dynamic). Both render through the shared `ModalChrome` + `ModalBands` so chrome stays consistent.
 - **No inline title or action band inside `content`.** They scroll away on tall content. Use `header` / `footer`.
 - **No re-introducing the `tap-target-compact` size** on modal buttons. The standard tap target is what the rest of the modal-button corpus uses.
 - **No `<table>` wrapped in `overflow-x: auto` inside `content`.** That creates a competing scroll container and breaks the "page owns horizontal scroll" invariant. Let the modal body's natural width carry the table.
 - **No re-rendering the title via the `title` prop alone.** That prop is `aria-label` only — the visible title goes in the `header` slot.
 
-### Reference implementation
+### Reference implementations
 
-`src/ui/components/MyCardsModal.tsx` is the canonical example — it uses all three slots, embeds `CardSelectionGrid`, and exercises the sticky-offset reset. Copy its shape when adding a new modal.
+- `src/ui/components/MyCardsModal.tsx` — canonical dynamic-stack consumer. Uses all three slots, embeds `CardSelectionGrid`, exercises the sticky-offset reset.
+- `src/ui/share/ShareMissingPage.tsx` — canonical static-`Modal` consumer. Route-level standalone with `useState(open)`, `onOpenChange` navigates away.
 
 ## Terminology
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -301,6 +301,50 @@ Use these icons consistently — picking the wrong glyph mis-signals what the af
 
 If you need a glyph that doesn't fit one of these, add it to `src/ui/components/Icons.tsx` (or `ShareIcon.tsx` for share variants) — don't reach for an emoji or a literal character (`×`, `→`, etc.) that might be misread.
 
+## Modals
+
+Every modal in the app is pushed onto the shared `ModalStack` (`src/ui/components/ModalStack.tsx`) — never as a standalone `<Dialog.Root>`. The shell handles the layout, the pinning, the sticky-offset CSS-variable reset, and the z-index stacking. Consumers supply three opt-in slots and trust the shell.
+
+### The shape
+
+`useModalStack().push({ id, title, header, content, footer, ... })`. The motion.div is a flex column inside `Dialog.Content`'s `max-h-[calc(100dvh-2rem)]`. `header` and `footer` sit in `shrink-0` bands above and below an `overflow-y-auto` body that holds `content`.
+
+- **`header`** — pinned at the top, outside the scroll area. Holds `<Dialog.Title>` and (for dismissible modals) the X close button. Stays visible while the body scrolls.
+- **`content`** — the scrollable middle. Body padding goes on a single wrapping `<div>` inside `content` (default `px-5 pt-3 pb-3`; richer modals can deviate).
+- **`footer`** — pinned at the bottom, outside the scroll area. Holds the action buttons. The shell renders its own `border-t border-border/30` separator — don't add another in the slot content.
+- **`title`** — accessibility-only `aria-label` fallback; the visible title lives in `<Dialog.Title>` inside `header`. Always pass `title` so the shell can label the dialog when `header` is omitted.
+
+### What goes where
+
+The standard chrome inside the slots:
+
+- **Header band**: `<div className="flex items-start justify-between gap-3 px-5 pt-5 pb-3">` containing `<Dialog.Title className="m-0 font-display text-[1.25rem] text-accent">{title}</Dialog.Title>` + `<button aria-label={tCommon("close")} className="-mt-1 -mr-1 cursor-pointer rounded-[var(--radius)] border-none bg-transparent p-1 text-[#2a1f12] hover:bg-hover"><XIcon size={18} /></button>`.
+- **Footer band**: `<div className="flex items-center justify-end gap-2 bg-panel px-5 pt-4 pb-5">` with the action buttons. Primary CTA: `tap-target text-tap cursor-pointer rounded-[var(--radius)] border-2 border-accent bg-accent font-semibold text-white hover:bg-accent-hover`. Secondary: `tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-white hover:bg-hover`. Don't reach for `tap-target-compact` — modals use the standard size.
+
+### Alert-style modals
+
+Confirm-style modals (`useConfirm`, `usePrompt`, `LogoutWarningModal`, `CardPackEditorModal`, the mid-game teach-mode prompt) omit the X close button (dismissal goes through an explicit button in the footer) and pass `dismissOnOutsideClick: false` + `dismissOnEscape: false` on the entry. Same three-slot shape — header carries just the title, footer carries the Cancel + Confirm buttons. Pair the two opt-outs together — Escape and outside-click are the same dismissal concept in users' minds.
+
+### Sticky offsets are automatic
+
+Anything inside `content` that uses `top: calc(var(--header-offset, 0px) + var(--contradiction-banner-offset, 0px))` (e.g. `CardSelectionGrid`'s sticky `<thead>`) pins at the modal scroll-container top, not where the page header sits. The shell resets both variables to `0px` on the scrolling body so descendants inherit the correct values via the cascade. Don't add a per-modal override.
+
+### Routes that look like modals
+
+Standalone landing pages at modal-shaped routes (today: `/share/{id}` — `ShareImportPage`, `ShareMissingPage`) still push through `ModalStack`. The route mounts `ModalStackProvider` + `ModalStackShell` at its top (`app/share/[id]/page.tsx` already does), and the page component is a thin opener that pushes the modal entry in `useEffect` on mount and pops on unmount. The modal's `onClose` navigates the user away (`router.replace("/play")`) so dismissal lands them somewhere sensible — there's nothing meaningful behind the modal on a route-level mount.
+
+### What NOT to do
+
+- **No standalone `<Dialog.Root>` inside the app.** Every modal pushes through `ModalStack`. The exceptions documented above are routes — they still push, they just live at a URL.
+- **No inline title or action band inside `content`.** They scroll away on tall content. Use `header` / `footer`.
+- **No re-introducing the `tap-target-compact` size** on modal buttons. The standard tap target is what the rest of the modal-button corpus uses.
+- **No `<table>` wrapped in `overflow-x: auto` inside `content`.** That creates a competing scroll container and breaks the "page owns horizontal scroll" invariant. Let the modal body's natural width carry the table.
+- **No re-rendering the title via the `title` prop alone.** That prop is `aria-label` only — the visible title goes in the `header` slot.
+
+### Reference implementation
+
+`src/ui/components/MyCardsModal.tsx` is the canonical example — it uses all three slots, embeds `CardSelectionGrid`, and exercises the sticky-offset reset. Copy its shape when adding a new modal.
+
 ## Terminology
 
 A few words have specific app-wide meaning. Stay consistent in both code and user-facing copy:

--- a/app/share/[id]/page.tsx
+++ b/app/share/[id]/page.tsx
@@ -1,12 +1,12 @@
 /**
  * Server-stored share landing page.
  *
- * Server-side: looks up the share by id. On hit, renders
- * `<ShareImportPage>`; on not-found / expired, renders
- * `<ShareMissingPage>`. Both branches sit inside the same
- * `ModalStackProvider` + `ConfirmProvider` + `ModalStackShell` so the
- * modal content (always rendered via `useModalStack().push`) has
- * access to confirm-style dialogs.
+ * Server-side: looks up the share by id. On not-found / expired,
+ * renders `<ShareMissingPage>` (a standalone static modal — no
+ * provider required). On hit, renders `<ShareImportPage>` inside
+ * `ModalStackProvider` + `ConfirmProvider` so the import flow can
+ * surface `useConfirm` warnings (dirty receiver game, save-as-new
+ * pack name, etc.) via the modal stack.
  */
 import {
     ModalStackProvider,
@@ -29,24 +29,18 @@ export default async function SharePageRoute({
 }): Promise<React.ReactElement> {
     const { id } = await params;
     let snapshot;
-    let isMissing = false;
     try {
         snapshot = await getShare({ id });
     } catch (e) {
         if (String(e).includes(ERR_SHARE_NOT_FOUND)) {
-            isMissing = true;
-        } else {
-            throw e;
+            return <ShareMissingPage shareId={id} />;
         }
+        throw e;
     }
     return (
         <ModalStackProvider>
             <ConfirmProvider>
-                {isMissing || snapshot === undefined ? (
-                    <ShareMissingPage shareId={id} />
-                ) : (
-                    <ShareImportPage snapshot={snapshot} />
-                )}
+                <ShareImportPage snapshot={snapshot} />
                 <ModalStackShell />
             </ConfirmProvider>
         </ModalStackProvider>

--- a/app/share/[id]/page.tsx
+++ b/app/share/[id]/page.tsx
@@ -1,12 +1,12 @@
 /**
  * Server-stored share landing page.
  *
- * Server-side: looks up the share by id; on not-found / expired,
- * renders a client-side missing-share modal. On hit, renders the
- * `<ShareImportPage>` with the snapshot. The actual import logic
- * (decode → toggle UI → apply to local game state) lives on the
- * client because it needs access to the receiver's
- * `<ClueProvider>`.
+ * Server-side: looks up the share by id. On hit, renders
+ * `<ShareImportPage>`; on not-found / expired, renders
+ * `<ShareMissingPage>`. Both branches sit inside the same
+ * `ModalStackProvider` + `ConfirmProvider` + `ModalStackShell` so the
+ * modal content (always rendered via `useModalStack().push`) has
+ * access to confirm-style dialogs.
  */
 import {
     ModalStackProvider,
@@ -29,18 +29,24 @@ export default async function SharePageRoute({
 }): Promise<React.ReactElement> {
     const { id } = await params;
     let snapshot;
+    let isMissing = false;
     try {
         snapshot = await getShare({ id });
     } catch (e) {
         if (String(e).includes(ERR_SHARE_NOT_FOUND)) {
-            return <ShareMissingPage shareId={id} />;
+            isMissing = true;
+        } else {
+            throw e;
         }
-        throw e;
     }
     return (
         <ModalStackProvider>
             <ConfirmProvider>
-                <ShareImportPage snapshot={snapshot} />
+                {isMissing || snapshot === undefined ? (
+                    <ShareMissingPage shareId={id} />
+                ) : (
+                    <ShareImportPage snapshot={snapshot} />
+                )}
                 <ModalStackShell />
             </ConfirmProvider>
         </ModalStackProvider>

--- a/src/ui/Clue.flow.test.tsx
+++ b/src/ui/Clue.flow.test.tsx
@@ -113,6 +113,7 @@ vi.mock("motion/react", () => {
         useReducedMotion: () => false,
         LayoutGroup: ({ children }: { children: ReactNode }) => children,
         Reorder: { Group: ReorderGroup, Item: ReorderItem },
+        useDragControls: () => ({ start: () => {} }),
     };
 });
 

--- a/src/ui/account/AccountModal.test.tsx
+++ b/src/ui/account/AccountModal.test.tsx
@@ -84,7 +84,12 @@ vi.mock("../onboarding/StartupCoordinator", () => ({
 import * as React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { DateTime } from "effect";
-import { AccountModal, ACCOUNT_MODAL_ID, mergeCardPacks } from "./AccountModal";
+import {
+    AccountModal,
+    AccountModalHeader,
+    ACCOUNT_MODAL_ID,
+    mergeCardPacks,
+} from "./AccountModal";
 import { TestQueryClientProvider } from "../../test-utils/queryClient";
 import {
     ModalStackProvider,
@@ -120,6 +125,7 @@ const AccountModalSeeder = () => {
         push({
             id: ACCOUNT_MODAL_ID,
             title: "Account",
+            header: <AccountModalHeader />,
             content: <AccountModal />,
         });
     }, [push]);

--- a/src/ui/account/AccountModal.tsx
+++ b/src/ui/account/AccountModal.tsx
@@ -149,9 +149,38 @@ export const mergeCardPacks = (
     return [...decodedServer, ...localOnly];
 };
 
-export function AccountModal() {
+/**
+ * Header band — title + X close. Pushed as the `header:` slot of the
+ * AccountModal entry. Reads the session itself so the title flips
+ * between "titleSignedOut" / "titleSignedIn"; React Query dedupes
+ * the call against `AccountModal`'s own session read.
+ */
+export function AccountModalHeader() {
     const t = useTranslations("account");
     const tCommon = useTranslations("common");
+    const session = useSession();
+    const { pop } = useModalStack();
+    const user = session.data?.user;
+    const isAnon = !user || user.isAnonymous;
+    return (
+        <div className="flex items-start justify-between gap-3 px-5 pt-5 pb-3">
+            <Dialog.Title className="m-0 font-display text-[1.25rem] text-accent">
+                {isAnon ? t("titleSignedOut") : t("titleSignedIn")}
+            </Dialog.Title>
+            <button
+                type="button"
+                aria-label={tCommon("close")}
+                onClick={pop}
+                className="-mt-1 -mr-1 cursor-pointer rounded-[var(--radius)] border-none bg-transparent p-1 text-[#2a1f12] hover:bg-hover"
+            >
+                <XIcon size={18} />
+            </button>
+        </div>
+    );
+}
+
+export function AccountModal() {
+    const t = useTranslations("account");
     const pathname = usePathname();
     const searchParams = useSearchParams();
     const session = useSession();
@@ -289,20 +318,7 @@ export function AccountModal() {
     };
 
     return (
-                <div className="flex flex-col">
-                    <div className="flex shrink-0 items-start justify-between gap-3 px-5 pt-5">
-                        <Dialog.Title className="m-0 font-display text-[1.25rem] text-accent">
-                            {isAnon ? t("titleSignedOut") : t("titleSignedIn")}
-                        </Dialog.Title>
-                        <button
-                            type="button"
-                            aria-label={tCommon("close")}
-                            onClick={pop}
-                            className="-mt-1 -mr-1 cursor-pointer rounded-[var(--radius)] border-none bg-transparent p-1 text-[#2a1f12] hover:bg-hover"
-                        >
-                            <XIcon size={18} />
-                        </button>
-                    </div>
+                <div>
                     <Dialog.Description className="px-5 pt-3 text-[1rem] leading-normal">
                         {isAnon ? t("descriptionSignedOut") : t("descriptionSignedIn")}
                     </Dialog.Description>
@@ -551,3 +567,4 @@ export function AccountModal() {
                 </div>
     );
 }
+

--- a/src/ui/account/AccountProvider.tsx
+++ b/src/ui/account/AccountProvider.tsx
@@ -45,11 +45,14 @@ import {
     ACCOUNT_MODAL_ID,
     ACCOUNT_MODAL_MAX_WIDTH,
     AccountModal,
+    AccountModalHeader,
 } from "./AccountModal";
 import {
     LOGOUT_WARNING_MAX_WIDTH,
     LOGOUT_WARNING_MODAL_ID,
-    LogoutWarningModalContent,
+    LogoutWarningBody,
+    LogoutWarningFooter,
+    LogoutWarningHeader,
 } from "./LogoutWarningModal";
 import { consumePendingAccountModalIntent } from "./pendingAccountModal";
 
@@ -144,6 +147,7 @@ export function AccountProvider({
             id: ACCOUNT_MODAL_ID,
             title: tAccount("titleSignedIn"),
             maxWidth: ACCOUNT_MODAL_MAX_WIDTH,
+            header: <AccountModalHeader />,
             content: <AccountModal />,
             ...(willFireTour ? { dismissOnOutsideClick: false } : {}),
         });
@@ -220,9 +224,15 @@ export function AccountProvider({
                 dismissOnOutsideClick: false,
                 dismissOnEscape: false,
                 maxWidth: LOGOUT_WARNING_MAX_WIDTH,
+                header: <LogoutWarningHeader />,
                 content: (
-                    <LogoutWarningModalContent
+                    <LogoutWarningBody
                         summary={next.summary}
+                        reason={next.reason}
+                    />
+                ),
+                footer: (
+                    <LogoutWarningFooter
                         reason={next.reason}
                         retrying={next.retrying}
                         onStay={onStay}

--- a/src/ui/account/LogoutWarningModal.tsx
+++ b/src/ui/account/LogoutWarningModal.tsx
@@ -13,11 +13,12 @@
  *     localStorage and signs out. The just-discarded changes are
  *     lost.
  *
- * Rendered via the global modal stack as `LogoutWarningModalContent`
- * (no own `Dialog.Root`). The shell handles outside-click / Escape
- * dismissal — both are blocked here via `dismissOnOutsideClick:
- * false` + `dismissOnEscape: false` so a stray click can't drop the
- * user into a half-warned state.
+ * Pushed onto the shared `ModalStack` via the standard three slots
+ * (`LogoutWarningHeader`, `LogoutWarningBody`, `LogoutWarningFooter`).
+ * Alert-style: `dismissOnOutsideClick: false` + `dismissOnEscape:
+ * false` so a stray click can't drop the user into a half-warned
+ * state. The header carries no X close — dismissal goes through the
+ * explicit footer buttons.
  */
 "use client";
 
@@ -28,15 +29,6 @@ import type {
     FlushReason,
     UnsyncedSummary,
 } from "../../data/cardPacksSync";
-
-interface LogoutWarningModalContentProps {
-    readonly summary: UnsyncedSummary | null;
-    readonly reason: FlushReason | null;
-    readonly retrying: boolean;
-    readonly onStay: () => void;
-    readonly onRetry: () => void;
-    readonly onSignOutAnyway: () => void;
-}
 
 interface SectionProps {
     readonly heading: string;
@@ -63,113 +55,134 @@ const Tag = ({ children }: { readonly children: ReactNode }) => (
 export const LOGOUT_WARNING_MODAL_ID = "logout-warning" as const;
 export const LOGOUT_WARNING_MAX_WIDTH = "min(92vw,460px)" as const;
 
-export function LogoutWarningModalContent({
+export function LogoutWarningHeader() {
+    const t = useTranslations("account.logoutWarning");
+    return (
+        <div className="flex items-start justify-between gap-3 px-5 pt-5 pb-3">
+            <Dialog.Title className="m-0 font-display text-[1.25rem] text-accent">
+                {t("title")}
+            </Dialog.Title>
+        </div>
+    );
+}
+
+export function LogoutWarningBody({
     summary,
     reason,
-    retrying,
-    onStay,
-    onRetry,
-    onSignOutAnyway,
-}: LogoutWarningModalContentProps) {
+}: {
+    readonly summary: UnsyncedSummary | null;
+    readonly reason: FlushReason | null;
+}) {
     const t = useTranslations("account.logoutWarning");
     const created = summary?.created ?? [];
     const modified = summary?.modified ?? [];
     const deleted = summary?.deleted ?? [];
 
     return (
-        <div className="flex max-h-[85vh] flex-col">
-            <div className="px-5 pt-5">
-                <Dialog.Title className="m-0 mb-2 font-display text-[1.125rem] text-accent">
-                    {t("title")}
-                </Dialog.Title>
-                <p className="m-0 text-[1rem] leading-snug text-[#2a1f12]">
-                    {reason === "offline"
-                        ? t("ledeOffline")
-                        : t("ledeServerError")}
-                </p>
-            </div>
-            <div className="flex-1 overflow-y-auto px-5">
-                {created.length > 0 ? (
-                    <Section
-                        heading={t("createdHeading", {
-                            count: created.length,
-                        })}
-                    >
-                        {created.map((p) => (
-                            <li
-                                key={p.id}
-                                className="truncate rounded bg-row-alt px-2 py-1"
-                            >
-                                {p.label}
-                            </li>
-                        ))}
-                    </Section>
-                ) : null}
-                {modified.length > 0 ? (
-                    <Section
-                        heading={t("modifiedHeading", {
-                            count: modified.length,
-                        })}
-                    >
-                        {modified.map((p) => (
-                            <li
-                                key={p.id}
-                                className="truncate rounded bg-row-alt px-2 py-1"
-                            >
-                                {p.label}
-                                {p.labelChanged ? (
-                                    <Tag>{t("tagRenamed")}</Tag>
-                                ) : null}
-                                {p.cardsChanged ? (
-                                    <Tag>{t("tagCardsChanged")}</Tag>
-                                ) : null}
-                            </li>
-                        ))}
-                    </Section>
-                ) : null}
-                {deleted.length > 0 ? (
-                    <Section
-                        heading={t("deletedHeading", {
-                            count: deleted.length,
-                        })}
-                    >
-                        {deleted.map((p) => (
-                            <li
-                                key={p.id}
-                                className="truncate rounded bg-row-alt px-2 py-1"
-                            >
-                                {p.label}
-                            </li>
-                        ))}
-                    </Section>
-                ) : null}
-            </div>
-            <div className="flex flex-wrap justify-end gap-2 px-5 pb-5 pt-4">
+        <div className="px-5 pt-3 pb-3">
+            <p className="m-0 text-[1rem] leading-snug text-[#2a1f12]">
+                {reason === "offline"
+                    ? t("ledeOffline")
+                    : t("ledeServerError")}
+            </p>
+            {created.length > 0 ? (
+                <Section
+                    heading={t("createdHeading", {
+                        count: created.length,
+                    })}
+                >
+                    {created.map((p) => (
+                        <li
+                            key={p.id}
+                            className="truncate rounded bg-row-alt px-2 py-1"
+                        >
+                            {p.label}
+                        </li>
+                    ))}
+                </Section>
+            ) : null}
+            {modified.length > 0 ? (
+                <Section
+                    heading={t("modifiedHeading", {
+                        count: modified.length,
+                    })}
+                >
+                    {modified.map((p) => (
+                        <li
+                            key={p.id}
+                            className="truncate rounded bg-row-alt px-2 py-1"
+                        >
+                            {p.label}
+                            {p.labelChanged ? (
+                                <Tag>{t("tagRenamed")}</Tag>
+                            ) : null}
+                            {p.cardsChanged ? (
+                                <Tag>{t("tagCardsChanged")}</Tag>
+                            ) : null}
+                        </li>
+                    ))}
+                </Section>
+            ) : null}
+            {deleted.length > 0 ? (
+                <Section
+                    heading={t("deletedHeading", {
+                        count: deleted.length,
+                    })}
+                >
+                    {deleted.map((p) => (
+                        <li
+                            key={p.id}
+                            className="truncate rounded bg-row-alt px-2 py-1"
+                        >
+                            {p.label}
+                        </li>
+                    ))}
+                </Section>
+            ) : null}
+        </div>
+    );
+}
+
+export function LogoutWarningFooter({
+    reason,
+    retrying,
+    onStay,
+    onRetry,
+    onSignOutAnyway,
+}: {
+    readonly reason: FlushReason | null;
+    readonly retrying: boolean;
+    readonly onStay: () => void;
+    readonly onRetry: () => void;
+    readonly onSignOutAnyway: () => void;
+}) {
+    const t = useTranslations("account.logoutWarning");
+    return (
+        <div className="flex flex-wrap items-center justify-end gap-2 bg-panel px-5 pt-4 pb-5">
+            <button
+                type="button"
+                onClick={onStay}
+                className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-transparent font-semibold text-[#2a1f12] hover:bg-hover"
+            >
+                {t("stayLoggedIn")}
+            </button>
+            {reason === "serverError" ? (
                 <button
                     type="button"
-                    onClick={onStay}
-                    className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-transparent font-semibold text-[#2a1f12] hover:bg-hover"
+                    onClick={onRetry}
+                    disabled={retrying}
+                    className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-panel font-semibold text-[#2a1f12] hover:bg-hover disabled:opacity-60"
                 >
-                    {t("stayLoggedIn")}
+                    {retrying ? t("tryingAgain") : t("tryAgain")}
                 </button>
-                {reason === "serverError" ? (
-                    <button
-                        type="button"
-                        onClick={onRetry}
-                        disabled={retrying}
-                        className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-panel font-semibold text-[#2a1f12] hover:bg-hover disabled:opacity-60"
-                    >
-                        {retrying ? t("tryingAgain") : t("tryAgain")}
-                    </button>
-                ) : null}
-                <button
-                    type="button"
-                    onClick={onSignOutAnyway}
-                    className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-accent bg-accent font-semibold text-white hover:bg-accent-hover"
-                >
-                    {t("signOutAnyway")}
-                </button>
-            </div>
+            ) : null}
+            <button
+                type="button"
+                onClick={onSignOutAnyway}
+                className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border-2 border-accent bg-accent font-semibold text-white hover:bg-accent-hover"
+            >
+                {t("signOutAnyway")}
+            </button>
         </div>
     );
 }

--- a/src/ui/components/InstallPromptModal.tsx
+++ b/src/ui/components/InstallPromptModal.tsx
@@ -15,16 +15,16 @@
  * like the tour. The trigger comes from the gate or from the
  * "Install app" overflow menu item.
  *
- * Rendered via the global modal stack — the content has no
- * `Dialog.Root` of its own. `useInstallPromptModalGate` watches the
- * consumer gate and pushes / pops the entry.
+ * Pushed onto the shared `ModalStack` with the standard three slots —
+ * `header` (title + X), `content` (description + benefits), `footer`
+ * (Not now / Install).
  */
 "use client";
 
 import * as Dialog from "@radix-ui/react-dialog";
 import { DateTime } from "effect";
 import { useTranslations } from "next-intl";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import {
     installAccepted,
     installDismissed,
@@ -46,107 +46,6 @@ const VIA_X_BUTTON = "x_button" satisfies InstallDismissVia;
 const INSTALL_PROMPT_MODAL_ID = "install-prompt" as const;
 const INSTALL_PROMPT_MAX_WIDTH = "min(92vw,480px)" as const;
 
-interface InstallPromptModalContentProps {
-    readonly trigger: InstallPromptTrigger;
-    readonly onInstall: () => Promise<boolean>;
-    readonly onSnooze: () => void;
-    readonly onClose: () => void;
-}
-
-function InstallPromptModalContent({
-    trigger,
-    onInstall,
-    onSnooze,
-    onClose,
-}: InstallPromptModalContentProps) {
-    const t = useTranslations("installPrompt");
-    const tCommon = useTranslations("common");
-    const notNowRef = useRef<HTMLButtonElement | null>(null);
-
-    // Bias focus toward "Not now" — the user wasn't seeking out an
-    // install, so a stray Enter on Install would feel hostile.
-    useEffect(() => {
-        const id = window.requestAnimationFrame(() => {
-            notNowRef.current?.focus();
-        });
-        return () => window.cancelAnimationFrame(id);
-    }, []);
-
-    const handleInstall = async (): Promise<void> => {
-        const ctx = computeInstallPromptAnalyticsContext(
-            loadInstallPromptState(),
-            DateTime.nowUnsafe(),
-        );
-        installPrompted({ trigger, ...ctx });
-        const accepted = await onInstall();
-        if (accepted) {
-            installAccepted({ trigger });
-        } else {
-            installDismissed({ trigger, via: VIA_NATIVE_DECLINE });
-        }
-        onClose();
-    };
-
-    const handleSnooze = (): void => {
-        installDismissed({ trigger, via: VIA_SNOOZE });
-        onSnooze();
-        onClose();
-    };
-
-    const handleXClose = (): void => {
-        installDismissed({ trigger, via: VIA_X_BUTTON });
-        onSnooze();
-        onClose();
-    };
-
-    return (
-        <div className="flex flex-col">
-            <div className="flex shrink-0 items-start justify-between gap-3 px-5 pt-5">
-                <Dialog.Title className="m-0 font-display text-[1.25rem] text-accent">
-                    {t("title")}
-                </Dialog.Title>
-                <button
-                    type="button"
-                    aria-label={tCommon("close")}
-                    onClick={handleXClose}
-                    className="-mt-1 -mr-1 cursor-pointer rounded-[var(--radius)] border-none bg-transparent p-1 text-[#2a1f12] hover:bg-hover"
-                >
-                    <XIcon size={18} />
-                </button>
-            </div>
-            <p className="px-5 pt-3 text-[1rem] leading-normal">
-                {t("description")}
-            </p>
-            <ul className="m-0 list-disc px-5 pl-9 pt-3 text-[1rem] leading-normal">
-                <li>{t("benefitOffline")}</li>
-                <li>{t("benefitHomeScreen")}</li>
-                <li>{t("benefitFastLaunch")}</li>
-            </ul>
-            <div className="mt-4 flex items-center justify-end gap-2 border-t border-border bg-panel px-5 pt-4 pb-5">
-                <button
-                    ref={notNowRef}
-                    type="button"
-                    onClick={handleSnooze}
-                    className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-white hover:bg-hover"
-                >
-                    {t("notNow")}
-                </button>
-                <button
-                    type="button"
-                    onClick={() => void handleInstall()}
-                    className={
-                        "tap-target text-tap inline-flex cursor-pointer items-center gap-2 rounded-[var(--radius)] border-2 border-accent bg-accent " +
-                        "font-semibold text-white hover:bg-accent-hover"
-                    }
-                >
-                    <span>{t("install")}</span>
-                    <ArrowRightIcon size={16} />
-                </button>
-            </div>
-        </div>
-    );
-}
-
 interface InstallPromptModalGateProps {
     readonly open: boolean;
     readonly trigger: InstallPromptTrigger;
@@ -164,33 +63,120 @@ function useInstallPromptModalGate({
     onClose,
 }: InstallPromptModalGateProps): void {
     const t = useTranslations("installPrompt");
+    const tCommon = useTranslations("common");
     const { push, popTo } = useModalStack();
     const handlersRef = useRef({ onInstall, onSnooze, onClose });
     handlersRef.current = { onInstall, onSnooze, onClose };
-    const titleRef = useRef("");
-    titleRef.current = t("title");
+    const tRef = useRef(t);
+    tRef.current = t;
+    const tCommonRef = useRef(tCommon);
+    tCommonRef.current = tCommon;
+    const notNowRef = useRef<HTMLButtonElement | null>(null);
+
+    const handleInstall = useCallback(async (): Promise<void> => {
+        const ctx = computeInstallPromptAnalyticsContext(
+            loadInstallPromptState(),
+            DateTime.nowUnsafe(),
+        );
+        installPrompted({ trigger, ...ctx });
+        const accepted = await handlersRef.current.onInstall();
+        if (accepted) {
+            installAccepted({ trigger });
+        } else {
+            installDismissed({ trigger, via: VIA_NATIVE_DECLINE });
+        }
+        popTo(INSTALL_PROMPT_MODAL_ID);
+        handlersRef.current.onClose();
+    }, [trigger, popTo]);
+
+    const handleSnooze = useCallback((): void => {
+        installDismissed({ trigger, via: VIA_SNOOZE });
+        handlersRef.current.onSnooze();
+        popTo(INSTALL_PROMPT_MODAL_ID);
+        handlersRef.current.onClose();
+    }, [trigger, popTo]);
+
+    const handleXClose = useCallback((): void => {
+        installDismissed({ trigger, via: VIA_X_BUTTON });
+        handlersRef.current.onSnooze();
+        popTo(INSTALL_PROMPT_MODAL_ID);
+        handlersRef.current.onClose();
+    }, [trigger, popTo]);
+
     useEffect(() => {
         if (!open) return;
+        const t = tRef.current;
+        const tCommon = tCommonRef.current;
+        const title = t("title");
         push({
             id: INSTALL_PROMPT_MODAL_ID,
-            title: titleRef.current,
+            title,
             maxWidth: INSTALL_PROMPT_MAX_WIDTH,
+            header: (
+                <div className="flex items-start justify-between gap-3 px-5 pt-5 pb-3">
+                    <Dialog.Title className="m-0 font-display text-[1.25rem] text-accent">
+                        {title}
+                    </Dialog.Title>
+                    <button
+                        type="button"
+                        aria-label={tCommon("close")}
+                        onClick={handleXClose}
+                        className="-mt-1 -mr-1 cursor-pointer rounded-[var(--radius)] border-none bg-transparent p-1 text-[#2a1f12] hover:bg-hover"
+                    >
+                        <XIcon size={18} />
+                    </button>
+                </div>
+            ),
             content: (
-                <InstallPromptModalContent
-                    trigger={trigger}
-                    onInstall={() => handlersRef.current.onInstall()}
-                    onSnooze={() => handlersRef.current.onSnooze()}
-                    onClose={() => {
-                        popTo(INSTALL_PROMPT_MODAL_ID);
-                        handlersRef.current.onClose();
-                    }}
-                />
+                <div className="px-5 pb-3">
+                    <p className="m-0 pt-3 text-[1rem] leading-normal">
+                        {t("description")}
+                    </p>
+                    <ul className="m-0 list-disc pl-4 pt-3 text-[1rem] leading-normal">
+                        <li>{t("benefitOffline")}</li>
+                        <li>{t("benefitHomeScreen")}</li>
+                        <li>{t("benefitFastLaunch")}</li>
+                    </ul>
+                </div>
+            ),
+            footer: (
+                <div className="flex items-center justify-end gap-2 bg-panel px-5 pt-4 pb-5">
+                    <button
+                        ref={notNowRef}
+                        type="button"
+                        onClick={handleSnooze}
+                        className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-white hover:bg-hover"
+                    >
+                        {t("notNow")}
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => void handleInstall()}
+                        className={
+                            "tap-target text-tap inline-flex cursor-pointer items-center gap-2 rounded-[var(--radius)] border-2 border-accent bg-accent " +
+                            "font-semibold text-white hover:bg-accent-hover"
+                        }
+                    >
+                        <span>{t("install")}</span>
+                        <ArrowRightIcon size={16} />
+                    </button>
+                </div>
             ),
         });
         return () => {
             popTo(INSTALL_PROMPT_MODAL_ID);
         };
-    }, [open, trigger, push, popTo]);
+    }, [open, push, popTo, handleInstall, handleSnooze, handleXClose]);
+
+    // Bias focus toward "Not now" — the user wasn't seeking out an
+    // install, so a stray Enter on Install would feel hostile.
+    useEffect(() => {
+        if (!open) return;
+        const id = window.requestAnimationFrame(() => {
+            notNowRef.current?.focus();
+        });
+        return () => window.cancelAnimationFrame(id);
+    }, [open]);
 }
 
 /**

--- a/src/ui/components/Modal.tsx
+++ b/src/ui/components/Modal.tsx
@@ -1,0 +1,172 @@
+/**
+ * Shared modal chrome — three-band (header / content / footer)
+ * layout with sticky-offset CSS-variable reset and Radix Dialog
+ * wiring. Two public surfaces:
+ *
+ * - `Modal`: static three-band modal. Use directly on a route page
+ *   when the modal IS the page, or in a parent that controls `open`
+ *   with `useState`. The simplest entry point — no provider needed.
+ *
+ * - `useModalStack().push({...})` (in `ModalStack.tsx`): dynamic
+ *   stack of modals. Pushes onto a global stack so an inner modal
+ *   can open another modal. The stack's shell renders through the
+ *   same `ModalChrome` + `ModalBands` building blocks below so the
+ *   visual chrome is identical regardless of static or dynamic
+ *   usage.
+ *
+ * Both surfaces share the sticky-offset reset on the scrolling body,
+ * so any embedded sticky `<thead>` (e.g. `CardSelectionGrid`'s
+ * player-name row) pins to the modal's scroll-container top instead
+ * of where the page header would otherwise sit.
+ */
+"use client";
+
+import * as Dialog from "@radix-ui/react-dialog";
+import { type ReactNode } from "react";
+
+const DEFAULT_MAX_WIDTH = "min(92vw,480px)" as const;
+const ROLE_ALERT_DIALOG = "alertdialog" as const;
+
+export interface ModalChromeProps {
+    /** Whether the modal is open. */
+    readonly open: boolean;
+    /** Accessible label fallback when the body doesn't render a
+     *  visible `Dialog.Title`. The visible title lives inside the
+     *  `header` band. */
+    readonly title?: string;
+    /** CSS width — defaults to `min(92vw,480px)`. Height always
+     *  auto-fits to content up to the viewport. */
+    readonly maxWidth?: string;
+    /** Backdrop click dismisses (default true). Set false for
+     *  confirm-style modals where dismissal must go through an
+     *  explicit button. */
+    readonly dismissOnOutsideClick?: boolean;
+    /** Escape dismisses (default true). Pair with
+     *  `dismissOnOutsideClick: false` for confirm-style modals. */
+    readonly dismissOnEscape?: boolean;
+    /** Radix `onOpenChange` — fired on backdrop click or Escape
+     *  (when not opted out above). The caller decides what "close"
+     *  means (navigate away, set local state, pop a stack). */
+    readonly onOpenChange?: (next: boolean) => void;
+    /** Children replace the entire `Dialog.Content` body. Use
+     *  `ModalBands` to render the standard three-band layout
+     *  inside. */
+    readonly children: ReactNode;
+}
+
+/**
+ * Outer Radix Dialog wrapper with the modal's chrome styling.
+ * `Modal` (static) and `ModalStack`'s shell (dynamic) both render
+ * through this so the outer chrome is identical across both
+ * surfaces.
+ */
+export function ModalChrome({
+    open,
+    title,
+    maxWidth = DEFAULT_MAX_WIDTH,
+    dismissOnOutsideClick,
+    dismissOnEscape,
+    onOpenChange,
+    children,
+}: ModalChromeProps) {
+    const isAlert =
+        dismissOnOutsideClick === false || dismissOnEscape === false;
+    return (
+        <Dialog.Root
+            open={open}
+            {...(onOpenChange !== undefined ? { onOpenChange } : {})}
+        >
+            <Dialog.Portal>
+                <Dialog.Overlay className="fixed inset-0 z-[var(--z-dialog-overlay)] bg-black/40" />
+                <Dialog.Content
+                    onEscapeKeyDown={(e) => {
+                        if (dismissOnEscape === false) e.preventDefault();
+                    }}
+                    onPointerDownOutside={(e) => {
+                        if (dismissOnOutsideClick === false) e.preventDefault();
+                    }}
+                    style={{ width: maxWidth }}
+                    className={
+                        "fixed left-1/2 top-1/2 z-[var(--z-dialog-content)] " +
+                        "max-h-[calc(100dvh-2rem)] -translate-x-1/2 -translate-y-1/2 " +
+                        "overflow-hidden rounded-[var(--radius)] border border-border " +
+                        "bg-panel shadow-[0_10px_28px_rgba(0,0,0,0.28)] focus:outline-none"
+                    }
+                    aria-describedby={undefined}
+                    {...(isAlert ? { role: ROLE_ALERT_DIALOG } : {})}
+                    aria-label={title}
+                >
+                    {children}
+                </Dialog.Content>
+            </Dialog.Portal>
+        </Dialog.Root>
+    );
+}
+
+export interface ModalBandsProps {
+    /** Optional pinned header band — title + close X, etc. */
+    readonly header?: ReactNode;
+    /** Scrollable body. Sticky descendants (`CardSelectionGrid`'s
+     *  `<thead>`) pin at the top of THIS scroll container. */
+    readonly content: ReactNode;
+    /** Optional pinned footer band — action buttons. */
+    readonly footer?: ReactNode;
+}
+
+/**
+ * The three-band layout: pinned header, scrollable body, pinned
+ * footer. The body resets `--header-offset` /
+ * `--contradiction-banner-offset` to `0px` so embedded sticky
+ * elements pin at the modal's scroll-container top instead of the
+ * page-header offset their `top:` calc normally inherits.
+ *
+ * `z-[40]` on the header and footer wins against any z-index inside
+ * `content` up through 39 (the checklist-style grid's sticky-header
+ * layer tops out there). `relative z-0` on the body wraps content in
+ * its own stacking context so its high-z descendants can't paint
+ * over the bands.
+ */
+export function ModalBands({ header, content, footer }: ModalBandsProps) {
+    return (
+        <div className="flex max-h-[calc(100dvh-2rem)] flex-col">
+            {header !== undefined && (
+                <div className="relative z-[40] shrink-0">{header}</div>
+            )}
+            <div
+                className="relative z-0 min-h-0 flex-1 overflow-y-auto"
+                style={{
+                    ["--header-offset" as never]: "0px",
+                    ["--contradiction-banner-offset" as never]: "0px",
+                }}
+            >
+                {content}
+            </div>
+            {footer !== undefined && (
+                <div className="relative z-[40] shrink-0 border-t border-border/30">
+                    {footer}
+                </div>
+            )}
+        </div>
+    );
+}
+
+export interface ModalProps extends Omit<ModalChromeProps, "children">, ModalBandsProps {}
+
+/**
+ * Static three-band modal. Pass `open`, `header`, `content`,
+ * `footer`. The chrome and band styling are identical to whatever
+ * `useModalStack().push(...)` renders, so the visual is the same
+ * regardless of static or dynamic usage.
+ */
+export function Modal({
+    header,
+    content,
+    footer,
+    ...chromeProps
+}: ModalProps) {
+    return (
+        <ModalChrome {...chromeProps}>
+            <ModalBands header={header} content={content} footer={footer} />
+        </ModalChrome>
+    );
+}

--- a/src/ui/components/ModalStack.tsx
+++ b/src/ui/components/ModalStack.tsx
@@ -28,7 +28,6 @@
  */
 "use client";
 
-import * as Dialog from "@radix-ui/react-dialog";
 import { AnimatePresence, motion } from "motion/react";
 import {
     createContext,
@@ -41,6 +40,7 @@ import {
     type ReactNode,
 } from "react";
 import { T_STANDARD, useReducedTransition } from "../motion";
+import { ModalBands, ModalChrome } from "./Modal";
 
 // `mode="wait"` makes the AnimatePresence run exit-then-enter
 // sequentially: the popped entry slides out fully before the revealed
@@ -49,15 +49,6 @@ import { T_STANDARD, useReducedTransition } from "../motion";
 // a grid stack so they don't collide layout-wise, which adds complexity
 // without much UX win at modal-swap timing (~200ms).
 const PRESENCE_WAIT_MODE = "wait" as const;
-
-const DEFAULT_MAX_WIDTH = "min(92vw,480px)" as const;
-
-// `role="alertdialog"` for entries that block backdrop / Escape
-// dismissal — matches the Radix `AlertDialog` role they previously
-// rendered. Assistive tech treats alertdialogs as time-critical and
-// reads them more aggressively, so we preserve that semantic for
-// confirms / prompts / logout-warning.
-const ROLE_ALERT_DIALOG = "alertdialog" as const;
 
 interface ModalEntry {
     /** Stable identifier — used for AnimatePresence key, popTo lookup,
@@ -290,128 +281,60 @@ function DialogShellInternal({
         if (stack.length > 0) setDialogOpen(true);
     }, [stack.length]);
 
+    // Both the chrome (Dialog.Root + Dialog.Content + outer styles)
+    // and the three-band layout (header / scrollable body with sticky-
+    // offset reset / footer) come from the shared `Modal` building
+    // blocks, so the stack's visual matches the static `Modal` used
+    // on route-level surfaces (e.g. `ShareImportPage`).
     return (
-        <Dialog.Root
+        <ModalChrome
             open={dialogOpen}
+            {...(top?.title !== undefined ? { title: top.title } : {})}
+            {...(top?.maxWidth !== undefined ? { maxWidth: top.maxWidth } : {})}
+            {...(top?.dismissOnOutsideClick !== undefined
+                ? { dismissOnOutsideClick: top.dismissOnOutsideClick }
+                : {})}
+            {...(top?.dismissOnEscape !== undefined
+                ? { dismissOnEscape: top.dismissOnEscape }
+                : {})}
             onOpenChange={(next) => {
-                // Backdrop click + Escape both flip `open` to false.
-                // Per-event opt-outs are wired below
-                // (`onPointerDownOutside`, `onEscapeKeyDown`). If both
-                // those handlers allow the close, Radix lets it through
-                // and we pop here.
                 if (!next) pop();
             }}
         >
-            <Dialog.Portal>
-                <Dialog.Overlay className="fixed inset-0 z-[var(--z-dialog-overlay)] bg-black/40" />
-                <Dialog.Content
-                    onEscapeKeyDown={(e) => {
-                        if (top?.dismissOnEscape === false) e.preventDefault();
-                    }}
-                    onPointerDownOutside={(e) => {
-                        if (top?.dismissOnOutsideClick === false) {
-                            e.preventDefault();
-                        }
-                    }}
-                    style={{ width: top?.maxWidth ?? DEFAULT_MAX_WIDTH }}
-                    className={
-                        "fixed left-1/2 top-1/2 z-[var(--z-dialog-content)] " +
-                        "max-h-[calc(100dvh-2rem)] -translate-x-1/2 -translate-y-1/2 " +
-                        "overflow-hidden rounded-[var(--radius)] border border-border " +
-                        "bg-panel shadow-[0_10px_28px_rgba(0,0,0,0.28)] focus:outline-none"
-                    }
-                    aria-describedby={undefined}
-                    {...(top?.dismissOnOutsideClick === false ||
-                    top?.dismissOnEscape === false
-                        ? { role: ROLE_ALERT_DIALOG }
-                        : {})}
-                    aria-label={top?.title}
-                >
-                    {/* Modal content components render their own
-                        `Dialog.Title` (which Radix uses to label the
-                        dialog) — the shell's `aria-label` above is the
-                        fallback that suppresses Radix's
-                        missing-Title dev warning when a content
-                        component opts to omit it.
-
-                        Layout: the motion.div is a flex column that
-                        fills the Dialog.Content's `max-h-[calc(100dvh-2rem)]`.
-                        `header` (optional) and `footer` (optional)
-                        sit in `shrink-0` bands at the top and bottom
-                        and stay pinned. `content` lives inside a
-                        `flex-1 min-h-0 overflow-y-auto` body so it
-                        scrolls when too tall to fit. The scroll body
-                        resets `--header-offset` /
-                        `--contradiction-banner-offset` to 0 so any
-                        sticky descendant (e.g. a
-                        `CardSelectionGrid`'s sticky `<thead>`) pins
-                        at the modal's scroll-container top rather
-                        than at the page-header offset its `top:` calc
-                        normally inherits from the page. */}
-                    <AnimatePresence
-                        mode={PRESENCE_WAIT_MODE}
-                        custom={direction}
-                        initial={false}
-                        onExitComplete={() => {
-                            if (stack.length === 0) setDialogOpen(false);
+            <AnimatePresence
+                mode={PRESENCE_WAIT_MODE}
+                custom={direction}
+                initial={false}
+                onExitComplete={() => {
+                    if (stack.length === 0) setDialogOpen(false);
+                }}
+            >
+                {top ? (
+                    <motion.div
+                        key={top.id}
+                        initial={{
+                            x: direction === 0 ? 0 : direction * 60,
+                            opacity: direction === 0 ? 1 : 0,
                         }}
+                        animate={{ x: 0, opacity: 1 }}
+                        exit={{
+                            x: direction === 0 ? 0 : -direction * 60,
+                            opacity: direction === 0 ? 1 : 0,
+                        }}
+                        transition={transition}
                     >
-                        {top ? (
-                            <motion.div
-                                key={top.id}
-                                initial={{
-                                    x: direction === 0 ? 0 : direction * 60,
-                                    opacity: direction === 0 ? 1 : 0,
-                                }}
-                                animate={{ x: 0, opacity: 1 }}
-                                exit={{
-                                    x: direction === 0 ? 0 : -direction * 60,
-                                    opacity: direction === 0 ? 1 : 0,
-                                }}
-                                transition={transition}
-                                className="flex max-h-[calc(100dvh-2rem)] flex-col"
-                            >
-                                {top.header !== undefined && (
-                                    <div className="relative z-[40] shrink-0">
-                                        {top.header}
-                                    </div>
-                                )}
-                                {/* `relative z-0` makes the body wrapper
-                                    its own stacking context — any
-                                    `z-index` on `top.content`'s
-                                    descendants resolves WITHIN this
-                                    context, so high-z body elements
-                                    (e.g. a `CardSelectionGrid`'s
-                                    sticky-left column at z-30) can't
-                                    paint over the header / footer
-                                    slots above and below.
-
-                                    Paired with `z-[40]` on the footer
-                                    slot: footer wins against any
-                                    content z-index up through 39. The
-                                    common stacking ladder used inside
-                                    cards / grids tops out at 39 so 40
-                                    is a comfortable buffer. */}
-                                <div
-                                    className="relative z-0 min-h-0 flex-1 overflow-y-auto"
-                                    style={{
-                                        ["--header-offset" as never]: "0px",
-                                        ["--contradiction-banner-offset" as never]:
-                                            "0px",
-                                    }}
-                                >
-                                    {top.content}
-                                </div>
-                                {top.footer !== undefined && (
-                                    <div className="relative z-[40] shrink-0 border-t border-border/30">
-                                        {top.footer}
-                                    </div>
-                                )}
-                            </motion.div>
-                        ) : null}
-                    </AnimatePresence>
-                </Dialog.Content>
-            </Dialog.Portal>
-        </Dialog.Root>
+                        <ModalBands
+                            {...(top.header !== undefined
+                                ? { header: top.header }
+                                : {})}
+                            content={top.content}
+                            {...(top.footer !== undefined
+                                ? { footer: top.footer }
+                                : {})}
+                        />
+                    </motion.div>
+                ) : null}
+            </AnimatePresence>
+        </ModalChrome>
     );
 }

--- a/src/ui/components/SplashModal.test.tsx
+++ b/src/ui/components/SplashModal.test.tsx
@@ -105,7 +105,7 @@ describe("SplashModal", () => {
         const onDismiss = vi.fn();
         const SplashModal = await importModal();
         render(wrapped(<SplashModal open onDismiss={onDismiss} />));
-        fireEvent.click(screen.getByRole("button", { name: "splash.close" }));
+        fireEvent.click(screen.getByRole("button", { name: "common.close" }));
         expect(onDismiss).toHaveBeenCalledWith(false);
         expect(captureCalls).toHaveLength(1);
         expect(captureCalls[0]).toMatchObject({

--- a/src/ui/components/SplashModal.tsx
+++ b/src/ui/components/SplashModal.tsx
@@ -1,10 +1,10 @@
 /**
  * About-app splash modal shown on `/play` for first-time and dormant
- * users. Wraps `<AboutContent />` with the splash chrome:
+ * users. Pushes onto the shared `ModalStack` with three pinned bands:
  *
- *   - X close in the top-right
- *   - "Start playing" primary button at the bottom
- *   - "Don't show this again" checkbox above the button
+ *   - `header`: title + X close
+ *   - `content`: scrollable `AboutContent`
+ *   - `footer`: "Start playing" primary CTA + "Don't show again" checkbox
  *
  * Both close paths funnel through the same dismiss handler so we
  * always emit `splash_screen_dismissed` with `method` ("x_button" |
@@ -12,19 +12,14 @@
  * Escape (handled by the modal stack shell) are treated as the X
  * close path.
  *
- * Rendered via the global modal stack (`SPLASH_MODAL_ID`). The
- * content component itself owns no `Dialog.Root` — the shell wraps
- * it. Mounting code (`useSplashGate`'s consumer) pushes this entry
- * when the splash gate flips true.
- *
  * The "show / don't show" decision lives in `useSplashGate` — this
- * component is only the chrome.
+ * file is only the chrome.
  */
 "use client";
 
 import * as Dialog from "@radix-ui/react-dialog";
 import { useTranslations } from "next-intl";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { splashScreenDismissed } from "../../analytics/events";
 import { AboutContent } from "./AboutContent";
 import { ArrowRightIcon, XIcon } from "./Icons";
@@ -32,85 +27,62 @@ import { useModalStack } from "./ModalStack";
 
 const SPLASH_MODAL_ID = "splash" as const;
 const SPLASH_MODAL_MAX_WIDTH = "min(92vw,640px)" as const;
+// Wire-format discriminators for `splashScreenDismissed`'s `method`.
+// Pulled to module scope so the i18next/no-literal-string lint rule
+// reads them as identifiers rather than user copy.
+const DISMISS_METHOD_X = "x_button" as const;
+const DISMISS_METHOD_CTA = "start_playing" as const;
 
-function SplashModalContent({
-    onDismiss,
+function SplashFooter({
+    ctaRef,
+    dontShowAgainRef,
+    onStartPlaying,
+    ctaLabel,
+    dontShowAgainLabel,
 }: {
-    /** Fires when the user closes the modal by any path. The caller
-     *  is responsible for pop()'ing the modal off the stack. */
-    readonly onDismiss: (dontShowAgain: boolean) => void;
+    readonly ctaRef: React.RefObject<HTMLButtonElement | null>;
+    readonly dontShowAgainRef: React.RefObject<boolean>;
+    readonly onStartPlaying: () => void;
+    readonly ctaLabel: string;
+    readonly dontShowAgainLabel: string;
 }) {
-    const t = useTranslations("splash");
+    // Footer owns the checkbox state and mirrors the latest value into
+    // the shared ref so the X-close handler in the header (which lives
+    // outside this subtree) can read the user's choice without a
+    // cross-slot React context.
     const [dontShowAgain, setDontShowAgain] = useState(false);
-    const ctaRef = useRef<HTMLButtonElement | null>(null);
-
-    // Bias focus toward the CTA on mount so a user who hits Enter on
-    // muscle memory accepts rather than dismisses. Single rAF lets the
-    // shell's slide animation begin before we steal focus.
     useEffect(() => {
-        const id = window.requestAnimationFrame(() => {
-            ctaRef.current?.focus();
-        });
-        return () => window.cancelAnimationFrame(id);
-    }, []);
-
-    const handleDismiss = (method: "start_playing" | "x_button") => {
-        splashScreenDismissed({
-            method,
-            dontShowAgainChecked: dontShowAgain,
-        });
-        onDismiss(dontShowAgain);
-    };
+        dontShowAgainRef.current = dontShowAgain;
+    }, [dontShowAgain, dontShowAgainRef]);
 
     return (
-        <div className="flex max-h-[90vh] flex-col">
-            <div className="flex shrink-0 items-start justify-between gap-3 px-5 pt-5">
-                <Dialog.Title className="m-0 font-display text-[1.25rem] text-accent">
-                    {t("title")}
-                </Dialog.Title>
-                <button
-                    type="button"
-                    aria-label={t("close")}
-                    onClick={() => handleDismiss("x_button")}
-                    className="-mt-1 -mr-1 cursor-pointer rounded-[var(--radius)] border-none bg-transparent p-1 text-[#2a1f12] hover:bg-hover"
-                >
-                    <XIcon size={18} />
-                </button>
-            </div>
-            <p className="sr-only">{t("description")}</p>
-            <div className="flex-1 overflow-y-auto px-5 pt-3 pb-5">
-                <AboutContent context="modal" />
-            </div>
-            <div className="shrink-0 border-t border-border bg-panel px-5 pt-4 pb-5">
-                <button
-                    ref={ctaRef}
-                    type="button"
-                    onClick={() => handleDismiss("start_playing")}
-                    className={
-                        "flex w-full cursor-pointer items-center justify-center gap-2 " +
-                        "rounded-[var(--radius)] border-2 border-accent bg-accent " +
-                        "px-6 py-3.5 text-[1.125rem] font-bold text-white " +
-                        "shadow-[0_4px_14px_rgba(122,28,28,0.35)] " +
-                        "hover:bg-accent-hover hover:shadow-[0_6px_18px_rgba(122,28,28,0.45)] " +
-                        "active:translate-y-[1px] active:shadow-[0_2px_8px_rgba(122,28,28,0.35)] " +
-                        "transition-all"
-                    }
-                >
-                    <span>{t("startPlaying")}</span>
-                    <ArrowRightIcon size={20} />
-                </button>
-                <label className="mt-3 flex cursor-pointer items-center justify-center gap-2 text-[1rem] text-muted">
-                    <input
-                        type="checkbox"
-                        checked={dontShowAgain}
-                        onChange={(e) =>
-                            setDontShowAgain(e.target.checked)
-                        }
-                        className="h-4 w-4 cursor-pointer accent-accent"
-                    />
-                    <span>{t("dontShowAgain")}</span>
-                </label>
-            </div>
+        <div className="bg-panel px-5 pt-4 pb-5">
+            <button
+                ref={ctaRef}
+                type="button"
+                onClick={onStartPlaying}
+                className={
+                    "flex w-full cursor-pointer items-center justify-center gap-2 " +
+                    "rounded-[var(--radius)] border-2 border-accent bg-accent " +
+                    "px-6 py-3.5 text-[1.125rem] font-bold text-white " +
+                    "shadow-[0_4px_14px_rgba(122,28,28,0.35)] " +
+                    "hover:bg-accent-hover hover:shadow-[0_6px_18px_rgba(122,28,28,0.45)] " +
+                    "active:translate-y-[1px] active:shadow-[0_2px_8px_rgba(122,28,28,0.35)] " +
+                    "transition-all"
+                }
+            >
+                <span>{ctaLabel}</span>
+                <ArrowRightIcon size={20} />
+            </button>
+            <label className="mt-3 flex cursor-pointer items-center justify-center gap-2 text-[1rem] text-muted">
+                <input
+                    type="checkbox"
+                    checked={dontShowAgain}
+                    onChange={(e) => setDontShowAgain(e.target.checked)}
+                    className="h-4 w-4 cursor-pointer accent-accent"
+                />
+                <span>{dontShowAgainLabel}</span>
+            </label>
         </div>
     );
 }
@@ -122,44 +94,100 @@ interface SplashModalGateProps {
 
 /**
  * Imperative gate hook. Watches `open` and pushes / pops the splash
- * content onto the modal stack accordingly. `onDismiss` is held in a
- * ref so a parent re-render that recreates the callback doesn't churn
- * the effect (which would unmount-remount the splash mid-display).
+ * onto the modal stack. `onDismiss` is held in a ref so a parent
+ * re-render that recreates the callback doesn't churn the effect
+ * (which would unmount-remount the splash mid-display).
  */
 export function useSplashModalGate({
     open,
     onDismiss,
 }: SplashModalGateProps): void {
     const t = useTranslations("splash");
+    const tCommon = useTranslations("common");
     const { push, popTo } = useModalStack();
-    // Capture handler + translated title in refs so the effect doesn't
-    // re-fire when the parent re-renders (which would re-push the
-    // entry every render — infinite mount loop). next-intl's
-    // `useTranslations` returns a new function reference each call in
-    // some test mocks, so we can't put `t` in the effect deps either.
     const onDismissRef = useRef(onDismiss);
     onDismissRef.current = onDismiss;
-    const titleRef = useRef("");
-    titleRef.current = t("title");
+    // next-intl's `useTranslations` returns a new function reference
+    // each call in some test mocks, so capturing in a ref keeps the
+    // effect deps stable.
+    const tRef = useRef(t);
+    tRef.current = t;
+    const tCommonRef = useRef(tCommon);
+    tCommonRef.current = tCommon;
+
+    const ctaRef = useRef<HTMLButtonElement | null>(null);
+    const dontShowAgainRef = useRef(false);
+
+    const dismiss = useCallback(
+        (method: typeof DISMISS_METHOD_X | typeof DISMISS_METHOD_CTA) => {
+            const dontShowAgain = dontShowAgainRef.current;
+            splashScreenDismissed({
+                method,
+                dontShowAgainChecked: dontShowAgain,
+            });
+            popTo(SPLASH_MODAL_ID);
+            onDismissRef.current(dontShowAgain);
+        },
+        [popTo],
+    );
+
     useEffect(() => {
         if (!open) return;
+        const t = tRef.current;
+        const tCommon = tCommonRef.current;
+        const title = t("title");
         push({
             id: SPLASH_MODAL_ID,
-            title: titleRef.current,
+            title,
             maxWidth: SPLASH_MODAL_MAX_WIDTH,
+            header: (
+                <div className="flex items-start justify-between gap-3 px-5 pt-5 pb-3">
+                    <Dialog.Title className="m-0 font-display text-[1.25rem] text-accent">
+                        {title}
+                    </Dialog.Title>
+                    <button
+                        type="button"
+                        aria-label={tCommon("close")}
+                        onClick={() => dismiss(DISMISS_METHOD_X)}
+                        className="-mt-1 -mr-1 cursor-pointer rounded-[var(--radius)] border-none bg-transparent p-1 text-[#2a1f12] hover:bg-hover"
+                    >
+                        <XIcon size={18} />
+                    </button>
+                </div>
+            ),
             content: (
-                <SplashModalContent
-                    onDismiss={(dontShowAgain) => {
-                        popTo(SPLASH_MODAL_ID);
-                        onDismissRef.current(dontShowAgain);
-                    }}
+                <>
+                    <p className="sr-only">{t("description")}</p>
+                    <div className="px-5 pt-3 pb-5">
+                        <AboutContent context="modal" />
+                    </div>
+                </>
+            ),
+            footer: (
+                <SplashFooter
+                    ctaRef={ctaRef}
+                    dontShowAgainRef={dontShowAgainRef}
+                    onStartPlaying={() => dismiss(DISMISS_METHOD_CTA)}
+                    ctaLabel={t("startPlaying")}
+                    dontShowAgainLabel={t("dontShowAgain")}
                 />
             ),
         });
         return () => {
             popTo(SPLASH_MODAL_ID);
         };
-    }, [open, push, popTo]);
+    }, [open, push, popTo, dismiss]);
+
+    // Bias focus toward the CTA on mount so a user who hits Enter on
+    // muscle memory accepts rather than dismisses. Single rAF lets the
+    // shell's slide animation begin before we steal focus.
+    useEffect(() => {
+        if (!open) return;
+        const id = window.requestAnimationFrame(() => {
+            ctaRef.current?.focus();
+        });
+        return () => window.cancelAnimationFrame(id);
+    }, [open]);
 }
 
 /**

--- a/src/ui/components/StaleGameModal.tsx
+++ b/src/ui/components/StaleGameModal.tsx
@@ -21,9 +21,9 @@
  * destructive action, so an Enter on muscle memory should NOT be the
  * thing that wipes it. Mirrors the install-prompt focus bias.
  *
- * Rendered via the global modal stack — the content component itself
- * has no `Dialog.Root`. `useStaleGameModalGate` watches the consumer
- * gate and pushes / pops the entry as the gate flips.
+ * Pushed onto the shared `ModalStack` with the standard three slots —
+ * `header` (title + X), `content` (one-paragraph description), `footer`
+ * (Keep working / Set up new game).
  */
 "use client";
 
@@ -74,89 +74,6 @@ const humanizeIdleDuration = (
     });
 };
 
-interface StaleGameModalContentProps {
-    readonly variant: StaleGameVariant;
-    readonly referenceTimestamp: DateTime.Utc;
-    readonly now: DateTime.Utc;
-    readonly onSetupNewGame: () => void;
-    readonly onKeepWorking: () => void;
-}
-
-function StaleGameModalContent({
-    variant,
-    referenceTimestamp,
-    now,
-    onSetupNewGame,
-    onKeepWorking,
-}: StaleGameModalContentProps) {
-    const t = useTranslations("staleGame");
-    const tCommon = useTranslations("common");
-    const keepWorkingRef = useRef<HTMLButtonElement | null>(null);
-
-    const idleDuration = useMemo(
-        () => DateTime.distance(referenceTimestamp, now),
-        [referenceTimestamp, now],
-    );
-    const humanDuration = humanizeIdleDuration(idleDuration, t);
-
-    // Focus the safe option on mount (single rAF — see SplashModal for
-    // the same pattern). Wiping the game is the destructive action;
-    // muscle-memory Enter should NOT be what triggers it.
-    useEffect(() => {
-        const id = window.requestAnimationFrame(() => {
-            keepWorkingRef.current?.focus();
-        });
-        return () => window.cancelAnimationFrame(id);
-    }, []);
-
-    const descriptionKey =
-        variant === STALE_GAME_VARIANT_STARTED
-            ? STALE_GAME_DESCRIPTION_KEY_STARTED
-            : STALE_GAME_DESCRIPTION_KEY_UNSTARTED;
-
-    return (
-        <div className="flex flex-col">
-            <div className="flex shrink-0 items-start justify-between gap-3 px-5 pt-5">
-                <Dialog.Title className="m-0 font-display text-[1.25rem] text-accent">
-                    {t("title")}
-                </Dialog.Title>
-                <button
-                    type="button"
-                    aria-label={tCommon("close")}
-                    onClick={onKeepWorking}
-                    className="-mt-1 -mr-1 cursor-pointer rounded-[var(--radius)] border-none bg-transparent p-1 text-[#2a1f12] hover:bg-hover"
-                >
-                    <XIcon size={18} />
-                </button>
-            </div>
-            <p className="px-5 pt-3 pb-1 text-[1rem] leading-normal">
-                {t(descriptionKey, { humanDuration })}
-            </p>
-            <div className="mt-4 flex items-center justify-end gap-2 border-t border-border bg-panel px-5 pt-4 pb-5">
-                <button
-                    ref={keepWorkingRef}
-                    type="button"
-                    onClick={onKeepWorking}
-                    className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-white hover:bg-hover"
-                >
-                    {t("keepWorking")}
-                </button>
-                <button
-                    type="button"
-                    onClick={onSetupNewGame}
-                    className={
-                        "tap-target text-tap inline-flex cursor-pointer items-center gap-2 rounded-[var(--radius)] border-2 border-accent bg-accent "
-                        + "font-semibold text-white hover:bg-accent-hover"
-                    }
-                >
-                    <span>{t("setupNew")}</span>
-                    <ArrowRightIcon size={16} />
-                </button>
-            </div>
-        </div>
-    );
-}
-
 interface StaleGameModalGateProps {
     readonly open: boolean;
     readonly variant: StaleGameVariant;
@@ -181,40 +98,100 @@ function useStaleGameModalGate({
     onKeepWorking,
 }: StaleGameModalGateProps): void {
     const t = useTranslations("staleGame");
+    const tCommon = useTranslations("common");
     const { push, popTo } = useModalStack();
-    // Hold callbacks + translated title in refs (see SplashModal for
-    // why — `useTranslations` returns an unstable reference under some
-    // test mocks, and the consumer recreates handlers every render).
     const handlersRef = useRef({ onSetupNewGame, onKeepWorking });
     handlersRef.current = { onSetupNewGame, onKeepWorking };
-    const titleRef = useRef("");
-    titleRef.current = t("title");
+    const tRef = useRef(t);
+    tRef.current = t;
+    const tCommonRef = useRef(tCommon);
+    tCommonRef.current = tCommon;
+    const keepWorkingRef = useRef<HTMLButtonElement | null>(null);
+
+    const idleDuration = useMemo(
+        () => DateTime.distance(referenceTimestamp, now),
+        [referenceTimestamp, now],
+    );
+
     useEffect(() => {
         if (!open) return;
+        const t = tRef.current;
+        const tCommon = tCommonRef.current;
+        const title = t("title");
+        const descriptionKey =
+            variant === STALE_GAME_VARIANT_STARTED
+                ? STALE_GAME_DESCRIPTION_KEY_STARTED
+                : STALE_GAME_DESCRIPTION_KEY_UNSTARTED;
+        const humanDuration = humanizeIdleDuration(idleDuration, t);
+        const dismissKeepWorking = () => {
+            popTo(STALE_GAME_MODAL_ID);
+            handlersRef.current.onKeepWorking();
+        };
+        const dismissSetupNewGame = () => {
+            popTo(STALE_GAME_MODAL_ID);
+            handlersRef.current.onSetupNewGame();
+        };
         push({
             id: STALE_GAME_MODAL_ID,
-            title: titleRef.current,
+            title,
             maxWidth: STALE_GAME_MAX_WIDTH,
+            header: (
+                <div className="flex items-start justify-between gap-3 px-5 pt-5 pb-3">
+                    <Dialog.Title className="m-0 font-display text-[1.25rem] text-accent">
+                        {title}
+                    </Dialog.Title>
+                    <button
+                        type="button"
+                        aria-label={tCommon("close")}
+                        onClick={dismissKeepWorking}
+                        className="-mt-1 -mr-1 cursor-pointer rounded-[var(--radius)] border-none bg-transparent p-1 text-[#2a1f12] hover:bg-hover"
+                    >
+                        <XIcon size={18} />
+                    </button>
+                </div>
+            ),
             content: (
-                <StaleGameModalContent
-                    variant={variant}
-                    referenceTimestamp={referenceTimestamp}
-                    now={now}
-                    onSetupNewGame={() => {
-                        popTo(STALE_GAME_MODAL_ID);
-                        handlersRef.current.onSetupNewGame();
-                    }}
-                    onKeepWorking={() => {
-                        popTo(STALE_GAME_MODAL_ID);
-                        handlersRef.current.onKeepWorking();
-                    }}
-                />
+                <p className="m-0 px-5 pt-3 pb-3 text-[1rem] leading-normal">
+                    {t(descriptionKey, { humanDuration })}
+                </p>
+            ),
+            footer: (
+                <div className="flex items-center justify-end gap-2 bg-panel px-5 pt-4 pb-5">
+                    <button
+                        ref={keepWorkingRef}
+                        type="button"
+                        onClick={dismissKeepWorking}
+                        className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-white hover:bg-hover"
+                    >
+                        {t("keepWorking")}
+                    </button>
+                    <button
+                        type="button"
+                        onClick={dismissSetupNewGame}
+                        className={
+                            "tap-target text-tap inline-flex cursor-pointer items-center gap-2 rounded-[var(--radius)] border-2 border-accent bg-accent "
+                            + "font-semibold text-white hover:bg-accent-hover"
+                        }
+                    >
+                        <span>{t("setupNew")}</span>
+                        <ArrowRightIcon size={16} />
+                    </button>
+                </div>
             ),
         });
         return () => {
             popTo(STALE_GAME_MODAL_ID);
         };
-    }, [open, variant, referenceTimestamp, now, push, popTo]);
+    }, [open, variant, idleDuration, push, popTo]);
+
+    // Focus the safe option on mount (single rAF — wiping is destructive).
+    useEffect(() => {
+        if (!open) return;
+        const id = window.requestAnimationFrame(() => {
+            keepWorkingRef.current?.focus();
+        });
+        return () => window.cancelAnimationFrame(id);
+    }, [open]);
 }
 
 /**

--- a/src/ui/components/modalSlotStore.ts
+++ b/src/ui/components/modalSlotStore.ts
@@ -1,0 +1,59 @@
+/**
+ * Tiny subscribable store for sharing state across modal slots
+ * (`header` / `content` / `footer`).
+ *
+ * Why this exists: `ModalStack` renders the three slots as siblings.
+ * State that lives in one slot (e.g. an `<input>` value in the
+ * `content` slot) often needs to drive UI in another slot (e.g.
+ * enabling the Save button in the `footer` slot). React Context
+ * doesn't work cleanly here — each slot would need to wrap itself
+ * in a Provider, and Providers in sibling subtrees don't share
+ * state. A store created in the opener's closure does: each slot
+ * subscribes to the SAME store reference and re-renders on change.
+ *
+ * Usage:
+ *   const store = createModalSlotStore({ value: "" });
+ *   push({
+ *     content: <Body store={store} />,
+ *     footer: <Footer store={store} />,
+ *   });
+ *   // Inside Body / Footer:
+ *   const value = useModalSlotStoreSelector(store, (s) => s.value);
+ *   store.set((s) => ({ ...s, value: "hello" }));
+ */
+import { useSyncExternalStore } from "react";
+
+export interface ModalSlotStore<T> {
+    readonly get: () => T;
+    readonly set: (updater: (current: T) => T) => void;
+    readonly subscribe: (listener: () => void) => () => void;
+}
+
+export function createModalSlotStore<T>(initial: T): ModalSlotStore<T> {
+    let state = initial;
+    const listeners = new Set<() => void>();
+    return {
+        get: () => state,
+        set: (updater) => {
+            state = updater(state);
+            listeners.forEach((fn) => fn());
+        },
+        subscribe: (listener) => {
+            listeners.add(listener);
+            return () => {
+                listeners.delete(listener);
+            };
+        },
+    };
+}
+
+export function useModalSlotStoreSelector<T, S>(
+    store: ModalSlotStore<T>,
+    selector: (s: T) => S,
+): S {
+    return useSyncExternalStore(
+        store.subscribe,
+        () => selector(store.get()),
+        () => selector(store.get()),
+    );
+}

--- a/src/ui/components/useTeachModeToggle.tsx
+++ b/src/ui/components/useTeachModeToggle.tsx
@@ -151,11 +151,21 @@ export function useTeachModeToggle(): (
                     // Defensive — clear without side effects if popTo
                     // closes us from outside.
                 },
+                header: (
+                    <div className="flex items-start justify-between gap-3 px-5 pt-5 pb-3">
+                        <Dialog.Title className="m-0 font-display text-[1.25rem] text-accent">
+                            {t("midGamePromptTitle")}
+                        </Dialog.Title>
+                    </div>
+                ),
                 content: (
-                    <MidGamePromptContent
+                    <Dialog.Description className="m-0 px-5 pt-3 pb-3 text-[1rem] leading-normal text-[#2a1f12]">
+                        {t("midGamePromptBody")}
+                    </Dialog.Description>
+                ),
+                footer: (
+                    <MidGamePromptFooter
                         onResolve={resolveChoice}
-                        title={t("midGamePromptTitle")}
-                        body={t("midGamePromptBody")}
                         optionKeepExplicit={t("midGameOptionKeepExplicit")}
                         optionAdoptDeductions={t(
                             "midGameOptionAdoptDeductions",
@@ -182,65 +192,44 @@ export function useTeachModeToggle(): (
     );
 }
 
-/**
- * Mid-game prompt body. Visual style matches `ConfirmModalContent` in
- * `useConfirm.tsx` — same `p-5` padding, same `font-display` title at
- * `text-[1.125rem]` accent, same `text-[1rem]` body copy, same right-
- * aligned button row with `border-accent bg-accent` for the primary
- * actions and a ghost `border-border bg-transparent` for cancel. The
- * one shape difference from `useConfirm` is two primary actions
- * instead of one; we render Cancel + two filled action buttons.
- */
-function MidGamePromptContent({
+function MidGamePromptFooter({
     onResolve,
-    title,
-    body,
     optionKeepExplicit,
     optionAdoptDeductions,
     optionCancel,
 }: {
     readonly onResolve: (choice: MidGameChoice) => void;
-    readonly title: string;
-    readonly body: string;
     readonly optionKeepExplicit: string;
     readonly optionAdoptDeductions: string;
     readonly optionCancel: string;
 }) {
     const primaryClass =
-        "tap-target text-tap cursor-pointer rounded-[var(--radius)] border font-semibold border-accent bg-accent text-white hover:bg-accent-hover";
+        "tap-target text-tap cursor-pointer rounded-[var(--radius)] border-2 font-semibold border-accent bg-accent text-white hover:bg-accent-hover";
     const cancelClass =
         "tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-transparent font-semibold text-[#2a1f12] hover:bg-hover";
     return (
-        <div className="p-5">
-            <Dialog.Title className="m-0 mb-2 font-display text-[1.125rem] text-accent">
-                {title}
-            </Dialog.Title>
-            <Dialog.Description className="m-0 text-[1rem] leading-normal text-[#2a1f12]">
-                {body}
-            </Dialog.Description>
-            <div className="mt-5 flex flex-wrap justify-end gap-2">
-                <button
-                    type="button"
-                    onClick={() => onResolve("cancel")}
-                    className={cancelClass}
-                >
-                    {optionCancel}
-                </button>
-                <button
-                    type="button"
-                    onClick={() => onResolve("keep-explicit")}
-                    className={primaryClass}
-                >
-                    {optionKeepExplicit}
-                </button>
-                <button
-                    type="button"
-                    onClick={() => onResolve("adopt-deductions")}
-                    className={primaryClass}
-                >
-                    {optionAdoptDeductions}
-                </button>
-            </div>
+        <div className="flex flex-wrap items-center justify-end gap-2 bg-panel px-5 pt-4 pb-5">
+            <button
+                type="button"
+                onClick={() => onResolve("cancel")}
+                className={cancelClass}
+            >
+                {optionCancel}
+            </button>
+            <button
+                type="button"
+                onClick={() => onResolve("keep-explicit")}
+                className={primaryClass}
+            >
+                {optionKeepExplicit}
+            </button>
+            <button
+                type="button"
+                onClick={() => onResolve("adopt-deductions")}
+                className={primaryClass}
+            >
+                {optionAdoptDeductions}
+            </button>
         </div>
     );
 }

--- a/src/ui/hooks/useConfirm.tsx
+++ b/src/ui/hooks/useConfirm.tsx
@@ -56,9 +56,15 @@ export function ConfirmProvider({ children }: { readonly children: ReactNode }) 
                     resolve(value);
                     pop();
                 };
+                const visibleTitle = opts.title ?? tCommon("confirmTitle");
+                const confirmLabel =
+                    opts.confirmLabel ?? tCommon("confirm");
+                const cancelLabel =
+                    opts.cancelLabel ?? tCommon("cancel");
+                const destructive = opts.destructive ?? true;
                 push({
                     id,
-                    title: opts.title ?? tCommon("confirmTitle"),
+                    title: visibleTitle,
                     dismissOnOutsideClick: false,
                     dismissOnEscape: false,
                     maxWidth: "min(90vw,420px)",
@@ -68,14 +74,40 @@ export function ConfirmProvider({ children }: { readonly children: ReactNode }) 
                     // path resolves first; this onClose's resolve(false)
                     // is then a no-op (Promise resolves once).
                     onClose: () => resolve(false),
+                    header: (
+                        <div className="flex items-start justify-between gap-3 px-5 pt-5 pb-3">
+                            <Dialog.Title className="m-0 font-display text-[1.25rem] text-accent">
+                                {visibleTitle}
+                            </Dialog.Title>
+                        </div>
+                    ),
                     content: (
-                        <ConfirmModalContent
-                            options={opts}
-                            onResolve={settle}
-                            confirmTitle={tCommon("confirmTitle")}
-                            defaultConfirmLabel={tCommon("confirm")}
-                            defaultCancelLabel={tCommon("cancel")}
-                        />
+                        <p className="m-0 px-5 pt-3 pb-3 text-[1rem] leading-normal text-[#2a1f12]">
+                            {opts.message}
+                        </p>
+                    ),
+                    footer: (
+                        <div className="flex flex-wrap items-center justify-end gap-2 bg-panel px-5 pt-4 pb-5">
+                            <button
+                                type="button"
+                                onClick={() => settle(false)}
+                                className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-transparent font-semibold text-[#2a1f12] hover:bg-hover"
+                            >
+                                {cancelLabel}
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => settle(true)}
+                                className={
+                                    "tap-target text-tap cursor-pointer rounded-[var(--radius)] border-2 font-semibold " +
+                                    (destructive
+                                        ? "border-accent bg-accent text-white hover:bg-accent-hover"
+                                        : "border-border bg-panel text-[#2a1f12] hover:bg-hover")
+                                }
+                            >
+                                {confirmLabel}
+                            </button>
+                        </div>
                     ),
                 });
             });
@@ -87,62 +119,6 @@ export function ConfirmProvider({ children }: { readonly children: ReactNode }) 
         <ConfirmContext.Provider value={confirm}>
             {children}
         </ConfirmContext.Provider>
-    );
-}
-
-function ConfirmModalContent({
-    options,
-    onResolve,
-    confirmTitle,
-    defaultConfirmLabel,
-    defaultCancelLabel,
-}: {
-    readonly options: ConfirmOptions;
-    readonly onResolve: (value: boolean) => void;
-    readonly confirmTitle: string;
-    readonly defaultConfirmLabel: string;
-    readonly defaultCancelLabel: string;
-}) {
-    const confirmLabel = options.confirmLabel ?? defaultConfirmLabel;
-    const cancelLabel = options.cancelLabel ?? defaultCancelLabel;
-    const destructive = options.destructive ?? true;
-    const visibleTitle = options.title ?? null;
-    return (
-        <div className="p-5">
-            {visibleTitle ? (
-                <Dialog.Title className="m-0 mb-2 font-display text-[1.125rem] text-accent">
-                    {visibleTitle}
-                </Dialog.Title>
-            ) : (
-                <Dialog.Title className="sr-only">
-                    {confirmTitle}
-                </Dialog.Title>
-            )}
-            <p className="m-0 text-[1rem] leading-normal text-[#2a1f12]">
-                {options.message}
-            </p>
-            <div className="mt-5 flex flex-wrap justify-end gap-2">
-                <button
-                    type="button"
-                    onClick={() => onResolve(false)}
-                    className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-transparent font-semibold text-[#2a1f12] hover:bg-hover"
-                >
-                    {cancelLabel}
-                </button>
-                <button
-                    type="button"
-                    onClick={() => onResolve(true)}
-                    className={
-                        "tap-target text-tap cursor-pointer rounded-[var(--radius)] border font-semibold " +
-                        (destructive
-                            ? "border-accent bg-accent text-white hover:bg-accent-hover"
-                            : "border-border bg-panel text-[#2a1f12] hover:bg-hover")
-                    }
-                >
-                    {confirmLabel}
-                </button>
-            </div>
-        </div>
     );
 }
 

--- a/src/ui/hooks/usePrompt.tsx
+++ b/src/ui/hooks/usePrompt.tsx
@@ -13,15 +13,18 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { useTranslations } from "next-intl";
 import {
     createContext,
-    type FormEvent,
     type ReactNode,
     useCallback,
     useContext,
     useEffect,
     useRef,
-    useState,
 } from "react";
 import { useModalStack } from "../components/ModalStack";
+import {
+    createModalSlotStore,
+    type ModalSlotStore,
+    useModalSlotStoreSelector,
+} from "../components/modalSlotStore";
 
 interface PromptOptions {
     readonly title: string;
@@ -49,6 +52,14 @@ export function PromptProvider({ children }: { readonly children: ReactNode }) {
             return new Promise<string | null>((resolve) => {
                 nextIdRef.current += 1;
                 const id = `${PROMPT_ID_PREFIX}-${nextIdRef.current}`;
+                // Shared subscribable store across the content (input)
+                // and footer (Save / Cancel buttons) slots. The
+                // content updates it on every keystroke; the footer
+                // reads it via `useSyncExternalStore` so the Save
+                // button's disabled state stays in sync.
+                const store = createModalSlotStore({
+                    value: opts.initialValue ?? "",
+                });
                 const settle = (value: string | null) => {
                     // Resolve FIRST. `pop()` synchronously fires this
                     // entry's `onClose`, which calls `resolve(null)` as
@@ -68,10 +79,32 @@ export function PromptProvider({ children }: { readonly children: ReactNode }) {
                     dismissOnEscape: false,
                     maxWidth: "min(90vw,420px)",
                     onClose: () => resolve(null),
+                    header: (
+                        <div className="flex items-start justify-between gap-3 px-5 pt-5 pb-3">
+                            <Dialog.Title className="m-0 font-display text-[1.25rem] text-accent">
+                                {opts.title}
+                            </Dialog.Title>
+                        </div>
+                    ),
                     content: (
                         <PromptModalContent
                             options={opts}
-                            onResolve={settle}
+                            store={store}
+                            onSubmit={() => {
+                                const trimmed = store.get().value.trim();
+                                if (trimmed.length > 0) settle(trimmed);
+                            }}
+                        />
+                    ),
+                    footer: (
+                        <PromptModalFooter
+                            options={opts}
+                            store={store}
+                            onCancel={() => settle(null)}
+                            onConfirm={() => {
+                                const trimmed = store.get().value.trim();
+                                if (trimmed.length > 0) settle(trimmed);
+                            }}
                             defaultConfirmLabel={tCommon("save")}
                             defaultCancelLabel={tCommon("cancel")}
                         />
@@ -89,26 +122,25 @@ export function PromptProvider({ children }: { readonly children: ReactNode }) {
     );
 }
 
+interface PromptStoreState {
+    readonly value: string;
+}
+
 function PromptModalContent({
     options,
-    onResolve,
-    defaultConfirmLabel,
-    defaultCancelLabel,
+    store,
+    onSubmit,
 }: {
     readonly options: PromptOptions;
-    readonly onResolve: (value: string | null) => void;
-    readonly defaultConfirmLabel: string;
-    readonly defaultCancelLabel: string;
+    readonly store: ModalSlotStore<PromptStoreState>;
+    readonly onSubmit: () => void;
 }) {
-    const [value, setValue] = useState(options.initialValue ?? "");
+    const value = useModalSlotStoreSelector(store, (s) => s.value);
     const inputRef = useRef<HTMLInputElement | null>(null);
 
     // Auto-focus + select on mount. Single rAF lets the modal's slide
     // animation start before we steal focus, so the cursor doesn't
-    // jump mid-transition. No retry timer needed since the content
-    // mounts inside the already-open shell — Radix's FocusScope
-    // doesn't fight us here the way it did when each modal owned its
-    // own Dialog.Root.
+    // jump mid-transition.
     useEffect(() => {
         const id = window.requestAnimationFrame(() => {
             const el = inputRef.current;
@@ -119,59 +151,75 @@ function PromptModalContent({
         return () => window.cancelAnimationFrame(id);
     }, []);
 
-    const trimmed = value.trim();
-    const canSubmit = trimmed.length > 0;
+    return (
+        <div className="px-5 pt-3 pb-3">
+            <p className="sr-only">{options.label}</p>
+            <label className="m-0 block text-[1rem] font-semibold text-[#2a1f12]">
+                {options.label}
+                <input
+                    ref={inputRef}
+                    type="text"
+                    value={value}
+                    onChange={(e) =>
+                        store.set(() => ({ value: e.target.value }))
+                    }
+                    onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                            e.preventDefault();
+                            onSubmit();
+                        }
+                    }}
+                    placeholder={options.placeholder}
+                    maxLength={options.maxLength}
+                    className="tap-target text-tap mt-1 block w-full rounded-[var(--radius)] border border-border bg-white text-[#2a1f12] focus:border-accent focus:outline-none"
+                />
+            </label>
+        </div>
+    );
+}
+
+function PromptModalFooter({
+    options,
+    store,
+    onCancel,
+    onConfirm,
+    defaultConfirmLabel,
+    defaultCancelLabel,
+}: {
+    readonly options: PromptOptions;
+    readonly store: ModalSlotStore<PromptStoreState>;
+    readonly onCancel: () => void;
+    readonly onConfirm: () => void;
+    readonly defaultConfirmLabel: string;
+    readonly defaultCancelLabel: string;
+}) {
+    const canSubmit = useModalSlotStoreSelector(
+        store,
+        (s) => s.value.trim().length > 0,
+    );
     const confirmLabel = options.confirmLabel ?? defaultConfirmLabel;
     const cancelLabel = options.cancelLabel ?? defaultCancelLabel;
 
-    const handleSubmit = useCallback(
-        (event: FormEvent<HTMLFormElement>) => {
-            event.preventDefault();
-            if (!canSubmit) return;
-            onResolve(trimmed);
-        },
-        [canSubmit, onResolve, trimmed],
-    );
-
     return (
-        <div className="p-5">
-            <Dialog.Title className="m-0 mb-2 font-display text-[1.125rem] text-accent">
-                {options.title}
-            </Dialog.Title>
-            <p className="sr-only">{options.label}</p>
-            <form onSubmit={handleSubmit}>
-                <label className="m-0 block text-[1rem] font-semibold text-[#2a1f12]">
-                    {options.label}
-                    <input
-                        ref={inputRef}
-                        type="text"
-                        value={value}
-                        onChange={(e) => setValue(e.target.value)}
-                        placeholder={options.placeholder}
-                        maxLength={options.maxLength}
-                        className="tap-target text-tap mt-1 block w-full rounded-[var(--radius)] border border-border bg-white text-[#2a1f12] focus:border-accent focus:outline-none"
-                    />
-                </label>
-                <div className="mt-5 flex flex-wrap justify-end gap-2">
-                    <button
-                        type="button"
-                        onClick={() => onResolve(null)}
-                        className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-transparent font-semibold text-[#2a1f12] hover:bg-hover"
-                    >
-                        {cancelLabel}
-                    </button>
-                    <button
-                        type="submit"
-                        disabled={!canSubmit}
-                        className={
-                            "tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-accent bg-accent font-semibold text-white hover:bg-accent-hover " +
-                            "disabled:cursor-not-allowed disabled:border-border disabled:bg-row-alt disabled:text-muted disabled:hover:bg-row-alt"
-                        }
-                    >
-                        {confirmLabel}
-                    </button>
-                </div>
-            </form>
+        <div className="flex flex-wrap items-center justify-end gap-2 bg-panel px-5 pt-4 pb-5">
+            <button
+                type="button"
+                onClick={onCancel}
+                className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-transparent font-semibold text-[#2a1f12] hover:bg-hover"
+            >
+                {cancelLabel}
+            </button>
+            <button
+                type="button"
+                onClick={onConfirm}
+                disabled={!canSubmit}
+                className={
+                    "tap-target text-tap cursor-pointer rounded-[var(--radius)] border-2 border-accent bg-accent font-semibold text-white hover:bg-accent-hover " +
+                    "disabled:cursor-not-allowed disabled:border-border disabled:bg-row-alt disabled:text-muted disabled:hover:bg-row-alt"
+                }
+            >
+                {confirmLabel}
+            </button>
         </div>
     );
 }

--- a/src/ui/setup/CardPackEditorModal.tsx
+++ b/src/ui/setup/CardPackEditorModal.tsx
@@ -26,6 +26,11 @@ import {
     XIcon,
 } from "../components/Icons";
 import { useModalStack } from "../components/ModalStack";
+import {
+    createModalSlotStore,
+    type ModalSlotStore,
+    useModalSlotStoreSelector,
+} from "../components/modalSlotStore";
 import { useConfirm } from "../hooks/useConfirm";
 import { usePrompt } from "../hooks/usePrompt";
 import { useClue } from "../state";
@@ -71,42 +76,62 @@ interface Props {
     readonly onSaved?: (savedPackId: string) => void;
 }
 
-function CardPackEditorModal({
-    initialCardSet,
-    initialPackId,
-    initialPackLabel,
-    initialPackIsBuiltIn = false,
-    applyToActiveGame,
-    onSaved,
-}: Props) {
-    const t = useTranslations("cardPackEditor");
+interface EditorStoreState {
+    readonly draft: CardSet;
+}
+
+function CardPackEditorHeader({
+    titleText,
+    onClose,
+}: {
+    readonly titleText: string;
+    readonly onClose: () => void;
+}) {
     const tCommon = useTranslations("common");
-    const { state, dispatch } = useClue();
-    const { pop } = useModalStack();
+    return (
+        <div className="flex items-start justify-between gap-3 px-5 pt-5 pb-3">
+            <Dialog.Title className="m-0 font-display text-[1.25rem] text-accent">
+                {titleText}
+            </Dialog.Title>
+            <button
+                type="button"
+                aria-label={tCommon("close")}
+                onClick={onClose}
+                className="-mt-1 -mr-1 cursor-pointer rounded-[var(--radius)] border-none bg-transparent p-1 text-fg hover:bg-hover"
+            >
+                <XIcon size={18} />
+            </button>
+        </div>
+    );
+}
+
+function CardPackEditorBody({
+    store,
+    applyToActiveGame,
+}: {
+    readonly store: ModalSlotStore<EditorStoreState>;
+    readonly applyToActiveGame: boolean;
+}) {
+    const t = useTranslations("cardPackEditor");
+    const { state } = useClue();
     const confirm = useConfirm();
-    const prompt = usePrompt();
-    const { savePack } = useCardPackActions();
+    const draft = useModalSlotStoreSelector(store, (s) => s.draft);
 
-    const [draft, setDraft] = useState<CardSet>(initialCardSet);
-
-    // Title flavor by state:
-    //   - editing a saved custom pack → "Edit card pack \"{label}\""
-    //   - editing a built-in pack     → "Customize card pack \"{label}\""
-    //   - no pack identity (the live deck has drifted from any saved
-    //     pack, so the modal can only Save-as-new) → "Create new card pack"
-    const titleText =
-        initialPackId === undefined
-            ? t("titleCreate")
-            : initialPackIsBuiltIn
-              ? t("titleCustomize", { label: initialPackLabel ?? "" })
-              : t("titleEdit", { label: initialPackLabel ?? "" });
-
-    const close = () => pop();
+    const setDraft: React.Dispatch<React.SetStateAction<CardSet>> = (
+        next,
+    ) => {
+        store.set((s) => ({
+            draft:
+                typeof next === "function"
+                    ? (next as (prev: CardSet) => CardSet)(s.draft)
+                    : next,
+        }));
+    };
 
     const cardHasSessionRefs = (cardId: string): boolean => {
         if (!applyToActiveGame) return false;
         const inKnownCards = state.knownCards.some(
-            kc => String(kc.card) === cardId,
+            (kc) => String(kc.card) === cardId,
         );
         const inSuggestions = state.suggestions.length > 0;
         return inKnownCards || inSuggestions;
@@ -114,11 +139,86 @@ function CardPackEditorModal({
 
     const categoryHasSessionRefs = (cat: Category): boolean => {
         if (!applyToActiveGame) return false;
-        const inKnownCards = state.knownCards.some(kc =>
-            cat.cards.some(c => c.id === kc.card),
+        const inKnownCards = state.knownCards.some((kc) =>
+            cat.cards.some((c) => c.id === kc.card),
         );
         const inSuggestions = state.suggestions.length > 0;
         return inKnownCards || inSuggestions;
+    };
+
+    return (
+        <div className="flex flex-col gap-3 px-5 pt-3 pb-3">
+            <p className="m-0 text-[1rem] leading-normal text-muted">
+                {t("helperText")}
+            </p>
+            <CategoriesEditor
+                draft={draft}
+                setDraft={setDraft}
+                confirmRemoveCategory={async (cat) => {
+                    if (!categoryHasSessionRefs(cat)) return true;
+                    return await confirm({
+                        message: t("removeCategoryConfirm", {
+                            name: cat.name,
+                        }),
+                    });
+                }}
+                confirmRemoveCard={async (entry) => {
+                    if (!cardHasSessionRefs(String(entry.id)))
+                        return true;
+                    return await confirm({
+                        message: t("removeCardConfirm", {
+                            card: entry.name,
+                        }),
+                    });
+                }}
+            />
+            <button
+                type="button"
+                className="tap-target text-tap self-start cursor-pointer rounded border border-border bg-control hover:bg-control-hover"
+                onClick={() =>
+                    setDraft((prev) => addCategoryToCardSet(prev))
+                }
+            >
+                {t("addCategory")}
+            </button>
+        </div>
+    );
+}
+
+function CardPackEditorFooter({
+    store,
+    initialPackId,
+    initialPackLabel,
+    initialPackIsBuiltIn,
+    applyToActiveGame,
+    onClose,
+    onSaved,
+}: {
+    readonly store: ModalSlotStore<EditorStoreState>;
+    readonly initialPackId: string | undefined;
+    readonly initialPackLabel: string | undefined;
+    readonly initialPackIsBuiltIn: boolean;
+    readonly applyToActiveGame: boolean;
+    readonly onClose: () => void;
+    readonly onSaved?: (savedPackId: string) => void;
+}) {
+    const t = useTranslations("cardPackEditor");
+    const tCommon = useTranslations("common");
+    const prompt = usePrompt();
+    const { savePack } = useCardPackActions();
+    const { state, dispatch } = useClue();
+
+    const applyDraftToActiveGameIfRequested = (draft: CardSet) => {
+        if (!applyToActiveGame) return;
+        // `setSetup` prunes session entries referencing removed
+        // cards/categories but preserves entries for the survivors.
+        dispatch({
+            type: "setSetup",
+            setup: GameSetup({
+                cardSet: draft,
+                playerSet: state.setup.playerSet,
+            }),
+        });
     };
 
     const saveAsNewPack = async () => {
@@ -131,117 +231,57 @@ function CardPackEditorModal({
         if (name === null) return;
         const trimmed = name.trim();
         if (trimmed.length === 0) return;
+        const draft = store.get().draft;
         const saved = await savePack({
             label: trimmed,
             cardSet: draft,
         });
         onSaved?.(saved.id);
-        applyDraftToActiveGameIfRequested();
-        close();
+        applyDraftToActiveGameIfRequested(draft);
+        onClose();
     };
 
     const updateLoadedPack = async () => {
         if (initialPackId === undefined || initialPackIsBuiltIn) return;
         const label = initialPackLabel ?? "";
+        const draft = store.get().draft;
         await savePack({
             label,
             cardSet: draft,
             existingId: initialPackId,
         });
         onSaved?.(initialPackId);
-        applyDraftToActiveGameIfRequested();
-        close();
-    };
-
-    const applyDraftToActiveGameIfRequested = () => {
-        if (!applyToActiveGame) return;
-        // `setSetup` prunes session entries referencing removed
-        // cards/categories but preserves entries for the survivors —
-        // exactly what we want here (a rename should not nuke the
-        // user's mid-game state).
-        dispatch({
-            type: "setSetup",
-            setup: GameSetup({
-                cardSet: draft,
-                playerSet: state.setup.playerSet,
-            }),
-        });
+        applyDraftToActiveGameIfRequested(draft);
+        onClose();
     };
 
     return (
-        <div className="flex flex-col">
-            <div className="flex shrink-0 items-start justify-between gap-3 px-5 pt-5">
-                <Dialog.Title className="m-0 font-display text-[1.25rem] text-accent">
-                    {titleText}
-                </Dialog.Title>
+        <div className="flex flex-wrap items-center justify-end gap-2 bg-panel px-5 pt-4 pb-5">
+            <button
+                type="button"
+                className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-white font-semibold text-[#2a1f12] hover:bg-hover"
+                onClick={onClose}
+            >
+                {t("cancel")}
+            </button>
+            <button
+                type="button"
+                className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-white font-semibold text-[#2a1f12] hover:bg-hover"
+                onClick={saveAsNewPack}
+            >
+                {t("saveAsNewPack")}
+            </button>
+            {initialPackId !== undefined && !initialPackIsBuiltIn && (
                 <button
                     type="button"
-                    aria-label={tCommon("close")}
-                    onClick={close}
-                    className="-mt-1 -mr-1 cursor-pointer rounded-[var(--radius)] border-none bg-transparent p-1 text-fg hover:bg-hover"
+                    className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border-2 border-accent bg-accent font-semibold text-white hover:bg-accent-hover"
+                    onClick={updateLoadedPack}
                 >
-                    <XIcon size={18} />
+                    {t("updatePack", {
+                        label: initialPackLabel ?? "",
+                    })}
                 </button>
-            </div>
-            <div className="flex flex-col gap-3 overflow-y-auto px-5 pt-3 pb-2">
-                <p className="m-0 text-[1rem] leading-normal text-muted">{t("helperText")}</p>
-                <CategoriesEditor
-                    draft={draft}
-                    setDraft={setDraft}
-                    confirmRemoveCategory={async (cat) => {
-                        if (!categoryHasSessionRefs(cat)) return true;
-                        return await confirm({
-                            message: t("removeCategoryConfirm", {
-                                name: cat.name,
-                            }),
-                        });
-                    }}
-                    confirmRemoveCard={async (entry) => {
-                        if (!cardHasSessionRefs(String(entry.id))) return true;
-                        return await confirm({
-                            message: t("removeCardConfirm", {
-                                card: entry.name,
-                            }),
-                        });
-                    }}
-                />
-                <button
-                    type="button"
-                    className="tap-target-compact text-tap-compact self-start cursor-pointer rounded border border-border bg-control hover:bg-control-hover"
-                    onClick={() =>
-                        setDraft(prev => addCategoryToCardSet(prev))
-                    }
-                >
-                    {t("addCategory")}
-                </button>
-            </div>
-            <div className="sticky bottom-0 z-[40] flex flex-wrap items-center justify-end gap-2 border-t border-border/30 bg-panel px-5 py-3">
-                <button
-                    type="button"
-                    className="tap-target-compact text-tap-compact cursor-pointer rounded border border-border bg-control hover:bg-control-hover"
-                    onClick={close}
-                >
-                    {t("cancel")}
-                </button>
-                <button
-                    type="button"
-                    className="tap-target-compact text-tap-compact cursor-pointer rounded border border-border bg-control hover:bg-control-hover"
-                    onClick={saveAsNewPack}
-                >
-                    {t("saveAsNewPack")}
-                </button>
-                {initialPackId !== undefined && !initialPackIsBuiltIn && (
-                    <button
-                        type="button"
-                        className="tap-target-compact text-tap-compact cursor-pointer rounded border-none bg-accent text-white hover:bg-accent-hover"
-                        onClick={updateLoadedPack}
-                    >
-                        {t("updatePack", {
-                            label: initialPackLabel ?? "",
-                        })}
-                    </button>
-                )}
-            </div>
+            )}
         </div>
     );
 }
@@ -662,7 +702,7 @@ const EDITOR_MODAL_MAX_WIDTH = "min(92vw, 720px)" as const;
  * "edits only close via explicit buttons" behavior.
  */
 export function useOpenCardPackEditor(): (args: Props) => void {
-    const { push } = useModalStack();
+    const { push, pop } = useModalStack();
     const tEditor = useTranslations("cardPackEditor");
     return (args) => {
         const title =
@@ -675,13 +715,43 @@ export function useOpenCardPackEditor(): (args: Props) => void {
                   : tEditor("titleEdit", {
                         label: args.initialPackLabel ?? "",
                     });
+        const store = createModalSlotStore<EditorStoreState>({
+            draft: args.initialCardSet,
+        });
+        const close = () => pop();
         push({
             id: EDITOR_MODAL_ID,
             title,
             maxWidth: EDITOR_MODAL_MAX_WIDTH,
             dismissOnOutsideClick: false,
             dismissOnEscape: false,
-            content: <CardPackEditorModal {...args} />,
+            header: (
+                <CardPackEditorHeader
+                    titleText={title}
+                    onClose={close}
+                />
+            ),
+            content: (
+                <CardPackEditorBody
+                    store={store}
+                    applyToActiveGame={args.applyToActiveGame}
+                />
+            ),
+            footer: (
+                <CardPackEditorFooter
+                    store={store}
+                    initialPackId={args.initialPackId}
+                    initialPackLabel={args.initialPackLabel}
+                    initialPackIsBuiltIn={
+                        args.initialPackIsBuiltIn ?? false
+                    }
+                    applyToActiveGame={args.applyToActiveGame}
+                    onClose={close}
+                    {...(args.onSaved !== undefined
+                        ? { onSaved: args.onSaved }
+                        : {})}
+                />
+            ),
         });
     };
 }

--- a/src/ui/setup/CardPackEditorModal.tsx
+++ b/src/ui/setup/CardPackEditorModal.tsx
@@ -34,6 +34,7 @@ import {
 import { useConfirm } from "../hooks/useConfirm";
 import { usePrompt } from "../hooks/usePrompt";
 import { useClue } from "../state";
+import { DelayedReorderItem } from "./shared/useReorderPressDelay";
 
 // Reorder.Group axis values — pulled to module scope so the
 // i18next/no-literal-string lint reads them as wire identifiers.
@@ -345,11 +346,11 @@ function CategoriesEditor({
             className="m-0 flex list-none flex-col gap-3 p-0"
         >
             {categoryDraft.map((category, idx) => (
-                <Reorder.Item
+                <DelayedReorderItem
                     key={String(category.id)}
                     value={category}
                     onDragEnd={() => commitCategoryReorder(categoryDraft)}
-                    className="flex touch-none flex-col gap-2 rounded border border-border/40 bg-control p-2"
+                    className="flex flex-col gap-2 rounded border border-border/40 bg-control p-2"
                 >
                     <CategoryHeader
                         category={category}
@@ -398,7 +399,7 @@ function CategoriesEditor({
                     >
                         {t("addCard")}
                     </button>
-                </Reorder.Item>
+                </DelayedReorderItem>
             ))}
         </Reorder.Group>
     );
@@ -454,11 +455,11 @@ function CardListEditor({
             className="m-0 flex list-none flex-col gap-1 p-0"
         >
             {cardDraft.map((entry, idx) => (
-                <Reorder.Item
+                <DelayedReorderItem
                     key={String(entry.id)}
                     value={entry}
                     onDragEnd={() => commitCardReorder(cardDraft)}
-                    className="flex touch-none items-center gap-2 rounded border border-border/40 bg-control px-1 py-0.5"
+                    className="flex items-center gap-2 rounded border border-border/40 bg-control px-1 py-0.5"
                 >
                     <CardRow
                         entry={entry}
@@ -480,7 +481,7 @@ function CardListEditor({
                             );
                         }}
                     />
-                </Reorder.Item>
+                </DelayedReorderItem>
             ))}
         </Reorder.Group>
     );

--- a/src/ui/setup/SetupWizard.test.tsx
+++ b/src/ui/setup/SetupWizard.test.tsx
@@ -85,6 +85,10 @@ vi.mock("motion/react", () => {
         useReducedMotion: () => false,
         LayoutGroup: ({ children }: { children: ReactNode }) => children,
         Reorder: { Group: ReorderGroup, Item: ReorderItem },
+        // `useDragControls` returns a no-op-able controller; tests
+        // don't exercise real drag, only that `useReorderPressDelay`
+        // can call `.start()` without exploding.
+        useDragControls: () => ({ start: () => {} }),
     };
 });
 

--- a/src/ui/setup/shared/PlayerListReorder.tsx
+++ b/src/ui/setup/shared/PlayerListReorder.tsx
@@ -7,6 +7,7 @@ import type { Player } from "../../../logic/GameObjects";
 import { useClue } from "../../state";
 import { ChevronLeftIcon, ChevronRightIcon } from "../../components/Icons";
 import { PlayerNameInput } from "./PlayerNameInput";
+import { DelayedReorderItem } from "./useReorderPressDelay";
 
 // Reorder.Group axis prop value — module-scope constant so the
 // i18next/no-literal-string lint treats it as a wire identifier.
@@ -70,11 +71,11 @@ export function PlayerListReorder() {
                 data-tour-anchor={PLAYERS_LIST_TOUR_ANCHOR}
             >
                 {draft.map((player, i) => (
-                    <Reorder.Item
+                    <DelayedReorderItem
                         key={player}
                         value={player}
                         onDragEnd={() => commitReorder(draft)}
-                        className="flex touch-none items-center gap-2 rounded border border-border/50 bg-control px-2 py-1.5"
+                        className="flex items-center gap-2 rounded border border-border/50 bg-control px-2 py-1.5"
                     >
                         <PlayerNameInput
                             player={player}
@@ -133,7 +134,7 @@ export function PlayerListReorder() {
                         >
                             {DRAG_HANDLE_GLYPH}
                         </span>
-                    </Reorder.Item>
+                    </DelayedReorderItem>
                 ))}
             </Reorder.Group>
 

--- a/src/ui/setup/shared/useReorderPressDelay.test.tsx
+++ b/src/ui/setup/shared/useReorderPressDelay.test.tsx
@@ -1,0 +1,158 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from "vitest";
+import { fireEvent, render } from "@testing-library/react";
+import { useDragControls } from "motion/react";
+import { useReorderPressDelay } from "./useReorderPressDelay";
+
+/**
+ * Per-test harness: renders a `<div>` wired up with the press-delay
+ * handlers and exposes the `DragControls` instance via a ref so the
+ * test can spy on `controls.start`.
+ */
+function Harness({
+    onMount,
+    targetTag = "div",
+}: {
+    readonly onMount: (controls: ReturnType<typeof useDragControls>) => void;
+    readonly targetTag?: "div" | "button";
+}) {
+    const controls = useDragControls();
+    onMount(controls);
+    const press = useReorderPressDelay(controls);
+    if (targetTag === "button") {
+        return (
+            <div data-testid="row" {...press}>
+                <button type="button" data-testid="inner-btn">
+                    inner
+                </button>
+            </div>
+        );
+    }
+    return <div data-testid="row" {...press} />;
+}
+
+const dispatchPointer = (
+    element: HTMLElement,
+    type: "pointerDown" | "pointerMove" | "pointerUp" | "pointerCancel",
+    coords: { x: number; y: number } = { x: 50, y: 50 },
+): void => {
+    fireEvent[type](element, {
+        clientX: coords.x,
+        clientY: coords.y,
+        pointerType: "touch",
+        pointerId: 1,
+    });
+};
+
+describe("useReorderPressDelay", () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    test("calls controls.start after the press delay elapses", () => {
+        let capturedControls!: ReturnType<typeof useDragControls>;
+        const { getByTestId } = render(
+            <Harness onMount={(c) => (capturedControls = c)} />,
+        );
+        const startSpy = vi.spyOn(capturedControls, "start");
+
+        dispatchPointer(getByTestId("row"), "pointerDown");
+        // Just before the 250ms threshold: nothing fired yet.
+        vi.advanceTimersByTime(249);
+        expect(startSpy).not.toHaveBeenCalled();
+        // Crossing 250ms fires the drag-start.
+        vi.advanceTimersByTime(1);
+        expect(startSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("pointer-up before the delay cancels drag-start", () => {
+        let capturedControls!: ReturnType<typeof useDragControls>;
+        const { getByTestId } = render(
+            <Harness onMount={(c) => (capturedControls = c)} />,
+        );
+        const startSpy = vi.spyOn(capturedControls, "start");
+        const row = getByTestId("row");
+
+        dispatchPointer(row, "pointerDown");
+        vi.advanceTimersByTime(100);
+        dispatchPointer(row, "pointerUp");
+        vi.advanceTimersByTime(500); // well past the original delay
+        expect(startSpy).not.toHaveBeenCalled();
+    });
+
+    test("pointer-cancel before the delay cancels drag-start", () => {
+        let capturedControls!: ReturnType<typeof useDragControls>;
+        const { getByTestId } = render(
+            <Harness onMount={(c) => (capturedControls = c)} />,
+        );
+        const startSpy = vi.spyOn(capturedControls, "start");
+        const row = getByTestId("row");
+
+        dispatchPointer(row, "pointerDown");
+        vi.advanceTimersByTime(100);
+        dispatchPointer(row, "pointerCancel");
+        vi.advanceTimersByTime(500);
+        expect(startSpy).not.toHaveBeenCalled();
+    });
+
+    test("pointer-move past the tolerance cancels drag-start (allows scroll)", () => {
+        let capturedControls!: ReturnType<typeof useDragControls>;
+        const { getByTestId } = render(
+            <Harness onMount={(c) => (capturedControls = c)} />,
+        );
+        const startSpy = vi.spyOn(capturedControls, "start");
+        const row = getByTestId("row");
+
+        dispatchPointer(row, "pointerDown", { x: 50, y: 50 });
+        // 9 px down — past the 8 px tolerance.
+        dispatchPointer(row, "pointerMove", { x: 50, y: 59 });
+        vi.advanceTimersByTime(500);
+        expect(startSpy).not.toHaveBeenCalled();
+    });
+
+    test("small jitter under the tolerance does NOT cancel drag-start", () => {
+        let capturedControls!: ReturnType<typeof useDragControls>;
+        const { getByTestId } = render(
+            <Harness onMount={(c) => (capturedControls = c)} />,
+        );
+        const startSpy = vi.spyOn(capturedControls, "start");
+        const row = getByTestId("row");
+
+        dispatchPointer(row, "pointerDown", { x: 50, y: 50 });
+        // 5 px diagonal — under the 8 px tolerance.
+        dispatchPointer(row, "pointerMove", { x: 53, y: 54 });
+        vi.advanceTimersByTime(250);
+        expect(startSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test("pointer-down on an interactive child does not arm the timer", () => {
+        let capturedControls!: ReturnType<typeof useDragControls>;
+        const { getByTestId } = render(
+            <Harness
+                onMount={(c) => (capturedControls = c)}
+                targetTag="button"
+            />,
+        );
+        const startSpy = vi.spyOn(capturedControls, "start");
+
+        dispatchPointer(getByTestId("inner-btn"), "pointerDown");
+        // Even after the full delay, no drag start — the press was on a button.
+        vi.advanceTimersByTime(500);
+        expect(startSpy).not.toHaveBeenCalled();
+    });
+
+    test("unmount cleans up the pending timer", () => {
+        let capturedControls!: ReturnType<typeof useDragControls>;
+        const { getByTestId, unmount } = render(
+            <Harness onMount={(c) => (capturedControls = c)} />,
+        );
+        const startSpy = vi.spyOn(capturedControls, "start");
+        dispatchPointer(getByTestId("row"), "pointerDown");
+        unmount();
+        vi.advanceTimersByTime(500);
+        expect(startSpy).not.toHaveBeenCalled();
+    });
+});

--- a/src/ui/setup/shared/useReorderPressDelay.tsx
+++ b/src/ui/setup/shared/useReorderPressDelay.tsx
@@ -1,0 +1,152 @@
+/**
+ * Press-delay hook for `Reorder.Item` drags. Pairs with Framer
+ * Motion's `useDragControls` (`dragListener={false}` +
+ * `dragControls={controls}` on the item) to gate drag activation
+ * behind a short hold.
+ *
+ * Why: `Reorder.Item`'s default auto-listener grabs every pointer-
+ * down on the item, so a casual swipe inside a modal body whose row
+ * IS the drag target can never scroll the body — the row eats the
+ * touch immediately. With this hook, the touch sits idle for
+ * `REORDER_PRESS_DELAY` milliseconds before drag activates. Casual
+ * swipes (which move more than `REORDER_PRESS_TOLERANCE_PX` before
+ * the timer fires) cancel the pending drag and pass through to the
+ * browser's natural scroll. Same model as dnd-kit's `PointerSensor`
+ * `activationConstraint`.
+ *
+ * Usage:
+ *   const controls = useDragControls();
+ *   const press = useReorderPressDelay(controls);
+ *   return (
+ *     <Reorder.Item
+ *       dragListener={false}
+ *       dragControls={controls}
+ *       style={{ touchAction: "pan-y" }}
+ *       {...press}
+ *     >...</Reorder.Item>
+ *   );
+ *
+ * The accompanying CSS rule `touch-action: pan-y` is load-bearing:
+ * it tells the browser "vertical scroll is mine until JS tells you
+ * otherwise." Once `controls.start(event)` fires, Framer's drag
+ * system takes over and the row tracks the pointer. Without
+ * `pan-y`, the browser still won't scroll on touchmove inside the
+ * row even before the timer fires (the previous bug).
+ */
+import { Duration } from "effect";
+import { Reorder, useDragControls, type DragControls } from "motion/react";
+import { useEffect, useRef, type ReactNode } from "react";
+
+// 250ms is the iOS-native drag-press delay; long enough that a flick
+// swipe-scroll never accidentally arms a drag, short enough that a
+// deliberate press-and-hold feels responsive. Matches dnd-kit's
+// default `PointerSensor` delay.
+const REORDER_PRESS_DELAY = Duration.millis(250);
+
+// Pixels of pointer movement (Euclidean distance from press origin)
+// that cancels the pending drag-start. A finger naturally jitters
+// 1-3 px on touchdown; a deliberate swipe usually clears 8 px within
+// the first frame. The Checklist's long-press uses 10 px, but
+// reorder benefits from a tighter window because the user's
+// "scroll" intent is the dominant case.
+const REORDER_PRESS_TOLERANCE_PX = 8;
+
+// CSS selector for interactive children that should never arm the
+// press timer. Pressing a trash / arrow button, or focusing an
+// input, must not stage a drag.
+const INTERACTIVE_SELECTOR =
+    "button, input, textarea, select, a, [contenteditable]";
+
+interface PressHandlers {
+    readonly onPointerDown: (e: React.PointerEvent) => void;
+    readonly onPointerMove: (e: React.PointerEvent) => void;
+    readonly onPointerUp: () => void;
+    readonly onPointerCancel: () => void;
+}
+
+export function useReorderPressDelay(
+    controls: DragControls,
+): PressHandlers {
+    const timerRef = useRef<number | null>(null);
+    const originRef = useRef<{ x: number; y: number } | null>(null);
+
+    const cancel = (): void => {
+        if (timerRef.current !== null) {
+            window.clearTimeout(timerRef.current);
+            timerRef.current = null;
+        }
+        originRef.current = null;
+    };
+
+    useEffect(() => () => cancel(), []);
+
+    return {
+        onPointerDown: (event) => {
+            // Skip interactive children — let the button / input handle
+            // the press itself. Without this, long-holding a trash
+            // button would arm the timer and slide into a drag mid-
+            // press.
+            const target = event.target as Element | null;
+            if (target?.closest(INTERACTIVE_SELECTOR)) return;
+            originRef.current = { x: event.clientX, y: event.clientY };
+            // Capture the event so the timer callback can replay it
+            // into `controls.start` — Framer needs a real pointer
+            // event to seed the drag.
+            const capturedEvent = event;
+            timerRef.current = window.setTimeout(() => {
+                timerRef.current = null;
+                controls.start(capturedEvent);
+            }, Duration.toMillis(REORDER_PRESS_DELAY));
+        },
+        onPointerMove: (event) => {
+            if (timerRef.current === null) return;
+            const origin = originRef.current;
+            if (origin === null) return;
+            const dx = event.clientX - origin.x;
+            const dy = event.clientY - origin.y;
+            if (Math.hypot(dx, dy) > REORDER_PRESS_TOLERANCE_PX) cancel();
+        },
+        onPointerUp: cancel,
+        onPointerCancel: cancel,
+    };
+}
+
+/**
+ * `Reorder.Item` wrapper that gates drag activation behind the
+ * press-delay above. Drop-in replacement: pass `value`, `onDragEnd`,
+ * `className`, and children — internally calls `useDragControls` and
+ * wires the manual `dragListener={false}` + `dragControls` + press
+ * handlers. `touch-action: pan-y` is set inline so the browser owns
+ * vertical scroll until the timer fires.
+ *
+ * Note that this component is generic over the reorder value type;
+ * Framer's `Reorder.Item` exposes the same generic via its `value`
+ * prop, so consumers get the full TypeScript inference.
+ */
+export function DelayedReorderItem<T>({
+    value,
+    onDragEnd,
+    className,
+    children,
+}: {
+    readonly value: T;
+    readonly onDragEnd?: () => void;
+    readonly className?: string;
+    readonly children: ReactNode;
+}) {
+    const controls = useDragControls();
+    const press = useReorderPressDelay(controls);
+    return (
+        <Reorder.Item
+            value={value}
+            dragListener={false}
+            dragControls={controls}
+            {...(onDragEnd !== undefined ? { onDragEnd } : {})}
+            {...(className !== undefined ? { className } : {})}
+            style={{ touchAction: "pan-y" }}
+            {...press}
+        >
+            {children}
+        </Reorder.Item>
+    );
+}

--- a/src/ui/share/ShareCreateModal.test.tsx
+++ b/src/ui/share/ShareCreateModal.test.tsx
@@ -108,9 +108,15 @@ import {
     useModalStack,
 } from "../components/ModalStack";
 import {
+    createModalSlotStore,
+    initialShareCreateHandlers,
+    initialShareCreateStoreState,
     SHARE_CREATE_MODAL_ID,
+    ShareCreateFooter,
+    ShareCreateHeader,
     ShareCreateModal,
     pickProgressLabelKey,
+    type ShareCreateHandlers,
 } from "./ShareCreateModal";
 
 /**
@@ -129,15 +135,36 @@ const ShareModalSeeder = ({
 }) => {
     const { push } = useModalStack();
     const pushedRef = useRef(false);
+    // Fresh store + handlersRef per seeder mount — same shape as
+    // `ShareProvider.pushShareModal`.
+    const storeRef = useRef(createModalSlotStore(initialShareCreateStoreState()));
+    const handlersRef = useRef<{ current: ShareCreateHandlers }>({
+        current: initialShareCreateHandlers(),
+    });
     if (!pushedRef.current) {
         pushedRef.current = true;
         push({
             id: SHARE_CREATE_MODAL_ID,
             title: "Share",
+            header: (
+                <ShareCreateHeader
+                    variant={variant}
+                    store={storeRef.current}
+                    handlersRef={handlersRef.current}
+                />
+            ),
             content: (
                 <ShareCreateModal
                     variant={variant}
+                    store={storeRef.current}
+                    handlersRef={handlersRef.current}
                     {...(resumeIntent !== undefined ? { resumeIntent } : {})}
+                />
+            ),
+            footer: (
+                <ShareCreateFooter
+                    store={storeRef.current}
+                    handlersRef={handlersRef.current}
                 />
             ),
         });

--- a/src/ui/share/ShareCreateModal.tsx
+++ b/src/ui/share/ShareCreateModal.tsx
@@ -85,6 +85,11 @@ import { DevSignInForm } from "../account/DevSignInForm";
 import { T_STANDARD, useReducedTransition } from "../motion";
 import { CheckIcon, ClipboardIcon, QrCodeIcon, XIcon } from "../components/Icons";
 import { useModalStack } from "../components/ModalStack";
+import {
+    createModalSlotStore,
+    type ModalSlotStore,
+    useModalSlotStoreSelector,
+} from "../components/modalSlotStore";
 import { QrCodeSvg } from "./QrCodeSvg";
 import { useCardPackUsage } from "../../data/cardPackUsage";
 import { useCustomCardPacks } from "../../data/customCardPacks";
@@ -431,7 +436,61 @@ interface ShareCreateModalProps {
     /** Pending OAuth share restored after Better Auth redirects back. */
     readonly resumeIntent?: PendingShareIntent;
     readonly onResumeConsumed?: () => void;
+    /** Shared store the body publishes state into so the `header` and
+     *  `footer` slots can subscribe to step / submitting / shareUrl /
+     *  etc. The opener (`pushShareModal` in `ShareProvider`) creates
+     *  it fresh per push. */
+    readonly store: ShareCreateStore;
+    /** Mutable holder for the imperative handlers (close, onCreate,
+     *  goBackToToggles, copy). The body fills these on every render;
+     *  the header/footer slots call them on click. Created fresh per
+     *  push by the opener. */
+    readonly handlersRef: { current: ShareCreateHandlers };
 }
+
+export interface ShareCreateStoreState {
+    readonly step: Step;
+    readonly submitting: boolean;
+    readonly shareUrl: string | null;
+    readonly hasCopied: boolean;
+    readonly qrShown: boolean;
+    readonly needsSignIn: boolean;
+}
+
+export type ShareCreateStore = ModalSlotStore<ShareCreateStoreState>;
+
+export interface ShareCreateHandlers {
+    readonly close: () => void;
+    readonly onCreate: () => Promise<void>;
+    readonly goBackToToggles: () => void;
+}
+
+/**
+ * Initial values for a fresh push. The body's `useEffect`s seed the
+ * remaining derived fields (`needsSignIn` from session) on mount.
+ */
+export const initialShareCreateStoreState = (): ShareCreateStoreState => ({
+    step: STEP_TOGGLES,
+    submitting: false,
+    shareUrl: null,
+    hasCopied: false,
+    qrShown: false,
+    needsSignIn: true,
+});
+
+/**
+ * Build the initial `ShareCreateHandlers` shape used by the opener
+ * before the body has rendered to fill them in. Calling any of these
+ * pre-mount no-ops is safe — they're guaranteed to be replaced before
+ * a user interaction can reach the slots.
+ */
+export const initialShareCreateHandlers = (): ShareCreateHandlers => ({
+    close: () => {},
+    onCreate: async () => {},
+    goBackToToggles: () => {},
+});
+
+export { createModalSlotStore };
 
 export const SHARE_CREATE_MODAL_ID = "share-create" as const;
 export const SHARE_CREATE_MODAL_MAX_WIDTH = "min(92vw,480px)" as const;
@@ -442,9 +501,10 @@ export function ShareCreateModal({
     forcedCardPackLabel,
     resumeIntent,
     onResumeConsumed,
+    store,
+    handlersRef,
 }: ShareCreateModalProps) {
     const t = useTranslations("share");
-    const tCommon = useTranslations("common");
     const tAccount = useTranslations("account");
     const { state, derived } = useClue();
     const pathname = usePathname();
@@ -837,43 +897,36 @@ export function ShareCreateModal({
         pop();
     };
 
-    const titleKey = TITLE_KEY_FOR[variant];
     const descriptionKey = DESCRIPTION_KEY_FOR[variant];
 
-    // Once the URL is in hand AND the user has either copied it or
-    // revealed the QR (the two ways someone "uses" the link), flip the
-    // bottom CTA to "Done" — clicking it closes the modal. Without the
-    // QR branch the user who scans-but-doesn't-copy is still nudged to
-    // "Copy link," which feels off after they've already shared.
-    const isDoneState = hasCopied || qrShown;
-    const ctaLabel = submitting
-        ? t(CREATING_KEY)
-        : needsSignIn && shareUrl === null
-            ? t(SIGN_IN_TO_SHARE_KEY)
-            : shareUrl === null
-                ? t(GENERATE_LINK_KEY)
-                : isDoneState
-                    ? t(DONE_KEY)
-                    : t(COPY_LINK_KEY);
+    // Publish reactive state to the shared store on every change so
+    // the `header` and `footer` slots (which live as siblings in
+    // `ModalStack`'s shell, not as descendants of this body) stay in
+    // sync. `useSyncExternalStore` in those slots only re-runs when
+    // the selected slice changes.
+    useEffect(() => {
+        store.set(() => ({
+            step,
+            submitting,
+            shareUrl,
+            hasCopied,
+            qrShown,
+            needsSignIn,
+        }));
+    }, [store, step, submitting, shareUrl, hasCopied, qrShown, needsSignIn]);
+
+    // Fill the imperative handler refs the footer / header slots call
+    // on click. Filled on every render so each handler's closure sees
+    // fresh state — refs aren't reactive, so the slots don't re-render
+    // when the handlers change identity.
+    handlersRef.current = {
+        close,
+        onCreate,
+        goBackToToggles,
+    };
 
     return (
-                <div className="flex flex-col">
-                    <div className="flex shrink-0 items-start justify-between gap-3 px-5 pt-5">
-                        <Dialog.Title className="m-0 font-display text-[1.25rem] text-accent">
-                            {step === STEP_TOGGLES
-                                ? t(titleKey)
-                                : t(SIGN_IN_TITLE_KEY)}
-                        </Dialog.Title>
-                        <button
-                            type="button"
-                            aria-label={tCommon("close")}
-                            onClick={close}
-                            className="-mt-1 -mr-1 cursor-pointer rounded-[var(--radius)] border-none bg-transparent p-1 text-[#2a1f12] hover:bg-hover"
-                        >
-                            <XIcon size={18} />
-                        </button>
-                    </div>
-                    <div className="relative grid grid-cols-[minmax(0,1fr)] [grid-template-areas:'stack'] overflow-hidden">
+                <div className="relative grid grid-cols-[minmax(0,1fr)] [grid-template-areas:'stack'] overflow-hidden">
                         <AnimatePresence custom={direction} initial={false} mode={PRESENCE_WAIT_MODE}>
                             {step === STEP_TOGGLES ? (
                                 <motion.div
@@ -1101,36 +1154,116 @@ export function ShareCreateModal({
                                 </motion.div>
                             )}
                         </AnimatePresence>
-                    </div>
-                    <div className="mt-4 flex items-center justify-end gap-2 border-t border-border bg-panel px-5 pt-4 pb-5">
-                        {step === STEP_SIGN_IN ? (
-                            <button
-                                type="button"
-                                onClick={goBackToToggles}
-                                className="tap-target text-tap mr-auto cursor-pointer rounded-[var(--radius)] border border-border bg-white hover:bg-hover"
-                            >
-                                {tCommon("back")}
-                            </button>
-                        ) : null}
-                        <button
-                            type="button"
-                            onClick={close}
-                            className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-white hover:bg-hover"
-                        >
-                            {tCommon("cancel")}
-                        </button>
-                        {step === STEP_TOGGLES ? (
-                            <button
-                                type="button"
-                                onClick={() => void onCreate()}
-                                disabled={submitting}
-                                className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border-2 border-accent bg-accent font-semibold text-white hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-40"
-                                data-share-cta
-                            >
-                                {ctaLabel}
-                            </button>
-                        ) : null}
-                    </div>
                 </div>
+    );
+}
+
+/**
+ * Header band — pinned at the modal's top. Subscribes to `step` from
+ * the shared store and renders the right title for the current step;
+ * the X close button calls `handlersRef.current.close()`.
+ */
+export function ShareCreateHeader({
+    variant,
+    store,
+    handlersRef,
+}: {
+    readonly variant: ShareVariant;
+    readonly store: ShareCreateStore;
+    readonly handlersRef: { current: ShareCreateHandlers };
+}) {
+    const t = useTranslations("share");
+    const tCommon = useTranslations("common");
+    const step = useModalSlotStoreSelector(store, (s) => s.step);
+    const titleKey = TITLE_KEY_FOR[variant];
+    return (
+        <div className="flex items-start justify-between gap-3 px-5 pt-5 pb-3">
+            <Dialog.Title className="m-0 font-display text-[1.25rem] text-accent">
+                {step === STEP_TOGGLES ? t(titleKey) : t(SIGN_IN_TITLE_KEY)}
+            </Dialog.Title>
+            <button
+                type="button"
+                aria-label={tCommon("close")}
+                onClick={() => handlersRef.current.close()}
+                className="-mt-1 -mr-1 cursor-pointer rounded-[var(--radius)] border-none bg-transparent p-1 text-[#2a1f12] hover:bg-hover"
+            >
+                <XIcon size={18} />
+            </button>
+        </div>
+    );
+}
+
+/**
+ * Footer band — pinned at the modal's bottom. Subscribes to step +
+ * submitting + shareUrl + hasCopied + qrShown + needsSignIn to drive
+ * the 4-state CTA label machine, and renders Back (sign-in step
+ * only) + Cancel + CTA (toggles step only). All button clicks route
+ * through `handlersRef.current.*` so the body owns the imperative
+ * side-effects.
+ */
+export function ShareCreateFooter({
+    store,
+    handlersRef,
+}: {
+    readonly store: ShareCreateStore;
+    readonly handlersRef: { current: ShareCreateHandlers };
+}) {
+    const t = useTranslations("share");
+    const tCommon = useTranslations("common");
+    const step = useModalSlotStoreSelector(store, (s) => s.step);
+    const submitting = useModalSlotStoreSelector(store, (s) => s.submitting);
+    const shareUrl = useModalSlotStoreSelector(store, (s) => s.shareUrl);
+    const hasCopied = useModalSlotStoreSelector(store, (s) => s.hasCopied);
+    const qrShown = useModalSlotStoreSelector(store, (s) => s.qrShown);
+    const needsSignIn = useModalSlotStoreSelector(
+        store,
+        (s) => s.needsSignIn,
+    );
+
+    // 4-state CTA label machine — same as the original inline footer.
+    // `isDoneState`: the user has either copied the URL or revealed
+    // the QR (either way, they've "used" the share — close on the
+    // next click).
+    const isDoneState = hasCopied || qrShown;
+    const ctaLabel = submitting
+        ? t(CREATING_KEY)
+        : needsSignIn && shareUrl === null
+            ? t(SIGN_IN_TO_SHARE_KEY)
+            : shareUrl === null
+                ? t(GENERATE_LINK_KEY)
+                : isDoneState
+                    ? t(DONE_KEY)
+                    : t(COPY_LINK_KEY);
+
+    return (
+        <div className="flex items-center justify-end gap-2 bg-panel px-5 pt-4 pb-5">
+            {step === STEP_SIGN_IN ? (
+                <button
+                    type="button"
+                    onClick={() => handlersRef.current.goBackToToggles()}
+                    className="tap-target text-tap mr-auto cursor-pointer rounded-[var(--radius)] border border-border bg-white hover:bg-hover"
+                >
+                    {tCommon("back")}
+                </button>
+            ) : null}
+            <button
+                type="button"
+                onClick={() => handlersRef.current.close()}
+                className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-white hover:bg-hover"
+            >
+                {tCommon("cancel")}
+            </button>
+            {step === STEP_TOGGLES ? (
+                <button
+                    type="button"
+                    onClick={() => void handlersRef.current.onCreate()}
+                    disabled={submitting}
+                    className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border-2 border-accent bg-accent font-semibold text-white hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-40"
+                    data-share-cta
+                >
+                    {ctaLabel}
+                </button>
+            ) : null}
+        </div>
     );
 }

--- a/src/ui/share/ShareImportPage.tsx
+++ b/src/ui/share/ShareImportPage.tsx
@@ -72,6 +72,7 @@ import { cardPackUsageQueryKey } from "../../data/cardPackUsage";
 import { authClient } from "../account/authClient";
 import { useSession } from "../hooks/useSession";
 import { XIcon } from "../components/Icons";
+import { Modal } from "../components/Modal";
 import { useConfirm } from "../hooks/useConfirm";
 import { CardSelectionGrid } from "../setup/shared/CardSelectionGrid";
 import { firstDealtHandSizes } from "../setup/firstDealt";
@@ -868,64 +869,30 @@ export function ShareImportPage({
             : t(INCLUDES_HEADER_KEY_FOR[receiveFlow]);
     const showPackBullet = receiveFlow !== RECEIVE_FLOW_PACK;
 
-    return (
-        <main className="mx-auto flex max-w-[640px] flex-col gap-5 px-5 py-8">
-            {/* Page heading uses the same hierarchy as SetupWizard +
-                SuggestionLogPanel: slab/display family (inherited
-                via the global h1 rule), uppercase + accent for the
-                "you are here" cue. */}
-            <h1 className="m-0 text-[1.5rem] uppercase tracking-[0.05em] text-accent">
-                {t("importTitle")}
-            </h1>
-            <Dialog.Root
-                open={open}
-                onOpenChange={(next) => !next && close(VIA_BACKDROP)}
+    // Header / content / footer are pre-built as `ReactNode` so the
+    // single `<Modal>` mount below stays readable. `Modal` (shared
+    // with `ModalStack`'s shell — see `src/ui/components/Modal.tsx`)
+    // owns the chrome, the three-band layout, and the sticky-offset
+    // reset that pins the embedded `CardSelectionGrid`'s `<thead>` at
+    // the modal's scroll-container top.
+    const modalHeader = (
+        <div className="flex items-start justify-between gap-3 px-5 pt-5 pb-3">
+            <Dialog.Title className="m-0 font-display text-[1.25rem] uppercase tracking-[0.05em] text-accent">
+                {t(TITLE_KEY_FOR[receiveFlow])}
+            </Dialog.Title>
+            <button
+                type="button"
+                onClick={() => close(VIA_X)}
+                aria-label={tCommon("close")}
+                className="-mt-1 -mr-1 cursor-pointer rounded-[var(--radius)] border-none bg-transparent p-1 text-[#2a1f12] hover:bg-hover"
             >
-                <Dialog.Portal>
-                    <Dialog.Overlay className="fixed inset-0 z-[var(--z-dialog-overlay)] bg-black/40" />
-                    <Dialog.Content
-                        className={
-                            "fixed left-1/2 top-1/2 z-[var(--z-dialog-content)] flex w-[min(92vw,480px)] flex-col " +
-                            "max-h-[calc(100dvh-2rem)] overflow-hidden " +
-                            "-translate-x-1/2 -translate-y-1/2 rounded-[var(--radius)] border border-border " +
-                            "bg-panel shadow-[0_10px_28px_rgba(0,0,0,0.28)] focus:outline-none"
-                        }
-                    >
-                        {/* Header band — pinned, doesn't scroll. The modal's
-                            structural ladder mirrors `ModalStack`'s shell:
-                            header is `shrink-0`, the body in between is the
-                            `flex-1 min-h-0 overflow-y-auto` scroll
-                            container, and the footer below is `shrink-0
-                            z-[40]` so any sticky-thead inside the body
-                            (e.g. `CardSelectionGrid`'s player-name row)
-                            pins to the top of THIS scroll context and the
-                            grid never scrolls past the action buttons. */}
-                        <div className="flex shrink-0 items-start justify-between gap-3 px-5 pt-5">
-                            {/* Modal title matches SuggestionLogPanel
-                                's `h2`: uppercase + accent + slab,
-                                one notch smaller than the page H1. */}
-                            <Dialog.Title className="m-0 text-[1.25rem] uppercase tracking-[0.05em] text-accent">
-                                {t(TITLE_KEY_FOR[receiveFlow])}
-                            </Dialog.Title>
-                            <button
-                                type="button"
-                                onClick={() => close(VIA_X)}
-                                aria-label={tCommon("close")}
-                                className="-mt-1 -mr-1 cursor-pointer rounded-[var(--radius)] border-none bg-transparent p-1 text-[#2a1f12] hover:bg-hover"
-                            >
-                                <XIcon size={18} />
-                            </button>
-                        </div>
-                        {/* Scrollable body. `relative z-0` traps inner
-                            stacking contexts (high-z grid cells, sticky
-                            thead at z-39) below the footer band (z-40) so
-                            the picker grid can't paint over the action
-                            buttons. `min-h-0` is the load-bearing piece —
-                            without it, `flex-1` can't shrink below the
-                            children's intrinsic height and the modal grows
-                            past the viewport regardless of `max-h`. */}
-                        <div className="relative z-0 flex min-h-0 flex-1 flex-col overflow-y-auto pb-4">
-                        {snapshot.ownerName !== null ? (
+                <XIcon size={18} />
+            </button>
+        </div>
+    );
+    const modalContent = (
+        <div className="pb-4">
+            {snapshot.ownerName !== null ? (
                             <Dialog.Description
                                 className="px-5 pt-3 text-[1rem] leading-normal"
                                 data-share-import-sender
@@ -1090,45 +1057,50 @@ export function ShareImportPage({
                                 />
                             </div>
                         ) : null}
-                        {receiveFlow === RECEIVE_FLOW_TRANSFER
-                            && teachModeSnapshot !== null && (
-                                <TeachModeTransferSummary
-                                    on={teachModeSnapshot}
-                                />
-                            )}
-                        </div>
-                        {/* Sticky footer band. `relative z-[40]` wins
-                            against any z-index inside the body up
-                            through 39 (the checklist-style grid's
-                            sticky-header layer tops out at 39). The
-                            scroll boundary above ends here, so the
-                            grid's body scrolls UNDER this row instead
-                            of pushing it off-screen. */}
-                        <div className="relative z-[40] flex shrink-0 items-center justify-end gap-2 border-t border-border bg-panel px-5 pt-4 pb-5">
-                            <button
-                                type="button"
-                                onClick={() => close(VIA_X)}
-                                className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-white hover:bg-hover"
-                            >
-                                {tCommon("cancel")}
-                            </button>
-                            <button
-                                type="button"
-                                onClick={() => void onImport()}
-                                disabled={submitting || isEmpty}
-                                data-share-import-cta
-                                className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border-2 border-accent bg-accent font-semibold text-white hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-40"
-                            >
-                                {submitting
-                                    ? t("importing")
-                                    : isAnonymous
-                                        ? t("signInToImport")
-                                        : t(ACTION_KEY_FOR[receiveFlow])}
-                            </button>
-                        </div>
-                    </Dialog.Content>
-                </Dialog.Portal>
-            </Dialog.Root>
+            {receiveFlow === RECEIVE_FLOW_TRANSFER
+                && teachModeSnapshot !== null && (
+                    <TeachModeTransferSummary on={teachModeSnapshot} />
+                )}
+        </div>
+    );
+    const modalFooter = (
+        <div className="flex items-center justify-end gap-2 bg-panel px-5 pt-4 pb-5">
+            <button
+                type="button"
+                onClick={() => close(VIA_X)}
+                className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border border-border bg-white hover:bg-hover"
+            >
+                {tCommon("cancel")}
+            </button>
+            <button
+                type="button"
+                onClick={() => void onImport()}
+                disabled={submitting || isEmpty}
+                data-share-import-cta
+                className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border-2 border-accent bg-accent font-semibold text-white hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-40"
+            >
+                {submitting
+                    ? t("importing")
+                    : isAnonymous
+                        ? t("signInToImport")
+                        : t(ACTION_KEY_FOR[receiveFlow])}
+            </button>
+        </div>
+    );
+
+    return (
+        <main className="mx-auto flex max-w-[640px] flex-col gap-5 px-5 py-8">
+            <h1 className="m-0 text-[1.5rem] uppercase tracking-[0.05em] text-accent">
+                {t("importTitle")}
+            </h1>
+            <Modal
+                open={open}
+                title={t(TITLE_KEY_FOR[receiveFlow])}
+                onOpenChange={(next) => !next && close(VIA_BACKDROP)}
+                header={modalHeader}
+                content={modalContent}
+                footer={modalFooter}
+            />
         </main>
     );
 }

--- a/src/ui/share/ShareMissingPage.test.tsx
+++ b/src/ui/share/ShareMissingPage.test.tsx
@@ -21,10 +21,6 @@ vi.mock("../../analytics/events", () => ({
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { ShareMissingPage } from "./ShareMissingPage";
-import {
-    ModalStackProvider,
-    ModalStackShell,
-} from "../components/ModalStack";
 
 beforeEach(() => {
     mockHasPersistedGameData = false;
@@ -32,30 +28,12 @@ beforeEach(() => {
     shareOpenFailedMock.mockReset();
 });
 
-// `ShareMissingPage` pushes its modal entry onto the global stack —
-// wrap with the provider so the push has a target and the shell
-// renders the content into the DOM.
-const renderInStack = (ui: React.ReactElement) =>
-    render(
-        <ModalStackProvider>
-            {ui}
-            <ModalStackShell />
-        </ModalStackProvider>,
-    );
-
 describe("ShareMissingPage", () => {
     test("empty local state offers to start a new game", async () => {
-        renderInStack(<ShareMissingPage shareId="missing-share" />);
+        render(<ShareMissingPage shareId="missing-share" />);
 
-        await waitFor(() => {
-            expect(screen.getByText("missingTitle")).toBeInTheDocument();
-        });
+        expect(screen.getByText("missingTitle")).toBeInTheDocument();
         expect(screen.getByText("missingBody")).toBeInTheDocument();
-        await waitFor(() => {
-            expect(
-                screen.getByText("missingActionStart"),
-            ).toBeInTheDocument();
-        });
         fireEvent.click(screen.getByText("missingActionStart"));
 
         expect(routerPushMock).toHaveBeenCalledWith("/play?view=setup");
@@ -70,7 +48,7 @@ describe("ShareMissingPage", () => {
 
     test("existing local progress offers to continue the current game", async () => {
         mockHasPersistedGameData = true;
-        renderInStack(<ShareMissingPage shareId="missing-share" />);
+        render(<ShareMissingPage shareId="missing-share" />);
 
         await waitFor(() => {
             expect(

--- a/src/ui/share/ShareMissingPage.test.tsx
+++ b/src/ui/share/ShareMissingPage.test.tsx
@@ -21,6 +21,10 @@ vi.mock("../../analytics/events", () => ({
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { ShareMissingPage } from "./ShareMissingPage";
+import {
+    ModalStackProvider,
+    ModalStackShell,
+} from "../components/ModalStack";
 
 beforeEach(() => {
     mockHasPersistedGameData = false;
@@ -28,12 +32,30 @@ beforeEach(() => {
     shareOpenFailedMock.mockReset();
 });
 
+// `ShareMissingPage` pushes its modal entry onto the global stack —
+// wrap with the provider so the push has a target and the shell
+// renders the content into the DOM.
+const renderInStack = (ui: React.ReactElement) =>
+    render(
+        <ModalStackProvider>
+            {ui}
+            <ModalStackShell />
+        </ModalStackProvider>,
+    );
+
 describe("ShareMissingPage", () => {
     test("empty local state offers to start a new game", async () => {
-        render(<ShareMissingPage shareId="missing-share" />);
+        renderInStack(<ShareMissingPage shareId="missing-share" />);
 
-        expect(screen.getByText("missingTitle")).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByText("missingTitle")).toBeInTheDocument();
+        });
         expect(screen.getByText("missingBody")).toBeInTheDocument();
+        await waitFor(() => {
+            expect(
+                screen.getByText("missingActionStart"),
+            ).toBeInTheDocument();
+        });
         fireEvent.click(screen.getByText("missingActionStart"));
 
         expect(routerPushMock).toHaveBeenCalledWith("/play?view=setup");
@@ -48,7 +70,7 @@ describe("ShareMissingPage", () => {
 
     test("existing local progress offers to continue the current game", async () => {
         mockHasPersistedGameData = true;
-        render(<ShareMissingPage shareId="missing-share" />);
+        renderInStack(<ShareMissingPage shareId="missing-share" />);
 
         await waitFor(() => {
             expect(

--- a/src/ui/share/ShareMissingPage.tsx
+++ b/src/ui/share/ShareMissingPage.tsx
@@ -3,14 +3,16 @@
 import * as Dialog from "@radix-ui/react-dialog";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { shareOpenFailed } from "../../analytics/events";
 import { routes } from "../../routes";
+import { useModalStack } from "../components/ModalStack";
 import { hasPersistedGameData } from "./useApplyShareSnapshot";
 import { hashShareId } from "./shareAnalytics";
 
 const SHARE_OPEN_FAILED_REASON = "not_found_or_expired" as const;
 const SETUP_VIEW_QUERY = "?view=setup" as const;
+const SHARE_MISSING_MODAL_ID = "share-missing" as const;
 
 export function ShareMissingPage({
     shareId,
@@ -19,6 +21,7 @@ export function ShareMissingPage({
 }) {
     const t = useTranslations("share");
     const router = useRouter();
+    const { push, popTo } = useModalStack();
     const [hasCurrentGame, setHasCurrentGame] = useState(false);
 
     useEffect(() => {
@@ -39,45 +42,65 @@ export function ShareMissingPage({
         ? t("missingActionContinue")
         : t("missingActionStart");
 
+    // Push the modal entry on mount and pop on unmount. `onClose`
+    // navigates the user off the route — there's nothing meaningful
+    // behind this modal on a fresh load. Held in a ref so identity
+    // changes (from the router) don't churn the effect.
+    const navTargetRef = useRef(target);
+    navTargetRef.current = target;
+    const routerRef = useRef(router);
+    routerRef.current = router;
+    const tRef = useRef(t);
+    tRef.current = t;
+
+    useEffect(() => {
+        const navigateAway = () => {
+            routerRef.current.push(navTargetRef.current);
+        };
+        const t = tRef.current;
+        push({
+            id: SHARE_MISSING_MODAL_ID,
+            title: t("missingTitle"),
+            maxWidth: "min(92vw,480px)",
+            onClose: navigateAway,
+            header: (
+                <div className="flex items-start justify-between gap-3 px-5 pt-5 pb-3">
+                    <Dialog.Title className="m-0 font-display text-[1.25rem] uppercase tracking-[0.05em] text-accent">
+                        {t("missingTitle")}
+                    </Dialog.Title>
+                </div>
+            ),
+            content: (
+                <Dialog.Description className="m-0 px-5 pt-3 pb-3 text-[1rem] leading-normal text-muted">
+                    {t("missingBody")}
+                </Dialog.Description>
+            ),
+            footer: (
+                <div className="flex items-center justify-end gap-2 bg-panel px-5 pt-4 pb-5">
+                    <button
+                        type="button"
+                        onClick={() => popTo(SHARE_MISSING_MODAL_ID)}
+                        className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border-2 border-accent bg-accent font-semibold text-white hover:bg-accent-hover"
+                        data-share-missing-cta
+                    >
+                        {actionLabel}
+                    </button>
+                </div>
+            ),
+        });
+        return () => {
+            popTo(SHARE_MISSING_MODAL_ID);
+        };
+    }, [push, popTo, actionLabel]);
+
+    // The page itself renders the section heading (matches the
+    // success-side ShareImportPage's `<main>` chrome). The modal is
+    // portaled by `ModalStack`.
     return (
         <main className="mx-auto flex max-w-[640px] flex-col gap-5 px-5 py-8">
-            {/* Page heading matches SetupWizard / SuggestionLogPanel
-                + the import page: uppercase + tracking + accent, slab
-                via the global h1 rule. */}
             <h1 className="m-0 text-[1.5rem] uppercase tracking-[0.05em] text-accent">
                 {t("importTitle")}
             </h1>
-            <Dialog.Root open>
-                <Dialog.Portal>
-                    <Dialog.Overlay className="fixed inset-0 z-[var(--z-dialog-overlay)] bg-black/40" />
-                    <Dialog.Content
-                        className={
-                            "fixed left-1/2 top-1/2 z-[var(--z-dialog-content)] flex w-[min(92vw,480px)] flex-col " +
-                            "-translate-x-1/2 -translate-y-1/2 rounded-[var(--radius)] border border-border " +
-                            "bg-panel shadow-[0_10px_28px_rgba(0,0,0,0.28)] focus:outline-none"
-                        }
-                    >
-                        <div className="px-5 pt-5">
-                            <Dialog.Title className="m-0 text-[1.25rem] uppercase tracking-[0.05em] text-accent">
-                                {t("missingTitle")}
-                            </Dialog.Title>
-                            <Dialog.Description className="pt-3 text-[1rem] leading-normal text-muted">
-                                {t("missingBody")}
-                            </Dialog.Description>
-                        </div>
-                        <div className="mt-4 flex items-center justify-end border-t border-border bg-panel px-5 pt-4 pb-5">
-                            <button
-                                type="button"
-                                onClick={() => router.push(target)}
-                                className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border-2 border-accent bg-accent font-semibold text-white hover:bg-accent-hover"
-                                data-share-missing-cta
-                            >
-                                {actionLabel}
-                            </button>
-                        </div>
-                    </Dialog.Content>
-                </Dialog.Portal>
-            </Dialog.Root>
         </main>
     );
 }

--- a/src/ui/share/ShareMissingPage.tsx
+++ b/src/ui/share/ShareMissingPage.tsx
@@ -3,16 +3,15 @@
 import * as Dialog from "@radix-ui/react-dialog";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { shareOpenFailed } from "../../analytics/events";
 import { routes } from "../../routes";
-import { useModalStack } from "../components/ModalStack";
+import { Modal } from "../components/Modal";
 import { hasPersistedGameData } from "./useApplyShareSnapshot";
 import { hashShareId } from "./shareAnalytics";
 
 const SHARE_OPEN_FAILED_REASON = "not_found_or_expired" as const;
 const SETUP_VIEW_QUERY = "?view=setup" as const;
-const SHARE_MISSING_MODAL_ID = "share-missing" as const;
 
 export function ShareMissingPage({
     shareId,
@@ -21,8 +20,8 @@ export function ShareMissingPage({
 }) {
     const t = useTranslations("share");
     const router = useRouter();
-    const { push, popTo } = useModalStack();
     const [hasCurrentGame, setHasCurrentGame] = useState(false);
+    const [open, setOpen] = useState(true);
 
     useEffect(() => {
         setHasCurrentGame(hasPersistedGameData());
@@ -42,65 +41,47 @@ export function ShareMissingPage({
         ? t("missingActionContinue")
         : t("missingActionStart");
 
-    // Push the modal entry on mount and pop on unmount. `onClose`
-    // navigates the user off the route — there's nothing meaningful
-    // behind this modal on a fresh load. Held in a ref so identity
-    // changes (from the router) don't churn the effect.
-    const navTargetRef = useRef(target);
-    navTargetRef.current = target;
-    const routerRef = useRef(router);
-    routerRef.current = router;
-    const tRef = useRef(t);
-    tRef.current = t;
+    const onAction = (): void => {
+        setOpen(false);
+        router.push(target);
+    };
 
-    useEffect(() => {
-        const navigateAway = () => {
-            routerRef.current.push(navTargetRef.current);
-        };
-        const t = tRef.current;
-        push({
-            id: SHARE_MISSING_MODAL_ID,
-            title: t("missingTitle"),
-            maxWidth: "min(92vw,480px)",
-            onClose: navigateAway,
-            header: (
-                <div className="flex items-start justify-between gap-3 px-5 pt-5 pb-3">
-                    <Dialog.Title className="m-0 font-display text-[1.25rem] uppercase tracking-[0.05em] text-accent">
-                        {t("missingTitle")}
-                    </Dialog.Title>
-                </div>
-            ),
-            content: (
-                <Dialog.Description className="m-0 px-5 pt-3 pb-3 text-[1rem] leading-normal text-muted">
-                    {t("missingBody")}
-                </Dialog.Description>
-            ),
-            footer: (
-                <div className="flex items-center justify-end gap-2 bg-panel px-5 pt-4 pb-5">
-                    <button
-                        type="button"
-                        onClick={() => popTo(SHARE_MISSING_MODAL_ID)}
-                        className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border-2 border-accent bg-accent font-semibold text-white hover:bg-accent-hover"
-                        data-share-missing-cta
-                    >
-                        {actionLabel}
-                    </button>
-                </div>
-            ),
-        });
-        return () => {
-            popTo(SHARE_MISSING_MODAL_ID);
-        };
-    }, [push, popTo, actionLabel]);
-
-    // The page itself renders the section heading (matches the
-    // success-side ShareImportPage's `<main>` chrome). The modal is
-    // portaled by `ModalStack`.
     return (
         <main className="mx-auto flex max-w-[640px] flex-col gap-5 px-5 py-8">
             <h1 className="m-0 text-[1.5rem] uppercase tracking-[0.05em] text-accent">
                 {t("importTitle")}
             </h1>
+            <Modal
+                open={open}
+                title={t("missingTitle")}
+                onOpenChange={(next) => {
+                    if (!next) onAction();
+                }}
+                header={
+                    <div className="flex items-start justify-between gap-3 px-5 pt-5 pb-3">
+                        <Dialog.Title className="m-0 font-display text-[1.25rem] uppercase tracking-[0.05em] text-accent">
+                            {t("missingTitle")}
+                        </Dialog.Title>
+                    </div>
+                }
+                content={
+                    <Dialog.Description className="m-0 px-5 pt-3 pb-3 text-[1rem] leading-normal text-muted">
+                        {t("missingBody")}
+                    </Dialog.Description>
+                }
+                footer={
+                    <div className="flex items-center justify-end gap-2 bg-panel px-5 pt-4 pb-5">
+                        <button
+                            type="button"
+                            onClick={onAction}
+                            className="tap-target text-tap cursor-pointer rounded-[var(--radius)] border-2 border-accent bg-accent font-semibold text-white hover:bg-accent-hover"
+                            data-share-missing-cta
+                        >
+                            {actionLabel}
+                        </button>
+                    </div>
+                }
+            />
         </main>
     );
 }

--- a/src/ui/share/ShareProvider.tsx
+++ b/src/ui/share/ShareProvider.tsx
@@ -37,9 +37,15 @@ import {
     type PendingShareIntent,
 } from "./pendingShare";
 import {
+    createModalSlotStore,
+    initialShareCreateHandlers,
+    initialShareCreateStoreState,
     SHARE_CREATE_MODAL_ID,
     SHARE_CREATE_MODAL_MAX_WIDTH,
+    ShareCreateFooter,
+    ShareCreateHeader,
     ShareCreateModal,
+    type ShareCreateHandlers,
     type ShareVariant,
 } from "./ShareCreateModal";
 
@@ -111,13 +117,35 @@ export function ShareProvider({
                 readonly resumeIntent?: PendingShareIntent;
             } = {},
         ) => {
+            // Fresh store + handlersRef per push — matches the
+            // body's existing "modal mounts fresh on each push" model,
+            // so push() with the same id (i.e. a re-push of share-
+            // create) starts from clean state. The body publishes
+            // reactive state into the store and fills handlersRef
+            // on every render so the header and footer slots see
+            // live state and handlers.
+            const store = createModalSlotStore(
+                initialShareCreateStoreState(),
+            );
+            const handlersRef: { current: ShareCreateHandlers } = {
+                current: initialShareCreateHandlers(),
+            };
             push({
                 id: SHARE_CREATE_MODAL_ID,
                 title: t(TITLE_KEY_FOR[variant]),
                 maxWidth: SHARE_CREATE_MODAL_MAX_WIDTH,
+                header: (
+                    <ShareCreateHeader
+                        variant={variant}
+                        store={store}
+                        handlersRef={handlersRef}
+                    />
+                ),
                 content: (
                     <ShareCreateModal
                         variant={variant}
+                        store={store}
+                        handlersRef={handlersRef}
                         {...(opts.forcedCardPack !== undefined
                             ? { forcedCardPack: opts.forcedCardPack }
                             : {})}
@@ -130,6 +158,12 @@ export function ShareProvider({
                         onResumeConsumed={() => {
                             resumeIntentRef.current = null;
                         }}
+                    />
+                ),
+                footer: (
+                    <ShareCreateFooter
+                        store={store}
+                        handlersRef={handlersRef}
                     />
                 ),
             });


### PR DESCRIPTION
## Summary

Two related cleanups across the modal surface area:

**1. Every modal renders through the same shared chrome.**
A new `Modal.tsx` component exports `Modal` (static three-band), `ModalChrome` (Radix Dialog wrapper), and `ModalBands` (header / scrollable body / footer with sticky-offset CSS-variable reset). `ModalStack` now renders through the same building blocks internally, so the visuals match regardless of whether a modal is pushed onto the dynamic stack or rendered statically on a route (`/share/{id}`). Every existing modal — `MyCardsModal`, `SplashModal`, `InstallPromptModal`, `StaleGameModal`, `AccountModal`, `LogoutWarningModal`, `CardPackEditorModal`, `useTeachModeToggle`, `useConfirm`, `usePrompt`, `ShareCreateModal`, `ShareImportPage`, `ShareMissingPage` — uses the same three-slot pattern (`header` / `content` / `footer`) with pinned top and bottom bands and a scrollable middle.

User-visible fixes:
- "Cards in your hand" modal: Done CTA is full standard size with proper padding; modal title is visible at the top; sticky "Player N" header pins at the modal body top instead of floating ~70 px down.
- Embedded sticky tables in modals (e.g. `CardSelectionGrid` in `MyCardsModal` / `ShareImportPage`) pin at the modal scroll-container top, not the page header offset.
- Action bars stay pinned at the bottom when modal content overflows.
- No more `tap-target-compact` on modal CTAs — standard button size everywhere.

A new `modalSlotStore.ts` (tiny `useSyncExternalStore`-based store) handles cross-slot state for modals where the header, content, and footer all need to react to the same values (`usePrompt`'s input value, `CardPackEditorModal`'s draft, `ShareCreateModal`'s step / submitting / shareUrl / etc.).

`AGENTS.md` now has a top-level Modals section documenting the pattern, the static-vs-dynamic split, what goes in each band, alert-style modal rules, and what NOT to do.

**2. Press-delay drag activation in reorder lists.**
Casual swipes inside the card-pack editor modal couldn't scroll the body because every row IS a `Reorder.Item` and Framer Motion's auto-listener captured the touch immediately. Same friction in `PlayerListReorder`. New `useReorderPressDelay` hook + `DelayedReorderItem` wrapper gate drag activation behind a 250 ms press-and-hold via Framer's `useDragControls`. The pointer can move up to 8 px before the timer fires; past that, the timer cancels and the browser owns the gesture (vertical scroll). Matches dnd-kit's `PointerSensor` activation-constraint model. Whole-row drag target is preserved; only activation timing changed.

## Test plan

Modal walkthrough (mobile 375×812 + desktop 1280×800 for every modal):
- [ ] **MyCardsModal** — set up a game, set "I am", don't mark cards, click "Select cards in your hand" from null state B. Title visible at top; Done button full-size with breathing room; sticky "Player N" header pins at modal top when scrolling the table.
- [ ] **SplashModal** — clear `effect-clue.*` localStorage, reload. Title + X pinned; About content scrolls; CTA + "Don't show again" pinned at bottom.
- [ ] **InstallPromptModal** — overflow menu → "Install app". Title + X pinned; 2 buttons pinned at bottom.
- [ ] **StaleGameModal** — seed a stale session and reload. Title + X pinned; "Keep working" + "Set up new game" pinned at bottom.
- [ ] **AccountModal** — overflow menu (signed-out and signed-in). Title + X pinned; body scrolls.
- [ ] **LogoutWarningModal** — sign in with unsynced pack changes, click sign out. Title pinned (no X); body scrolls; 3 buttons pinned. Escape / outside-click do NOT dismiss.
- [ ] **CardPackEditorModal** — open from setup or My Card Packs. Title + X pinned; card list scrolls; Cancel / Save buttons pinned. Escape / outside-click do NOT dismiss.
- [ ] **Mid-game teach-mode prompt** — toggle teach-mode on mid-game from overflow menu. Three buttons pinned at bottom.
- [ ] **useConfirm / usePrompt** — trigger via "Delete pack" and "Rename pack" in My Card Packs. Save button disabled while empty; Enter submits.
- [ ] **ShareCreateModal** — open all three flows (pack from setup row, invite from overflow, transfer from overflow). For each: title + X pinned at top; CTA pinned at bottom. Anon user sees "Sign in to share" → click slides body, header title swaps, footer swaps to Back + Cancel. Back returns. After URL generated: CTA flips Copy → Done.
- [ ] **ShareImportPage** — `/share/{valid-id}`. Title + X pinned; body scrolls; Cancel + "Add to my game" pinned. Embedded `CardSelectionGrid` (invite flow) sticky header pins at modal body top. X / Cancel / outside-click / Escape navigate to `/play`.
- [ ] **ShareMissingPage** — `/share/{expired-id}`. CTA navigates to `/play` (or `/play?view=setup` if no game in progress).

Reorder press-delay walkthrough (mobile 375×812 especially — touch is where this matters):
- [ ] **CardPackEditorModal** — open the editor; swipe vertically over a category row → body scrolls smoothly. Long-press (250 ms) a category → drag activates and reorders. Long-press a card row inside a category → reorders within that category. Tap arrow / trash buttons → fire immediately, no drag. Long-hold a trash button for >250 ms → does NOT start a drag.
- [ ] **PlayerListReorder** (setup wizard "Players" step) — swipe over a player row → scrolls. Long-press → reorders.
- [ ] **Desktop** — mouse-drag still works (250 ms hold then drag).

Other:
- [ ] Setup wizard's "Known cards" / "My cards" steps — sticky `<thead>` still pins below the fixed page header (unchanged: those render on the page, not in a modal).

## Commits

1. `a7a5f9d` — Initial MyCardsModal fix (foundational ModalStack header-slot + sticky-offset reset)
2. `41c3206` — Migrate all `ModalStack`-using modals (Splash / Install / Stale / Account / Logout / CardPackEditor / TeachToggle / Confirm / Prompt) to header/content/footer slots; introduce `modalSlotStore`
3. `95ec288` — Extract static `Modal` component; migrate `ShareImportPage` + `ShareMissingPage` to use it; `ModalStack` shell renders through the same `ModalChrome` + `ModalBands`
4. `f1803c1` — Migrate `ShareCreateModal` (multi-step toggles ↔ sign-in) to the three-slot pattern via `modalSlotStore` for cross-slot reactive state
5. `5f96200` — Add press-delay drag activation for reorder lists (`CardPackEditorModal` categories + cards, `PlayerListReorder` players); 7 unit tests for the helper

## Verification

- `pnpm typecheck` ✓
- `pnpm lint` ✓
- `pnpm test` ✓ (1588 passed, +7 new reorder-press tests)
- `pnpm knip` ✓
- `pnpm i18n:check` ✓
- `pnpm dev` boots clean; `/play` HTTP 200
- **No browser-based visual verification** — please walk the test plan above before merging.

Do NOT merge until I (the human) have walked the test plan in the next-dev preview.

https://claude.ai/code/session_01Lboj2k11qxPDBYmowLZSzN