### PR TITLE
Tone dropdown badges in lockstep with the pill

### DIFF
--- a/src/ui/components/SuggestionForm.help.test.tsx
+++ b/src/ui/components/SuggestionForm.help.test.tsx
@@ -410,3 +410,313 @@ describe("SuggestionForm — submit button warning", () => {
         ).toBeNull();
     });
 });
+
+// -----------------------------------------------------------------------
+// Badge elevation styling — option-row badges stay muted until the pill
+// itself is in the matching error / warning state due to that option
+// being committed. Same precedence as the pill (error > warning > muted).
+// -----------------------------------------------------------------------
+
+type Elevation = "error" | "warning" | "muted";
+
+const findBadge = (row: HTMLElement, labelKey: RegExp): HTMLElement | null => {
+    const spans = Array.from(row.querySelectorAll<HTMLElement>("span"));
+    return (
+        spans.find(
+            s =>
+                labelKey.test(s.textContent ?? "") &&
+                /\bborder\b/.test(s.className),
+        ) ?? null
+    );
+};
+
+const elevationOf = (badge: HTMLElement): Elevation => {
+    const cls = badge.className;
+    if (cls.includes("bg-danger-bg")) return "error";
+    if (cls.includes("bg-warning-bg")) return "warning";
+    return "muted";
+};
+
+const hasAlertIcon = (badge: HTMLElement): boolean =>
+    badge.querySelector("svg") !== null;
+
+describe("SuggestionForm — badge elevation tracks pill state", () => {
+    test("hard-conflict preview is muted; elevates to error on commit", async () => {
+        // Cross-role conflict: pick Bob as Refuter. Before committing
+        // him as Suggester, his row in the Suggester dropdown should
+        // show a muted "Refuter" preview. After committing him as
+        // Suggester too, the same row should elevate to error.
+        setMockContext({
+            selfPlayerId: A,
+            knowledge: emptyKnowledge,
+        });
+        const user = userEvent.setup();
+        renderForm(<SuggestionForm setup={setup} onSubmit={vi.fn()} />);
+
+        // Stage 1: only Refuter committed.
+        // Skip suggester first by clicking elsewhere; instead navigate
+        // straight to refuter via tab keys is fragile in jsdom — easier
+        // to first commit a suggester (Anisha), then refuter (Bob),
+        // then RE-OPEN suggester and verify Bob's row.
+        const sp1 = await openPopover(user, /pillSuggester/);
+        await user.click(within(sp1).getByRole("option", { name: /Anisha/ }));
+        // close downstream popovers if any.
+        await user.keyboard("{Escape}");
+        const rp = await openPopover(user, /pillRefuter/);
+        await user.click(within(rp).getByRole("option", { name: /Bob/ }));
+        await user.keyboard("{Escape}");
+
+        // Re-open Suggester: Bob is currently the Refuter (preview
+        // conflict), but Bob is NOT yet the suggester — muted.
+        const sp2 = await openPopover(user, /pillSuggester/);
+        const bobRow = within(sp2).getByRole("option", { name: /Bob/ });
+        const previewBadge = findBadge(bobRow, /pillBadgeRoleRefuter/);
+        expect(previewBadge).not.toBeNull();
+        expect(elevationOf(previewBadge!)).toBe("muted");
+        expect(hasAlertIcon(previewBadge!)).toBe(false);
+
+        // Stage 2: commit Bob as Suggester too — both pills go error.
+        await user.click(bobRow);
+        await user.keyboard("{Escape}");
+        const sp3 = await openPopover(user, /pillSuggester/);
+        const bobRow2 = within(sp3).getByRole("option", { name: /Bob/ });
+        const errorBadge = findBadge(bobRow2, /pillBadgeRoleRefuter/);
+        expect(errorBadge).not.toBeNull();
+        expect(elevationOf(errorBadge!)).toBe("error");
+        expect(hasAlertIcon(errorBadge!)).toBe(true);
+    });
+
+    test("Passers 'Can refute' is muted before pill warning, elevates after commit", async () => {
+        // Anisha holds Mustard. Open Passers without checking Anisha:
+        // her row shows the "Can refute" info chip in muted style.
+        // After checking her into passers, the pill warns and her chip
+        // elevates to warning.
+        setMockContext({
+            selfPlayerId: A,
+            knowledge: withCells([[A, MUSTARD, "Y"]]),
+        });
+        const user = userEvent.setup();
+        renderForm(<SuggestionForm setup={setup} onSubmit={vi.fn()} />);
+
+        const sp = await openPopover(user, /pillSuggester/);
+        await user.click(within(sp).getByRole("option", { name: /Bob/ }));
+        const cp = document.querySelector<HTMLElement>(
+            "[data-suggestion-form-popover='true']",
+        )!;
+        await user.click(
+            within(cp).getByRole("option", { name: /Col\. Mustard/ }),
+        );
+        await user.keyboard("{Escape}");
+
+        // Before commit: muted "Can refute" on Anisha's row.
+        const pp1 = await openPopover(user, /pillPassers/);
+        const anishaRow1 = within(pp1).getByRole("option", { name: /Anisha/ });
+        const mutedBadge = findBadge(anishaRow1, /pillBadgeCanRefute/);
+        expect(mutedBadge).not.toBeNull();
+        expect(elevationOf(mutedBadge!)).toBe("muted");
+        expect(hasAlertIcon(mutedBadge!)).toBe(false);
+
+        // Check Anisha as passer → pill warns → re-open and verify.
+        await user.click(anishaRow1);
+        await user.keyboard("{Escape}");
+        const pp2 = await openPopover(user, /pillPassers/);
+        const anishaRow2 = within(pp2).getByRole("option", { name: /Anisha/ });
+        const warnBadge = findBadge(anishaRow2, /pillBadgeCanRefute/);
+        expect(warnBadge).not.toBeNull();
+        expect(elevationOf(warnBadge!)).toBe("warning");
+        expect(hasAlertIcon(warnBadge!)).toBe(true);
+    });
+
+    test("Refuter 'Cannot refute' is muted before commit, elevates to warning after", async () => {
+        // Self (Anisha) holds NONE of the suggested cards. Picking
+        // Anisha as refuter fires `refuterCannotRefute`. Before the
+        // commit, her row in the Refuter dropdown shows muted
+        // "Cannot refute"; after commit it elevates to warning.
+        setMockContext({
+            selfPlayerId: A,
+            knowledge: withCells([
+                [A, MUSTARD, "N"],
+                [A, KNIFE, "N"],
+                [A, KITCHEN, "N"],
+            ]),
+        });
+        const user = userEvent.setup();
+        renderForm(<SuggestionForm setup={setup} onSubmit={vi.fn()} />);
+
+        const sp = await openPopover(user, /pillSuggester/);
+        await user.click(within(sp).getByRole("option", { name: /Bob/ }));
+        const c1 = document.querySelector<HTMLElement>(
+            "[data-suggestion-form-popover='true']",
+        )!;
+        await user.click(
+            within(c1).getByRole("option", { name: /Col\. Mustard/ }),
+        );
+        const c2 = document.querySelector<HTMLElement>(
+            "[data-suggestion-form-popover='true']",
+        )!;
+        await user.click(within(c2).getByRole("option", { name: /Knife/ }));
+        const c3 = document.querySelector<HTMLElement>(
+            "[data-suggestion-form-popover='true']",
+        )!;
+        await user.click(
+            within(c3).getByRole("option", { name: /^Kitchen$/ }),
+        );
+        await user.keyboard("{Escape}");
+
+        // Open Refuter — Anisha's row shows muted "Cannot refute".
+        const rp1 = await openPopover(user, /pillRefuter/);
+        const anishaRow1 = within(rp1).getByRole("option", { name: /Anisha/ });
+        const mutedBadge = findBadge(anishaRow1, /pillBadgeCannotRefute/);
+        expect(mutedBadge).not.toBeNull();
+        expect(elevationOf(mutedBadge!)).toBe("muted");
+        expect(hasAlertIcon(mutedBadge!)).toBe(false);
+
+        // Pick Anisha → pill warns → re-open and verify elevation.
+        await user.click(anishaRow1);
+        await user.keyboard("{Escape}");
+        const rp2 = await openPopover(user, /pillRefuter/);
+        const anishaRow2 = within(rp2).getByRole("option", { name: /Anisha/ });
+        const warnBadge = findBadge(anishaRow2, /pillBadgeCannotRefute/);
+        expect(warnBadge).not.toBeNull();
+        expect(elevationOf(warnBadge!)).toBe("warning");
+        expect(hasAlertIcon(warnBadge!)).toBe(true);
+    });
+
+    test("only the committed cause elevates — other rows stay muted", async () => {
+        // Both Anisha and Cho hold cards that could refute. Only
+        // Anisha is added as a passer. Anisha's "Can refute" badge
+        // should be warning; Cho's should stay muted.
+        setMockContext({
+            selfPlayerId: A,
+            knowledge: withCells([
+                [A, MUSTARD, "Y"],
+                [C, KNIFE, "Y"],
+            ]),
+        });
+        const user = userEvent.setup();
+        renderForm(<SuggestionForm setup={setup} onSubmit={vi.fn()} />);
+
+        const sp = await openPopover(user, /pillSuggester/);
+        await user.click(within(sp).getByRole("option", { name: /Bob/ }));
+        const c1 = document.querySelector<HTMLElement>(
+            "[data-suggestion-form-popover='true']",
+        )!;
+        await user.click(
+            within(c1).getByRole("option", { name: /Col\. Mustard/ }),
+        );
+        const c2 = document.querySelector<HTMLElement>(
+            "[data-suggestion-form-popover='true']",
+        )!;
+        await user.click(within(c2).getByRole("option", { name: /Knife/ }));
+        await user.keyboard("{Escape}");
+
+        // Check only Anisha as passer.
+        const pp1 = await openPopover(user, /pillPassers/);
+        const anishaRowOpen = within(pp1).getByRole("option", {
+            name: /Anisha/,
+        });
+        await user.click(anishaRowOpen);
+        await user.keyboard("{Escape}");
+
+        // Re-open and verify per-row elevation.
+        const pp2 = await openPopover(user, /pillPassers/);
+        const anishaRow = within(pp2).getByRole("option", { name: /Anisha/ });
+        const choRow = within(pp2).getByRole("option", { name: /Cho/ });
+
+        const anishaBadge = findBadge(anishaRow, /pillBadgeCanRefute/);
+        const choBadge = findBadge(choRow, /pillBadgeCanRefute/);
+        expect(anishaBadge).not.toBeNull();
+        expect(choBadge).not.toBeNull();
+        expect(elevationOf(anishaBadge!)).toBe("warning");
+        expect(elevationOf(choBadge!)).toBe("muted");
+        expect(hasAlertIcon(anishaBadge!)).toBe(true);
+        expect(hasAlertIcon(choBadge!)).toBe(false);
+    });
+
+    test("Passers error elevation when committed passer is also the suggester", async () => {
+        // Bob is suggester. Reopen suggester pill while bob is also
+        // checked as a passer → both pills carry `suggesterInPassers`.
+        setMockContext({
+            selfPlayerId: A,
+            knowledge: emptyKnowledge,
+        });
+        const user = userEvent.setup();
+        renderForm(<SuggestionForm setup={setup} onSubmit={vi.fn()} />);
+
+        const sp = await openPopover(user, /pillSuggester/);
+        await user.click(within(sp).getByRole("option", { name: /Bob/ }));
+        const c1 = document.querySelector<HTMLElement>(
+            "[data-suggestion-form-popover='true']",
+        )!;
+        await user.click(
+            within(c1).getByRole("option", { name: /Col\. Mustard/ }),
+        );
+        await user.keyboard("{Escape}");
+
+        // Open Passers and check Bob (who is the current suggester).
+        const pp1 = await openPopover(user, /pillPassers/);
+        const bobRowOpen = within(pp1).getByRole("option", { name: /Bob/ });
+        // Preview "Suggester" badge should be muted before commit.
+        const previewBadge = findBadge(bobRowOpen, /pillBadgeRoleSuggester/);
+        expect(previewBadge).not.toBeNull();
+        expect(elevationOf(previewBadge!)).toBe("muted");
+
+        await user.click(bobRowOpen);
+        await user.keyboard("{Escape}");
+
+        // Re-open and verify Bob's badge is now error.
+        const pp2 = await openPopover(user, /pillPassers/);
+        const bobRow = within(pp2).getByRole("option", { name: /Bob/ });
+        const errorBadge = findBadge(bobRow, /pillBadgeRoleSuggester/);
+        expect(errorBadge).not.toBeNull();
+        expect(elevationOf(errorBadge!)).toBe("error");
+        expect(hasAlertIcon(errorBadge!)).toBe(true);
+    });
+
+    test("muted baseline: 'Cannot refute' on Passers row uses muted class without AlertIcon", async () => {
+        // Self has no card in the suggestion (all N, all categories
+        // filled) — no pill warning fires on Passers (since Anisha is
+        // not selected as passer), so her "Cannot refute" badge should
+        // be muted with no AlertIcon.
+        setMockContext({
+            selfPlayerId: A,
+            knowledge: withCells([
+                [A, MUSTARD, "N"],
+                [A, KNIFE, "N"],
+                [A, KITCHEN, "N"],
+            ]),
+        });
+        const user = userEvent.setup();
+        renderForm(<SuggestionForm setup={setup} onSubmit={vi.fn()} />);
+
+        const sp = await openPopover(user, /pillSuggester/);
+        await user.click(within(sp).getByRole("option", { name: /Bob/ }));
+        const c1 = document.querySelector<HTMLElement>(
+            "[data-suggestion-form-popover='true']",
+        )!;
+        await user.click(
+            within(c1).getByRole("option", { name: /Col\. Mustard/ }),
+        );
+        const c2 = document.querySelector<HTMLElement>(
+            "[data-suggestion-form-popover='true']",
+        )!;
+        await user.click(within(c2).getByRole("option", { name: /Knife/ }));
+        const c3 = document.querySelector<HTMLElement>(
+            "[data-suggestion-form-popover='true']",
+        )!;
+        await user.click(
+            within(c3).getByRole("option", { name: /^Kitchen$/ }),
+        );
+        await user.keyboard("{Escape}");
+
+        const pp = await openPopover(user, /pillPassers/);
+        const anishaRow = within(pp).getByRole("option", { name: /Anisha/ });
+        const badge = findBadge(anishaRow, /pillBadgeCannotRefute/);
+        expect(badge).not.toBeNull();
+        expect(elevationOf(badge!)).toBe("muted");
+        expect(hasAlertIcon(badge!)).toBe(false);
+        // Visible framing — the muted class carries `bg-control` so it
+        // contrasts against the dropdown's `bg-panel` background.
+        expect(badge!.className).toMatch(/bg-control/);
+    });
+});

