### PR TITLE
Defer pill "touched" until close, and wrap long warning-banner copy

### DIFF
--- a/src/ui/components/SuggestionForm.tsx
+++ b/src/ui/components/SuggestionForm.tsx
@@ -290,19 +290,22 @@ export const SuggestionForm = forwardRef<
     // button should get focus." See the effect below.
     const [openPillId, setOpenPillId] = useState<OpenTarget>(null);
     const pillFormRef = useRef<PillFormHandle>(null);
-    // Tracks whether the user has addressed the Refuter pill — opened
-    // it (whether or not they selected) or attempted submit. Drives
-    // the soft warning `someoneCanRefuteButNobodyMarked` for the
-    // blank case so a pristine new form doesn't fire the instant
-    // we know a non-suggester has a card. Edit mode treats the
-    // stored suggestion's refuter as already affirmed.
+    // Tracks whether the user has addressed the Refuter pill — by
+    // closing it after opening it (whether they committed a value,
+    // picked Nobody, or closed without selecting) or by clicking
+    // Add. Drives the soft warning `someoneCanRefuteButNobodyMarked`
+    // for the blank case so a pristine new form doesn't fire the
+    // instant we know a non-suggester has a card, and merely
+    // *opening* the pill (without giving the user a beat to look
+    // at it) doesn't fire it either. Edit mode treats the stored
+    // suggestion's refuter as already affirmed.
     const [refuterTouched, setRefuterTouched] = useState<boolean>(
         suggestion !== undefined,
     );
     // Same shape as `refuterTouched`, for the Seen-card pill. Drives
-    // `selfSuggesterMissingSeenCard` — the warning that fires when
-    // self is the suggester and was refuted, but no shown card has
-    // been recorded.
+    // `selfSuggesterMissingSeenCard` / `selfRefuterMissingSeenCard`
+    // — the warnings that fire when self was involved in the
+    // refutation but no shown card has been recorded.
     const [seenCardTouched, setSeenCardTouched] = useState<boolean>(
         suggestion !== undefined,
     );
@@ -314,16 +317,29 @@ export const SuggestionForm = forwardRef<
         [],
     );
 
