### PR TITLE
Tour the solver's features on /about and the splash modal

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,8 +67,8 @@ Scripts that require `pnpm install`:
 - `pnpm i18n:check` — orphan-key audit (`scripts/check-i18n-keys.mjs`)
 - `pnpm dev` — Next.js dev server (used by Claude's `next-dev` preview and by Codex browser verification). It starts at `PORT` or `3000`, then automatically uses the next available port if that one is busy.
 - `pnpm db:up` / `pnpm db:down` — local Docker Postgres for server actions, auth, sharing, and card-pack sync
-- `pnpm build` — static export
-- `pnpm start` — serve the static export
+- `pnpm build` — Next.js production build for Vercel SSR (`next build`), followed by the Serwist PWA worker step (`serwist build`) that emits `public/sw.js`
+- `pnpm start` — serve the built app (`next start`)
 
 Claude's `next-dev` preview configured in `.claude/launch.json` runs `pnpm install && exec pnpm dev` itself, so those previews are self-healing for `node_modules` and the dev server receives shutdown signals directly. They are **not** self-healing for `.env.local` — see "Worktree env setup" below. In Codex, use the local preview workflow below. The pre-commit checks above are not self-healing either; if any of them fails with a module-not-found error, run `pnpm install` first and retry.
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -34,7 +34,94 @@
         "motivation": "Every suggestion leaks information. Keeping track of who must have what gets hard fast — too much to do in your head.",
         "videoCallout": "This solver does the bookkeeping for you. It finds clues you'd miss and teaches the strategy as you play. Watch the kickoff video to learn the logic — so you can be the best detective in the room.",
         "videoTitle": "Clue strategy explainer",
-        "pageHeading": "About the Clue solver"
+        "pageHeading": "About the Clue solver",
+        "walkthrough": {
+            "heading": "Inside the solver",
+            "smartDeductions": {
+                "heading": "Smart deductions as you play",
+                "checklist": {
+                    "title": "A checklist that deduces for you",
+                    "body": "Mark what each player has, and the solver fills in the rest — propagating every clue across the grid and flagging contradictions the moment they appear.",
+                    "imageAlt": "Animation of the checklist filling in deductions as a suggestion is logged"
+                },
+                "suggestionLog": {
+                    "title": "Every suggestion, captured",
+                    "body": "Each guess at the table — who suggested what, who passed, who refuted — gets logged. When it is your turn to refute, the My Cards panel even suggests which card to show, picking the one that leaks the least information about your hand.",
+                    "imageAlt": "Animation of adding a suggestion and watching it land in the suggestion log"
+                },
+                "cellExplanation": {
+                    "title": "See exactly how it got there",
+                    "body": "Tap any cell to see the breakdown. The solver traces every deduction back to the clues that produced it — so you can follow the logic, or double-check its work.",
+                    "imageAlt": "Animation of tapping a cell to open its explanation panel"
+                }
+            },
+            "hypotheses": {
+                "heading": "Test your hunches",
+                "manual": {
+                    "title": "Have a hunch? Test it out.",
+                    "body": "Mark a what-if and the solver tells you whether it is verifiable (must be true), falsifiable (must be false), or unsubstantiated (no way to know yet). Run theories without committing to them in the real game.",
+                    "imageAlt": "Animation of marking a hypothesis and the solver classifying it"
+                },
+                "suggested": {
+                    "title": "Hunches we noticed for you",
+                    "body": "When another player's behavior gives them away — a suggestion they could have refuted but did not, or a pattern in the cards they have shown — the solver flags hunches of its own for you to test.",
+                    "imageAlt": "Animation of the solver surfacing a suggested hypothesis"
+                }
+            },
+            "invite": {
+                "heading": "Play with everyone at your table",
+                "setup": {
+                    "title": "One setup, everyone joins",
+                    "body": "Set up the game once — roster, hand sizes, card pack — then send an invite link. Each player joins on their own device with their own private hand, no duplicate entry.",
+                    "imageAlt": "Animation of setting up a game and inviting players"
+                }
+            },
+            "cardPacks": {
+                "heading": "Custom card packs",
+                "create": {
+                    "title": "Build your own deck",
+                    "body": "Not playing classic? Build a custom card pack with your own suspects, weapons, and rooms.",
+                    "imageAlt": "Animation of building a custom card pack"
+                },
+                "share": {
+                    "title": "Share it with the table",
+                    "body": "Send your pack to the other players so the whole table is on the same deck — no waiting for everyone to type it in themselves.",
+                    "imageAlt": "Animation of sharing a card pack with other players"
+                },
+                "save": {
+                    "title": "Save shared packs for next time",
+                    "body": "Packs other players share with you land in your library. Save them once and they are ready for every future game.",
+                    "imageAlt": "Animation of saving a shared card pack to your library"
+                }
+            },
+            "platforms": {
+                "heading": "Anywhere you play",
+                "desktopMobile": {
+                    "title": "Built for every screen",
+                    "body": "Full keyboard controls on desktop. Touch-friendly on mobile. Install it as an app for a home-screen shortcut and offline access — same game, same data, your choice of device.",
+                    "imageAlt": "The Clue solver running on a desktop browser"
+                }
+            },
+            "teachMe": {
+                "heading": "Or, solve it yourself",
+                "intro": "If you would rather not have the solver give it all away, Teach Me mode hands the deductions back. You mark each cell yourself, and the solver only weighs in when you ask. Solve the case, learn the strategy.",
+                "turnOn": {
+                    "title": "Turn it on at setup",
+                    "body": "Pick Teach Me when you set up the game. The solver steps back, leaving the deductions for you to make on your own.",
+                    "imageAlt": "The Teach Me toggle on the game setup screen"
+                },
+                "markCell": {
+                    "title": "Mark each cell yourself",
+                    "body": "As you spot what a player must (or must not) have, mark the cell. When you want a second opinion, the Check button asks the solver to verify your mark — without revealing anything else.",
+                    "imageAlt": "The Check button inside a cell explanation panel in Teach Me mode"
+                },
+                "checkResult": {
+                    "title": "See if your mark holds up",
+                    "body": "The solver tells you whether your mark is supported by the clues, contradicted by them, or still unsubstantiated — and shows the reasoning when you want to see it.",
+                    "imageAlt": "The Teach Me Check result banner showing the verdict on a marked cell"
+                }
+            }
+        }
     },
     "toolbar": {
         "undo": "Undo{shortcut}",

--- a/next.config.ts
+++ b/next.config.ts
@@ -38,12 +38,6 @@ const nextConfig: NextConfig = {
     // hydration runs once on mount, not twice. We still opt into
     // React 19's other strictness via `strict: true` in tsconfig.
     reactStrictMode: false,
-    images: {
-        // We don't use Next/Image; disable image optimization
-        // defensively so a stray `<Image>` somewhere can't accidentally
-        // route through the optimizer pipeline.
-        unoptimized: true,
-    },
 };
 
 /**

--- a/src/ui/components/AboutContent.test.tsx
+++ b/src/ui/components/AboutContent.test.tsx
@@ -16,11 +16,20 @@ vi.mock("../../analytics/posthog", () => ({
 }));
 
 vi.mock("next-intl", () => ({
-    useTranslations: () => (key: string) => key,
+    useTranslations: (namespace?: string) => {
+        const prefix = namespace !== undefined ? `${namespace}.` : "";
+        return (key: string) => `${prefix}${key}`;
+    },
 }));
 
 vi.mock("react-youtube", () => ({
     default: () => <div data-testid="yt-mock">video</div>,
+}));
+
+vi.mock("next/image", () => ({
+    default: ({ alt }: { alt: string }) => (
+        <div data-testid="next-image" data-alt={alt} />
+    ),
 }));
 
 afterEach(() => {
@@ -37,9 +46,32 @@ describe("AboutContent", () => {
         const AboutContent = await importContent();
         render(<AboutContent context="page" />);
         expect(screen.getByTestId("yt-mock")).toBeInTheDocument();
-        expect(screen.getByText("title")).toBeInTheDocument();
-        expect(screen.getByText("motivation")).toBeInTheDocument();
-        expect(screen.getByText("videoCallout")).toBeInTheDocument();
+        expect(screen.getByText("about.title")).toBeInTheDocument();
+        expect(screen.getByText("about.motivation")).toBeInTheDocument();
+        expect(screen.getByText("about.videoCallout")).toBeInTheDocument();
+    });
+
+    test("renders the walkthrough with every major section", async () => {
+        const AboutContent = await importContent();
+        render(<AboutContent context="page" />);
+        // Walkthrough container heading
+        expect(
+            screen.getByText("about.walkthrough.heading"),
+        ).toBeInTheDocument();
+        // One assertion per major section heading is enough to prove the
+        // walkthrough mounted end-to-end without enumerating all 12 sub-sections.
+        for (const heading of [
+            "about.walkthrough.smartDeductions.heading",
+            "about.walkthrough.hypotheses.heading",
+            "about.walkthrough.invite.heading",
+            "about.walkthrough.cardPacks.heading",
+            "about.walkthrough.platforms.heading",
+            "about.walkthrough.teachMe.heading",
+        ]) {
+            expect(screen.getByText(heading)).toBeInTheDocument();
+        }
+        // 13 walkthrough images render (one per sub-section).
+        expect(screen.getAllByTestId("next-image")).toHaveLength(13);
     });
 
     test("does not fire any analytics events on plain render", async () => {

--- a/src/ui/components/AboutContent.tsx
+++ b/src/ui/components/AboutContent.tsx
@@ -31,29 +31,62 @@ import { YouTubeEmbed } from "./YouTubeEmbed";
 
 const VIDEO_ID = "ijkDbdlpY6c";
 
-const IMAGE_SIZES = "(max-width: 800px) 92vw, 640px";
+// Phone-shaped gifs (01–09) are 500×766 and feel out of place when
+// stretched to the full content column on desktop. Cap them around a
+// phone width and center the frame so the parchment sits around them;
+// on mobile the column is narrower than 400px so the wrapper hits the
+// column width first and the gif fills naturally.
+const PHONE_FRAME_MAX_WIDTH = "max-w-[400px]";
+
+const IMAGE_SIZES_PHONE = "(max-width: 400px) 92vw, 400px";
+const IMAGE_SIZES_FULL = "(max-width: 800px) 92vw, 640px";
+
+// Frame-width discriminators. Pulled to module scope so the
+// i18next/no-literal-string lint rule reads them as identifiers
+// rather than user copy.
+const FRAME_PHONE = "phone" as const;
+const FRAME_FULL = "full" as const;
+
+type FrameWidth = typeof FRAME_PHONE | typeof FRAME_FULL;
 
 function WalkthroughSubsection({
     image,
     alt,
     title,
     body,
+    frameWidth,
     priority = false,
 }: {
     readonly image: StaticImageData;
     readonly alt: string;
     readonly title: string;
     readonly body: string;
+    readonly frameWidth: FrameWidth;
     readonly priority?: boolean;
 }) {
+    const frameClass =
+        frameWidth === FRAME_PHONE
+            ? `mx-auto w-full ${PHONE_FRAME_MAX_WIDTH}`
+            : "w-full";
+    const sizes =
+        frameWidth === FRAME_PHONE ? IMAGE_SIZES_PHONE : IMAGE_SIZES_FULL;
     return (
         <section className="flex flex-col gap-3">
-            <div className="overflow-hidden rounded-[var(--radius)] border border-border/30 bg-panel shadow-sm">
+            <div
+                className={`${frameClass} overflow-hidden rounded-[var(--radius)] border border-border/30 bg-panel shadow-sm`}
+            >
+                {/*
+                  * Shave 2px off every edge of the asset to hide any
+                  * hairline artifact at the source-image boundary. The
+                  * image is sized 4px wider than its container and pulled
+                  * back with a negative margin; the wrapper's
+                  * `overflow-hidden` clips the result.
+                  */}
                 <Image
                     src={image}
                     alt={alt}