--- a/src/ui/components/SuggestionForm.tsx
+++ b/src/ui/components/SuggestionForm.tsx
@@ -638,15 +638,104 @@ export const SuggestionForm = forwardRef<
     // --- Help-layer badge renderers -----------------------------------
     //
     // Every player row in Suggester / Passers / Refuter first checks
-    // for a cross-role hard conflict — picking that option would land
-    // a `validateFormConsistency` error on the pill, so we badge it
-    // (red, AlertIcon) BEFORE selection. If no hard conflict, fall
-    // back to soft `help.evidenceByPlayer`: in Passers, definiteYes
-    // is a warning (the player can refute, so listing them as passing
-    // contradicts what we know); in Refuter, definiteNo is the
-    // warning side. Returns `null` for any option / card we have
-    // nothing to say about — the underlying dropdown swallows the
-    // null cleanly. Suggester has no soft layer.
+    // for a cross-role hard conflict — picking that option WOULD land
+    // a `validateFormConsistency` error on the pill, so we surface the
+    // role label BEFORE selection. Without a conflict, fall back to
+    // soft `help.evidenceByPlayer` ("Can refute" / "Cannot refute").
+    //
+    // The CHIP STYLE is governed by `BadgeElevation`: every option is
+    // muted until the pill itself is in the matching error / warning
+    // state due to THIS option being committed. Then the chip elevates
+    // to error / warning, in lockstep with the pill. Precedence
+    // matches the pill: error > warning > muted.
+    //
+    // Returns `null` when there's no informational text to show.
+
+    /* eslint-disable i18next/no-literal-string -- internal pill-error-code and elevation-tag values, not user-facing copy */
+    const elevationForSuggester = useCallback(
+        (player: Player): BadgeElevation => {
+            const code = errors.get(PILL_SUGGESTER);
+            if (
+                (code === "suggesterIsRefuter" ||
+                    code === "suggesterInPassers") &&
+                player === form.suggester
+            ) {
+                return "error";
+            }
+            return "muted";
+        },
+        [errors, form.suggester],
+    );
+
+    const elevationForPasser = useCallback(
+        (player: Player): BadgeElevation => {
+            const code = errors.get(PILL_PASSERS);
+            if (code === "suggesterInPassers" && player === form.suggester) {
+                return "error";
+            }
+            if (code === "refuterInPassers" && player === form.refuter) {
+                return "error";
+            }
+            const w = warnings.get(PILL_PASSERS);
+            if (
+                w !== undefined &&
+                w.kind === "passersIncludePlayersWhoCanRefute" &&
+                w.players.some(p => p === player)
+            ) {
+                return "warning";
+            }
+            return "muted";
+        },
+        [errors, warnings, form.suggester, form.refuter],
+    );
+
+    const elevationForRefuter = useCallback(
+        (player: Player): BadgeElevation => {
+            const code = errors.get(PILL_REFUTER);
+            if (
+                (code === "suggesterIsRefuter" ||
+                    code === "refuterInPassers") &&
+                player === form.refuter
+            ) {
+                return "error";
+            }
+            const w = warnings.get(PILL_REFUTER);
+            if (
+                w !== undefined &&
+                w.kind === "refuterCannotRefute" &&
+                player === form.refuter
+            ) {
+                return "warning";
+            }
+            return "muted";
+        },
+        [errors, warnings, form.refuter],
+    );
+
+    const elevationForShownCard = useCallback(
+        (card: Card): BadgeElevation => {
+            const code = errors.get(PILL_SEEN);
+            if (
+                (code === "seenCardNotSuggested" ||
+                    code === "seenCardWithoutRefuter") &&
+                card === form.seenCard
+            ) {
+                return "error";
+            }
+            const w = warnings.get(PILL_SEEN);
+            if (
+                w !== undefined &&
+                w.kind === "shownCardNotInRefuterHand" &&
+                card === form.seenCard
+            ) {
+                return "warning";
+            }
+            return "muted";
+        },
+        [errors, warnings, form.seenCard],
+    );
+    /* eslint-enable i18next/no-literal-string */
+
     const renderSuggesterBadge = useCallback(
         (player: Player): ReactNode => {
             const conflict = findHardRoleConflict(
@@ -656,14 +745,19 @@ export const SuggestionForm = forwardRef<
                 "suggester",
             );
             if (conflict !== null) {
-                return renderHardRoleConflictBadge(conflict, t);
+                return renderHardRoleConflictBadge(
+                    conflict,
+                    t,
+                    elevationForSuggester(player),
+                );
             }
             return null;
         },
-        [form, t],
+        [form, t, elevationForSuggester],
     );
     const renderPasserBadge = useCallback(
         (player: Player): ReactNode => {
+            const elevation = elevationForPasser(player);
             const conflict = findHardRoleConflict(
                 player,
                 form,
@@ -671,17 +765,18 @@ export const SuggestionForm = forwardRef<
                 "passer",
             );
             if (conflict !== null) {
-                return renderHardRoleConflictBadge(conflict, t);
+                return renderHardRoleConflictBadge(conflict, t, elevation);
             }
             if (!help.active) return null;
             const evidence = help.evidenceByPlayer.get(player);
             if (evidence === undefined) return null;
-            return renderPasserOptionBadge(evidence, t);
+            return renderPasserOptionBadge(evidence, t, elevation);
         },
-        [form, help, t],
+        [form, help, t, elevationForPasser],
     );
     const renderRefuterBadge = useCallback(
         (player: Player): ReactNode => {
+            const elevation = elevationForRefuter(player);
             const conflict = findHardRoleConflict(
                 player,
                 form,
@@ -689,14 +784,14 @@ export const SuggestionForm = forwardRef<
                 "refuter",
             );
             if (conflict !== null) {
-                return renderHardRoleConflictBadge(conflict, t);
+                return renderHardRoleConflictBadge(conflict, t, elevation);
             }
             if (!help.active) return null;
             const evidence = help.evidenceByPlayer.get(player);
             if (evidence === undefined) return null;
-            return renderRefuterOptionBadge(evidence, t);
+            return renderRefuterOptionBadge(evidence, t, elevation);
         },
-        [form, help, t],
+        [form, help, t, elevationForRefuter],
     );
     // Shown-card option badges render whenever we have advice for the
     // current refuter — self gets the full tier-bearing badge, other
