### PR TITLE
Teach-mode Y/N/O/C keyboard shortcuts on the checklist grid

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -351,7 +351,8 @@
     "teachMode": {
         "yourMarkLabel": "Your mark",
         "markOff": "Off",
-        "checkThisCellButton": "Check {card}",
+        "shortcutHint": "Type ({y}, {n}, or {off}) to toggle your mark, ({check}) to check.",
+        "checkThisCellButton": "Check {card}{shortcut}",
         "verdictVerifiable": "You are right — this is provable from the evidence.",
         "verdictFalsifiable": "This contradicts the evidence — the evidence proves <deducerVerdict></deducerVerdict>.",
         "verdictPlausible": "This could be true, but there is no proof yet — keep gathering clues.",

--- a/src/ui/components/Checklist.teachMode.test.tsx
+++ b/src/ui/components/Checklist.teachMode.test.tsx
@@ -1,0 +1,180 @@
+import { act, fireEvent, renderHook } from "@testing-library/react";
+import { HashMap } from "effect";
+import { createElement, forwardRef } from "react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+// -----------------------------------------------------------------------
+// Mocks — same shape as Checklist.deduce.test.tsx, plus stubs for the
+// tour and teach-mode-check providers so we don't have to mount the
+// full Clue shell. We only care that `<Checklist />` installs its
+// window keydown listener under our ClueProvider + SelectionProvider.
+// -----------------------------------------------------------------------
+
+vi.mock("next-intl", () => {
+    const t = (key: string, values?: Record<string, unknown>): string =>
+        values ? `${key}:${JSON.stringify(values)}` : key;
+    (t as unknown as { rich: unknown }).rich = (key: string): string => key;
+    return {
+        useTranslations: () => t,
+        useLocale: () => "en",
+    };
+});
+
+vi.mock("../hooks/useIsDesktop", () => ({
+    useIsDesktop: () => true,
+}));
+
+vi.mock("../hooks/useHasKeyboard", () => ({
+    useHasKeyboard: () => true,
+}));
+
+vi.mock("../hooks/useConfetti", () => ({
+    useConfetti: () => ({ fireConfetti: () => {} }),
+}));
+
+vi.mock("../hooks/useReducedTransition", () => ({
+    useReducedTransition: () => false,
+}));
+
+vi.mock("motion/react", () => {
+    const motion = new Proxy(
+        {},
+        {
+            get: (_t, tag: string) =>
+                forwardRef(
+                    (
+                        props: Record<string, unknown>,
+                        ref: React.Ref<HTMLElement>,
+                    ) => {
+                        const {
+                            layout: _layout,
+                            layoutId: _layoutId,
+                            initial: _initial,
+                            animate: _animate,
+                            exit: _exit,
+                            transition: _transition,
+                            variants: _variants,
+                            custom: _custom,
+                            whileHover: _whileHover,
+                            whileTap: _whileTap,
+                            ...rest
+                        } = props;
+                        return createElement(tag, { ...rest, ref });
+                    },
+                ),
+        },
+    );
+    return {
+        motion,
+        AnimatePresence: ({ children }: { children: ReactNode }) => children,
+        useReducedMotion: () => false,
+        LayoutGroup: ({ children }: { children: ReactNode }) => children,
+    };
+});
+
+// Stub the tour provider — Checklist reads `currentStep` for cell-tour
+// gating, but the gate-under-test (the hypothesis-handler bail-out on
+// teach mode) doesn't depend on any tour state.
+vi.mock("../tour/TourProvider", () => ({
+    useTour: () => ({ currentStep: undefined }),
+}));
+
+// Stub the teach-mode-check context — Checklist calls
+// `useTeachModeCheck()` for the toolbar's "Check my work" flow, which
+// is unrelated to the keydown gate this test verifies.
+vi.mock("./TeachModeCheckContext", () => ({
+    useTeachModeCheck: () => ({
+        verdictForCell: () => undefined,
+        runCheck: () => {},
+        banner: null,
+        clearBanner: () => {},
+    }),
+}));
+
+import { CLASSIC_SETUP_3P } from "../../logic/GameSetup";
+import { PlayerOwner } from "../../logic/GameObjects";
+import { Cell } from "../../logic/Knowledge";
+import { cardByName } from "../../logic/test-utils/CardByName";
+import { TestQueryClientProvider } from "../../test-utils/queryClient";
+import { SelectionProvider, useSelection } from "../SelectionContext";
+import { ClueProvider, useClue } from "../state";
+import { Checklist } from "./Checklist";
+
+const setup = CLASSIC_SETUP_3P;
+const PLAYER_1 = setup.players[0]!;
+const KNIFE = cardByName(setup, "Knife");
+const cell = Cell(PlayerOwner(PLAYER_1), KNIFE);
+
+const makeWrapper = () => {
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+        <TestQueryClientProvider>
+            <ClueProvider>
+                <SelectionProvider>
+                    {children}
+                    <Checklist />
+                </SelectionProvider>
+            </ClueProvider>
+        </TestQueryClientProvider>
+    );
+    return Wrapper;
+};
+
+const renderUnderProvider = () => {
+    const wrapper = makeWrapper();
+    return renderHook(
+        () => ({
+            clue: useClue(),
+            sel: useSelection(),
+        }),
+        { wrapper },
+    );
+};
+
+beforeEach(() => {
+    window.localStorage.clear();
+});
+
+describe("Checklist — hypothesis keydown listener is gated on teach mode", () => {
+    test("pressing Y with the popover open in teach mode does NOT set a hypothesis", () => {
+        const h = renderUnderProvider();
+        act(() => {
+            h.result.current.clue.dispatch({ type: "setSetup", setup });
+        });
+        act(() => {
+            h.result.current.clue.dispatch({
+                type: "setTeachMode",
+                enabled: true,
+            });
+        });
+        act(() => {
+            h.result.current.sel.setPopoverCell(cell);
+        });
+
+        act(() => {
+            fireEvent.keyDown(window, { key: "y" });
+        });
+
+        // Gate worked: no hypothesis was set.
+        expect(HashMap.size(h.result.current.clue.state.hypotheses)).toBe(0);
+    });
+
+    test("pressing Y with the popover open OUTSIDE teach mode still sets a hypothesis (gate doesn't over-fire)", () => {
+        const h = renderUnderProvider();
+        act(() => {
+            h.result.current.clue.dispatch({ type: "setSetup", setup });
+        });
+        // teachMode stays false (default).
+        act(() => {
+            h.result.current.sel.setPopoverCell(cell);
+        });
+
+        act(() => {
+            fireEvent.keyDown(window, { key: "y" });
+        });
+
+        expect(
+            HashMap.get(h.result.current.clue.state.hypotheses, cell),
+        ).toMatchObject({ _tag: "Some", value: "Y" });
+    });
+});

