### PR TITLE
Preserve teach-me marks and hypotheses across the toggle

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -92,7 +92,8 @@
             "setUserDeduction": "marking {owner} {value, select, Y {has} other {does not have}} {card}",
             "clearUserDeduction": "clearing your mark on {owner} / {card}",
             "clearUserDeductions": "clearing all your teach-me marks",
-            "replaceUserDeductions": "filling your teach-me board from the deducer"
+            "replaceUserDeductions": "filling your teach-me board from the deducer",
+            "replaceHypotheses": "carrying your teach-me marks over as hypotheses"
         }
     },
     "setup": {
@@ -370,11 +371,11 @@
         "bannerDismissAria": "Dismiss feedback",
         "bannerSummaryAnd": " and ",
         "midGamePromptTitle": "Turn on teach-me mode?",
-        "midGamePromptBody": "Teach-me mode hides the solver's deductions so you can work the puzzle yourself. You can either start from your own explicit marks (and figure out the rest), or adopt everything the Clue Solver has already deduced as your starting point.",
+        "midGamePromptBody": "Teach-me mode hides the solver's deductions so you can work the puzzle yourself. You can either start from your own explicit marks (any active hypotheses come along as editable marks too), or adopt everything the Clue Solver has already deduced as your starting point.",
         "midGameOptionKeepExplicit": "Start with my explicit marks only",
         "midGameOptionAdoptDeductions": "Adopt the Clue Solver's deductions",
         "exitPromptTitle": "Exit teach-me mode?",
-        "exitPromptBody": "Leaving teach-me mode reveals all the deductions the solver has worked out, which may take the thinking and fun out of the rest of this game. You can turn teach-me back on later — your marks will be waiting.",
+        "exitPromptBody": "Leaving teach-me mode reveals all the deductions the solver has worked out, which may take the thinking and fun out of the rest of this game. Any marks that the solver can't already prove will be carried over as hypotheses so you can keep them in view. You can turn teach-me back on later — your marks will be waiting.",
         "exitPromptConfirm": "Exit teach-me mode",
         "menuLabel": "Teach me mode",
         "menuLabelActive": "Teach me mode (on)",

--- a/src/logic/ClueState.ts
+++ b/src/logic/ClueState.ts
@@ -164,6 +164,19 @@ export type ClueAction =
     | { type: "setUiMode"; mode: UiMode }
     | { type: "setHypothesis"; cell: Cell; value: HypothesisValue }
     | { type: "clearHypothesis"; cell: Cell }
+    /**
+     * Bulk-replace `hypotheses` and `hypothesisOrder` together. Used by
+     * the teach-mode exit path, which folds the user's unsubstantiated
+     * marks into the hypotheses map so the marks remain visible in
+     * non-teach mode. Existing hypothesis positions in
+     * `hypothesisOrder` are preserved; freshly converted marks append
+     * to the end. Atomic so the two slices can't drift apart.
+     */
+    | {
+          type: "replaceHypotheses";
+          hypotheses: HypothesisMap;
+          hypothesisOrder: ReadonlyArray<Cell>;
+      }
     | { type: "replaceSession"; session: GameSession }
     | { type: "setPendingSuggestion"; draft: PendingSuggestionDraft | null }
     /**

--- a/src/logic/TeachMode.test.ts
+++ b/src/logic/TeachMode.test.ts
@@ -1,0 +1,236 @@
+import { HashMap, Option } from "effect";
+import { describe, expect, test } from "vitest";
+
+import { CaseFileOwner, Card, Player, PlayerOwner } from "./GameObjects";
+import { emptyHypotheses, type HypothesisMap } from "./Hypothesis";
+import {
+    Cell,
+    Knowledge,
+    N as N_VAL,
+    Y as Y_VAL,
+    emptyKnowledge,
+} from "./Knowledge";
+import {
+    cellKey,
+    emptyUserDeductions,
+    mergeHypothesesIntoUserDeductions,
+    mergeUnsubstantiatedMarksIntoHypotheses,
+    type UserDeductionMap,
+} from "./TeachMode";
+
+function getOrFail<K, V>(map: HashMap.HashMap<K, V>, key: K): V {
+    return Option.getOrThrow(HashMap.get(map, key));
+}
+
+const ALICE = Player("Alice");
+const BOB = Player("Bob");
+const KNIFE = Card("knife");
+const ROPE = Card("rope");
+const PLUM = Card("plum");
+
+const cellAliceKnife = Cell(PlayerOwner(ALICE), KNIFE);
+const cellAliceRope = Cell(PlayerOwner(ALICE), ROPE);
+const cellBobKnife = Cell(PlayerOwner(BOB), KNIFE);
+const cellCasePlum = Cell(CaseFileOwner(), PLUM);
+
+const ud = (entries: ReadonlyArray<readonly [Cell, "Y" | "N"]>): UserDeductionMap =>
+    entries.reduce<UserDeductionMap>(
+        (acc, [cell, v]) => HashMap.set(acc, cell, v),
+        emptyUserDeductions,
+    );
+
+const hyp = (entries: ReadonlyArray<readonly [Cell, "Y" | "N"]>): HypothesisMap =>
+    entries.reduce<HypothesisMap>(
+        (acc, [cell, v]) => HashMap.set(acc, cell, v),
+        emptyHypotheses,
+    );
+
+const knowledgeWith = (
+    entries: ReadonlyArray<readonly [Cell, "Y" | "N"]>,
+): Knowledge =>
+    Knowledge({
+        checklist: entries.reduce(
+            (acc, [cell, v]) => HashMap.set(acc, cell, v),
+            emptyKnowledge.checklist,
+        ),
+        handSizes: emptyKnowledge.handSizes,
+    });
+
+describe("mergeHypothesesIntoUserDeductions", () => {
+    test("returns userDeductions unchanged when hypotheses is empty", () => {
+        const userDeductions = ud([[cellAliceKnife, Y_VAL]]);
+        const out = mergeHypothesesIntoUserDeductions(
+            userDeductions,
+            emptyHypotheses,
+        );
+        // HashMap iteration is a no-op; reference identity is preserved
+        // because we never call HashMap.set.
+        expect(out).toBe(userDeductions);
+    });
+
+    test("hypotheses-only input becomes the entire merged map", () => {
+        const out = mergeHypothesesIntoUserDeductions(
+            emptyUserDeductions,
+            hyp([[cellAliceKnife, Y_VAL], [cellBobKnife, N_VAL]]),
+        );
+        expect(HashMap.size(out)).toBe(2);
+        expect(getOrFail(out, cellAliceKnife)).toBe(Y_VAL);
+        expect(getOrFail(out, cellBobKnife)).toBe(N_VAL);
+    });
+
+    test("disjoint cells produce the union", () => {
+        const out = mergeHypothesesIntoUserDeductions(
+            ud([[cellAliceKnife, Y_VAL]]),
+            hyp([[cellBobKnife, N_VAL]]),
+        );
+        expect(HashMap.size(out)).toBe(2);
+        expect(getOrFail(out, cellAliceKnife)).toBe(Y_VAL);
+        expect(getOrFail(out, cellBobKnife)).toBe(N_VAL);
+    });
+
+    test("conflicting cell: hypothesis value wins", () => {
+        const out = mergeHypothesesIntoUserDeductions(
+            ud([[cellAliceKnife, Y_VAL]]),
+            hyp([[cellAliceKnife, N_VAL]]),
+        );
+        expect(HashMap.size(out)).toBe(1);
+        expect(getOrFail(out, cellAliceKnife)).toBe(N_VAL);
+    });
+
+    test("same value on same cell: no-op semantically (value preserved)", () => {
+        const out = mergeHypothesesIntoUserDeductions(
+            ud([[cellAliceKnife, Y_VAL]]),
+            hyp([[cellAliceKnife, Y_VAL]]),
+        );
+        expect(HashMap.size(out)).toBe(1);
+        expect(getOrFail(out, cellAliceKnife)).toBe(Y_VAL);
+    });
+});
+
+describe("mergeUnsubstantiatedMarksIntoHypotheses", () => {
+    test("empty userDeductions: returns inputs unchanged (identity)", () => {
+        const hypotheses = hyp([[cellAliceKnife, Y_VAL]]);
+        const order = [cellAliceKnife];
+        const out = mergeUnsubstantiatedMarksIntoHypotheses(
+            emptyUserDeductions,
+            knowledgeWith([]),
+            hypotheses,
+            order,
+        );
+        expect(out.hypotheses).toBe(hypotheses);
+        expect(out.hypothesisOrder).toBe(order);
+    });
+
+    test("substantiated mark is skipped (no change)", () => {
+        const hypotheses = emptyHypotheses;
+        const order: ReadonlyArray<Cell> = [];
+        const knowledge = knowledgeWith([[cellAliceKnife, Y_VAL]]);
+        const out = mergeUnsubstantiatedMarksIntoHypotheses(
+            ud([[cellAliceKnife, Y_VAL]]),
+            knowledge,
+            hypotheses,
+            order,
+        );
+        expect(out.hypotheses).toBe(hypotheses);
+        expect(out.hypothesisOrder).toBe(order);
+    });
+
+    test("unsubstantiated mark is added and appended to order", () => {
+        const out = mergeUnsubstantiatedMarksIntoHypotheses(
+            ud([[cellAliceKnife, Y_VAL]]),
+            knowledgeWith([]),
+            emptyHypotheses,
+            [],
+        );
+        expect(HashMap.size(out.hypotheses)).toBe(1);
+        expect(getOrFail(out.hypotheses, cellAliceKnife)).toBe(Y_VAL);
+        expect(out.hypothesisOrder).toHaveLength(1);
+        expect(out.hypothesisOrder[0]).toEqual(cellAliceKnife);
+    });
+
+    test("contradicting mark (user Y, knowledge N) is unsubstantiated and added", () => {
+        const out = mergeUnsubstantiatedMarksIntoHypotheses(
+            ud([[cellAliceKnife, Y_VAL]]),
+            knowledgeWith([[cellAliceKnife, N_VAL]]),
+            emptyHypotheses,
+            [],
+        );
+        expect(getOrFail(out.hypotheses, cellAliceKnife)).toBe(Y_VAL);
+        expect(out.hypothesisOrder).toHaveLength(1);
+    });
+
+    test("knowledge === undefined: every mark counts as unsubstantiated", () => {
+        const out = mergeUnsubstantiatedMarksIntoHypotheses(
+            ud([
+                [cellAliceKnife, Y_VAL],
+                [cellBobKnife, N_VAL],
+                [cellCasePlum, Y_VAL],
+            ]),
+            undefined,
+            emptyHypotheses,
+            [],
+        );
+        expect(HashMap.size(out.hypotheses)).toBe(3);
+        expect(out.hypothesisOrder).toHaveLength(3);
+    });
+
+    test("mark already in hypotheses with different value: mark wins, order position preserved", () => {
+        const priorOrder = [cellAliceKnife, cellBobKnife];
+        const out = mergeUnsubstantiatedMarksIntoHypotheses(
+            ud([[cellAliceKnife, N_VAL]]),
+            knowledgeWith([]),
+            hyp([[cellAliceKnife, Y_VAL], [cellBobKnife, Y_VAL]]),
+            priorOrder,
+        );
+        // Mark overwrites the prior hypothesis Y → N.
+        expect(getOrFail(out.hypotheses, cellAliceKnife)).toBe(N_VAL);
+        // Bob untouched.
+        expect(getOrFail(out.hypotheses, cellBobKnife)).toBe(Y_VAL);
+        // Order: existing positions intact, nothing appended.
+        expect(out.hypothesisOrder).toEqual(priorOrder);
+    });
+
+    test("multiple new marks all append AFTER existing order entries", () => {
+        const priorOrder = [cellBobKnife];
+        const out = mergeUnsubstantiatedMarksIntoHypotheses(
+            ud([
+                [cellAliceKnife, Y_VAL],
+                [cellAliceRope, N_VAL],
+                [cellCasePlum, Y_VAL],
+            ]),
+            knowledgeWith([]),
+            hyp([[cellBobKnife, Y_VAL]]),
+            priorOrder,
+        );
+        // First entry is still bob; the three new cells follow in some order.
+        expect(out.hypothesisOrder[0]).toEqual(cellBobKnife);
+        expect(out.hypothesisOrder).toHaveLength(4);
+        const appendedKeys = new Set(
+            out.hypothesisOrder.slice(1).map(cellKey),
+        );
+        expect(appendedKeys.has(cellKey(cellAliceKnife))).toBe(true);
+        expect(appendedKeys.has(cellKey(cellAliceRope))).toBe(true);
+        expect(appendedKeys.has(cellKey(cellCasePlum))).toBe(true);
+    });
+
+    test("mix of substantiated and unsubstantiated: only unsubstantiated added", () => {
+        const out = mergeUnsubstantiatedMarksIntoHypotheses(
+            ud([
+                [cellAliceKnife, Y_VAL], // substantiated
+                [cellBobKnife, N_VAL], // unsubstantiated (knowledge has no entry)
+                [cellAliceRope, Y_VAL], // unsubstantiated (knowledge has different value)
+            ]),
+            knowledgeWith([
+                [cellAliceKnife, Y_VAL],
+                [cellAliceRope, N_VAL],
+            ]),
+            emptyHypotheses,
+            [],
+        );
+        expect(HashMap.size(out.hypotheses)).toBe(2);
+        expect(HashMap.has(out.hypotheses, cellAliceKnife)).toBe(false);
+        expect(getOrFail(out.hypotheses, cellBobKnife)).toBe(N_VAL);
+        expect(getOrFail(out.hypotheses, cellAliceRope)).toBe(Y_VAL);
+        expect(out.hypothesisOrder).toHaveLength(2);
+    });
+});

--- a/src/logic/TeachMode.ts
+++ b/src/logic/TeachMode.ts
@@ -4,7 +4,8 @@ import { allCardIds, categoryOfCard } from "./CardSet";
 import type { Owner, Player } from "./GameObjects";
 import { CaseFileOwner, PlayerOwner } from "./GameObjects";
 import type { GameSetup } from "./GameSetup";
-import { Cell, getCell, type CellValue, type Knowledge } from "./Knowledge";
+import { Cell, getCell, getCellByOwnerCard, type CellValue, type Knowledge } from "./Knowledge";
+import type { HypothesisMap } from "./Hypothesis";
 import type { DeductionResult } from "./Deducer";
 
 /**
@@ -277,6 +278,88 @@ export const seedFromOwnHand = (
         }
     }
     return m;
+};
+
+/**
+ * Fold `hypotheses` into `userDeductions` for the teach-mode entry
+ * merge: each hypothesis becomes (or overwrites) a user-deduction
+ * mark. Hypothesis value wins on conflict — it represents the user's
+ * most recent edit in non-teach mode. Existing user-deduction entries
+ * for cells NOT in hypotheses are preserved.
+ */
+export const mergeHypothesesIntoUserDeductions = (
+    userDeductions: UserDeductionMap,
+    hypotheses: HypothesisMap,
+): UserDeductionMap => {
+    let out = userDeductions;
+    HashMap.forEach(hypotheses, (value, cell) => {
+        out = HashMap.set(out, cell, value);
+    });
+    return out;
+};
+
+export interface HypothesisMergeResult {
+    readonly hypotheses: HypothesisMap;
+    readonly hypothesisOrder: ReadonlyArray<Cell>;
+}
+
+/**
+ * Teach-mode exit merge: every user-deduction mark NOT substantiated by
+ * `knowledge` (the deducer's real-only output) becomes a hypothesis on
+ * the same cell. `userDeductions` itself is left untouched — the marks
+ * stay available for the next teach-mode session.
+ *
+ * - Substantiated mark: `getCellByOwnerCard(knowledge, owner, card) ===
+ *   value`. Skipped — adding it as a hypothesis would be redundant noise
+ *   in the hypotheses panel.
+ * - Contradicting mark (user Y, knowledge N): NOT substantiated → added
+ *   as a hypothesis, which then surfaces as `directly-contradicted` in
+ *   the hypothesis-conflict banner. Visible conflict beats vanished mark.
+ * - `knowledge === undefined` (deducer failed or not yet computed): be
+ *   conservative; every mark counts as unsubstantiated and becomes a
+ *   hypothesis.
+ * - Mark for a cell already in `hypotheses`: the mark's value wins
+ *   (overwrites the prior hypothesis). The cell's position in
+ *   `hypothesisOrder` is preserved.
+ * - New hypothesis cells append to the END of `hypothesisOrder` — bulk
+ *   conversion is not a fresh user action, so it shouldn't shove
+ *   existing hypotheses down the BehavioralInsights panel.
+ *
+ * When the merge produces no changes, returns the original `hypotheses`
+ * and `hypothesisOrder` references so the caller can skip a no-op
+ * dispatch via `===` comparison.
+ */
+export const mergeUnsubstantiatedMarksIntoHypotheses = (
+    userDeductions: UserDeductionMap,
+    knowledge: Knowledge | undefined,
+    hypotheses: HypothesisMap,
+    hypothesisOrder: ReadonlyArray<Cell>,
+): HypothesisMergeResult => {
+    let outHypotheses = hypotheses;
+    const appended: Cell[] = [];
+    const existingKeys = new Set<string>(hypothesisOrder.map(cellKey));
+    HashMap.forEach(userDeductions, (value, cell) => {
+        const substantiated =
+            knowledge !== undefined
+            && getCellByOwnerCard(knowledge, cell.owner, cell.card) === value;
+        if (substantiated) return;
+        outHypotheses = HashMap.set(outHypotheses, cell, value);
+        const k = cellKey(cell);
+        if (!existingKeys.has(k)) {
+            appended.push(cell);
+            existingKeys.add(k);
+        }
+    });
+    if (outHypotheses === hypotheses && appended.length === 0) {
+        return { hypotheses, hypothesisOrder };
+    }
+    return {
+        hypotheses: outHypotheses,
+        hypothesisOrder:
+            appended.length === 0
+                ? hypothesisOrder
+                : [...hypothesisOrder, ...appended],
+    };
 };
 
 /**

--- a/src/logic/describeAction.ts
+++ b/src/logic/describeAction.ts
@@ -212,6 +212,8 @@ export const describeAction = (
                     findCardEntry(setup, action.cell.card)?.name ??
                     String(action.cell.card),
             });
+        case "replaceHypotheses":
+            return t("actions.replaceHypotheses");
         case "reorderPlayers":
             return t("actions.reorderPlayers");
         case "reorderCategories":

--- a/src/ui/components/useTeachModeToggle.test.tsx
+++ b/src/ui/components/useTeachModeToggle.test.tsx
@@ -1,0 +1,620 @@
+import { act, renderHook, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { HashMap, Option } from "effect";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+// next-intl + motion/react mocks. The latter so jsdom doesn't choke on
+// the modal animation; the former so the modal button text is the raw
+// key (lets us click "midGameOptionKeepExplicit" etc. without
+// translation indirection).
+vi.mock("next-intl", () => {
+    const t = (key: string, values?: Record<string, unknown>): string =>
+        values ? `${key}:${JSON.stringify(values)}` : key;
+    (t as unknown as { rich: unknown }).rich = (key: string): string => key;
+    return {
+        useTranslations: () => t,
+        useLocale: () => "en",
+    };
+});
+
+vi.mock("motion/react", async () => {
+    const { forwardRef, createElement } = await import("react");
+    const motion = new Proxy(
+        {},
+        {
+            get: (_t, tag: string) =>
+                forwardRef(
+                    (
+                        props: Record<string, unknown>,
+                        ref: React.Ref<HTMLElement>,
+                    ) => {
+                        const {
+                            layout: _layout,
+                            layoutId: _layoutId,
+                            initial: _initial,
+                            animate: _animate,
+                            exit: _exit,
+                            transition: _transition,
+                            variants: _variants,
+                            custom: _custom,
+                            whileHover: _whileHover,
+                            whileTap: _whileTap,
+                            drag: _drag,
+                            ...rest
+                        } = props;
+                        return createElement(tag, { ...rest, ref });
+                    },
+                ),
+        },
+    );
+    return {
+        motion,
+        AnimatePresence: ({ children }: { children: ReactNode }) => children,
+        useReducedMotion: () => false,
+        LayoutGroup: ({ children }: { children: ReactNode }) => children,
+    };
+});
+
+// Imports below the mocks. Vitest hoists vi.mock to the top, so this
+// order doesn't matter at runtime — it just keeps the file readable.
+import { emptyHypotheses } from "../../logic/Hypothesis";
+import { Cell, N as N_VAL, Y as Y_VAL } from "../../logic/Knowledge";
+import { CLASSIC_SETUP_3P } from "../../logic/GameSetup";
+import { PlayerOwner } from "../../logic/GameObjects";
+import { cardByName } from "../../logic/test-utils/CardByName";
+import { emptyUserDeductions } from "../../logic/TeachMode";
+import { TestQueryClientProvider } from "../../test-utils/queryClient";
+import { ClueProvider, useClue } from "../state";
+import { ConfirmProvider } from "../hooks/useConfirm";
+import { ModalStackProvider, ModalStackShell } from "./ModalStack";
+import { useTeachModeToggle } from "./useTeachModeToggle";
+
+function getOrFail<K, V>(map: HashMap.HashMap<K, V>, key: K): V {
+    return Option.getOrThrow(HashMap.get(map, key));
+}
+
+const silenceConsoleError = () =>
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+beforeEach(() => {
+    window.localStorage.clear();
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+// Renders the provider tree needed for the toggle hook: state, modal
+// stack, confirm. ModalStackShell renders any pushed modal into the
+// DOM so the test can click confirm/cancel buttons via userEvent.
+const Wrapper = ({ children }: { readonly children: ReactNode }) => (
+    <TestQueryClientProvider>
+        <ClueProvider>
+            <ModalStackProvider>
+                <ConfirmProvider>
+                    <ModalStackShell />
+                    {children}
+                </ConfirmProvider>
+            </ModalStackProvider>
+        </ClueProvider>
+    </TestQueryClientProvider>
+);
+
+// Renders both the toggle and a state observer in the same provider
+// tree so we can drive the toggle and read the resulting state.
+const renderToggle = () => {
+    const harness = renderHook(
+        () => ({
+            requestSetTeachMode: useTeachModeToggle(),
+            clue: useClue(),
+        }),
+        { wrapper: Wrapper },
+    );
+    return harness;
+};
+
+// Seed a known game session with two players, one card per known-card
+// list. Lets us populate `userDeductions` / `hypotheses` deterministically
+// in each test.
+const seedSession = (clue: ReturnType<typeof useClue>) => {
+    const setup = CLASSIC_SETUP_3P;
+    const [first, second] = setup.players;
+    const knife = cardByName(setup, "Knife");
+    const rope = cardByName(setup, "Rope");
+    if (
+        first === undefined
+        || second === undefined
+        || knife === undefined
+        || rope === undefined
+    ) {
+        throw new Error("CLASSIC_SETUP_3P missing expected fixtures");
+    }
+    clue.dispatch({
+        type: "replaceSession",
+        session: {
+            setup,
+            hands: [{ player: first, cards: [knife] }],
+            handSizes: [],
+            suggestions: [],
+            accusations: [],
+            hypotheses: emptyHypotheses,
+            hypothesisOrder: [],
+            pendingSuggestion: null,
+            selfPlayerId: null,
+            firstDealtPlayerId: null,
+            dismissedInsights: new Map(),
+            teachMode: false,
+            userDeductions: emptyUserDeductions,
+        },
+    });
+    return { first, second, knife, rope };
+};
+
+describe("useTeachModeToggle — entry", () => {
+    test("wizard source: seeds from own hand, does NOT merge hypotheses", () => {
+        silenceConsoleError();
+        const { result } = renderToggle();
+        const setup = CLASSIC_SETUP_3P;
+        const [first, second] = setup.players;
+        const knife = cardByName(setup, "Knife");
+        if (first === undefined || second === undefined || knife === undefined) {
+            throw new Error("missing fixtures");
+        }
+
+        // Seed: self is `first`, holds Knife, has a hypothesis on
+        // (second, Rope) = Y. The wizard path replaces userDeductions
+        // wholesale from seedFromOwnHand and never reads hypotheses.
+        const rope = cardByName(setup, "Rope")!;
+        act(() => {
+            result.current.clue.dispatch({
+                type: "replaceSession",
+                session: {
+                    setup,
+                    hands: [{ player: first, cards: [knife] }],
+                    handSizes: [],
+                    suggestions: [],
+                    accusations: [],
+                    hypotheses: HashMap.set(
+                        emptyHypotheses,
+                        Cell(PlayerOwner(second), rope),
+                        Y_VAL,
+                    ),
+                    hypothesisOrder: [Cell(PlayerOwner(second), rope)],
+                    pendingSuggestion: null,
+                    selfPlayerId: first,
+                    firstDealtPlayerId: null,
+                    dismissedInsights: new Map(),
+                    teachMode: false,
+                    userDeductions: emptyUserDeductions,
+                },
+            });
+        });
+
+        act(() => result.current.requestSetTeachMode(true, "wizard"));
+
+        // teachMode flipped on.
+        expect(result.current.clue.state.teachMode).toBe(true);
+        // userDeductions has the own-hand seed (Y on first's column for
+        // Knife, N elsewhere), and does NOT contain the rope hypothesis.
+        expect(
+            HashMap.get(
+                result.current.clue.state.userDeductions,
+                Cell(PlayerOwner(second), rope),
+            )._tag,
+        ).toBe("None");
+        // The hypothesis itself is still present in state.
+        expect(
+            HashMap.size(result.current.clue.state.hypotheses),
+        ).toBe(1);
+    });
+
+    test("overflowMenu + keep-explicit: folds active hypotheses into userDeductions", async () => {
+        silenceConsoleError();
+        const user = userEvent.setup();
+        const { result } = renderToggle();
+        const setup = CLASSIC_SETUP_3P;
+        const [first, second] = setup.players;
+        const knife = cardByName(setup, "Knife");
+        const rope = cardByName(setup, "Rope");
+        if (
+            first === undefined
+            || second === undefined
+            || knife === undefined
+            || rope === undefined
+        ) {
+            throw new Error("missing fixtures");
+        }
+        const cellSecondRope = Cell(PlayerOwner(second), rope);
+
+        act(() => {
+            result.current.clue.dispatch({
+                type: "replaceSession",
+                session: {
+                    setup,
+                    hands: [],
+                    handSizes: [],
+                    suggestions: [],
+                    accusations: [],
+                    hypotheses: HashMap.set(
+                        emptyHypotheses,
+                        cellSecondRope,
+                        N_VAL,
+                    ),
+                    hypothesisOrder: [cellSecondRope],
+                    pendingSuggestion: null,
+                    selfPlayerId: null,
+                    firstDealtPlayerId: null,
+                    dismissedInsights: new Map(),
+                    teachMode: false,
+                    userDeductions: emptyUserDeductions,
+                },
+            });
+        });
+
+        act(() =>
+            result.current.requestSetTeachMode(true, "overflowMenu"),
+        );
+
+        // Modal is now in the DOM with the i18n key as button text.
+        const keepBtn = await screen.findByText(
+            "midGameOptionKeepExplicit",
+        );
+        await act(async () => {
+            await user.click(keepBtn);
+        });
+
+        // teachMode on, userDeductions now includes the (second, rope)
+        // hypothesis as a mark.
+        expect(result.current.clue.state.teachMode).toBe(true);
+        expect(
+            getOrFail(
+                result.current.clue.state.userDeductions,
+                cellSecondRope,
+            ),
+        ).toBe(N_VAL);
+    });
+
+    test("overflowMenu + keep-explicit + empty hypotheses: no merge dispatch (userDeductions unchanged)", async () => {
+        silenceConsoleError();
+        const user = userEvent.setup();
+        const { result } = renderToggle();
+        const { first, knife } = seedSession(result.current.clue);
+
+        // Pre-populate userDeductions with an unrelated mark to verify
+        // it's preserved.
+        const cellFirstKnife = Cell(PlayerOwner(first), knife);
+        act(() => {
+            result.current.clue.dispatch({
+                type: "setUserDeduction",
+                cell: cellFirstKnife,
+                value: Y_VAL,
+            });
+        });
+        const before = result.current.clue.state.userDeductions;
+
+        act(() =>
+            result.current.requestSetTeachMode(true, "overflowMenu"),
+        );
+        const keepBtn = await screen.findByText(
+            "midGameOptionKeepExplicit",
+        );
+        await act(async () => {
+            await user.click(keepBtn);
+        });
+
+        // Same reference — no replaceUserDeductions dispatch happened.
+        expect(result.current.clue.state.userDeductions).toBe(before);
+        expect(result.current.clue.state.teachMode).toBe(true);
+    });
+
+    test("overflowMenu + keep-explicit + conflicting hypothesis: hypothesis value wins", async () => {
+        silenceConsoleError();
+        const user = userEvent.setup();
+        const { result } = renderToggle();
+        const { first, knife } = seedSession(result.current.clue);
+        const cell = Cell(PlayerOwner(first), knife);
+
+        act(() => {
+            result.current.clue.dispatch({
+                type: "setUserDeduction",
+                cell,
+                value: Y_VAL,
+            });
+            result.current.clue.dispatch({
+                type: "setHypothesis",
+                cell,
+                value: N_VAL,
+            });
+        });
+
+        act(() =>
+            result.current.requestSetTeachMode(true, "overflowMenu"),
+        );
+        const keepBtn = await screen.findByText(
+            "midGameOptionKeepExplicit",
+        );
+        await act(async () => {
+            await user.click(keepBtn);
+        });
+
+        expect(
+            getOrFail(
+                result.current.clue.state.userDeductions,
+                cell,
+            ),
+        ).toBe(N_VAL);
+    });
+
+    test("overflowMenu + adopt-deductions: seeds from knowledge, hypotheses are NOT merged in", async () => {
+        silenceConsoleError();
+        const user = userEvent.setup();
+        const { result } = renderToggle();
+        const setup = CLASSIC_SETUP_3P;
+        const [first, second] = setup.players;
+        const knife = cardByName(setup, "Knife");
+        const rope = cardByName(setup, "Rope");
+        if (
+            first === undefined
+            || second === undefined
+            || knife === undefined
+            || rope === undefined
+        ) {
+            throw new Error("missing fixtures");
+        }
+        const cellSecondRope = Cell(PlayerOwner(second), rope);
+
+        act(() => {
+            result.current.clue.dispatch({
+                type: "replaceSession",
+                session: {
+                    setup,
+                    // Real knowledge: first holds Knife.
+                    hands: [{ player: first, cards: [knife] }],
+                    handSizes: [],
+                    suggestions: [],
+                    accusations: [],
+                    hypotheses: HashMap.set(
+                        emptyHypotheses,
+                        cellSecondRope,
+                        Y_VAL,
+                    ),
+                    hypothesisOrder: [cellSecondRope],
+                    pendingSuggestion: null,
+                    selfPlayerId: null,
+                    firstDealtPlayerId: null,
+                    dismissedInsights: new Map(),
+                    teachMode: false,
+                    userDeductions: emptyUserDeductions,
+                },
+            });
+        });
+
+        act(() =>
+            result.current.requestSetTeachMode(true, "overflowMenu"),
+        );
+        const adoptBtn = await screen.findByText(
+            "midGameOptionAdoptDeductions",
+        );
+        await act(async () => {
+            await user.click(adoptBtn);
+        });
+
+        // adopt-deductions snapshots the deducer's checklist into
+        // userDeductions and DOES NOT pull in the hypothesis on
+        // (second, rope).
+        expect(
+            HashMap.get(
+                result.current.clue.state.userDeductions,
+                cellSecondRope,
+            )._tag,
+        ).toBe("None");
+        // (first, Knife) is a real fact — seeded as Y.
+        expect(
+            getOrFail(
+                result.current.clue.state.userDeductions,
+                Cell(PlayerOwner(first), knife),
+            ),
+        ).toBe(Y_VAL);
+    });
+});
+
+describe("useTeachModeToggle — exit", () => {
+    test("wizard source: marks not proved by the deducer become hypotheses", () => {
+        silenceConsoleError();
+        const { result } = renderToggle();
+        const { first, knife, rope } = seedSession(result.current.clue);
+        const cellFirstKnife = Cell(PlayerOwner(first), knife);
+        const cellFirstRope = Cell(PlayerOwner(first), rope);
+
+        // Seeded session: first holds Knife (real fact). Solver knows
+        // (first, Knife) = Y. We add a teach-mode mark on the same
+        // cell (substantiated — skipped) AND on (first, Rope) = N
+        // (unsubstantiated — should become a hypothesis).
+        act(() => {
+            result.current.clue.dispatch({
+                type: "setTeachMode",
+                enabled: true,
+            });
+            result.current.clue.dispatch({
+                type: "setUserDeduction",
+                cell: cellFirstKnife,
+                value: Y_VAL,
+            });
+            result.current.clue.dispatch({
+                type: "setUserDeduction",
+                cell: cellFirstRope,
+                value: N_VAL,
+            });
+        });
+        expect(HashMap.size(result.current.clue.state.hypotheses)).toBe(0);
+
+        act(() => result.current.requestSetTeachMode(false, "wizard"));
+
+        // teachMode off.
+        expect(result.current.clue.state.teachMode).toBe(false);
+        // userDeductions preserved.
+        expect(
+            HashMap.size(result.current.clue.state.userDeductions),
+        ).toBeGreaterThanOrEqual(2);
+        // (first, Knife) substantiated by Knife being in first's hand
+        // → NOT added as a hypothesis. (first, Rope) is unknown →
+        // added.
+        expect(
+            HashMap.get(
+                result.current.clue.state.hypotheses,
+                cellFirstKnife,
+            )._tag,
+        ).toBe("None");
+        expect(
+            getOrFail(
+                result.current.clue.state.hypotheses,
+                cellFirstRope,
+            ),
+        ).toBe(N_VAL);
+        expect(result.current.clue.state.hypothesisOrder).toContainEqual(
+            cellFirstRope,
+        );
+    });
+
+    test("wizard source + no userDeductions: no replaceHypotheses dispatch", () => {
+        silenceConsoleError();
+        const { result } = renderToggle();
+        seedSession(result.current.clue);
+        act(() => {
+            result.current.clue.dispatch({
+                type: "setTeachMode",
+                enabled: true,
+            });
+        });
+        const hypothesesBefore = result.current.clue.state.hypotheses;
+        const orderBefore = result.current.clue.state.hypothesisOrder;
+
+        act(() => result.current.requestSetTeachMode(false, "wizard"));
+
+        // Same references — no replaceHypotheses fired.
+        expect(result.current.clue.state.hypotheses).toBe(hypothesesBefore);
+        expect(result.current.clue.state.hypothesisOrder).toBe(orderBefore);
+        expect(result.current.clue.state.teachMode).toBe(false);
+    });
+
+    test("wizard source + mark conflicts with existing hypothesis: mark wins, order position preserved", () => {
+        silenceConsoleError();
+        const { result } = renderToggle();
+        const { first, rope } = seedSession(result.current.clue);
+        const cellFirstRope = Cell(PlayerOwner(first), rope);
+
+        // Set hypothesis Y on (first, rope), then enter teach mode,
+        // mark the same cell N, then exit.
+        act(() => {
+            result.current.clue.dispatch({
+                type: "setHypothesis",
+                cell: cellFirstRope,
+                value: Y_VAL,
+            });
+            result.current.clue.dispatch({
+                type: "setTeachMode",
+                enabled: true,
+            });
+            result.current.clue.dispatch({
+                type: "setUserDeduction",
+                cell: cellFirstRope,
+                value: N_VAL,
+            });
+        });
+        const orderBefore =
+            result.current.clue.state.hypothesisOrder;
+
+        act(() => result.current.requestSetTeachMode(false, "wizard"));
+
+        // Hypothesis value overwritten with the mark's value.
+        expect(
+            getOrFail(
+                result.current.clue.state.hypotheses,
+                cellFirstRope,
+            ),
+        ).toBe(N_VAL);
+        // Order array reference preserved (no append happened).
+        expect(result.current.clue.state.hypothesisOrder).toEqual(
+            orderBefore,
+        );
+    });
+
+    test("overflowMenu source + confirm: merge runs and teachMode flips off", async () => {
+        silenceConsoleError();
+        const user = userEvent.setup();
+        const { result } = renderToggle();
+        const { first, rope } = seedSession(result.current.clue);
+        const cellFirstRope = Cell(PlayerOwner(first), rope);
+
+        act(() => {
+            result.current.clue.dispatch({
+                type: "setTeachMode",
+                enabled: true,
+            });
+            result.current.clue.dispatch({
+                type: "setUserDeduction",
+                cell: cellFirstRope,
+                value: Y_VAL,
+            });
+        });
+
+        act(() =>
+            result.current.requestSetTeachMode(false, "overflowMenu"),
+        );
+        // useConfirm renders the confirm dialog with the i18n key as
+        // its label.
+        const confirmBtn = await screen.findByText(
+            "exitPromptConfirm",
+        );
+        await act(async () => {
+            await user.click(confirmBtn);
+        });
+
+        expect(result.current.clue.state.teachMode).toBe(false);
+        expect(
+            getOrFail(
+                result.current.clue.state.hypotheses,
+                cellFirstRope,
+            ),
+        ).toBe(Y_VAL);
+    });
+
+    test("overflowMenu source + cancel: nothing changes", async () => {
+        silenceConsoleError();
+        const user = userEvent.setup();
+        const { result } = renderToggle();
+        const { first, rope } = seedSession(result.current.clue);
+        const cellFirstRope = Cell(PlayerOwner(first), rope);
+
+        act(() => {
+            result.current.clue.dispatch({
+                type: "setTeachMode",
+                enabled: true,
+            });
+            result.current.clue.dispatch({
+                type: "setUserDeduction",
+                cell: cellFirstRope,
+                value: Y_VAL,
+            });
+        });
+        const userDeductionsBefore =
+            result.current.clue.state.userDeductions;
+        const hypothesesBefore = result.current.clue.state.hypotheses;
+
+        act(() =>
+            result.current.requestSetTeachMode(false, "overflowMenu"),
+        );
+        const cancelBtn = await screen.findByText("cancel");
+        await act(async () => {
+            await user.click(cancelBtn);
+        });
+
+        // teachMode still on; nothing dispatched.
+        expect(result.current.clue.state.teachMode).toBe(true);
+        expect(result.current.clue.state.userDeductions).toBe(
+            userDeductionsBefore,
+        );
+        expect(result.current.clue.state.hypotheses).toBe(hypothesesBefore);
+    });
+});

--- a/src/ui/components/useTeachModeToggle.tsx
+++ b/src/ui/components/useTeachModeToggle.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import * as Dialog from "@radix-ui/react-dialog";
-import { Result } from "effect";
+import { HashMap, Result } from "effect";
 import { useTranslations } from "next-intl";
 import { useCallback, useRef } from "react";
 import {
+    mergeHypothesesIntoUserDeductions,
+    mergeUnsubstantiatedMarksIntoHypotheses,
     seedFromKnowledge,
     seedFromOwnHand,
 } from "../../logic/TeachMode";
@@ -51,6 +53,32 @@ export function useTeachModeToggle(): (
         (enabled: boolean, source: "wizard" | "overflowMenu" | "shareImport") => {
             if (!enabled) {
                 const finishOff = () => {
+                    // Marks the solver can't already prove ride along
+                    // as hypotheses so they stay visible in non-teach
+                    // mode. The mark itself stays in `userDeductions`
+                    // (preserved across exits). Substantiated marks
+                    // are skipped — the solver already shows them.
+                    const knowledge = Result.isSuccess(
+                        derived.deductionResult,
+                    )
+                        ? derived.deductionResult.success
+                        : undefined;
+                    const merged = mergeUnsubstantiatedMarksIntoHypotheses(
+                        state.userDeductions,
+                        knowledge,
+                        state.hypotheses,
+                        state.hypothesisOrder,
+                    );
+                    if (
+                        merged.hypotheses !== state.hypotheses
+                        || merged.hypothesisOrder !== state.hypothesisOrder
+                    ) {
+                        dispatch({
+                            type: "replaceHypotheses",
+                            hypotheses: merged.hypotheses,
+                            hypothesisOrder: merged.hypothesisOrder,
+                        });
+                    }
                     dispatch({ type: "setTeachMode", enabled: false });
                     if (source !== "wizard") {
                         teachModeDisabled({
@@ -131,9 +159,24 @@ export function useTeachModeToggle(): (
                         midGameAction: "keepDeduced",
                     });
                 } else {
-                    // "keep-explicit" — user's existing marks stay as
-                    // they are (empty if none, prior teach-mode marks
-                    // if the user toggled off then on again).
+                    // "keep-explicit" — user's existing marks stay,
+                    // with any active hypotheses folded in so the
+                    // user's non-teach-mode work isn't dropped on the
+                    // floor. Hypothesis value wins on conflict — it's
+                    // the user's most recent edit in non-teach mode.
+                    if (HashMap.size(state.hypotheses) > 0) {
+                        const mergedDeductions =
+                            mergeHypothesesIntoUserDeductions(
+                                state.userDeductions,
+                                state.hypotheses,
+                            );
+                        if (mergedDeductions !== state.userDeductions) {
+                            dispatch({
+                                type: "replaceUserDeductions",
+                                userDeductions: mergedDeductions,
+                            });
+                        }
+                    }
                     teachModeEnabled({
                         source,
                         midGameAction: "previousMarks",
@@ -186,6 +229,9 @@ export function useTeachModeToggle(): (
             state.setup.players,
             state.setup.cardSet,
             state.handSizes,
+            state.userDeductions,
+            state.hypotheses,
+            state.hypothesisOrder,
             t,
             tCommon,
         ],

--- a/src/ui/state.test.tsx
+++ b/src/ui/state.test.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook } from "@testing-library/react";
-import { HashMap } from "effect";
+import { HashMap, Option } from "effect";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -1152,6 +1152,87 @@ describe("derived values", () => {
         expect(conflict?.entries.length).toBe(1);
         expect(conflict?.entries[0]?.cell).toEqual(Cell(PlayerOwner(A), KNIFE));
         expect(conflict?.entries[0]?.value).toBe(N_VAL);
+    });
+});
+
+describe("replaceHypotheses", () => {
+    test("replaces both hypotheses and hypothesisOrder atomically", () => {
+        const { result } = renderClue();
+        const [first] = result.current.state.setup.players;
+        const knife = cardByName(result.current.state.setup, "Knife");
+        if (first === undefined || knife === undefined) {
+            throw new Error("default setup is missing players or knife");
+        }
+        const cell = Cell(PlayerOwner(first), knife);
+
+        act(() => {
+            result.current.dispatch({
+                type: "replaceHypotheses",
+                hypotheses: HashMap.set(emptyHypotheses, cell, Y_VAL),
+                hypothesisOrder: [cell],
+            });
+        });
+
+        expect(HashMap.size(result.current.state.hypotheses)).toBe(1);
+        expect(
+            Option.getOrUndefined(
+                HashMap.get(result.current.state.hypotheses, cell),
+            ),
+        ).toBe(Y_VAL);
+        expect(result.current.state.hypothesisOrder).toEqual([cell]);
+    });
+
+    test("dispatching with empty inputs clears both slices", () => {
+        const { result } = renderClue();
+        const [first] = result.current.state.setup.players;
+        const knife = cardByName(result.current.state.setup, "Knife");
+        if (first === undefined || knife === undefined) {
+            throw new Error("default setup is missing players or knife");
+        }
+        const cell = Cell(PlayerOwner(first), knife);
+
+        act(() => {
+            result.current.dispatch({
+                type: "setHypothesis",
+                cell,
+                value: Y_VAL,
+            });
+        });
+        expect(HashMap.size(result.current.state.hypotheses)).toBe(1);
+
+        act(() => {
+            result.current.dispatch({
+                type: "replaceHypotheses",
+                hypotheses: emptyHypotheses,
+                hypothesisOrder: [],
+            });
+        });
+        expect(HashMap.size(result.current.state.hypotheses)).toBe(0);
+        expect(result.current.state.hypothesisOrder).toEqual([]);
+    });
+
+    test("is undoable — prior slices restored after undo", () => {
+        const { result } = renderClue();
+        const [first] = result.current.state.setup.players;
+        const knife = cardByName(result.current.state.setup, "Knife");
+        if (first === undefined || knife === undefined) {
+            throw new Error("default setup is missing players or knife");
+        }
+        const cell = Cell(PlayerOwner(first), knife);
+
+        act(() => {
+            result.current.dispatch({
+                type: "replaceHypotheses",
+                hypotheses: HashMap.set(emptyHypotheses, cell, N_VAL),
+                hypothesisOrder: [cell],
+            });
+        });
+        expect(HashMap.size(result.current.state.hypotheses)).toBe(1);
+        expect(result.current.canUndo).toBe(true);
+
+        act(() => result.current.undo());
+        expect(HashMap.size(result.current.state.hypotheses)).toBe(0);
+        expect(result.current.state.hypothesisOrder).toEqual([]);
     });
 });
 

--- a/src/ui/state.tsx
+++ b/src/ui/state.tsx
@@ -583,6 +583,13 @@ const reducer = (state: ClueState, action: ClueAction): ClueState => {
                 ),
             };
 
+        case "replaceHypotheses":
+            return {
+                ...state,
+                hypotheses: action.hypotheses,
+                hypothesisOrder: action.hypothesisOrder,
+            };
+
         case "dismissInsight": {
             const next = new Map(state.dismissedInsights);
             next.set(action.key, action.atConfidence);


### PR DESCRIPTION
## Summary

Toggling teach-me mode no longer drops the user's work in either direction.

- **Entering teach-me mode** via "Start with my explicit marks only": any hypotheses you set in non-teach-mode come along as editable marks (hypothesis value wins on conflict — it's the more recent edit).
- **Exiting teach-me mode**: any marks the solver can't already prove are carried over as hypotheses so they stay visible in non-teach-mode. Marks the solver already derives are skipped — no point cluttering the hypothesis panel with redundant entries. The mark's value wins on conflict; existing positions in `hypothesisOrder` are preserved, new cells append to the end.
- The mid-game prompt body and exit prompt body have updated copy that mentions the new behavior.

"Adopt the Clue Solver's deductions" and the wizard's entry path are unchanged — those are intentional "start fresh" / "first-time setup" paths.

## Test plan

- [ ] Set a hypothesis on a cell in non-teach mode → open overflow menu → Teach me mode → "Start with my explicit marks only" — cell renders as a mark in teach mode.
- [ ] In teach mode, mark a cell the solver hasn't proved → overflow menu → Teach me mode → confirm exit — cell renders as a hypothesis in non-teach mode.
- [ ] Repeat exit with a mark the solver DOES prove — no entry added to the hypothesis panel.
- [ ] Re-enter teach mode → marks are restored (round-trip preserved).
- [ ] Adopt-deductions path still snapshots from the solver and ignores hypotheses.
- [ ] Wizard toggle still seeds from own hand only.
- [ ] Pre-commit: `pnpm typecheck && pnpm lint && pnpm test && pnpm knip && pnpm i18n:check` all green (1614 tests pass).

## Commits

- `Preserve teach-me marks and hypotheses across the toggle` — two pure merge helpers in `src/logic/TeachMode.ts`, a new atomic `replaceHypotheses` reducer action so `hypotheses` + `hypothesisOrder` update together on exit, both wired into `useTeachModeToggle.tsx`'s existing entry "keep-explicit" branch and exit `finishOff` path. New tests: helper-level unit tests (12), reducer-level tests (3), and a hook integration test file covering wizard + overflowMenu sources with full modal-DOM interactions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)