### PR TITLE
Pin open setup-wizard step header to top while scrolling

### DIFF
--- a/src/ui/setup/SetupStepPanel.tsx
+++ b/src/ui/setup/SetupStepPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AnimatePresence, motion } from "motion/react";
-import { useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { T_STANDARD, useReducedTransition } from "../motion";
 import { AlertIcon, CheckIcon } from "../components/Icons";
 import type { StepValidation, WizardStepId } from "./wizardSteps";
@@ -125,6 +125,37 @@ export function SetupStepPanel({
     const isComplete = state === "complete";
     const isEditMode = wizardMode === "edit";
 
+    // While the panel is open, publish its sticky header's height to
+    // `--setup-accordion-header-offset` so descendant sticky-thead
+    // rules (e.g. `CardSelectionGrid`'s `<thead>`) can stack BELOW
+    // the pinned accordion header instead of behind it. Matches the
+    // `--header-offset` ResizeObserver pattern in `Clue.tsx`. Cleared
+    // to `0px` on collapse so closed panels don't leave a phantom
+    // offset behind. Only one panel is `editing` at a time, so the
+    // single document-root variable is safely owned by the open one.
+    const headerRef = useRef<HTMLButtonElement>(null);
+    useEffect(() => {
+        if (!isEditing) return;
+        const el = headerRef.current;
+        if (!el) return;
+        const root = document.documentElement;
+        const write = () =>
+            root.style.setProperty(
+                "--setup-accordion-header-offset",
+                `${el.offsetHeight}px`,
+            );
+        write();
+        const ro = new ResizeObserver(write);
+        ro.observe(el);
+        return () => {
+            ro.disconnect();
+            root.style.setProperty(
+                "--setup-accordion-header-offset",
+                "0px",
+            );
+        };
+    }, [isEditing]);
+
     // Dim the header only in flow mode's "pending" treatment.
     // Edit mode renders every closed step at full opacity — they're
     // all equally accessible, dimming would mis-signal "locked."
@@ -158,8 +189,23 @@ export function SetupStepPanel({
             aria-current={isEditing ? "step" : undefined}
         >
             <button
+                ref={headerRef}
                 type="button"
+                // When the panel is open, the header pins to the top
+                // of the page (below the fixed page header + the
+                // contradiction banner if present) so the user keeps
+                // sight of the current step's question as they scroll
+                // through long body content. `bg-panel` covers the
+                // body content scrolling under it, and the conditional
+                // `border-b` carries the body/header divider with the
+                // sticky header (instead of the body wrapper, where
+                // it would scroll out of view). Closed panels stay
+                // in normal flow — no sticky treatment.
                 className={`flex w-full items-center justify-between gap-3 rounded-t-[var(--radius)] px-4 py-3 text-left ${
+                    isEditing
+                        ? "sticky top-[calc(var(--contradiction-banner-offset,0px)+var(--header-offset,0px))] z-[var(--z-checklist-sticky-header)] border-b border-border/30 bg-panel"
+                        : ""
+                } ${
                     headerClickable
                         ? "cursor-pointer hover:bg-hover"
                         : "cursor-default"
@@ -230,7 +276,7 @@ export function SetupStepPanel({
                         onAnimationComplete={() => setBodyAnimating(false)}
                         className={bodyAnimating ? "overflow-hidden" : ""}
                     >
-                        <div className="border-t border-border/30 px-4 py-4">
+                        <div className="px-4 py-4">
                             <div className="flex flex-col gap-4">
                                 {children}
 

--- a/src/ui/setup/shared/CardSelectionGrid.tsx
+++ b/src/ui/setup/shared/CardSelectionGrid.tsx
@@ -70,17 +70,22 @@ const CELL_INTERACTIVE_RING =
 //   - --z-checklist-sticky-header (39): thead non-corner cells —
 //     covers the body's sticky-left column on horizontal scroll
 //
-// `top` resolves to "below the fixed page header (and contradiction
-// banner if it's visible)" via the same CSS variables Clue.tsx
-// publishes for the play-mode Checklist. When the wizard is the only
-// thing on screen, those variables fall back to 0 so the thead pins
-// to viewport top. The `z-index` on the thead element itself is
-// load-bearing — `position: sticky` alone doesn't elevate the thead
-// above tbody in the table's stacking, so without the explicit
-// z-index the body's `<td>` (later in document order) would paint
-// over the thead during scroll. Matches `Checklist.tsx`'s thead.
+// `top` resolves to "below the fixed page header, the contradiction
+// banner if it's visible, and the sticky setup accordion-step header
+// when this grid is rendered inside an open wizard step." Each
+// offset is published by its owner (Clue.tsx for `--header-offset`,
+// GlobalContradictionBanner for `--contradiction-banner-offset`,
+// SetupStepPanel for `--setup-accordion-header-offset`) via
+// ResizeObserver; outside their scope each falls back to 0 so the
+// thead degrades gracefully (e.g. when this grid is rendered in the
+// share-import modal, none of the wizard offset applies). The
+// `z-index` on the thead element itself is load-bearing —
+// `position: sticky` alone doesn't elevate the thead above tbody in
+// the table's stacking, so without the explicit z-index the body's
+// `<td>` (later in document order) would paint over the thead
+// during scroll. Matches `Checklist.tsx`'s thead.
 const STICKY_THEAD_TOP =
-    "sticky top-[calc(var(--contradiction-banner-offset,0px)+var(--header-offset,0px))] z-[var(--z-checklist-sticky-header)]";
+    "sticky top-[calc(var(--contradiction-banner-offset,0px)+var(--header-offset,0px)+var(--setup-accordion-header-offset,0px))] z-[var(--z-checklist-sticky-header)]";
 const STICKY_FIRST_COL =
     "sticky left-0 z-[var(--z-checklist-sticky-column)]";
 const STICKY_FIRST_COL_HEADER =


### PR DESCRIPTION
## Summary

When a setup wizard step is open and its body content scrolls past the viewport, the step's question header (e.g. "5. Do you know any other player's cards?") now stays pinned to the top of the page so you don't lose track of which step you're filling out. Closed steps stay in normal flow as before. The card-selection table's column header pins right below the sticky question header, so the player columns remain readable while still leaving the step's question visible above. The sticky footer ("Back / Next") continues to pin to the bottom of the viewport.

This makes the long card-selection steps (steps 5 and 6) significantly easier to navigate — and adds a small visual anchor for every other step too.

## Test plan

- [ ] Open each setup step (Card pack → Who's playing → Which player are you → Hand sizes → My cards → Other players' cards → Teach me mode → Invite others). With the step open and the body taller than the viewport, scroll the page; confirm the step header pins to the top below the page header.
- [ ] Confirm closed steps do NOT pin — scroll past them and they scroll out of view naturally.
- [ ] Switch between steps; previously-open step un-pins immediately, newly-open step takes over.
- [ ] Steps 5 / 6 (with `CardSelectionGrid`): table thead (Player columns + counter) pins right below the sticky step header — no overlap, no painted-over text. On mobile step 6, exercise the paginator (`< Player N of M >`).
- [ ] Trigger a contradiction (mark the same suspect "yes" for two players); reopen a step. Sticky step header should sit below both the banner and the page header.
- [ ] Sticky footer remains pinned to the bottom on desktop; on mobile it sits above the BottomNav.
- [ ] No console warnings or errors during the walk.

## Commit log

- `Pin open setup-wizard step header to top while scrolling` —
  `SetupStepPanel` publishes its open header's height to a new CSS variable `--setup-accordion-header-offset` via `ResizeObserver`, clearing to `0px` on collapse. The header `<button>` becomes `position: sticky` (top = `--header-offset + --contradiction-banner-offset`, `z-[var(--z-checklist-sticky-header)]`, `bg-panel`) when `isEditing` and `static` otherwise. The body wrapper's `border-t` migrates to the button as `border-b` so the divider stays with the sticky header. `CardSelectionGrid`'s `STICKY_THEAD_TOP` adds the new offset to its `top:` formula so the table head stacks below the pinned step header; outside the wizard the variable falls back to `0` and behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)