-                    sizes={IMAGE_SIZES}
-                    className="block h-auto w-full"
+                    sizes={sizes}
+                    className="-m-[2px] block h-auto w-[calc(100%+4px)] max-w-none"
                     {...(priority ? { priority: true } : {})}
                 />
             </div>
@@ -105,6 +138,7 @@ function Walkthrough() {
                     alt={t("smartDeductions.checklist.imageAlt")}
                     title={t("smartDeductions.checklist.title")}
                     body={t("smartDeductions.checklist.body")}
+                    frameWidth={FRAME_PHONE}
                     priority
                 />
                 <WalkthroughSubsection
@@ -112,12 +146,14 @@ function Walkthrough() {
                     alt={t("smartDeductions.suggestionLog.imageAlt")}
                     title={t("smartDeductions.suggestionLog.title")}
                     body={t("smartDeductions.suggestionLog.body")}
+                    frameWidth={FRAME_PHONE}
                 />
                 <WalkthroughSubsection
                     image={cellExplanationGif}
                     alt={t("smartDeductions.cellExplanation.imageAlt")}
                     title={t("smartDeductions.cellExplanation.title")}
                     body={t("smartDeductions.cellExplanation.body")}
+                    frameWidth={FRAME_PHONE}
                 />
             </MajorSection>
 
@@ -127,12 +163,14 @@ function Walkthrough() {
                     alt={t("hypotheses.manual.imageAlt")}
                     title={t("hypotheses.manual.title")}
                     body={t("hypotheses.manual.body")}
+                    frameWidth={FRAME_PHONE}
                 />
                 <WalkthroughSubsection
                     image={suggestedHypothesesGif}
                     alt={t("hypotheses.suggested.imageAlt")}
                     title={t("hypotheses.suggested.title")}
                     body={t("hypotheses.suggested.body")}
+                    frameWidth={FRAME_PHONE}
                 />
             </MajorSection>
 
@@ -142,6 +180,7 @@ function Walkthrough() {
                     alt={t("invite.setup.imageAlt")}
                     title={t("invite.setup.title")}
                     body={t("invite.setup.body")}
+                    frameWidth={FRAME_PHONE}
                 />
             </MajorSection>
 
@@ -151,18 +190,21 @@ function Walkthrough() {
                     alt={t("cardPacks.create.imageAlt")}
                     title={t("cardPacks.create.title")}
                     body={t("cardPacks.create.body")}
+                    frameWidth={FRAME_PHONE}
                 />
                 <WalkthroughSubsection
                     image={sharePackGif}
                     alt={t("cardPacks.share.imageAlt")}
                     title={t("cardPacks.share.title")}
                     body={t("cardPacks.share.body")}
+                    frameWidth={FRAME_PHONE}
                 />
                 <WalkthroughSubsection
                     image={savePackGif}
                     alt={t("cardPacks.save.imageAlt")}
                     title={t("cardPacks.save.title")}
                     body={t("cardPacks.save.body")}
+                    frameWidth={FRAME_PHONE}
                 />
             </MajorSection>
 
@@ -172,6 +214,7 @@ function Walkthrough() {
                     alt={t("platforms.desktopMobile.imageAlt")}
                     title={t("platforms.desktopMobile.title")}
                     body={t("platforms.desktopMobile.body")}
+                    frameWidth={FRAME_FULL}
                 />
             </MajorSection>
 
@@ -184,18 +227,21 @@ function Walkthrough() {
                     alt={t("teachMe.turnOn.imageAlt")}
                     title={t("teachMe.turnOn.title")}
                     body={t("teachMe.turnOn.body")}
+                    frameWidth={FRAME_FULL}
                 />
                 <WalkthroughSubsection
                     image={teachMeCheckButtonPng}
                     alt={t("teachMe.markCell.imageAlt")}
                     title={t("teachMe.markCell.title")}
                     body={t("teachMe.markCell.body")}
+                    frameWidth={FRAME_FULL}
                 />
                 <WalkthroughSubsection
                     image={teachMeCheckBannerPng}
                     alt={t("teachMe.checkResult.imageAlt")}
                     title={t("teachMe.checkResult.title")}
                     body={t("teachMe.checkResult.body")}
+                    frameWidth={FRAME_FULL}
                 />
             </MajorSection>
         </div>

--- a/src/ui/components/AboutContent.tsx
+++ b/src/ui/components/AboutContent.tsx
@@ -1,8 +1,9 @@
 /**
  * Shared "about" content for the splash modal on `/play` and the
  * standalone `/about` page. The video at the top is the kickoff
- * explainer; the copy below pitches what the solver does for you and
- * sends you to the video for the strategy lesson.
+ * strategy explainer; the copy below pitches what the solver does
+ * for you; the walkthrough below that tours each feature with a
+ * paired gif or screenshot.
  *
  * `context` is forwarded to every analytics event the user can fire
  * from this surface so PostHog can split engagement by where they
@@ -10,10 +11,196 @@
  */
 "use client";
 
+import Image, { type StaticImageData } from "next/image";
 import { useTranslations } from "next-intl";
+import { type ReactNode } from "react";
+import checklistGif from "../../../public/images/walkthrough/walkthrough/01-checklist-suggest-form.gif";
+import suggestionLogGif from "../../../public/images/walkthrough/walkthrough/02-adding-suggestion.gif";
+import cellExplanationGif from "../../../public/images/walkthrough/walkthrough/03-cell-explanation.gif";
+import manualHypothesisGif from "../../../public/images/walkthrough/walkthrough/04-manual-hypothesis.gif";
+import suggestedHypothesesGif from "../../../public/images/walkthrough/walkthrough/05-suggested-hypotheses.gif";
+import gameSetupGif from "../../../public/images/walkthrough/walkthrough/06-game-setup.gif";
+import createPackGif from "../../../public/images/walkthrough/walkthrough/07-create-card-pack.gif";
+import sharePackGif from "../../../public/images/walkthrough/walkthrough/08-share-card-pack.gif";
+import savePackGif from "../../../public/images/walkthrough/walkthrough/09-save-card-pack.gif";
+import desktopPng from "../../../public/images/walkthrough/walkthrough/10-desktop.png";
+import teachMeSetupPng from "../../../public/images/walkthrough/11-teach-me-setup.png";
+import teachMeCheckButtonPng from "../../../public/images/walkthrough/12-teach-me-check-button.png";
+import teachMeCheckBannerPng from "../../../public/images/walkthrough/13-teach-me-check-banner.png";
 import { YouTubeEmbed } from "./YouTubeEmbed";
 
 const VIDEO_ID = "ijkDbdlpY6c";
+
+const IMAGE_SIZES = "(max-width: 800px) 92vw, 640px";
+
+function WalkthroughSubsection({
+    image,
+    alt,
+    title,
+    body,
+    priority = false,
+}: {
+    readonly image: StaticImageData;
+    readonly alt: string;
+    readonly title: string;
+    readonly body: string;
+    readonly priority?: boolean;
+}) {
+    return (
+        <section className="flex flex-col gap-3">
+            <div className="overflow-hidden rounded-[var(--radius)] border border-border/30 bg-panel shadow-sm">
+                <Image
+                    src={image}
+                    alt={alt}
+                    sizes={IMAGE_SIZES}
+                    className="block h-auto w-full"
+                    {...(priority ? { priority: true } : {})}
+                />
+            </div>
+            <div className="flex flex-col gap-2">
+                <h3 className="m-0 font-display text-[1.125rem] leading-tight text-accent">
+                    {title}
+                </h3>
+                <p className="m-0 text-[0.9375rem] leading-relaxed">{body}</p>
+            </div>
+        </section>
+    );
+}
+
+function MajorSection({
+    heading,
+    intro,
+    children,
+}: {
+    readonly heading: string;
+    readonly intro?: string;
+    readonly children: ReactNode;
+}) {
+    return (
+        <div className="flex flex-col gap-5">
+            <div className="flex flex-col gap-2">
+                <h2 className="m-0 font-display text-[1.375rem] leading-tight">
+                    {heading}
+                </h2>
+                {intro !== undefined && (
+                    <p className="m-0 text-[1rem] leading-relaxed">{intro}</p>
+                )}
+            </div>
+            {children}
+        </div>
+    );
+}
+
+function Walkthrough() {
+    const t = useTranslations("about.walkthrough");
+    return (
+        <div className="mt-4 flex flex-col gap-8">
+            <h2 className="m-0 font-display text-[1.5rem] leading-tight text-accent">
+                {t("heading")}
+            </h2>
+
+            <MajorSection heading={t("smartDeductions.heading")}>
+                <WalkthroughSubsection
+                    image={checklistGif}
+                    alt={t("smartDeductions.checklist.imageAlt")}
+                    title={t("smartDeductions.checklist.title")}
+                    body={t("smartDeductions.checklist.body")}
+                    priority
+                />
+                <WalkthroughSubsection
+                    image={suggestionLogGif}
+                    alt={t("smartDeductions.suggestionLog.imageAlt")}
+                    title={t("smartDeductions.suggestionLog.title")}
+                    body={t("smartDeductions.suggestionLog.body")}
+                />
+                <WalkthroughSubsection
+                    image={cellExplanationGif}
+                    alt={t("smartDeductions.cellExplanation.imageAlt")}
+                    title={t("smartDeductions.cellExplanation.title")}
+                    body={t("smartDeductions.cellExplanation.body")}
+                />
+            </MajorSection>
+
+            <MajorSection heading={t("hypotheses.heading")}>
+                <WalkthroughSubsection
+                    image={manualHypothesisGif}
+                    alt={t("hypotheses.manual.imageAlt")}
+                    title={t("hypotheses.manual.title")}
+                    body={t("hypotheses.manual.body")}
+                />
+                <WalkthroughSubsection
+                    image={suggestedHypothesesGif}
+                    alt={t("hypotheses.suggested.imageAlt")}
+                    title={t("hypotheses.suggested.title")}
+                    body={t("hypotheses.suggested.body")}
+                />
+            </MajorSection>
+
+            <MajorSection heading={t("invite.heading")}>
+                <WalkthroughSubsection
+                    image={gameSetupGif}
+                    alt={t("invite.setup.imageAlt")}
+                    title={t("invite.setup.title")}
+                    body={t("invite.setup.body")}
+                />
+            </MajorSection>
+
+            <MajorSection heading={t("cardPacks.heading")}>
+                <WalkthroughSubsection
+                    image={createPackGif}
+                    alt={t("cardPacks.create.imageAlt")}
+                    title={t("cardPacks.create.title")}
+                    body={t("cardPacks.create.body")}
+                />
+                <WalkthroughSubsection
+                    image={sharePackGif}
+                    alt={t("cardPacks.share.imageAlt")}
+                    title={t("cardPacks.share.title")}
+                    body={t("cardPacks.share.body")}
+                />
+                <WalkthroughSubsection
+                    image={savePackGif}
+                    alt={t("cardPacks.save.imageAlt")}
+                    title={t("cardPacks.save.title")}
+                    body={t("cardPacks.save.body")}
+                />
+            </MajorSection>
+
+            <MajorSection heading={t("platforms.heading")}>
+                <WalkthroughSubsection
+                    image={desktopPng}
+                    alt={t("platforms.desktopMobile.imageAlt")}
+                    title={t("platforms.desktopMobile.title")}
+                    body={t("platforms.desktopMobile.body")}
+                />
+            </MajorSection>
+
+            <MajorSection
+                heading={t("teachMe.heading")}
+                intro={t("teachMe.intro")}
+            >
+                <WalkthroughSubsection
+                    image={teachMeSetupPng}
+                    alt={t("teachMe.turnOn.imageAlt")}
+                    title={t("teachMe.turnOn.title")}
+                    body={t("teachMe.turnOn.body")}
+                />
+                <WalkthroughSubsection
+                    image={teachMeCheckButtonPng}
+                    alt={t("teachMe.markCell.imageAlt")}
+                    title={t("teachMe.markCell.title")}
+                    body={t("teachMe.markCell.body")}
+                />
+                <WalkthroughSubsection
+                    image={teachMeCheckBannerPng}
+                    alt={t("teachMe.checkResult.imageAlt")}
+                    title={t("teachMe.checkResult.title")}
+                    body={t("teachMe.checkResult.body")}
+                />
+            </MajorSection>
+        </div>
+    );
+}
 
 export function AboutContent({
     context,
@@ -37,6 +224,7 @@ export function AboutContent({
             <p className="m-0 text-[1rem] leading-relaxed">
                 {t("videoCallout")}
             </p>
+            <Walkthrough />
         </div>
     );
 }

--- a/src/ui/components/SplashModal.test.tsx
+++ b/src/ui/components/SplashModal.test.tsx
@@ -25,6 +25,12 @@ vi.mock("react-youtube", () => ({
     default: () => <div data-testid="yt-mock" />,
 }));
 
+vi.mock("next/image", () => ({
+    default: ({ alt }: { alt: string }) => (
+        <div data-testid="next-image" data-alt={alt} />
+    ),
+}));
+
 afterEach(() => {
     captureCalls.length = 0;
 });

--- a/static-asset-modules.d.ts
+++ b/static-asset-modules.d.ts
@@ -1,0 +1,11 @@
+// Static asset module declarations for TypeScript.
+//
+// Next.js generates `next-env.d.ts` on `next dev` / `next build` with
+// these same `next` / `next/image-types/global` references, but that
+// file is gitignored. CI's `pnpm typecheck` step runs `tsc --noEmit`
+// without first running `next`, so the generated file is missing and
+// `import x from "../public/images/foo.gif"` fails with TS2307. This
+// committed shim provides the same declarations so the typecheck job
+// is self-sufficient.
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />


### PR DESCRIPTION
## Summary

Adds a feature walkthrough to the standalone `/about` page and the splash modal that greets first-time and dormant users on `/play`. Both surfaces already share `AboutContent`, so the walkthrough lands in one place and renders in two.

The walkthrough is six major sections paired with the 13 gifs and screenshots committed earlier (`public/images/walkthrough/...`):

- **Smart deductions as you play** — the auto-deducing checklist, the suggestion log (which also surfaces the My Cards refute hint), and cell-explanation breakdowns.
- **Test your hunches** — manual hypotheses and the suggested hunches the solver flags on its own.
- **Play with everyone at your table** — one setup, an invite link per player, private hands.
- **Custom card packs** — build, share, and save shared packs to your library.
- **Anywhere you play** — desktop keyboard, mobile touch, installable PWA.
- **Or, solve it yourself: Teach Me mode** — turn it on at setup, mark cells yourself, ask the solver to check your work.

Each sub-section pairs an image with a short feature blurb. The 9 phone-shaped gifs sit at ~phone width and centered on desktop (so the parchment breathes around them) and fill the column on mobile. The desktop hero PNG and the three Teach Me strips fill the content column; their wider aspect ratios make the strips render naturally shorter than the hero, matching the "the strips are cropped sections of the same desktop view" framing.

Walkthrough images use `next/image` with static imports so dimensions are inferred at build, layout shift is zero, PNG screenshots get edge-optimized to WebP on Vercel, and lazy loading is on by default below the fold (first gif is `priority`). The stale `images: { unoptimized: true }` flag in `next.config.ts` — added back when the app shipped as a static export — is dropped. `AGENTS.md`'s build description was rewritten to match the current Vercel-SSR-plus-Serwist reality (the static-export wording predated the move to Fluid Compute).

A 2px crop is applied to every walkthrough image via negative margin + `calc(100% + 4px)` width, clipped by the wrapper's existing `overflow-hidden` — hides hairline edge artifacts in the source assets without resorting to transforms or clip-path.

A small `static-asset-modules.d.ts` shim was committed at the repo root because CI's `typecheck` job runs `tsc --noEmit` without first running `next dev` / `next build`, so the gitignored `next-env.d.ts` that normally carries the `next/image-types/global` reference is absent and the gif/png static imports fail with TS2307. The shim carries the same two reference directives so typecheck is self-sufficient.

## Test plan

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm test` (1773 passed), `pnpm knip`, `pnpm i18n:check` — all green.
- [x] Typecheck verified self-sufficient: deleted local `next-env.d.ts` (the auto-generated file CI doesn't have) and re-ran `pnpm typecheck` — clean.
- [x] `/about` at desktop (1280×900): all 6 major sections + 13 sub-sections render; phone gifs sit centered at ~400px wide; desktop hero fills the column; Teach Me strips render at the same width but ~110px shorter than the hero.
- [x] `/about` at mobile (375×812): no horizontal scroll; phone gifs fill the narrower column naturally; Teach Me strips remain proportionally shorter than the hero.
- [x] Splash modal on `/play` (clear `effect-clue.splash.v1` and reload): header pinned top, "Let's solve a murder!" CTA pinned in the sticky footer regardless of scroll, walkthrough scrolls between them.
- [x] PNG optimization round-trip confirmed: `/_next/image?url=...11-teach-me-setup...&w=1920&q=75` returns `image/webp` at 33 KB (down from 127 KB raw).
- [x] No console errors. Dev-mode LCP "consider eager" warnings appear as each gif scrolls into view — known Next 16 dev false positive when lazy-loading large assets; absent in production builds.

## Commits

- `e885cb7` Add feature walkthrough to /about page and splash modal — wires the 13 assets into a new `<Walkthrough />` sub-component appended inside `AboutContent`, with i18n copy under `about.walkthrough.{majorSection}.{subSection}` and tests covering all 6 major-section headings. Drops `images.unoptimized` from `next.config.ts` and rewrites the `pnpm build` / `pnpm start` lines in `AGENTS.md`.
- `e278d80` Frame walkthrough images by aspect: phone-width for gifs, full for desktop — adds a `frameWidth: "phone" | "full"` discriminator to the sub-section component (constants hoisted to module scope per the codebase's `i18next/no-literal-string` convention), caps phone gifs at ~400px centered, leaves the desktop hero and Teach Me strips at full content width, and applies the 2px edge crop.
- `cfb0463` Commit static-asset module shim so CI typecheck finds gif/png imports — adds `static-asset-modules.d.ts` at the repo root with `/// <reference types="next" />` + `/// <reference types="next/image-types/global" />` so the typecheck job no longer depends on a prior `next dev` / `next build` to emit the gitignored `next-env.d.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)