### PR TITLE
Fix Passed-by popover marking form dirty on open-and-close

### DIFF
--- a/src/ui/components/SuggestionPills.test.tsx
+++ b/src/ui/components/SuggestionPills.test.tsx
@@ -207,6 +207,88 @@ describe("MultiSelectList — onCommit identity stability", () => {
         expect(onCommit).toHaveBeenCalledTimes(1);
         expect(onCommit).toHaveBeenCalledWith(NOBODY);
     });
+
+    // Regression guard for the user-reported bug: opening the "Passed by"
+    // popover and closing it without toggling anything used to commit an
+    // empty `[]`, which the parent form treats as "has input" (its
+    // `hasAnyInput` check is `nonRefuters !== null`) and surfaces an X
+    // clear button. The popover should be a no-op when the user makes no
+    // selection.
+    test("does not commit on unmount when toggled set is unchanged", () => {
+        const onCommit = vi.fn();
+        const { unmount } = render(
+            <MultiSelectList
+                options={playerOpts}
+                selected={[]}
+                nobodyChosen={false}
+                nobodyLabel="Nobody"
+                commitHint="Press Enter"
+                onCommit={onCommit}
+            />,
+        );
+        unmount();
+        expect(onCommit).not.toHaveBeenCalled();
+    });
+
+    // Same protection covers the case where the parent already had
+    // NOBODY chosen. Without the dirty-check, an open-and-close would
+    // commit `[]` and silently clear the NOBODY selection.
+    test("does not commit on unmount when nobodyChosen and untouched", () => {
+        const onCommit = vi.fn();
+        const { unmount } = render(
+            <MultiSelectList
+                options={playerOpts}
+                selected={[]}
+                nobodyChosen={true}
+                nobodyLabel="Nobody"
+                commitHint="Press Enter"
+                onCommit={onCommit}
+            />,
+        );
+        unmount();
+        expect(onCommit).not.toHaveBeenCalled();
+    });
+
+    // Pre-selected players, opened and closed without touching the
+    // list: also a no-op. Without the dirty-check this committed the
+    // same array back, which is a wasted re-render at best and could
+    // mask other bugs.
+    test("does not commit on unmount when selection is unchanged", () => {
+        const onCommit = vi.fn();
+        const { unmount } = render(
+            <MultiSelectList
+                options={playerOpts}
+                selected={[A, B]}
+                nobodyChosen={false}
+                nobodyLabel="Nobody"
+                commitHint="Press Enter"
+                onCommit={onCommit}
+            />,
+        );
+        unmount();
+        expect(onCommit).not.toHaveBeenCalled();
+    });
+
+    // User toggles A on then off, ending where they started: still a
+    // no-op on close. Set-equality lets the cleanup recognise this.
+    test("does not commit on unmount when toggles cancel out", async () => {
+        const user = userEvent.setup();
+        const onCommit = vi.fn();
+        const { unmount } = render(
+            <MultiSelectList
+                options={playerOpts}
+                selected={[]}
+                nobodyChosen={false}
+                nobodyLabel="Nobody"
+                commitHint="Press Enter"
+                onCommit={onCommit}
+            />,
+        );
+        await user.click(screen.getByRole("option", { name: /Anisha/ }));
+        await user.click(screen.getByRole("option", { name: /Anisha/ }));
+        unmount();
+        expect(onCommit).not.toHaveBeenCalled();
+    });
 });
 
 describe("SingleSelectList — keyboard scroll-into-view", () => {

--- a/src/ui/components/SuggestionPills.tsx
+++ b/src/ui/components/SuggestionPills.tsx
@@ -43,6 +43,14 @@ export type Nobody = typeof NOBODY;
 
 export const isNobody = (v: unknown): v is Nobody => v === NOBODY;
 
+// Set-equality on two arrays of Player (or any branded-string) values.
+// Used by MultiSelectList's unmount cleanup to detect "user did not
+// change the toggled set" so a stray open/close is a true no-op.
+const sameSet = <T,>(
+    a: ReadonlyArray<T>,
+    b: ReadonlyArray<T>,
+): boolean => a.length === b.length && a.every(item => b.includes(item));
+
 // ---- Pill status ------------------------------------------------------
 
 export type PillStatus =
@@ -703,9 +711,21 @@ export function MultiSelectList({
     const onCommitRef = useRef(onCommit);
     onCommitRef.current = onCommit;
     const committedRef = useRef(false);
+    // Capture the initial `selected` so the cleanup can detect "user
+    // didn't change anything" and skip the commit. Opening a popover
+    // and closing it without toggling should be a no-op — otherwise
+    // an empty `toggled` would overwrite `null` (no selection) with
+    // `[]`, which the parent form treats as "has input" and surfaces
+    // an X clear button. Same protection covers the `nobodyChosen`
+    // case, where the prior NOBODY would otherwise get clobbered by
+    // an empty array on a stray open/close.
+    const initialSelectedRef = useRef<ReadonlyArray<Player>>(selected);
     useEffect(
         () => () => {
             if (committedRef.current) return;
+            if (sameSet(initialSelectedRef.current, toggledRef.current)) {
+                return;
+            }
             onCommitRef.current(toggledRef.current, { advance: false });
         },
         [],


### PR DESCRIPTION
Opening the "Passed by" pill in the suggestion form and closing it
without picking anyone used to silently set `nonRefuters` from `null`
to `[]`. The parent form's `hasAnyInput` check treats anything that
isn't `null` as "user typed something" and surfaces the X clear button
— so the form looked dirty even though the user never made a
selection. The same flow also clobbered an existing NOBODY choice on a
stray open/close.

`MultiSelectList`'s unmount cleanup unconditionally commits the
toggled set so Esc / click-outside / pill-switch persist what the user
toggled. Tighten the cleanup with a dirty check: capture the initial
`selected` in a ref on mount and skip the commit when the toggled set
matches it (set-equality, since toggle order isn't meaningful). Explicit
commits (Enter, Space on Nobody, mouse-clicking Nobody, OK button) still
flip `committedRef` and short-circuit ahead of the dirty check, so user
intent paths are unchanged.

Added four regression tests covering: untouched empty, untouched with
NOBODY, untouched with pre-selected players, and toggles that cancel
out.