### PR TITLE
Fix tour close-step: cell-explanation panel now actually closes

### DIFF
--- a/src/ui/components/Checklist.tap.test.tsx
+++ b/src/ui/components/Checklist.tap.test.tsx
@@ -298,6 +298,61 @@ describe("Checklist — touch tap protocol", () => {
     });
 });
 
+describe("Checklist — explanation row mount/unmount", () => {
+    // The cell-explanation row is wired via a plain DOM mount/unmount.
+    // An earlier implementation kept the row mounted through Framer
+    // Motion's `AnimatePresence propagate` so the inner motion.div
+    // could collapse its height to 0 on exit. That combination — empty
+    // `exit={{}}` on the tr + propagating inner AP — sometimes failed
+    // to actually run the inner exit under Framer Motion 12, leaving
+    // the panel mounted at full height after popoverCell had already
+    // cleared. The user-visible symptom was "panel won't close" after
+    // the tour's close-step click. These tests pin the simpler
+    // invariant: when popoverCell clears (or moves to another card),
+    // the previous cell's explanation row is gone from the DOM.
+
+    const explainPanelCount = (): number =>
+        document.querySelectorAll('[data-tour-anchor="cell-explanation-panel"]')
+            .length;
+
+    test("clicking an open cell unmounts the explanation panel", async () => {
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        await waitForChecklist();
+        fireEvent.pointerDown(getCell(0, 0), { pointerType: "mouse" });
+        fireEvent.click(getCell(0, 0));
+        await waitFor(() => expect(explainPanelCount()).toBe(1));
+        fireEvent.pointerDown(getCell(0, 0), { pointerType: "mouse" });
+        fireEvent.click(getCell(0, 0));
+        await waitFor(() => expect(explainPanelCount()).toBe(0));
+    });
+
+    test("switching cells leaves exactly one explanation panel mounted (the new one)", async () => {
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        await waitForChecklist();
+        // Open (0, 0).
+        fireEvent.pointerDown(getCell(0, 0), { pointerType: "mouse" });
+        fireEvent.click(getCell(0, 0));
+        await waitFor(() => expect(isOpen(0, 0)).toBe(true));
+        expect(explainPanelCount()).toBe(1);
+        // Switch to (1, 0) — different row.
+        fireEvent.pointerDown(getCell(1, 0), { pointerType: "mouse" });
+        fireEvent.click(getCell(1, 0));
+        await waitFor(() => expect(isOpen(1, 0)).toBe(true));
+        // The previous row's panel must be gone, not stacked alongside.
+        expect(explainPanelCount()).toBe(1);
+    });
+
+    test("clicking outside the open cell unmounts the explanation panel", async () => {
+        render(<Clue />, { wrapper: TestQueryClientProvider });
+        await waitForChecklist();
+        fireEvent.pointerDown(getCell(0, 0), { pointerType: "mouse" });
+        fireEvent.click(getCell(0, 0));
+        await waitFor(() => expect(explainPanelCount()).toBe(1));
+        fireEvent.click(document.body);
+        await waitFor(() => expect(explainPanelCount()).toBe(0));
+    });
+});
+
 describe("Checklist — touch long-press protocol", () => {
     // Use REAL timers — vi.useFakeTimers (even with `toFake` narrowed
     // to setTimeout/clearTimeout) blocks React's scheduler enough that

--- a/src/ui/components/Checklist.tsx
+++ b/src/ui/components/Checklist.tsx
@@ -76,7 +76,6 @@ import { label, matches } from "../keyMap";
 import { AnimatePresence, motion, type Transition } from "motion/react";
 import {
     T_CELEBRATE,
-    T_EXPLAIN_ROW,
     T_FAST,
     T_STANDARD,
     T_WIGGLE,
@@ -829,7 +828,6 @@ export function Checklist() {
     const tableRowEntryTransition = useReducedTransition(
         TABLE_ROW_ENTRY_TRANSITION,
     );
-    const explainRowTransition = useReducedTransition(T_EXPLAIN_ROW);
     const tableCollapseTransition = useReducedTransition(
         TABLE_COLLAPSE_TRANSITION,
     );
@@ -1382,16 +1380,29 @@ export function Checklist() {
                                 const explainTr = showExplain ? (
                                     <motion.tr
                                         key={`explain-${String(entry.id)}`}
-                                        // `exit` (even empty) is what
-                                        // AnimatePresence keys off to keep
-                                        // the row mounted while the inner
-                                        // `AnimatePresence propagate`
-                                        // collapses height + borders. Without
-                                        // it, the parent tr unmounts
-                                        // immediately and the inner exit
-                                        // animation never runs to completion.
-                                        exit={{}}
-                                        transition={explainRowTransition}
+                                        // No exit prop: when popoverCell
+                                        // clears (or moves to a different
+                                        // card), the AnimatePresence above
+                                        // drops this child from its tracked
+                                        // list and the tr unmounts on the
+                                        // next commit. A prior version
+                                        // wrapped an inner motion.div in
+                                        // `AnimatePresence propagate` to
+                                        // run a 150ms height collapse, but
+                                        // the combination of empty
+                                        // `exit={{}}` on the tr + a
+                                        // propagating inner AP sometimes
+                                        // failed to fire the inner exit —
+                                        // the tr stayed mounted at full
+                                        // height after popoverCell had
+                                        // already cleared. The user-
+                                        // visible symptom was "panel won't
+                                        // close" after the tour's close-
+                                        // step click. Letting the tr
+                                        // unmount immediately is simpler
+                                        // and reliable; the 150ms collapse
+                                        // animation is gone, which reads
+                                        // as an instant dismiss.
                                         className="relative z-[var(--z-checklist-explain-row)]"
                                     >
                                         <td
@@ -1414,95 +1425,35 @@ export function Checklist() {
                                                 explainRowNodeRef.current = el;
                                             }}
                                         >
-                                            <AnimatePresence propagate>
-                                                <motion.div
-                                                    key="content"
-                                                    initial={{
-                                                        height: 0,
-                                                        borderTopWidth: 0,
-                                                        borderBottomWidth: 0,
-                                                    }}
-                                                    animate={{
-                                                        // eslint-disable-next-line i18next/no-literal-string -- CSS auto value
-                                                        height: "auto",
-                                                        borderTopWidth: 3,
-                                                        borderBottomWidth: 3,
-                                                    }}
-                                                    exit={{
-                                                        height: 0,
-                                                        borderTopWidth: 0,
-                                                        borderBottomWidth: 0,
-                                                    }}
-                                                    transition={
-                                                        explainRowTransition
-                                                    }
-                                                    style={
-                                                        STYLE_OVERFLOW_HIDDEN
-                                                    }
-                                                    // Only the top and bottom
-                                                    // border widths animate
-                                                    // alongside `height` so
-                                                    // the horizontal borders
-                                                    // collapse in lockstep
-                                                    // with the box (no
-                                                    // residual sliver after
-                                                    // height hits 0). The
-                                                    // right border stays at
-                                                    // its static
-                                                    // `border-r-[3px]`
-                                                    // Tailwind value — the
-                                                    // panel only grows
-                                                    // vertically, so the
-                                                    // right edge has nothing
-                                                    // to interpolate, and
-                                                    // animating
-                                                    // `borderRightWidth`
-                                                    // from 0→3 shifts the
-                                                    // panel's content left
-                                                    // by 3px mid-flight. At
-                                                    // `height: 0` the right
-                                                    // border has no vertical
-                                                    // extent so it stays
-                                                    // invisible. Tailwind
-                                                    // classes are the
-                                                    // rest-state source of
-                                                    // truth (color + 3px
-                                                    // widths); motion's
-                                                    // inline values agree at
-                                                    // the open steady state.
-                                                    // 3px matches the open
-                                                    // cell's accent ring
-                                                    // width so the cell's
-                                                    // vertical outline and
-                                                    // the panel's horizontal
-                                                    // border meet at clean
-                                                    // L-junctions with no
-                                                    // tab sticking out at
-                                                    // either bottom corner.
-                                                    // `contain-inline-size`
-                                                    // stops the inner
-                                                    // sections' min-widths
-                                                    // from propagating up
-                                                    // into <main>'s
-                                                    // min-w-max calculation
-                                                    // and pushing the
-                                                    // checklist past the
-                                                    // SuggestionLogPanel.
-                                                    className="border-t-[3px] border-r-[3px] border-b-[3px] border-accent bg-panel contain-inline-size"
-                                                >
-                                                    {explainContent}
-                                                </motion.div>
-                                            </AnimatePresence>
-                                            {/* Mask the 2px accent border
+                                            <div
+                                                // `contain-inline-size`
+                                                // stops the inner
+                                                // sections' min-widths
+                                                // from propagating up into
+                                                // <main>'s min-w-max
+                                                // calculation and pushing
+                                                // the checklist past the
+                                                // SuggestionLogPanel. The
+                                                // 3px top / bottom / right
+                                                // accent borders match the
+                                                // open cell's ring so the
+                                                // cell's vertical outline
+                                                // meets the panel's
+                                                // horizontal border at
+                                                // clean L-junctions with
+                                                // no tab sticking out at
+                                                // either bottom corner.
+                                                className="border-t-[3px] border-r-[3px] border-b-[3px] border-accent bg-panel contain-inline-size"
+                                            >
+                                                {explainContent}
+                                            </div>
+                                            {/* Mask the 3px accent border
                                                 directly under the open cell
                                                 so the cell flows seamlessly
                                                 into the details box. Lives
-                                                outside the height-animated
-                                                motion.div (which has
-                                                `overflow: hidden` and would
-                                                otherwise clip the cover) so
-                                                it can paint over the
-                                                motion.div's `border-t`. */}
+                                                outside the panel <div>
+                                                above so it can paint over
+                                                the panel's `border-t`. */}
                                             {openCellMetrics !== null && (
                                                 <div
                                                     aria-hidden

--- a/src/ui/motion.ts
+++ b/src/ui/motion.ts
@@ -25,17 +25,6 @@ export const T_STANDARD: Transition = {
 };
 
 /**
- * Tuned for the checklist cell-explanation row's expand/collapse.
- * Shorter duration + Material-standard easeInOut (no slow tail) so
- * the height + border-width animation lands cleanly at zero — no
- * faint border sliver lingering after the panel collapses.
- */
-export const T_EXPLAIN_ROW: Transition = {
-    duration: Duration.toSeconds(Duration.millis(150)),
-    ease: [0.4, 0, 0.2, 1],
-};
-
-/**
  * How long to wait after starting a view/pane transition before
  * running post-transition side effects (opening a popover anchored to
  * a newly-visible pill, scrolling to a freshly-revealed row, focusing


### PR DESCRIPTION
## Summary

In the `checklistSuggest` tour, step 8 (\"Click the cell to close\") asks the user to click the spotlit cell to dismiss its explanation panel. Clicking advanced the tour to step 9 but left the panel mounted at full height — step 9's case-file spotlight then rendered on top of a stale panel below.

This change makes the panel close cleanly on the close-step click, with no leftover row beneath step 9.

## Behavior changes

- The cell-explanation panel now appears and disappears in lockstep with `popoverCell`. The previous 150ms height-collapse animation on dismiss is gone, which reads as an instant tidy-up.
- Same close behavior holds for the regular (non-tour) cell click flow: opening one cell while another is open no longer leaves a phantom panel beneath.

## Verification

Walked the tour at desktop (1280×800) and mobile (375×812) in `next-dev`:

- Step 8 click closes the panel; tour advances to step 9 with a clean grid.
- Step 9 → step 8 (back) re-opens the panel.
- Step 8 → step 7 (back) keeps the panel open (DEDUCTIONS / LEADS / HYPOTHESIS chain unaffected).
- Walked the rest of the tour through step 13 (mobile) / 13 (desktop) — no regressions.

Also verified normal cell behavior outside the tour: open / switch / close all work; no stacked panels.

Pre-commit: typecheck ✓ / lint ✓ / test ✓ (1775 passed, +3 new) / knip ✓ / i18n:check ✓.

## Test plan

- [ ] Walk `checklistSuggest` tour to step 8 on the Vercel preview (desktop). Confirm clicking the cell closes the panel and advances to step 9.
- [ ] Same walk on mobile viewport.
- [ ] Back from step 9 → step 8: panel re-opens.
- [ ] Back from step 8 → step 7: panel stays open.
- [ ] Outside the tour: open one cell, open another — only the new panel is visible.

## Commits

\`\`\`
$(git log --oneline origin/main..HEAD)
\`\`\`

### Root cause (technical)

Framer Motion 12 + the existing structure — \`motion.tr\` with empty \`exit={{}}\` wrapping an \`AnimatePresence propagate\` + height-animated \`motion.div\` — sometimes failed to actually run the inner exit when \`popoverCell\` cleared. The motion.tr stayed mounted with the inner div at \`height: auto\` long after the React state had cleared. The replacement is a plain \`<div>\` inside the existing \`motion.tr\` — mount/unmount is now driven entirely by \`popoverCell\`, no \`AnimatePresence propagate\` involvement. Cleaned up the now-unused \`T_EXPLAIN_ROW\` transition and its \`useReducedTransition\` consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)