### PR TITLE
Visually distinguish the Case file column in the Checklist

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -42,6 +42,12 @@
     --color-row-header: #e5d9b8;
     /* Dossier manila for the case-file header strip. */
     --color-case-file-bg: #ead9b0;
+    /* Slightly darker manila for the case-file COLUMN header inside
+     * the checklist table. Reads as a deliberately darker tile within
+     * the `bg-row-header` strip; visually echoes the lighter
+     * `--color-case-file-bg` manila of the CaseFileHeader summary box
+     * sitting above the table, tying the column to the summary above. */
+    --color-case-file-header-bg: #d6c79a;
     /* Press-down hover tint shared by every `hover:bg-hover` site that
      * isn't a secondary button — transparent close-X buttons, modal
      * Cancel buttons, overflow-menu items, the toolbar's white pills.
@@ -286,6 +292,15 @@
 }
 @utility text-tap-compact {
     font-size: var(--tap-text-compact);
+}
+
+@utility checklist-case-file-divider {
+    /* 5px wide so `border-style: double` renders two visible parallel
+     * tan lines with a ~1.67px transparent gap between them. The gap
+     * shows whatever sits in the cell behind it — cream on body cells,
+     * maroon on category-header rows, the darker manila on the column
+     * header — so the divider reads cohesively top-to-bottom. */
+    border-left: 5px double var(--color-border);
 }
 
 html,

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -1304,11 +1304,24 @@ export function Checklist() {
                             {!hasKeyboard ? null : label("global.gotoChecklist")}
                         </th>
                         <AnimatePresence initial={false} mode={MOTION_SYNC}>
-                        {owners.flatMap(owner => {
+                        {owners.flatMap((owner, idx) => {
+                            const isCaseFile = owner._tag === "CaseFile";
+                            const isLastPlayer =
+                                owner._tag === "Player"
+                                && owners[idx + 1]?._tag === "CaseFile";
+                            const bgClass = isCaseFile
+                                ? CASE_FILE_HEADER_BG_CLASS
+                                : ROW_HEADER_BG_CLASS;
+                            const dividerClass = isCaseFile
+                                ? CASE_FILE_DIVIDER_CLASS
+                                : "";
+                            const lastPlayerClass = isLastPlayer
+                                ? CASE_FILE_LAST_PLAYER_SUPPRESS
+                                : "";
                             const cell = (
                                 <motion.th
                                     key={ownerKey(owner, playerColumnKeys)}
-                                    className={`${COLUMN_HEADER_STACK} overflow-hidden border-r border-b border-border bg-row-header p-0 text-center align-top font-semibold`}
+                                    className={`${COLUMN_HEADER_STACK} overflow-hidden border-r border-b border-border ${bgClass} p-0 text-center align-top font-semibold${dividerClass}${lastPlayerClass}`}
                                     layout={LAYOUT_POSITION}
                                     initial={TABLE_COLUMN_HIDDEN}
                                     animate={TABLE_COLUMN_VISIBLE}
@@ -1358,9 +1371,21 @@ export function Checklist() {
                                         </div>,
                                     )}
                                 </motion.th>
+                                {/* The maroon category strip is split into
+                                    two td's so the doubled vertical divider
+                                    between the last player column and the
+                                    case-file column paints cleanly through
+                                    this row. `border-spacing-0` keeps the
+                                    maroon visually continuous across the
+                                    split, while the gap inside the
+                                    doubled-border lines shows the maroon
+                                    underneath. */}
                                 <td
-                                    colSpan={cardSpan - 1}
-                                    className="border-r border-b border-border bg-category-header"
+                                    colSpan={owners.length - 1}
+                                    className="border-b border-border bg-category-header"
+                                />
+                                <td
+                                    className="border-r border-b border-border bg-category-header checklist-case-file-divider"
                                 />
                             </motion.tr>,
                             ...category.cards.flatMap(entry => {
@@ -1691,8 +1716,35 @@ export function Checklist() {
                                                 : revealVerdict === VERDICT_PLAUSIBLE
                                                 ? REVEAL_CLASS_PLAUSIBLE
                                                 : "";
+                                        // Doubled vertical divider between the
+                                        // last player column and the case-file
+                                        // column. `checklist-case-file-divider`
+                                        // paints a 5px `border-style: double`
+                                        // on the case-file cell's left edge;
+                                        // `!border-r-0` on the last player
+                                        // cell strips its right border so the
+                                        // doubled pair renders symmetrically
+                                        // (two lines of equal weight with a
+                                        // clean gap between them). When the
+                                        // case-file cell is open the divider
+                                        // is suppressed by appending
+                                        // `!border-l-0` in
+                                        // `interactiveTdClassName` below — the
+                                        // accent box-shadow ring should be the
+                                        // only treatment on that edge.
+                                        const isCaseFileCol = colIdx === totalCols - 1;
+                                        const isLastPlayerCol = colIdx === totalCols - 2;
+                                        const dividerClass = isCaseFileCol
+                                            ? CASE_FILE_DIVIDER_CLASS
+                                            : "";
+                                        const lastPlayerSuppress = isLastPlayerCol
+                                            ? CASE_FILE_LAST_PLAYER_SUPPRESS
+                                            : "";
                                         const tdClassName =
-                                            baseTdClassName + revealClass;
+                                            baseTdClassName
+                                            + revealClass
+                                            + dividerClass
+                                            + lastPlayerSuppress;
                                         // Arrow-key grid navigation: walk to
                                         // the nearest neighbour cell with a
                                         // data-cell-row/col pair. Shared by
@@ -1799,9 +1851,24 @@ export function Checklist() {
                                             // in `app/globals.css`.
                                             const isLastOwnerCol =
                                                 colIdx === totalCols - 1;
+                                            // When the case-file cell is open,
+                                            // suppress its doubled left border
+                                            // (added via
+                                            // `checklist-case-file-divider`
+                                            // in `tdClassName`) so the accent
+                                            // box-shadow ring is the only
+                                            // treatment on the cell's left
+                                            // edge — otherwise the tan doubled
+                                            // lines would sit just inside the
+                                            // oxblood ring and read as visual
+                                            // clutter.
+                                            const openSuppressDivider =
+                                                isOpen && isLastOwnerCol
+                                                    ? CASE_FILE_OPEN_SUPPRESS
+                                                    : "";
                                             const interactiveTdClassName =
                                                 isOpen
-                                                    ? `${tdClassName}${CELL_EXPANDED}${cellExpandedToneClass(display)}${isLastOwnerCol ? " cell-expanded-focus-last-col" : ""}`
+                                                    ? `${tdClassName}${CELL_EXPANDED}${cellExpandedToneClass(display)}${isLastOwnerCol ? " cell-expanded-focus-last-col" : ""}${openSuppressDivider}`
                                                     : tdClassName;
                                             cell = (
                                                 <motion.td
@@ -2294,6 +2361,19 @@ const CELL_EXPANDED =
 const CELL_EXPANDED_TONE_BLANK = " !bg-panel" as const;
 const CELL_EXPANDED_TONE_Y = " cell-expanded-tone-yes" as const;
 const CELL_EXPANDED_TONE_N = " cell-expanded-tone-no" as const;
+
+// Visual treatment of the case-file column. The doubled vertical
+// border lives on the case-file cell's left edge, so its adjacent
+// last-player cell strips its own right border via
+// `CASE_FILE_LAST_PLAYER_SUPPRESS` to render the doubled pair
+// symmetrically. When the case-file cell is open the divider is
+// suppressed by `CASE_FILE_OPEN_SUPPRESS` so the 3px accent
+// box-shadow ring is the only treatment on that edge.
+const CASE_FILE_DIVIDER_CLASS = " checklist-case-file-divider" as const;
+const CASE_FILE_LAST_PLAYER_SUPPRESS = " !border-r-0" as const;
+const CASE_FILE_OPEN_SUPPRESS = " !border-l-0" as const;
+const CASE_FILE_HEADER_BG_CLASS = "bg-case-file-header-bg" as const;
+const ROW_HEADER_BG_CLASS = "bg-row-header" as const;
 
 const cellExpandedToneClass = (display: CellDisplay): string => {
     const tone: CellValue | undefined =


### PR DESCRIPTION
## Summary

The Case file column on the right of the deduction grid now reads as clearly separated from the player columns. Two small visual changes:

- **Doubled vertical border** between the last player column and the Case file column, drawn top-to-bottom across the column header, every category strip, and every body cell row. Two parallel tan lines with a clean transparent gap between them.
- **Slightly darker manila background** on the Case file column header (`#d6c79a` vs the warmer beige `#e5d9b8` of player columns) so the column reads as a distinct surface within the row-header strip and visually echoes the lighter manila of the Case file summary box sitting above the table.

Body text contrast against the new header bg is ~9.3:1, clear of WCAG AAA.

## Screenshots

7-player desktop view (1280×800):

![checklist-7-players-desktop](https://github.com/user-attachments/assets/checklist-after.png)

## Test plan

- [x] `pnpm typecheck` ✓
- [x] `pnpm lint` ✓
- [x] `pnpm test` ✓ (1772/1772)
- [x] `pnpm knip` ✓
- [x] `pnpm i18n:check` ✓
- [x] Desktop (1280×800), 7 players, default state — doubled border + darker bg both visible
- [x] Desktop, popover open on a Player cell — case-file column treatment unaffected
- [x] Desktop, popover open on a Case file cell — doubled left border suppressed so the accent box-shadow ring renders cleanly
- [x] Mobile (375×812), 7 players, horizontal-scroll to the right edge — doubled border tracks with the case-file column, no console errors
- [ ] Verify the same scenarios on the Vercel preview build

## Commits

- `be62f77` Visually distinguish the Case file column in the Checklist
  - New `--color-case-file-header-bg: #d6c79a` token alongside `--color-case-file-bg` in `app/globals.css`.
  - New `@utility checklist-case-file-divider` painting 5px `border-style: double` on the Case file cell's left edge with `--color-border` as the line color.
  - In `Checklist.tsx`: the case-file column `<th>` swaps in the darker bg + divider; case-file body cells get the divider; the category-header `<td>` is split into a player-section td + case-file-section td so the divider paints cleanly through the maroon strip. The last-player cell strips its `border-r` (`!border-r-0`) so the doubled pair renders symmetrically. When the case-file cell is open the divider is suppressed (`!border-l-0`) so the 3px accent ring is the only treatment on that edge — no visual clutter at the boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)