### PR TITLE
Refresh About walkthrough copy and reorder text above each image

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -64,7 +64,7 @@
                 },
                 "suggested": {
                     "title": "Hunches we noticed for you",
-                    "body": "When another player's behavior gives them away — a suggestion they could have refuted but did not, or a pattern in the cards they have shown — the solver flags hunches of its own for you to test.",
+                    "body": "When another player's behavior gives them away — a card they've been suggesting many times, or a pattern in the cards they have shown — the solver flags hunches of its own for you to test.",
                     "imageAlt": "Animation of the solver surfacing a suggested hypothesis"
                 }
             },
@@ -72,7 +72,7 @@
                 "heading": "Play with everyone at your table",
                 "setup": {
                     "title": "One setup, everyone joins",
-                    "body": "Set up the game once — roster, hand sizes, card pack — then send an invite link. Each player joins on their own device with their own private hand, no duplicate entry.",
+                    "body": "Set up the game once — roster, hand sizes, card pack — then send an invite link. Each player joins on their own device with their own private hand, no setup required to join.",
                     "imageAlt": "Animation of setting up a game and inviting players"
                 }
             },
@@ -80,7 +80,7 @@
                 "heading": "Custom card packs",
                 "create": {
                     "title": "Build your own deck",
-                    "body": "Not playing classic? Build a custom card pack with your own suspects, weapons, and rooms.",
+                    "body": "Not playing classic? Build a custom card pack with your own suspects, weapons, and rooms - or any other categories you want. How about _motive_, or _cool catchphrase_? Let your imagination run wild.",
                     "imageAlt": "Animation of building a custom card pack"
                 },
                 "share": {
@@ -112,12 +112,12 @@
                 },
                 "markCell": {
                     "title": "Mark each cell yourself",
-                    "body": "As you spot what a player must (or must not) have, mark the cell. When you want a second opinion, the Check button asks the solver to verify your mark — without revealing anything else.",
+                    "body": "As you spot what a player must (or must not) have, mark the cell. When you want a second opinion, the Check button asks the solver to verify your mark, without revealing anything else. The solver tells you whether your mark is supported by the clues, contradicted by them, or still unsubstantiated. Do it for a single cell...",
                     "imageAlt": "The Check button inside a cell explanation panel in Teach Me mode"
                 },
                 "checkResult": {
                     "title": "See if your mark holds up",
-                    "body": "The solver tells you whether your mark is supported by the clues, contradicted by them, or still unsubstantiated — and shows the reasoning when you want to see it.",
+                    "body": "...or check the whole grid at once. Get an overall spoiler-free check, or let the solver point out which specific cells have logical issues.",
                     "imageAlt": "The Teach Me Check result banner showing the verdict on a marked cell"
                 }
             }

--- a/src/ui/components/AboutContent.tsx
+++ b/src/ui/components/AboutContent.tsx
@@ -72,6 +72,12 @@ function WalkthroughSubsection({
         frameWidth === FRAME_PHONE ? IMAGE_SIZES_PHONE : IMAGE_SIZES_FULL;
     return (
         <section className="flex flex-col gap-3">
+            <div className="flex flex-col gap-2">
+                <h3 className="m-0 font-display text-[1.125rem] leading-tight text-accent">
+                    {title}
+                </h3>
+                <p className="m-0 text-[0.9375rem] leading-relaxed">{body}</p>
+            </div>
             <div
                 className={`${frameClass} overflow-hidden rounded-[var(--radius)] border border-border/30 bg-panel shadow-sm`}
             >
@@ -89,12 +95,6 @@ function WalkthroughSubsection({
                     className="-m-[2px] block h-auto w-[calc(100%+4px)] max-w-none"
                     {...(priority ? { priority: true } : {})}
                 />
-            </div>
-            <div className="flex flex-col gap-2">
-                <h3 className="m-0 font-display text-[1.125rem] leading-tight text-accent">
-                    {title}
-                </h3>
-                <p className="m-0 text-[0.9375rem] leading-relaxed">{body}</p>
             </div>
         </section>
     );
@@ -119,7 +119,9 @@ function MajorSection({
                     <p className="m-0 text-[1rem] leading-relaxed">{intro}</p>
                 )}
             </div>
-            {children}
+            <div className="flex flex-col [&>*+*]:mt-10 [&>*+*]:border-t [&>*+*]:border-accent/30 [&>*+*]:pt-10">
+                {children}
+            </div>
         </div>
     );
 }
@@ -127,7 +129,7 @@ function MajorSection({
 function Walkthrough() {
     const t = useTranslations("about.walkthrough");
     return (
-        <div className="mt-4 flex flex-col gap-8">
+        <div className="mt-4 flex flex-col [&>*+*]:mt-10 [&>*+*]:border-t [&>*+*]:border-accent/30 [&>*+*]:pt-10">
             <h2 className="m-0 font-display text-[1.5rem] leading-tight text-accent">
                 {t("heading")}
             </h2>


### PR DESCRIPTION
Sharpen a few walkthrough strings on the About page (suggested hunches
example, invite tagline, custom card pack pitch, Teach Me Check button
and Check result steps). Swap each subsection layout so the heading and
body sit above the screenshot, and add a thick divider between
subsections so it is clear which paragraph belongs to which image.