### PR TITLE
Flow Your Cards category pills inline with card names

### DIFF
--- a/src/ui/components/MyHandPanel.tsx
+++ b/src/ui/components/MyHandPanel.tsx
@@ -2,7 +2,7 @@
 
 import { motion, useReducedMotion } from "motion/react";
 import { useTranslations } from "next-intl";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import {
     myCardsSectionToggled,
     MY_CARDS_SURFACE_SECTION,
@@ -395,24 +395,26 @@ export function MyHandPanelBody() {
     }
 
     return (
-        <ul className="m-0 flex list-none flex-wrap gap-x-3 gap-y-1 p-0">
-            {grouped.map(group => (
-                <li
-                    key={String(group.id)}
-                    className="flex items-center gap-1.5 text-[1rem]"
-                >
+        <div className="m-0 text-[1rem] leading-7">
+            {grouped.map((group, idx) => (
+                <Fragment key={String(group.id)}>
+                    {idx > 0 && " "}
                     {/* Category pill — mirrors the deduction-grid
                         category-header style (bg-category-header,
                         white text, uppercase, tracking-[0.05em]) so
-                        the chip row reads in the same visual
-                        vocabulary the user has already learned in the
-                        grid. */}
-                    <span className="rounded bg-category-header px-1.5 py-0 text-[0.75rem] font-semibold uppercase tracking-[0.05em] text-white">
+                        the chip reads in the same visual vocabulary
+                        the user has already learned in the grid. The
+                        non-breaking space after the pill keeps it
+                        glued to its first card name so a line wrap
+                        never strands the pill alone at the right
+                        edge. */}
+                    <span className="inline-block rounded bg-category-header px-1.5 py-0 align-middle text-[0.75rem] font-semibold uppercase tracking-[0.05em] text-white">
                         {group.label}
                     </span>
-                    <span>{group.cards.join(", ")}</span>
-                </li>
+                    {"\u00a0"}
+                    {group.cards.join(", ")}
+                </Fragment>
             ))}
-        </ul>
+        </div>
     );
 }


### PR DESCRIPTION
## Behavior

The Your Cards panel previously rendered each category as its own row: a `SUSPECT`/`WEAPON`/`ROOM` pill on the left, the comma-joined card names on the right, wrapping within the row. With multiple cards in a category the names broke onto a second line within that row, and every new category started a fresh row below.

Now the whole listing flows as one wrapping line of text — pills and card names sit inline, the line wraps naturally wherever there's a group break, and the next category's pill can sit right next to the previous category's last card name if there's room. Less formal but quicker to scan when the user just wants to see what cards they have.

## Commits

- **Flow Your Cards category pills inline with card names** — `src/ui/components/MyHandPanel.tsx`: replace the per-category `<ul>`/`<li>` flex rows with a single `<div>` of inline-flowing text. Each group contributes pill + NBSP + comma-joined names. The NBSP keeps the pill glued to its first card so a wrap never strands the pill alone at the right edge. Pills become `inline-block align-middle` so the smaller pill font (`0.75rem`) sits cleanly against the surrounding `1rem` text.

## Verification

- Pre-commit: typecheck ✓ / lint ✓ / test ✓ (1849 passed) / knip ✓ / i18n:check ✓.
- Manual browser walkthrough was not possible in the remote session container (no `.env.local` available; `pnpm dev` hard-requires `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`). Existing `MyHandPanel` tests assert on `panel.textContent` and still pass — but the pill baseline alignment against the 1rem card text should be eyeballed in `next-dev` at desktop and mobile widths before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3GZK4Nbt5SjFLjCRbSY2b)_