-    // Flip `refuterTouched` / `seenCardTouched` true the moment the
-    // corresponding pill becomes the open one — whether via user
-    // click, keyboard nav, or auto-advance after a previous pill
-    // commit. We watch `openPillId` instead of intercepting
-    // `onOpenPillIdChange` so internal `setOpenPillId(...)` calls
-    // (from `commitAndAdvance`) also count as "the pill was
-    // addressed".
+    // Flip `refuterTouched` / `seenCardTouched` true when the user
+    // is *done* with the pill — that is, when `openPillId`
+    // transitions FROM that pill to anything else (closed, or a
+    // different pill open). All of these count as "the user is
+    // done": a value commit (commitAndAdvance moves openPillId to
+    // the next pill), picking Nobody (same), closing without
+    // selecting (openPillId → null), or clicking another pill
+    // (Radix closes the current one). Firing on close (rather
+    // than on open) gives the user a beat to look at the dropdown
+    // before the warning surfaces.
+    //
+    // `doSubmit` flips both flags true on Add click independently
+    // of this effect — that path doesn't need a pill close.
+    const prevOpenPillIdRef = useRef<OpenTarget>(openPillId);
     useEffect(() => {
-        if (openPillId === PILL_REFUTER) setRefuterTouched(true);
-        if (openPillId === PILL_SEEN) setSeenCardTouched(true);
+        const prev = prevOpenPillIdRef.current;
+        prevOpenPillIdRef.current = openPillId;
+        if (prev === PILL_REFUTER && openPillId !== PILL_REFUTER) {
+            setRefuterTouched(true);
+        }
+        if (prev === PILL_SEEN && openPillId !== PILL_SEEN) {
+            setSeenCardTouched(true);
+        }
     }, [openPillId]);
 
     /**

--- a/src/ui/components/SuggestionPills.tsx
+++ b/src/ui/components/SuggestionPills.tsx
@@ -424,7 +424,13 @@ export function PillPopover({
                             e.preventDefault();
                         }
                     }}
-                    className="z-[var(--z-popover)] min-w-[200px] rounded-[var(--radius)] border border-border bg-panel p-1 text-[1rem] shadow-[0_6px_16px_rgba(0,0,0,0.18)]"
+                    // `max-w-[calc(100vw-1rem)]` caps the popover at
+                    // viewport width so long warning-banner copy or
+                    // long option rows can't push it past the
+                    // visible edge. The banner inside has default
+                    // `white-space: normal`, so capping the
+                    // container is enough to make it wrap.
+                    className="z-[var(--z-popover)] min-w-[200px] max-w-[calc(100vw-1rem)] rounded-[var(--radius)] border border-border bg-panel p-1 text-[1rem] shadow-[0_6px_16px_rgba(0,0,0,0.18)]"
                 >
                     {disabled ? (
                         <div


### PR DESCRIPTION
## Summary

Two refinements to the soft-warning UI introduced across #250-#252.

### Defer "touched" until the user is done with the pill

Previously `refuterTouched` / `seenCardTouched` flipped true the **moment the pill opened**, so the warning banner appeared the instant the user clicked the trigger — before they'd had a chance to look at the dropdown. The flags now flip true when `openPillId` transitions **FROM** that pill to anything else: a value commit (auto-advance to the next pill), picking Nobody (same), closing without selecting (Escape / outside-click → `openPillId === null`), or clicking another pill (Radix closes the current). The submit handler's explicit flip on Add click is unchanged.

Net effect: the user gets a beat to read the dropdown without being barked at; the warning only appears once they've actually addressed the pill.

### Wrap long warning-banner copy at viewport edges

Some explanations — e.g. **"Player 3 does not have this card — it cannot be what was shown."** — were wider than the visible viewport, so the popover's right edge slid offscreen and the banner (plus the per-row "Do not have" badge) got clipped. The fix caps the popover at `max-w-[calc(100vw-1rem)]`. The banner inside uses default `white-space: normal`, so capping the container is enough to make it wrap. Long option rows also re-flow inside the capped width (label uses `flex-1`, badge stays at intrinsic size).

## Commits

- **`02369a4` Defer touched flags until pill close + wrap warning banner** — Replaces the open-driven `useEffect` with a previous-value-ref pattern: a `prevOpenPillIdRef` captures the prior `openPillId` every render; the effect compares prev vs current and flips the relevant flag only on a "FROM the pill TO anything else" transition. Comment blocks at each `useState` are refreshed so "opened it (whether or not they selected)" no longer reads as the source of truth — replaced with "closed it (after committing, picking Nobody, or closing without selecting)." Popover content `max-w` lives on the single Radix `Popover.Content` className in `SuggestionPills.tsx`; affects all consumers of `PillPopover` uniformly (the suggestion form's six pills + the accusation form's three).

## Test plan

- [x] `pnpm typecheck` · `pnpm lint` · `pnpm test` (1849/1849) · `pnpm knip` · `pnpm i18n:check`
- [ ] No new unit tests — the touched-flag wiring is internal form state, and exercising it via the warning banner needs a `ClueProvider` + Knowledge fixture that the form-rendering tests don't currently set up; the change is narrow (a `useRef` + transition comparison) and the existing 13 validator tests already pin the `*Touched=true` / `false` behavior at the validator layer.
- [ ] Manual browser walk — needs verifying that (a) opening the Refuter pill on a "someone could refute" state does NOT show the warning yet, closing without selecting DOES, and (b) the warning-banner text wraps cleanly on a narrow mobile viewport so neither the banner nor the dropdown rows extend offscreen. Couldn't run in this remote env (`.env.local` not available).

---
_Generated by [Claude Code](https://claude.ai/code/session_01SSZPURRhTDpgTDieTEq7zP)_