--- a/src/ui/components/Checklist.teachMode.test.tsx
+++ b/src/ui/components/Checklist.teachMode.test.tsx
@@ -1,8 +1,8 @@
-import { act, fireEvent, renderHook } from "@testing-library/react";
+import { act, cleanup, fireEvent, renderHook } from "@testing-library/react";
 import { HashMap } from "effect";
 import { createElement, forwardRef } from "react";
 import type { ReactNode } from "react";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 // -----------------------------------------------------------------------
 // Mocks — same shape as Checklist.deduce.test.tsx, plus stubs for the
@@ -74,15 +74,15 @@ vi.mock("motion/react", () => {
 });
 
 // Stub the tour provider — Checklist reads `currentStep` for cell-tour
-// gating, but the gate-under-test (the hypothesis-handler bail-out on
-// teach mode) doesn't depend on any tour state.
+// gating, but the keydown gates under test don't depend on any tour
+// state.
 vi.mock("../tour/TourProvider", () => ({
     useTour: () => ({ currentStep: undefined }),
 }));
 
 // Stub the teach-mode-check context — Checklist calls
 // `useTeachModeCheck()` for the toolbar's "Check my work" flow, which
-// is unrelated to the keydown gate this test verifies.
+// is unrelated to the keydown gates this file verifies.
 vi.mock("./TeachModeCheckContext", () => ({
     useTeachModeCheck: () => ({
         verdictForCell: () => undefined,
@@ -94,7 +94,7 @@ vi.mock("./TeachModeCheckContext", () => ({
 
 import { CLASSIC_SETUP_3P } from "../../logic/GameSetup";
 import { PlayerOwner } from "../../logic/GameObjects";
-import { Cell } from "../../logic/Knowledge";
+import { Cell, N, Y } from "../../logic/Knowledge";
 import { cardByName } from "../../logic/test-utils/CardByName";
 import { TestQueryClientProvider } from "../../test-utils/queryClient";
 import { SelectionProvider, useSelection } from "../SelectionContext";
@@ -131,13 +131,195 @@ const renderUnderProvider = () => {
     );
 };
 
+// Locate a checklist cell (`<td>`) by the (cell card, owner index). The
+// `data-cell-row` / `data-cell-col` attributes are written by the
+// Checklist render so the test can target the same cell the production
+// keydown handler reads via `document.activeElement`. We pick the
+// first interactive cell on the Knife row + Player 1 column.
+//
+// jsdom doesn't resolve implicit ARIA roles on `<th>`, so we walk
+// `<tr>` elements directly and match on the first cell's text.
+const findKnifePlayer1Cell = (): HTMLElement | null => {
+    const rows = document.querySelectorAll<HTMLTableRowElement>("tr");
+    for (const tr of rows) {
+        const firstTh = tr.querySelector<HTMLTableCellElement>("th");
+        if (firstTh?.textContent?.includes("Knife")) {
+            return tr.querySelector<HTMLElement>(
+                "[data-cell-row][data-cell-col='0']",
+            );
+        }
+    }
+    return null;
+};
+
+const enableTeachMode = (
+    h: ReturnType<typeof renderUnderProvider>,
+    teach: boolean,
+) => {
+    act(() => {
+        h.result.current.clue.dispatch({ type: "setSetup", setup });
+    });
+    act(() => {
+        h.result.current.clue.dispatch({
+            type: "setTeachMode",
+            enabled: teach,
+        });
+    });
+    // Move out of setup mode so the focused-cell fallback gate
+    // (`uiMode !== "setup"`) lets through Y/N/O on the focused cell.
+    act(() => {
+        h.result.current.clue.dispatch({
+            type: "setUiMode",
+            mode: "checklist",
+        });
+    });
+};
+
 beforeEach(() => {
     window.localStorage.clear();
+    // The URL drives `setUiMode` via the ClueProvider hydration
+    // effect — without clearing it, a previous test's setUiMode call
+    // bleeds the `?view=` param into the next mount.
+    window.history.replaceState(null, "", "/");
 });
 
-describe("Checklist — hypothesis keydown listener is gated on teach mode", () => {
-    test("pressing Y with the popover open in teach mode does NOT set a hypothesis", () => {
+afterEach(() => {
+    // Defensive unmount + DOM clear so stale Checklists from previous
+    // renders can't shadow the `findKnifePlayer1Cell` lookup.
+    cleanup();
+    document.body.innerHTML = "";
+});
+
+describe("Checklist keyboard — teach mode dispatches setUserDeduction (not setHypothesis)", () => {
+    test("Y with the popover open in teach mode sets a USER DEDUCTION, not a hypothesis", () => {
         const h = renderUnderProvider();
+        enableTeachMode(h, true);
+        act(() => {
+            h.result.current.sel.setPopoverCell(cell);
+        });
+
+        act(() => {
+            fireEvent.keyDown(window, { key: "y" });
+        });
+
+        expect(HashMap.size(h.result.current.clue.state.hypotheses)).toBe(0);
+        expect(
+            HashMap.get(h.result.current.clue.state.userDeductions, cell),
+        ).toMatchObject({ _tag: "Some", value: Y });
+    });
+
+    test("N with the popover open in teach mode sets the user mark to N", () => {
+        const h = renderUnderProvider();
+        enableTeachMode(h, true);
+        act(() => {
+            h.result.current.sel.setPopoverCell(cell);
+        });
+
+        act(() => {
+            fireEvent.keyDown(window, { key: "n" });
+        });
+
+        expect(
+            HashMap.get(h.result.current.clue.state.userDeductions, cell),
+        ).toMatchObject({ _tag: "Some", value: N });
+    });
+
+    test("O with the popover open in teach mode clears any existing user mark", () => {
+        const h = renderUnderProvider();
+        enableTeachMode(h, true);
+        // Seed a Y mark on the cell.
+        act(() => {
+            h.result.current.clue.dispatch({
+                type: "setUserDeduction",
+                cell,
+                value: Y,
+            });
+        });
+        act(() => {
+            h.result.current.sel.setPopoverCell(cell);
+        });
+
+        act(() => {
+            fireEvent.keyDown(window, { key: "o" });
+        });
+
+        expect(
+            HashMap.get(h.result.current.clue.state.userDeductions, cell),
+        ).toMatchObject({ _tag: "None" });
+    });
+});
+
+describe("Checklist keyboard — teach mode + focused-cell fallback (panel closed)", () => {
+    test("Y on a focused cell with NO popover open marks that focused cell", () => {
+        const h = renderUnderProvider();
+        enableTeachMode(h, true);
+        // No popover. Focus the Knife / Player 1 cell directly.
+        const focusEl = findKnifePlayer1Cell();
+        expect(focusEl).not.toBeNull();
+        act(() => {
+            focusEl!.focus();
+        });
+        expect(document.activeElement).toBe(focusEl);
+
+        act(() => {
+            fireEvent.keyDown(window, { key: "y" });
+        });
+
+        // The mark landed on the focused cell (Knife / Player 1).
+        expect(
+            HashMap.get(h.result.current.clue.state.userDeductions, cell),
+        ).toMatchObject({ _tag: "Some", value: Y });
+        // No hypothesis was set anywhere.
+        expect(HashMap.size(h.result.current.clue.state.hypotheses)).toBe(0);
+    });
+
+    test("Y on a non-cell focused element is a no-op (focused-cell ref doesn't leak)", () => {
+        const h = renderUnderProvider();
+        enableTeachMode(h, true);
+        // First focus a cell to populate `focusedCellRef`.
+        const focusEl = findKnifePlayer1Cell();
+        expect(focusEl).not.toBeNull();
+        act(() => {
+            focusEl!.focus();
+        });
+        // Now move focus off the cell onto a button — the handler
+        // verifies activeElement is a checklist cell at keypress time,
+        // so the ref's stale value must not bleed through.
+        const stranger = document.createElement("button");
+        document.body.appendChild(stranger);
+        act(() => {
+            stranger.focus();
+        });
+        expect(document.activeElement).toBe(stranger);
+
+        act(() => {
+            fireEvent.keyDown(window, { key: "y" });
+        });
+
+        expect(
+            HashMap.size(h.result.current.clue.state.userDeductions),
+        ).toBe(0);
+        document.body.removeChild(stranger);
+    });
+
+    test("Y with no popover AND no focused cell is a no-op", () => {
+        const h = renderUnderProvider();
+        enableTeachMode(h, true);
+        // Don't focus any cell. document.activeElement is body.
+
+        act(() => {
+            fireEvent.keyDown(window, { key: "y" });
+        });
+
+        expect(
+            HashMap.size(h.result.current.clue.state.userDeductions),
+        ).toBe(0);
+        expect(HashMap.size(h.result.current.clue.state.hypotheses)).toBe(0);
+    });
+
+    test("Y on a focused cell in SETUP mode is a no-op (focused-cell fallback gated on uiMode)", () => {
+        const h = renderUnderProvider();
+        // Enable teach mode but leave uiMode at the default "setup".
         act(() => {
             h.result.current.clue.dispatch({ type: "setSetup", setup });
         });
@@ -147,24 +329,29 @@ describe("Checklist — hypothesis keydown listener is gated on teach mode", () 
                 enabled: true,
             });
         });
+        // Explicitly assert we're in setup mode.
+        expect(h.result.current.clue.state.uiMode).toBe("setup");
+
+        const focusEl = findKnifePlayer1Cell();
+        expect(focusEl).not.toBeNull();
         act(() => {
-            h.result.current.sel.setPopoverCell(cell);
+            focusEl!.focus();
         });
 
         act(() => {
             fireEvent.keyDown(window, { key: "y" });
         });
 
-        // Gate worked: no hypothesis was set.
-        expect(HashMap.size(h.result.current.clue.state.hypotheses)).toBe(0);
+        expect(
+            HashMap.size(h.result.current.clue.state.userDeductions),
+        ).toBe(0);
     });
+});
 
-    test("pressing Y with the popover open OUTSIDE teach mode still sets a hypothesis (gate doesn't over-fire)", () => {
+describe("Checklist keyboard — non-teach mode behavior unchanged", () => {
+    test("Y with the popover open OUTSIDE teach mode still sets a hypothesis", () => {
         const h = renderUnderProvider();
-        act(() => {
-            h.result.current.clue.dispatch({ type: "setSetup", setup });
-        });
-        // teachMode stays false (default).
+        enableTeachMode(h, false);
         act(() => {
             h.result.current.sel.setPopoverCell(cell);
         });
@@ -176,5 +363,26 @@ describe("Checklist — hypothesis keydown listener is gated on teach mode", () 
         expect(
             HashMap.get(h.result.current.clue.state.hypotheses, cell),
         ).toMatchObject({ _tag: "Some", value: "Y" });
+    });
+
+    test("Y on a focused cell with no popover in NON-teach mode is a no-op (no fallback)", () => {
+        const h = renderUnderProvider();
+        enableTeachMode(h, false);
+        const focusEl = findKnifePlayer1Cell();
+        expect(focusEl).not.toBeNull();
+        act(() => {
+            focusEl!.focus();
+        });
+
+        act(() => {
+            fireEvent.keyDown(window, { key: "y" });
+        });
+
+        // No hypothesis dispatched — the non-teach branch requires
+        // popoverCell !== null. Focused-cell fallback is teach-mode only.
+        expect(HashMap.size(h.result.current.clue.state.hypotheses)).toBe(0);
+        expect(
+            HashMap.size(h.result.current.clue.state.userDeductions),
+        ).toBe(0);
     });
 });

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -353,12 +353,14 @@ export function Checklist() {
         realKnowledge,
         jointKnowledge,
         jointFailed,
+        teachMode: state.teachMode,
     });
     analyticsCtxRef.current = {
         hypotheses,
         realKnowledge,
         jointKnowledge,
         jointFailed,
+        teachMode: state.teachMode,
     };
     useEffect(() => {
         const onKeyDown = (e: KeyboardEvent) => {
@@ -373,6 +375,12 @@ export function Checklist() {
             const cell = popoverCellRef.current;
             if (cell === null) return;
             const ctx = analyticsCtxRef.current;
+            // In teach mode the panel body renders `TeachModeCellCheck`
+            // instead of the hypothesis section, and it owns its own
+            // Y/N/O/C shortcuts on the same letter keys. Skip here so
+            // a single press never dispatches both `setHypothesis` and
+            // `setUserDeduction`.
+            if (ctx.teachMode) return;
             const prevValue = hypothesisValueFor(ctx.hypotheses, cell);
             const cellStatus = statusFor(
                 cell,

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -305,6 +305,14 @@ export function Checklist() {
     //   - no why popover is open (`popoverCell === null`).
     const popoverCellRef = useRef<Cell | null>(popoverCell);
     popoverCellRef.current = popoverCell;
+    // Most-recently-focused cell. In teach mode the Y/N/O shortcuts
+    // mark the focused cell when no popover is open, so the user can
+    // sweep the grid by tab/arrow + Y/N/O without first opening the
+    // explanation panel each time. Updated by each cell's `onFocus`;
+    // the keydown handler validates that `document.activeElement` is
+    // still a checklist cell before reading the ref so a stale value
+    // can't bleed into a press while focus is on a button elsewhere.
+    const focusedCellRef = useRef<Cell | null>(null);
     // Touch two-tap protocol. On touch devices, the first tap on a
     // cell only focuses it; a second tap on the already-focused cell
     // is what opens its explanation row. Mouse and keyboard remain
@@ -354,6 +362,7 @@ export function Checklist() {
         jointKnowledge,
         jointFailed,
         teachMode: state.teachMode,
+        uiMode: state.uiMode,
     });
     analyticsCtxRef.current = {
         hypotheses,
@@ -361,6 +370,7 @@ export function Checklist() {
         jointKnowledge,
         jointFailed,
         teachMode: state.teachMode,
+        uiMode: state.uiMode,
     };
     useEffect(() => {
         const onKeyDown = (e: KeyboardEvent) => {
@@ -372,15 +382,66 @@ export function Checklist() {
             ) {
                 return;
             }
-            const cell = popoverCellRef.current;
-            if (cell === null) return;
             const ctx = analyticsCtxRef.current;
-            // In teach mode the panel body renders `TeachModeCellCheck`
-            // instead of the hypothesis section, and it owns its own
-            // Y/N/O/C shortcuts on the same letter keys. Skip here so
-            // a single press never dispatches both `setHypothesis` and
-            // `setUserDeduction`.
-            if (ctx.teachMode) return;
+            const popover = popoverCellRef.current;
+            // Teach mode: Y/N/O fire on whichever cell the user is
+            // currently engaging with — the open explanation panel's
+            // cell if any, else the focused cell. The focused-cell
+            // fallback is gated on (a) we're not in setup mode (the
+            // wizard's grid uses these keys for nothing — user marks
+            // there go through known-cards, not user-deductions) and
+            // (b) the activeElement is still a `<td>` checklist cell,
+            // so `focusedCellRef` can't bleed into a press while the
+            // user's focus has moved to a button elsewhere.
+            //
+            // C is intentionally NOT handled here — it's owned by
+            // `TeachModeCellCheck`, whose lifetime is exactly the
+            // panel's open lifetime, so C correctly only fires when
+            // the panel is open.
+            if (ctx.teachMode) {
+                const activeEl =
+                    typeof document !== "undefined"
+                        ? document.activeElement
+                        : null;
+                const activeIsCell =
+                    activeEl instanceof HTMLElement
+                    && activeEl.hasAttribute("data-cell-row");
+                const focusedFallback =
+                    ctx.uiMode !== "setup" && activeIsCell
+                        ? focusedCellRef.current
+                        : null;
+                const teachCell = popover ?? focusedFallback;
+                if (teachCell === null) return;
+                if (matches("teachMode.markY", e)) {
+                    e.preventDefault();
+                    dispatch({
+                        type: "setUserDeduction",
+                        cell: teachCell,
+                        value: Y,
+                    });
+                } else if (matches("teachMode.markN", e)) {
+                    e.preventDefault();
+                    dispatch({
+                        type: "setUserDeduction",
+                        cell: teachCell,
+                        value: N,
+                    });
+                } else if (matches("teachMode.markOff", e)) {
+                    e.preventDefault();
+                    dispatch({
+                        type: "setUserDeduction",
+                        cell: teachCell,
+                        value: null,
+                    });
+                }
+                return;
+            }
+            // Non-teach mode: hypothesis Y/N/O only fire on an open
+            // popover. No focused-cell fallback — the visual hint
+            // lives inside the panel, so the shortcut shouldn't fire
+            // when the user has no panel-anchored context.
+            if (popover === null) return;
+            const cell = popover;
             const prevValue = hypothesisValueFor(ctx.hypotheses, cell);
             const cellStatus = statusFor(
                 cell,
@@ -1640,11 +1701,13 @@ export function Checklist() {
                                         const onGridArrowKey = (
                                             e: React.KeyboardEvent<HTMLTableCellElement>,
                                         ) => navigateGrid(e, rowIdx, colIdx, bounds);
-                                        const onCellFocus = () =>
+                                        const onCellFocus = () => {
                                             rememberChecklistCell(
                                                 rowIdx,
                                                 colIdx,
                                             );
+                                            focusedCellRef.current = cellRef;
+                                        };
                                         // Tour anchors:
                                         //   - `setup-known-cell` ("Mark
                                         //     the cards you were dealt")

--- a/src/ui/components/TeachModeCellCheck.test.tsx
+++ b/src/ui/components/TeachModeCellCheck.test.tsx
@@ -1,0 +1,255 @@
+import { act, fireEvent, renderHook } from "@testing-library/react";
+import { HashMap } from "effect";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { CLASSIC_SETUP_3P } from "../../logic/GameSetup";
+import { PlayerOwner } from "../../logic/GameObjects";
+import { Cell, N, Y } from "../../logic/Knowledge";
+import { cardByName } from "../../logic/test-utils/CardByName";
+import { TestQueryClientProvider } from "../../test-utils/queryClient";
+import { ClueProvider, useClue } from "../state";
+import { TeachModeCellCheck } from "./TeachModeCellCheck";
+
+// Light i18n shim — preserves namespace + key + interpolated values so
+// the test can assert on the rendered button label including the
+// `{shortcut}` suffix.
+vi.mock("next-intl", () => {
+    const t = (key: string, values?: Record<string, unknown>): string => {
+        if (!values) return key;
+        // Render in a deterministic form. The Check-button assertions
+        // care about the `shortcut` placeholder specifically, so when
+        // present we splice it in directly; other values append as
+        // `:{json}` for easy contains-checks.
+        if ("shortcut" in values) {
+            const { shortcut, ...rest } = values;
+            const restJson = Object.keys(rest).length
+                ? `:${JSON.stringify(rest)}`
+                : "";
+            return `${key}${restJson}${String(shortcut ?? "")}`;
+        }
+        return `${key}:${JSON.stringify(values)}`;
+    };
+    (t as unknown as { rich: unknown }).rich = (
+        key: string,
+        values?: Record<string, unknown>,
+    ): unknown => (values === undefined ? key : key);
+    return { useTranslations: () => t };
+});
+
+// useHasKeyboard is mocked via a mutable flag so each test can toggle
+// the keyboard / touch path without juggling jsdom userAgent.
+let hasKeyboardOverride = true;
+vi.mock("../hooks/useHasKeyboard", () => ({
+    useHasKeyboard: () => hasKeyboardOverride,
+}));
+
+// Spy on the analytics emitter so we can assert how many times Check
+// fired (zero, one, etc.) without sending real PostHog events.
+vi.mock("../../analytics/events", async () => {
+    const actual = await vi.importActual<
+        typeof import("../../analytics/events")
+    >("../../analytics/events");
+    return {
+        ...actual,
+        teachModeCellCheckUsed: vi.fn(),
+    };
+});
+
+import { teachModeCellCheckUsed } from "../../analytics/events";
+
+const setup = CLASSIC_SETUP_3P;
+const PLAYER_1 = setup.players[0]!;
+const KNIFE = cardByName(setup, "Knife");
+const cell = Cell(PlayerOwner(PLAYER_1), KNIFE);
+
+// Single provider hosts BOTH the renderHook (so the test can read /
+// dispatch via `useClue`) AND the panel under test, so the panel's
+// `useClue()` sees the same state object the test mutates.
+const makeWrapper = () => {
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+        <TestQueryClientProvider>
+            <ClueProvider>
+                {children}
+                <TeachModeCellCheck cell={cell} setup={setup} />
+            </ClueProvider>
+        </TestQueryClientProvider>
+    );
+    return Wrapper;
+};
+
+const renderPanel = () => {
+    const wrapper = makeWrapper();
+    const h = renderHook(() => useClue(), { wrapper });
+    act(() => {
+        h.result.current.dispatch({ type: "setSetup", setup });
+    });
+    act(() => {
+        h.result.current.dispatch({ type: "setTeachMode", enabled: true });
+    });
+    return { h };
+};
+
+beforeEach(() => {
+    window.localStorage.clear();
+    hasKeyboardOverride = true;
+    vi.mocked(teachModeCellCheckUsed).mockClear();
+});
+
+afterEach(() => {
+    // Make sure the window keydown listener installed by the panel
+    // doesn't leak across tests.
+    document.body.innerHTML = "";
+});
+
+describe("TeachModeCellCheck — keyboard shortcuts", () => {
+    test("Y dispatches setUserDeduction(cell, Y)", () => {
+        const { h } = renderPanel();
+        act(() => {
+            fireEvent.keyDown(window, { key: "y" });
+        });
+        const mark = HashMap.get(h.result.current.state.userDeductions, cell);
+        expect(mark).toMatchObject({ _tag: "Some", value: Y });
+    });
+
+    test("N dispatches setUserDeduction(cell, N)", () => {
+        const { h } = renderPanel();
+        act(() => {
+            fireEvent.keyDown(window, { key: "n" });
+        });
+        const mark = HashMap.get(h.result.current.state.userDeductions, cell);
+        expect(mark).toMatchObject({ _tag: "Some", value: N });
+    });
+
+    test("O clears any existing mark", () => {
+        const { h } = renderPanel();
+        // Seed an existing Y mark first.
+        act(() => {
+            h.result.current.dispatch({
+                type: "setUserDeduction",
+                cell,
+                value: Y,
+            });
+        });
+        expect(
+            HashMap.get(h.result.current.state.userDeductions, cell),
+        ).toMatchObject({ _tag: "Some", value: Y });
+
+        act(() => {
+            fireEvent.keyDown(window, { key: "o" });
+        });
+        expect(
+            HashMap.get(h.result.current.state.userDeductions, cell),
+        ).toMatchObject({ _tag: "None" });
+    });
+
+    test("uppercase letters fire the same shortcuts (case-insensitive)", () => {
+        const { h } = renderPanel();
+        act(() => {
+            fireEvent.keyDown(window, { key: "Y" });
+        });
+        const mark = HashMap.get(h.result.current.state.userDeductions, cell);
+        expect(mark).toMatchObject({ _tag: "Some", value: Y });
+    });
+
+    test("C reveals the verdict and fires analytics once", () => {
+        renderPanel();
+        // Pre-reveal: Check button is visible.
+        expect(document.body.textContent).toContain("checkThisCellButton");
+
+        act(() => {
+            fireEvent.keyDown(window, { key: "c" });
+        });
+
+        expect(teachModeCellCheckUsed).toHaveBeenCalledTimes(1);
+        // Post-reveal: the Check button is replaced by the verdict
+        // banner — its label string is no longer present in the body.
+        // (The actual verdict for a fresh game with no marks is
+        // "unknown", which the panel renders without the
+        // "checkThisCellButton" string.)
+        expect(document.body.textContent).not.toContain("checkThisCellButton");
+    });
+
+    test("C is a no-op while already revealed (does not re-fire analytics)", () => {
+        renderPanel();
+        // First press reveals.
+        act(() => {
+            fireEvent.keyDown(window, { key: "c" });
+        });
+        expect(teachModeCellCheckUsed).toHaveBeenCalledTimes(1);
+
+        // Second press while still revealed.
+        act(() => {
+            fireEvent.keyDown(window, { key: "c" });
+        });
+        expect(teachModeCellCheckUsed).toHaveBeenCalledTimes(1);
+    });
+
+    test("setting a new mark via keyboard collapses the verdict so C is live again", () => {
+        renderPanel();
+        act(() => {
+            fireEvent.keyDown(window, { key: "c" });
+        });
+        expect(teachModeCellCheckUsed).toHaveBeenCalledTimes(1);
+        // The Check button is gone now.
+        expect(document.body.textContent).not.toContain("checkThisCellButton");
+
+        // Setting a fresh mark collapses the reveal, restoring the
+        // Check button and re-arming the C shortcut.
+        act(() => {
+            fireEvent.keyDown(window, { key: "y" });
+        });
+        expect(document.body.textContent).toContain("checkThisCellButton");
+
+        act(() => {
+            fireEvent.keyDown(window, { key: "c" });
+        });
+        expect(teachModeCellCheckUsed).toHaveBeenCalledTimes(2);
+    });
+
+    test("keystroke targeted at a text input is ignored", () => {
+        const { h } = renderPanel();
+        // Mount a stray text input — simulates the SuggestionLogPanel
+        // text input sitting alongside the panel on desktop.
+        const input = document.createElement("input");
+        input.type = "text";
+        document.body.appendChild(input);
+        input.focus();
+
+        act(() => {
+            fireEvent.keyDown(input, { key: "y" });
+        });
+        const mark = HashMap.get(h.result.current.state.userDeductions, cell);
+        expect(mark).toMatchObject({ _tag: "None" });
+    });
+});
+
+describe("TeachModeCellCheck — keyboard hint visibility", () => {
+    test("renders the shortcut hint when useHasKeyboard returns true", () => {
+        hasKeyboardOverride = true;
+        renderPanel();
+        expect(document.body.textContent).toContain("shortcutHint");
+    });
+
+    test("does NOT render the shortcut hint when useHasKeyboard returns false", () => {
+        hasKeyboardOverride = false;
+        renderPanel();
+        expect(document.body.textContent).not.toContain("shortcutHint");
+    });
+
+    test("Check button label includes the (C) suffix when useHasKeyboard returns true", () => {
+        hasKeyboardOverride = true;
+        renderPanel();
+        // The next-intl mock splices `shortcut` directly into the
+        // returned string. `shortcutSuffix` returns ` (C)` on keyboard.
+        expect(document.body.textContent).toContain("checkThisCellButton");
+        expect(document.body.textContent).toContain(" (C)");
+    });
+
+    test("Check button label omits the (C) suffix when useHasKeyboard returns false", () => {
+        hasKeyboardOverride = false;
+        renderPanel();
+        expect(document.body.textContent).toContain("checkThisCellButton");
+        expect(document.body.textContent).not.toContain(" (C)");
+    });
+});

--- a/src/ui/components/TeachModeCellCheck.test.tsx
+++ b/src/ui/components/TeachModeCellCheck.test.tsx
@@ -1,11 +1,10 @@
-import { act, fireEvent, renderHook } from "@testing-library/react";
-import { HashMap } from "effect";
+import { act, cleanup, fireEvent, renderHook } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import { CLASSIC_SETUP_3P } from "../../logic/GameSetup";
 import { PlayerOwner } from "../../logic/GameObjects";
-import { Cell, N, Y } from "../../logic/Knowledge";
+import { Cell, Y } from "../../logic/Knowledge";
 import { cardByName } from "../../logic/test-utils/CardByName";
 import { TestQueryClientProvider } from "../../test-utils/queryClient";
 import { ClueProvider, useClue } from "../state";
@@ -17,10 +16,6 @@ import { TeachModeCellCheck } from "./TeachModeCellCheck";
 vi.mock("next-intl", () => {
     const t = (key: string, values?: Record<string, unknown>): string => {
         if (!values) return key;
-        // Render in a deterministic form. The Check-button assertions
-        // care about the `shortcut` placeholder specifically, so when
-        // present we splice it in directly; other values append as
-        // `:{json}` for easy contains-checks.
         if ("shortcut" in values) {
             const { shortcut, ...rest } = values;
             const restJson = Object.keys(rest).length
@@ -97,61 +92,15 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-    // Make sure the window keydown listener installed by the panel
-    // doesn't leak across tests.
+    // Unmount React trees so each component's `useEffect` cleanup
+    // fires — critical for the window-keydown listener, which would
+    // otherwise accumulate across tests and fire the analytics spy
+    // multiple times on a single press.
+    cleanup();
     document.body.innerHTML = "";
 });
 
-describe("TeachModeCellCheck — keyboard shortcuts", () => {
-    test("Y dispatches setUserDeduction(cell, Y)", () => {
-        const { h } = renderPanel();
-        act(() => {
-            fireEvent.keyDown(window, { key: "y" });
-        });
-        const mark = HashMap.get(h.result.current.state.userDeductions, cell);
-        expect(mark).toMatchObject({ _tag: "Some", value: Y });
-    });
-
-    test("N dispatches setUserDeduction(cell, N)", () => {
-        const { h } = renderPanel();
-        act(() => {
-            fireEvent.keyDown(window, { key: "n" });
-        });
-        const mark = HashMap.get(h.result.current.state.userDeductions, cell);
-        expect(mark).toMatchObject({ _tag: "Some", value: N });
-    });
-
-    test("O clears any existing mark", () => {
-        const { h } = renderPanel();
-        // Seed an existing Y mark first.
-        act(() => {
-            h.result.current.dispatch({
-                type: "setUserDeduction",
-                cell,
-                value: Y,
-            });
-        });
-        expect(
-            HashMap.get(h.result.current.state.userDeductions, cell),
-        ).toMatchObject({ _tag: "Some", value: Y });
-
-        act(() => {
-            fireEvent.keyDown(window, { key: "o" });
-        });
-        expect(
-            HashMap.get(h.result.current.state.userDeductions, cell),
-        ).toMatchObject({ _tag: "None" });
-    });
-
-    test("uppercase letters fire the same shortcuts (case-insensitive)", () => {
-        const { h } = renderPanel();
-        act(() => {
-            fireEvent.keyDown(window, { key: "Y" });
-        });
-        const mark = HashMap.get(h.result.current.state.userDeductions, cell);
-        expect(mark).toMatchObject({ _tag: "Some", value: Y });
-    });
-
+describe("TeachModeCellCheck — C keyboard shortcut", () => {
     test("C reveals the verdict and fires analytics once", () => {
         renderPanel();
         // Pre-reveal: Check button is visible.
@@ -164,10 +113,15 @@ describe("TeachModeCellCheck — keyboard shortcuts", () => {
         expect(teachModeCellCheckUsed).toHaveBeenCalledTimes(1);
         // Post-reveal: the Check button is replaced by the verdict
         // banner — its label string is no longer present in the body.
-        // (The actual verdict for a fresh game with no marks is
-        // "unknown", which the panel renders without the
-        // "checkThisCellButton" string.)
         expect(document.body.textContent).not.toContain("checkThisCellButton");
+    });
+
+    test("uppercase C is also accepted (case-insensitive binding)", () => {
+        renderPanel();
+        act(() => {
+            fireEvent.keyDown(window, { key: "C" });
+        });
+        expect(teachModeCellCheckUsed).toHaveBeenCalledTimes(1);
     });
 
     test("C is a no-op while already revealed (does not re-fire analytics)", () => {
@@ -185,30 +139,62 @@ describe("TeachModeCellCheck — keyboard shortcuts", () => {
         expect(teachModeCellCheckUsed).toHaveBeenCalledTimes(1);
     });
 
-    test("setting a new mark via keyboard collapses the verdict so C is live again", () => {
-        renderPanel();
+    test("changing the mark (via reducer dispatch) collapses the reveal so C is live again", () => {
+        const { h } = renderPanel();
         act(() => {
             fireEvent.keyDown(window, { key: "c" });
         });
         expect(teachModeCellCheckUsed).toHaveBeenCalledTimes(1);
-        // The Check button is gone now.
         expect(document.body.textContent).not.toContain("checkThisCellButton");
 
-        // Setting a fresh mark collapses the reveal, restoring the
-        // Check button and re-arming the C shortcut.
+        // Dispatch a fresh mark via the reducer (mirrors what
+        // Checklist's window-level Y/N/O handler does on a key
+        // press — the dispatch happens OUTSIDE this component, not
+        // through its local `setMark`).
         act(() => {
-            fireEvent.keyDown(window, { key: "y" });
+            h.result.current.dispatch({
+                type: "setUserDeduction",
+                cell,
+                value: Y,
+            });
         });
+        // The mark-reset effect collapses the verdict on any change
+        // to `userMark` (whether via local `setMark` or external
+        // dispatch), so the Check button is back.
         expect(document.body.textContent).toContain("checkThisCellButton");
 
+        // C re-fires now that the panel is back to its pre-reveal
+        // state.
         act(() => {
             fireEvent.keyDown(window, { key: "c" });
         });
         expect(teachModeCellCheckUsed).toHaveBeenCalledTimes(2);
     });
 
-    test("keystroke targeted at a text input is ignored", () => {
-        const { h } = renderPanel();
+    test("clicking a MarkPicker option also collapses the reveal", () => {
+        renderPanel();
+        act(() => {
+            fireEvent.keyDown(window, { key: "c" });
+        });
+        expect(teachModeCellCheckUsed).toHaveBeenCalledTimes(1);
+        expect(document.body.textContent).not.toContain("checkThisCellButton");
+
+        // Local `setMark` path: clicking the Y MarkPicker button (index
+        // 1) flips userDeductions from empty → {cell: Y}. The
+        // mark-reset effect detects the change and collapses the
+        // verdict. (Clicking Off (index 0) on an already-empty mark
+        // would be a no-op and not exercise the effect.)
+        const yButton = Array.from(
+            document.querySelectorAll<HTMLButtonElement>('[role="radio"]'),
+        )[1];
+        act(() => {
+            yButton?.click();
+        });
+        expect(document.body.textContent).toContain("checkThisCellButton");
+    });
+
+    test("C targeted at a text input is ignored", () => {
+        renderPanel();
         // Mount a stray text input — simulates the SuggestionLogPanel
         // text input sitting alongside the panel on desktop.
         const input = document.createElement("input");
@@ -217,10 +203,11 @@ describe("TeachModeCellCheck — keyboard shortcuts", () => {
         input.focus();
 
         act(() => {
-            fireEvent.keyDown(input, { key: "y" });
+            fireEvent.keyDown(input, { key: "c" });
         });
-        const mark = HashMap.get(h.result.current.state.userDeductions, cell);
-        expect(mark).toMatchObject({ _tag: "None" });
+        // Analytics never fired and the Check button is still present.
+        expect(teachModeCellCheckUsed).toHaveBeenCalledTimes(0);
+        expect(document.body.textContent).toContain("checkThisCellButton");
     });
 });
 

--- a/src/ui/components/TeachModeCellCheck.tsx
+++ b/src/ui/components/TeachModeCellCheck.tsx
@@ -2,7 +2,7 @@
 
 import { HashMap, Result } from "effect";
 import { useTranslations } from "next-intl";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { findCardEntry, type GameSetup } from "../../logic/GameSetup";
 import { ownerLabel } from "../../logic/GameObjects";
 import {
@@ -20,6 +20,8 @@ import {
 } from "../../logic/TeachMode";
 import { teachModeCellCheckUsed } from "../../analytics/events";
 import { useClue } from "../state";
+import { useHasKeyboard } from "../hooks/useHasKeyboard";
+import { label, matches, shortcutSuffix } from "../keyMap";
 import { AlertIcon, CheckIcon, LightbulbIcon } from "./Icons";
 import { ProseChecklistIcon } from "./CellGlyph";
 import { buildCellWhy } from "./cellWhy";
@@ -57,6 +59,7 @@ export function TeachModeCellCheck({
     const tReasons = useTranslations("reasons");
     const { state, derived, dispatch } = useClue();
     const [revealed, setRevealed] = useState(false);
+    const hasKeyboard = useHasKeyboard();
 
     const cardLabel =
         findCardEntry(setup, cell.card)?.name ?? String(cell.card);
@@ -93,12 +96,65 @@ export function TeachModeCellCheck({
         setRevealed(false);
     };
 
+    // Window-level keyboard shortcuts (Y / N / O / C). The listener is
+    // installed once on mount and removed on unmount, so its lifetime
+    // matches the panel's open lifetime. Latest values for the
+    // callbacks and `revealed` flow through refs so the listener
+    // doesn't need re-registering on every render.
+    const setMarkRef = useRef(setMark);
+    setMarkRef.current = setMark;
+    const onCheckClickRef = useRef(onCheckClick);
+    onCheckClickRef.current = onCheckClick;
+    const revealedRef = useRef(revealed);
+    revealedRef.current = revealed;
+    useEffect(() => {
+        const onKeyDown = (e: KeyboardEvent) => {
+            const target = e.target as Element | null;
+            if (
+                target instanceof HTMLInputElement
+                || target instanceof HTMLTextAreaElement
+                || (target instanceof HTMLElement && target.isContentEditable)
+            ) {
+                return;
+            }
+            if (matches("teachMode.markY", e)) {
+                e.preventDefault();
+                setMarkRef.current(Y);
+            } else if (matches("teachMode.markN", e)) {
+                e.preventDefault();
+                setMarkRef.current(N);
+            } else if (matches("teachMode.markOff", e)) {
+                e.preventDefault();
+                setMarkRef.current(null);
+            } else if (matches("teachMode.check", e)) {
+                // Mirror the button's visibility: only fire pre-reveal,
+                // so the analytics event doesn't double-fire after the
+                // verdict is already shown.
+                if (revealedRef.current) return;
+                e.preventDefault();
+                onCheckClickRef.current();
+            }
+        };
+        window.addEventListener("keydown", onKeyDown);
+        return () => window.removeEventListener("keydown", onKeyDown);
+    }, []);
+
     return (
         <section className="flex flex-col gap-3 px-4 py-3">
             <div className="text-[1.125rem] font-bold uppercase tracking-wide text-accent">
                 {t("yourMarkLabel")}
             </div>
             <MarkPicker value={userMark} onChange={setMark} />
+            {hasKeyboard && (
+                <p className="m-0 text-[1rem] text-muted">
+                    {t("shortcutHint", {
+                        y: label("teachMode.markY"),
+                        n: label("teachMode.markN"),
+                        off: label("teachMode.markOff"),
+                        check: label("teachMode.check"),
+                    })}
+                </p>
+            )}
             <div className="border-t border-border" />
             {revealed ? (
                 <VerdictDisplay
@@ -119,7 +175,10 @@ export function TeachModeCellCheck({
                     onClick={onCheckClick}
                     className="self-start cursor-pointer rounded border border-accent bg-accent px-3 py-1.5 text-[1.125rem] font-semibold text-panel hover:bg-accent/90 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2"
                 >
-                    {t("checkThisCellButton", { card: cardLabel })}
+                    {t("checkThisCellButton", {
+                        card: cardLabel,
+                        shortcut: shortcutSuffix("teachMode.check", hasKeyboard),
+                    })}
                 </button>
             )}
         </section>

--- a/src/ui/components/TeachModeCellCheck.tsx
+++ b/src/ui/components/TeachModeCellCheck.tsx
@@ -90,19 +90,24 @@ export function TeachModeCellCheck({
 
     const setMark = (next: UserDeductionValue | null) => {
         dispatch({ type: "setUserDeduction", cell, value: next });
-        // Setting a new value invalidates the previously-shown verdict
-        // — collapse the reveal so the user has to press "Check this
-        // cell" again to see the updated verdict.
-        setRevealed(false);
     };
 
-    // Window-level keyboard shortcuts (Y / N / O / C). The listener is
-    // installed once on mount and removed on unmount, so its lifetime
-    // matches the panel's open lifetime. Latest values for the
-    // callbacks and `revealed` flow through refs so the listener
-    // doesn't need re-registering on every render.
-    const setMarkRef = useRef(setMark);
-    setMarkRef.current = setMark;
+    // Setting a new value invalidates the previously-shown verdict —
+    // collapse the reveal so the user has to press "Check" again to
+    // see the updated verdict. Runs for any mark change, whether the
+    // mark moved via this component's `MarkPicker` or via Checklist's
+    // window-level Y/N/O handler (which dispatches `setUserDeduction`
+    // directly, bypassing `setMark`).
+    useEffect(() => {
+        setRevealed(false);
+    }, [userMark, cell]);
+
+    // C shortcut: reveal the verdict. Y/N/O are owned by Checklist's
+    // window-level handler (so they also work when this panel is
+    // closed but a cell is focused) — the only reason C lives here
+    // and not there is that the verdict's reveal state is local to
+    // this component, and gating C on `!revealed` keeps the analytics
+    // event from double-firing once the verdict is already shown.
     const onCheckClickRef = useRef(onCheckClick);
     onCheckClickRef.current = onCheckClick;
     const revealedRef = useRef(revealed);
@@ -117,23 +122,10 @@ export function TeachModeCellCheck({
             ) {
                 return;
             }
-            if (matches("teachMode.markY", e)) {
-                e.preventDefault();
-                setMarkRef.current(Y);
-            } else if (matches("teachMode.markN", e)) {
-                e.preventDefault();
-                setMarkRef.current(N);
-            } else if (matches("teachMode.markOff", e)) {
-                e.preventDefault();
-                setMarkRef.current(null);
-            } else if (matches("teachMode.check", e)) {
-                // Mirror the button's visibility: only fire pre-reveal,
-                // so the analytics event doesn't double-fire after the
-                // verdict is already shown.
-                if (revealedRef.current) return;
-                e.preventDefault();
-                onCheckClickRef.current();
-            }
+            if (!matches("teachMode.check", e)) return;
+            if (revealedRef.current) return;
+            e.preventDefault();
+            onCheckClickRef.current();
         };
         window.addEventListener("keydown", onKeyDown);
         return () => window.removeEventListener("keydown", onKeyDown);

--- a/src/ui/keyMap.ts
+++ b/src/ui/keyMap.ts
@@ -115,6 +115,14 @@ type BindingId =
     | "hypothesis.setOff"
     | "hypothesis.setY"
     | "hypothesis.setN"
+    // Teach-mode cell controls — only active when the teach-mode
+    // cell explanation panel is mounted (i.e. a cell is open AND
+    // `state.teachMode` is true). The handler lives inside
+    // `TeachModeCellCheck`, whose lifetime is exactly the panel's.
+    | "teachMode.markOff"
+    | "teachMode.markY"
+    | "teachMode.markN"
+    | "teachMode.check"
     // Navigation primitives (scoped)
     | "nav.up"
     | "nav.down"
@@ -193,6 +201,31 @@ const DEFAULT_KEY_MAP: Record<BindingId, KeyBinding> = {
         id: "hypothesis.setN",
         description: "Set the hypothesis on the open cell to N",
         combos: [combo.bareCI("n", "N")],
+    },
+    // Teach-mode mark shortcuts intentionally use the same letters as
+    // the hypothesis triple — the two are mutually exclusive (the panel
+    // body switches between hypothesis and teach-mode UIs based on
+    // `state.teachMode`), and the Checklist hypothesis handler gates
+    // itself on `!state.teachMode` so only one path can fire per press.
+    "teachMode.markOff": {
+        id: "teachMode.markOff",
+        description: "Turn off the teach-mode mark on the open cell",
+        combos: [combo.bareCI("o", "O")],
+    },
+    "teachMode.markY": {
+        id: "teachMode.markY",
+        description: "Mark the open cell as has (teach mode)",
+        combos: [combo.bareCI("y", "Y")],
+    },
+    "teachMode.markN": {
+        id: "teachMode.markN",
+        description: "Mark the open cell as does-not-have (teach mode)",
+        combos: [combo.bareCI("n", "N")],
+    },
+    "teachMode.check": {
+        id: "teachMode.check",
+        description: "Check the open cell against the deducer's verdict",
+        combos: [combo.bareCI("c", "C")],
     },
     "nav.up": {
         id: "nav.up",


### PR DESCRIPTION
## Summary

- **Teach-me mode** now responds to four keyboard shortcuts on the checklist grid:
  - **Y / N / O** set the user's mark on the focused cell — works whether the cell explanation panel is open or closed. Sweep the grid by tab/arrow, press a letter, move on.
  - **C** presses "Check this cell" to reveal the verdict — only while the panel is open (its `revealed` state is local to the panel).
  - A hint line below the MarkPicker (`Type ({y}, {n}, or {off}) to toggle your mark, ({check}) to check.`) and a trailing `(C)` on the Check button advertise the shortcuts when the panel is open. Touch devices see neither (gated on `useHasKeyboard()`).
- **Non-teach mode** is unchanged: hypothesis Y/N/O still require an open popover, no focused-cell fallback.
- **Latent bug fixed**: with the new teach-mode bindings sharing letter keys with the hypothesis bindings, the existing hypothesis listener would have fired alongside the teach-mode handler. The hypothesis handler now bails out when `state.teachMode` is true.

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm test` — 1607 passed (+19 from baseline 1588), via two new test files
- [x] `pnpm knip`
- [x] `pnpm i18n:check`
- [x] Manual walk at desktop 1280×800 in `next-dev`:
  - Closed panel + focused cell + Y/N/O → mark lands on the focused cell. Hypotheses stays empty.
  - Tab to a different cell + Y → mark lands on the new focused cell.
  - Open panel + C → verdict revealed; Check button hides.
  - Open panel + N after C → mark flips to N, verdict collapses, Check button re-arms (re-pressing C re-fires analytics).
  - C with closed panel → no-op (panel stays closed).
  - Focus a non-cell button + Y → no mark dispatched (focused-cell ref doesn't leak through the activeElement gate).
  - Typing Y/N/O/C inside a text input → no shortcut fires.
  - Disabled teach mode: closed-panel Y → no hypothesis. Open-panel Y → hypothesis set (existing behavior preserved).
- [x] No console warnings during any interaction.
- [ ] **Verify on Vercel preview** — exercise the four shortcuts with the panel open AND closed, with focus on a cell AND with focus elsewhere.

## Commits

1. `Add keyboard shortcuts to Teach Me cell explanation panel` — introduces the four `teachMode.*` bindings in `keyMap.ts`, adds the in-panel keydown handler, hint line, and `(C)` button suffix in `TeachModeCellCheck.tsx`, and gates the existing hypothesis-shortcut keydown handler on `!state.teachMode` in `Checklist.tsx`. Adds `messages/en.json` entries (`teachMode.shortcutHint` + `{shortcut}` placeholder on `teachMode.checkThisCellButton`).
2. `Teach-mode Y/N/O work on the focused cell with no panel open` — hoists teach-mode Y/N/O dispatch out of `TeachModeCellCheck` into `Checklist`'s window keydown handler so the shortcuts fire on the focused cell when no panel is open. Introduces a `focusedCellRef` updated by each cell's `onFocus`, gated by `state.uiMode !== "setup"` and an `activeElement is a checklist cell` check at keypress time. Adds a `useEffect` in `TeachModeCellCheck` that collapses the verdict on any `userMark` change (covers both the local MarkPicker click path and external Checklist dispatch). Expands `Checklist.teachMode.test.tsx` with focused-cell + non-cell-focus + setup-mode + non-teach-mode-fallback cases; prunes `TeachModeCellCheck.test.tsx` to cover only C + hint visibility + button suffix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)