### PR TITLE
Adjust sticky footer z-index from 40 to 39

### DIFF
--- a/src/ui/setup/SetupWizard.tsx
+++ b/src/ui/setup/SetupWizard.tsx
@@ -578,15 +578,25 @@ export function SetupWizard() {
     const stickyFooter = (
         <div
             className={
-                // z-index must clear the card-selection grid's
-                // sticky-left tiers (`--z-checklist-sticky-column`
-                // at 30 for card-name cells, `--z-checklist-sticky-header`
-                // at 39 for the thead). Without this, the grid's
-                // sticky-left card-name column paints over the CTA
-                // bar as the user scrolls vertically past the bar's
-                // pin position — "Conservatory" / "Dining room" et
-                // al leak through the bg-panel.
-                "sticky bottom-0 z-[40] flex flex-wrap items-center gap-2 " +
+                // z-index sits just below `--z-app-chrome` (40) so
+                // the page header's `bg-bg` paints over the footer
+                // when scroll lands the section's natural bottom in
+                // the header's vertical zone — otherwise the
+                // footer's `bg-panel` would leak through the
+                // header's transparent stack and visually overlap
+                // the title.
+                //
+                // Still clears the card-selection grid's sticky-left
+                // tiers (`--z-checklist-sticky-column` at 30 for the
+                // card-name cells): without z > 30 those cells leak
+                // through the bg-panel — "Conservatory" / "Dining
+                // room" et al — as the user scrolls vertically past
+                // the bar's pin position. The grid's sticky-top
+                // thead (`--z-checklist-sticky-header` at 39) ties
+                // with the footer at 39; the footer paints over it
+                // via DOM source order (the footer is rendered after
+                // `{children}` in `SetupStepPanel`).
+                "sticky bottom-0 z-[39] flex flex-wrap items-center gap-2 " +
                 "rounded-b-[var(--radius)] border-t border-border/30 " +
                 "bg-panel px-4 py-3 " +
                 "[padding-bottom:calc(env(safe-area-inset-bottom,0px)+0.75rem)] " +


### PR DESCRIPTION
## Summary

Adjusts the z-index of the sticky footer in SetupWizard from 40 to 39 to fix a visual layering issue where the footer's background would leak through the page header when scrolling.

## Changes

- **Z-index adjustment**: Changed `z-[40]` to `z-[39]` on the sticky footer element
- **Documentation update**: Expanded the comment explaining the z-index rationale to clarify:
  - The footer now sits just below the app chrome (40) so the header's background paints over it when the section scrolls into the header's vertical zone
  - The footer still clears the card-selection grid's sticky-left columns (z-index 30)
  - The footer ties with the grid's sticky header (both at 39), with the footer winning via DOM source order since it renders after `{children}` in `SetupStepPanel`

## Implementation Details

The z-index change prevents the footer's `bg-panel` from visually overlapping the page header's title when the user scrolls vertically. The footer maintains proper layering above the card-selection grid's sticky columns while allowing the header to paint over it when needed.

https://claude.ai/code/session_01KDSXJFPQaVjKKVBb9VLaYF