@@ -708,9 +803,9 @@ export const SuggestionForm = forwardRef<
             const badge = help.shownCardAdvice.get(card);
             return badge === undefined || badge === null
                 ? null
-                : renderShownCardBadgeNode(badge, t);
+                : renderShownCardBadgeNode(badge, t, elevationForShownCard(card));
         },
-        [help, t],
+        [help, t, elevationForShownCard],
     );
 
     // --- Slot configs --------------------------------------------------
@@ -1705,9 +1800,23 @@ const BADGE_ERROR_CLASS =
     "border border-danger-border bg-danger-bg px-1.5 py-0.5 " +
     "text-[0.85em] text-danger";
 
+// Muted needs a visible background on `bg-panel` popovers — `bg-control`
+// reads as a deliberate, slight lift on the cream popover surface, and
+// the aged-paper border parallels the warning / error badge shape.
 const BADGE_MUTED_CLASS =
-    "ml-2 inline-flex items-center rounded-[var(--radius)] bg-panel " +
-    "px-1.5 py-0.5 text-[0.85em] text-muted";
+    "ml-2 inline-flex items-center rounded-[var(--radius)] " +
+    "border border-border bg-control px-1.5 py-0.5 " +
+    "text-[0.85em] text-muted";
+
+/**
+ * Visual elevation for an option-row badge. Dropdown option badges
+ * stay informational (`muted`) until the pill itself surfaces an error
+ * or warning whose CAUSE is this specific option — then the badge
+ * elevates to match the pill's tone. The text label is identical
+ * across all three elevations; only the chip style + presence of
+ * `AlertIcon` changes.
+ */
+type BadgeElevation = "error" | "warning" | "muted";
 
 /**
  * The role a player currently occupies in `form`. Used by
@@ -1769,15 +1878,33 @@ const HARD_CONFLICT_BADGE_KEY: Record<FormPlayerRole, string> = {
     passer: "pillBadgeRolePasser",
 };
 
+const renderElevatedBadge = (
+    elevation: BadgeElevation,
+    label: string,
+): ReactNode => {
+    if (elevation === "muted") {
+        return <span className={BADGE_MUTED_CLASS}>{label}</span>;
+    }
+    return (
+        <span
+            className={
+                elevation === "error"
+                    ? BADGE_ERROR_CLASS
+                    : BADGE_WARNING_CLASS
+            }
+            role="status"
+        >
+            <AlertIcon className="h-[0.95em] w-[0.95em]" />
+            {label}
+        </span>
+    );
+};
+
 const renderHardRoleConflictBadge = (
     role: FormPlayerRole,
     t: TFnAny,
-): ReactNode => (
-    <span className={BADGE_ERROR_CLASS} role="status">
-        <AlertIcon className="h-[0.95em] w-[0.95em]" />
-        {t(HARD_CONFLICT_BADGE_KEY[role])}
-    </span>
-);
+    elevation: BadgeElevation,
+): ReactNode => renderElevatedBadge(elevation, t(HARD_CONFLICT_BADGE_KEY[role]));
 
 // Tier label key map — mirrors the one in RefuteAdvicePanel so the
 // dropdown badges read in the same vocabulary as the advice panel.
@@ -1791,21 +1918,13 @@ const TIER_LABEL_KEY: Record<RefuteAdviceTier, string> = {
 const renderPasserOptionBadge = (
     evidence: RefuteEvidence,
     t: TFnAny,
+    elevation: BadgeElevation,
 ): ReactNode => {
     if (evidence === "definiteYes") {
-        return (
-            <span className={BADGE_WARNING_CLASS} role="status">
-                <AlertIcon className="h-[0.95em] w-[0.95em]" />
-                {t("pillBadgeCanRefute")}
-            </span>
-        );
+        return renderElevatedBadge(elevation, t("pillBadgeCanRefute"));
     }
     if (evidence === "definiteNo") {
-        return (
-            <span className={BADGE_MUTED_CLASS}>
-                {t("pillBadgeCannotRefute")}
-            </span>
-        );
+        return renderElevatedBadge(elevation, t("pillBadgeCannotRefute"));
     }
     return null;
 };
@@ -1813,21 +1932,13 @@ const renderPasserOptionBadge = (
 const renderRefuterOptionBadge = (
     evidence: RefuteEvidence,
     t: TFnAny,
+    elevation: BadgeElevation,
 ): ReactNode => {
     if (evidence === "definiteYes") {
-        return (
-            <span className={BADGE_MUTED_CLASS}>
-                {t("pillBadgeCanRefute")}
-            </span>
-        );
+        return renderElevatedBadge(elevation, t("pillBadgeCanRefute"));
     }
     if (evidence === "definiteNo") {
-        return (
-            <span className={BADGE_WARNING_CLASS} role="status">
-                <AlertIcon className="h-[0.95em] w-[0.95em]" />
-                {t("pillBadgeCannotRefute")}
-            </span>
-        );
+        return renderElevatedBadge(elevation, t("pillBadgeCannotRefute"));
     }
     return null;
 };
@@ -1835,17 +1946,14 @@ const renderRefuterOptionBadge = (
 const renderShownCardBadgeNode = (
     badge: ShownCardBadge,
     t: TFnAny,
+    elevation: BadgeElevation,
 ): ReactNode => {
     if (badge === null) return null;
     if (badge.kind === "doNotHave") {
-        return (
-            <span className={BADGE_WARNING_CLASS} role="status">
-                <AlertIcon className="h-[0.95em] w-[0.95em]" />
-                {t("pillBadgeDoNotHave")}
-            </span>
-        );
+        return renderElevatedBadge(elevation, t("pillBadgeDoNotHave"));
     }
-    // Candidate: tier label + optional Forced / Recommended.
+    // Candidate: tier label + optional Forced / Recommended. These chips
+    // stay muted regardless of pill state — they're advice, not warnings.
     return (
         <span className="ml-2 inline-flex items-center gap-1">
             <span className={BADGE_MUTED_CLASS}>


### PR DESCRIPTION
## What changes for the user

Two fixes to the per-option badges inside the suggestion-form pill dropdowns (Suggester / Passers / Refuter / Shown card):

1. **The non-warning badge is now visible.** Chips like "Cannot refute" were rendering on the same cream as the dropdown popover, so they read as plain text with no badge framing. The muted chip now carries a parchment-edge border and a slightly darker fill that parallels the warning / error chip shape — it actually looks like a badge against the popover surface.

2. **Warning / error styling on options is now in lockstep with the pill.** Before this change, a dropdown option would flash a red "Suggester" preview or a mustard "Can refute" chip before the user had committed anything invalid — the pill itself was still neutral, but the dropdown was already raising alarms. Now every row keeps its informational text (Can refute / Cannot refute / Suggester role preview / Do not have) in the muted style by default, so users still see the info in advance; the visual alarm only lights up when the pill itself is in the matching error / warning state due to that specific option being committed. Precedence matches the pill: error > warning > muted.

The candidate tier chips inside the Shown-card dropdown (tier label + Forced / Recommended) stay muted under every pill state — they're advice, not warnings.

## Commit log

- **Tone dropdown badges in lockstep with the pill** — introduces a `BadgeElevation = "error" | "warning" | "muted"` type and a single `renderElevatedBadge` helper that picks chip class + `AlertIcon` based on elevation. Adds four per-pill elevation computers (`elevationForSuggester` / `elevationForPasser` / `elevationForRefuter` / `elevationForShownCard`) that close over the existing `errors` (from `validateFormConsistency`) and `warnings` (from `validateFormSoft`) maps and only return `"error"` / `"warning"` when the matching pill code/warning is present AND this option is the cause. The four low-level badge renderers (`renderHardRoleConflictBadge`, `renderPasserOptionBadge`, `renderRefuterOptionBadge`, `renderShownCardBadgeNode`) now take an elevation argument; the four per-pill `useCallback` renderers compute elevation per option and pass it through. `BADGE_MUTED_CLASS` swaps `bg-panel` for `border border-border bg-control` so it stands out on the popover. Adds 6 elevation-style assertions in `SuggestionForm.help.test.tsx` covering hard-conflict muted preview → error elevation on commit, Passers warning elevation only on the committed cause, Passers error elevation when the committed passer is the suggester, Refuter warning elevation, per-row isolation, and the muted baseline (verifying `bg-control` is on the class).

https://claude.ai/code/session_01QUsi4NG79p9fBK5Dw91Gh2

---
_Generated by [Claude Code](https://claude.ai/code/session_01QUsi4NG79p9fBK5Dw91Gh2)_