### PR TITLE
Collapse redundant prior-suggestion warning when refuter has no cards

### DIFF
--- a/src/ui/components/SuggestionForm.subsumePriorWarnings.test.ts
+++ b/src/ui/components/SuggestionForm.subsumePriorWarnings.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, test } from "vitest";
+import { Player } from "../../logic/GameObjects";
+import { CLASSIC_SETUP_3P } from "../../logic/GameSetup";
+import { cardByName } from "../../logic/test-utils/CardByName";
+import {
+    PILL_PASSERS,
+    PILL_REFUTER,
+    PILL_SEEN,
+    subsumePriorWarnings,
+    type PillId,
+    type SoftWarning,
+} from "./SuggestionForm";
+
+// ----------------------------------------------------------------------------
+// `subsumePriorWarnings` removes redundant prior-log warnings before the
+// display layer renders them. Today the only rule is:
+//
+//   • If `refuterCannotRefute` (W2) is present in the REFUTER slot, drop
+//     the SEENCARD-slot warning (W3 / W5 / W6) — the named refuter has
+//     none of the suggested cards, so questions about which card they
+//     showed are downstream noise.
+//
+// Other cross-slot pairs (W4 + SEENCARD; W1 + anything) are kept because
+// they describe genuinely different players or dimensions, OR they're
+// mutex by construction (W4 vs W3/W5/W6) and never co-fire.
+// ----------------------------------------------------------------------------
+
+const setup = CLASSIC_SETUP_3P;
+const ANISHA = Player("Anisha");
+const BOB = Player("Bob");
+const CHO = Player("Cho");
+const KNIFE = cardByName(setup, "Knife");
+
+const mapOf = (
+    entries: ReadonlyArray<readonly [PillId, SoftWarning]>,
+): ReadonlyMap<PillId, SoftWarning> => new Map(entries);
+
+describe("subsumePriorWarnings — W2 silences the SEENCARD slot", () => {
+    test("W2 + W3 → SEENCARD dropped", () => {
+        const input = mapOf([
+            [
+                PILL_REFUTER,
+                { kind: "refuterCannotRefute", player: CHO },
+            ],
+            [
+                PILL_SEEN,
+                { kind: "shownCardNotInRefuterHand", player: CHO },
+            ],
+        ]);
+        const out = subsumePriorWarnings(input);
+        expect(out.has(PILL_SEEN)).toBe(false);
+        expect(out.get(PILL_REFUTER)?.kind).toBe("refuterCannotRefute");
+    });
+
+    test("W2 + W5 → SEENCARD dropped", () => {
+        const input = mapOf([
+            [
+                PILL_REFUTER,
+                { kind: "refuterCannotRefute", player: CHO },
+            ],
+            [PILL_SEEN, { kind: "selfSuggesterMissingSeenCard" }],
+        ]);
+        const out = subsumePriorWarnings(input);
+        expect(out.has(PILL_SEEN)).toBe(false);
+        expect(out.size).toBe(1);
+    });
+
+    test("W2 + W6 → SEENCARD dropped (the screenshot scenario)", () => {
+        const input = mapOf([
+            [
+                PILL_REFUTER,
+                { kind: "refuterCannotRefute", player: ANISHA },
+            ],
+            [PILL_SEEN, { kind: "selfRefuterMissingSeenCard" }],
+        ]);
+        const out = subsumePriorWarnings(input);
+        expect(out.has(PILL_SEEN)).toBe(false);
+        expect(out.get(PILL_REFUTER)).toEqual({
+            kind: "refuterCannotRefute",
+            player: ANISHA,
+        });
+    });
+
+    test("W2 + W6 alongside W1 keeps W1 (different player)", () => {
+        const input = mapOf([
+            [
+                PILL_PASSERS,
+                {
+                    kind: "passersIncludePlayersWhoCanRefute",
+                    players: [BOB],
+                },
+            ],
+            [
+                PILL_REFUTER,
+                { kind: "refuterCannotRefute", player: ANISHA },
+            ],
+            [PILL_SEEN, { kind: "selfRefuterMissingSeenCard" }],
+        ]);
+        const out = subsumePriorWarnings(input);
+        expect(out.has(PILL_SEEN)).toBe(false);
+        expect(out.get(PILL_PASSERS)?.kind).toBe(
+            "passersIncludePlayersWhoCanRefute",
+        );
+        expect(out.get(PILL_REFUTER)?.kind).toBe("refuterCannotRefute");
+        expect(out.size).toBe(2);
+    });
+});
+
+describe("subsumePriorWarnings — pass-through cases", () => {
+    test("W2 alone → unchanged", () => {
+        const input = mapOf([
+            [
+                PILL_REFUTER,
+                { kind: "refuterCannotRefute", player: CHO },
+            ],
+        ]);
+        const out = subsumePriorWarnings(input);
+        expect(out).toBe(input);
+    });
+
+    test("W3 alone (no W2) → unchanged", () => {
+        const input = mapOf([
+            [
+                PILL_SEEN,
+                { kind: "shownCardNotInRefuterHand", player: CHO },
+            ],
+        ]);
+        const out = subsumePriorWarnings(input);
+        expect(out).toBe(input);
+        expect(out.get(PILL_SEEN)?.kind).toBe("shownCardNotInRefuterHand");
+    });
+
+    test("W5 alone (no W2) → unchanged", () => {
+        const input = mapOf([
+            [PILL_SEEN, { kind: "selfSuggesterMissingSeenCard" }],
+        ]);
+        const out = subsumePriorWarnings(input);
+        expect(out).toBe(input);
+    });
+
+    test("W6 alone (no W2) → unchanged", () => {
+        const input = mapOf([
+            [PILL_SEEN, { kind: "selfRefuterMissingSeenCard" }],
+        ]);
+        const out = subsumePriorWarnings(input);
+        expect(out).toBe(input);
+    });
+
+    test("W4 + W1 → unchanged (W4 is mutex with SEENCARD; nothing to subsume)", () => {
+        const input = mapOf([
+            [
+                PILL_PASSERS,
+                {
+                    kind: "passersIncludePlayersWhoCanRefute",
+                    players: [BOB],
+                },
+            ],
+            [
+                PILL_REFUTER,
+                {
+                    kind: "someoneCanRefuteButNobodyMarked",
+                    players: [CHO],
+                },
+            ],
+        ]);
+        const out = subsumePriorWarnings(input);
+        expect(out).toBe(input);
+        expect(out.size).toBe(2);
+    });
+
+    test("W1 alone → unchanged", () => {
+        const input = mapOf([
+            [
+                PILL_PASSERS,
+                {
+                    kind: "passersIncludePlayersWhoCanRefute",
+                    players: [BOB],
+                },
+            ],
+        ]);
+        const out = subsumePriorWarnings(input);
+        expect(out).toBe(input);
+    });
+
+    test("empty map → unchanged", () => {
+        const input = mapOf([]);
+        const out = subsumePriorWarnings(input);
+        expect(out).toBe(input);
+        expect(out.size).toBe(0);
+    });
+
+    // Defensive: a refuter warning of a kind OTHER than
+    // `refuterCannotRefute` (today only `someoneCanRefuteButNobodyMarked`)
+    // must not trigger the subsumption. The guard checks `.kind` so a
+    // future warning added to the REFUTER slot wouldn't accidentally
+    // silence SEENCARD.
+    test("REFUTER slot with non-W2 kind does not silence SEENCARD", () => {
+        const input = mapOf([
+            [
+                PILL_REFUTER,
+                {
+                    kind: "someoneCanRefuteButNobodyMarked",
+                    players: [BOB],
+                },
+            ],
+            // Hypothetical: W3 is mutex with W4 in practice (W3 needs
+            // refuter set, W4 needs blank). We still construct the
+            // pair directly to confirm the helper's guard works on the
+            // wire-shape alone, independent of the validator's mutex
+            // invariants. Use KNIFE to satisfy the SoftWarning shape.
+            [
+                PILL_SEEN,
+                { kind: "shownCardNotInRefuterHand", player: BOB },
+            ],
+        ]);
+        const out = subsumePriorWarnings(input);
+        expect(out).toBe(input);
+        expect(out.has(PILL_SEEN)).toBe(true);
+        // Touch KNIFE to keep the fixture honest if a future case
+        // wants to assert against a specific shown card.
+        expect(KNIFE).toBeDefined();
+    });
+});

--- a/src/ui/components/SuggestionForm.tsx
+++ b/src/ui/components/SuggestionForm.tsx
@@ -1661,6 +1661,36 @@ export const validateFormSoft = (
 };
 
 /**
+ * Prior-log-only redundancy filter. When the named refuter has none
+ * of the suggested cards (`refuterCannotRefute`), the SEENCARD-slot
+ * warnings (`shownCardNotInRefuterHand`, `selfSuggesterMissingSeenCard`,
+ * `selfRefuterMissingSeenCard`) all describe consequences of the same
+ * impossibility — the refuter couldn't have shown any card, so asking
+ * which one is downstream noise. Drop the SEENCARD entry so the row
+ * reads with one clear actionable warning.
+ *
+ * The form itself does NOT apply this — each pill renders its own
+ * warning in place, so the in-pill copy stays specific to that pill's
+ * context (the user is actively editing one pill at a time).
+ *
+ * Other cross-slot pairs (W4 + SEENCARD; W1 + anything) are kept as
+ * separate warnings: W4 is mutex with the SEENCARD warnings by
+ * construction (they require contradictory refuter states), and W1
+ * always describes a different player from the REFUTER/SEENCARD slot
+ * so both are independently actionable.
+ */
+export const subsumePriorWarnings = (
+    warnings: ReadonlyMap<PillId, SoftWarning>,
+): ReadonlyMap<PillId, SoftWarning> => {
+    const refuter = warnings.get(PILL_REFUTER);
+    if (refuter?.kind !== "refuterCannotRefute") return warnings;
+    if (!warnings.has(PILL_SEEN)) return warnings;
+    const next = new Map(warnings);
+    next.delete(PILL_SEEN);
+    return next;
+};
+
+/**
  * Minimal callable shape `briefWarningMessage` needs from the i18n
  * translator. Lifted to a named interface so callers (and tests)
  * can pass a thin mock without importing the full next-intl

--- a/src/ui/components/SuggestionLogPanel.tsx
+++ b/src/ui/components/SuggestionLogPanel.tsx
@@ -49,6 +49,7 @@ import { AccusationForm, type AccusationFormHandle } from "./AccusationForm";
 import {
     briefWarningMessage,
     formStateFromDraft,
+    subsumePriorWarnings,
     SuggestionForm,
     type SuggestionFormHandle,
     validateFormSoft,
@@ -1413,19 +1414,27 @@ function PriorSuggestionItem({
         const knowledge = Result.isSuccess(deductionResult)
             ? deductionResult.success
             : undefined;
-        return validateFormSoft(formStateFromDraft(s, setup), {
-            knowledge,
-            selfPlayerId: state.selfPlayerId,
-            solverMode: state.solverMode ?? SOLVER_MODE_SOLVE,
-            categoryCount: setup.categories.length,
-            players: setup.players,
-            // Stored suggestions are always treated as "user
-            // affirmed" — the previous submit already locked the
-            // refuter and seen-card values (whether a player,
-            // Nobody, or blank).
-            refuterTouched: true,
-            seenCardTouched: true,
-        });
+        // `subsumePriorWarnings` collapses redundant pairs (today:
+        // `refuterCannotRefute` silences the SEENCARD slot). The form
+        // does not apply this — each pill renders its own warning in
+        // place — but the prior-log row reads one entry at a time, so
+        // showing both halves of an "X can't refute / what card did X
+        // show?" pair is noise.
+        return subsumePriorWarnings(
+            validateFormSoft(formStateFromDraft(s, setup), {
+                knowledge,
+                selfPlayerId: state.selfPlayerId,
+                solverMode: state.solverMode ?? SOLVER_MODE_SOLVE,
+                categoryCount: setup.categories.length,
+                players: setup.players,
+                // Stored suggestions are always treated as "user
+                // affirmed" — the previous submit already locked the
+                // refuter and seen-card values (whether a player,
+                // Nobody, or blank).
+                refuterTouched: true,
+                seenCardTouched: true,
+            }),
+        );
     }, [
         isEditing,
         s,

--- a/src/ui/components/SuggestionLogPanel.warningBadge.test.tsx
+++ b/src/ui/components/SuggestionLogPanel.warningBadge.test.tsx
@@ -17,7 +17,9 @@ import {
     PILL_PASSERS,
     PILL_REFUTER,
     PILL_SEEN,
+    subsumePriorWarnings,
     validateFormSoft,
+    type PillId,
     type SoftWarning,
 } from "./SuggestionForm";
 
@@ -76,7 +78,7 @@ const warnsFor = (
     s: DraftSuggestion,
     knowledge: Knowledge,
     selfPlayerId: Player | null = null,
-): ReadonlyMap<string, SoftWarning> =>
+): ReadonlyMap<PillId, SoftWarning> =>
     validateFormSoft(formStateFromDraft(s, setup), {
         knowledge,
         selfPlayerId,
@@ -417,6 +419,127 @@ describe("prior-log: selfRefuterMissingSeenCard on stored suggestions", () => {
         });
         const w = warnsFor(s, emptyKnowledge, ANISHA);
         expect(w.has(PILL_SEEN)).toBe(false);
+    });
+});
+
+// Subsumption happens between `validateFormSoft` and the display
+// loop in <PriorSuggestionItem>. These cases pin the integration —
+// the validator produces the redundant pair, `subsumePriorWarnings`
+// collapses it. The unit test for the helper alone lives in
+// `SuggestionForm.subsumePriorWarnings.test.ts`.
+describe("prior-log: subsumePriorWarnings on validateFormSoft output", () => {
+    test("self refuted + has none of these cards → only refuterCannotRefute remains (screenshot)", () => {
+        // ANISHA = self. ANISHA is the refuter for a suggestion by
+        // BOB, but Knowledge says ANISHA has none of the suggested
+        // cards. The validator emits BOTH:
+        //   • W2 refuterCannotRefute (ANISHA can't possibly refute)
+        //   • W6 selfRefuterMissingSeenCard (no shown card recorded)
+        // After subsumption only W2 should remain — asking "what
+        // card did you show?" is downstream noise when ANISHA can't
+        // refute at all.
+        const k = knowledgeWith([
+            [ANISHA, MUSTARD, "N"],
+            [ANISHA, KNIFE, "N"],
+            [ANISHA, KITCHEN, "N"],
+        ]);
+        const s = draft({
+            suggester: BOB,
+            cards: [MUSTARD, KNIFE, KITCHEN],
+            nonRefuters: [],
+            refuter: ANISHA,
+        });
+        const raw = warnsFor(s, k, ANISHA);
+        // Sanity check: the validator emits both warnings.
+        expect(raw.get(PILL_REFUTER)?.kind).toBe("refuterCannotRefute");
+        expect(raw.get(PILL_SEEN)?.kind).toBe("selfRefuterMissingSeenCard");
+
+        // After subsumption only the REFUTER warning survives.
+        const subsumed = subsumePriorWarnings(raw);
+        expect(subsumed.has(PILL_SEEN)).toBe(false);
+        expect(subsumed.get(PILL_REFUTER)?.kind).toBe("refuterCannotRefute");
+        expect(subsumed.size).toBe(1);
+    });
+
+    test("other refuter has none + self suggested → only refuterCannotRefute remains", () => {
+        // Self (ANISHA) suggests; CHO refutes; but Knowledge says
+        // CHO has none of the cards. Validator emits W2 + W5
+        // (selfSuggesterMissingSeenCard). Subsumed → W2 only.
+        const k = knowledgeWith([
+            [CHO, MUSTARD, "N"],
+            [CHO, KNIFE, "N"],
+            [CHO, KITCHEN, "N"],
+        ]);
+        const s = draft({
+            suggester: ANISHA,
+            cards: [MUSTARD, KNIFE, KITCHEN],
+            nonRefuters: [],
+            refuter: CHO,
+        });
+        const raw = warnsFor(s, k, ANISHA);
+        expect(raw.get(PILL_REFUTER)?.kind).toBe("refuterCannotRefute");
+        expect(raw.get(PILL_SEEN)?.kind).toBe(
+            "selfSuggesterMissingSeenCard",
+        );
+
+        const subsumed = subsumePriorWarnings(raw);
+        expect(subsumed.has(PILL_SEEN)).toBe(false);
+        expect(subsumed.get(PILL_REFUTER)?.kind).toBe("refuterCannotRefute");
+    });
+
+    test("W2 + W3 → only refuterCannotRefute remains", () => {
+        // CHO is the refuter with seenCard=KNIFE; Knowledge says CHO
+        // has N for all three cards (including KNIFE). The validator
+        // emits both W2 and W3; subsumption keeps only W2.
+        const k = knowledgeWith([
+            [CHO, MUSTARD, "N"],
+            [CHO, KNIFE, "N"],
+            [CHO, KITCHEN, "N"],
+        ]);
+        const s = draft({
+            suggester: ANISHA,
+            cards: [MUSTARD, KNIFE, KITCHEN],
+            nonRefuters: [],
+            refuter: CHO,
+            seenCard: KNIFE,
+        });
+        const raw = warnsFor(s, k);
+        expect(raw.get(PILL_REFUTER)?.kind).toBe("refuterCannotRefute");
+        expect(raw.get(PILL_SEEN)?.kind).toBe("shownCardNotInRefuterHand");
+
+        const subsumed = subsumePriorWarnings(raw);
+        expect(subsumed.has(PILL_SEEN)).toBe(false);
+        expect(subsumed.get(PILL_REFUTER)?.kind).toBe("refuterCannotRefute");
+    });
+
+    test("W1 + W2 (different players) → both remain after subsumption", () => {
+        // BOB is a passer who has KNIFE (W1 — passer could refute).
+        // CHO is the refuter but Knowledge says CHO has none of the
+        // suggested cards (W2). Both warnings describe different
+        // players and stay independently actionable.
+        const k = knowledgeWith([
+            [BOB, KNIFE, "Y"],
+            [CHO, MUSTARD, "N"],
+            [CHO, KNIFE, "N"],
+            [CHO, KITCHEN, "N"],
+        ]);
+        const s = draft({
+            suggester: ANISHA,
+            cards: [MUSTARD, KNIFE, KITCHEN],
+            nonRefuters: [BOB],
+            refuter: CHO,
+        });
+        const raw = warnsFor(s, k);
+        expect(raw.get(PILL_PASSERS)?.kind).toBe(
+            "passersIncludePlayersWhoCanRefute",
+        );
+        expect(raw.get(PILL_REFUTER)?.kind).toBe("refuterCannotRefute");
+
+        const subsumed = subsumePriorWarnings(raw);
+        expect(subsumed.get(PILL_PASSERS)?.kind).toBe(
+            "passersIncludePlayersWhoCanRefute",
+        );
+        expect(subsumed.get(PILL_REFUTER)?.kind).toBe("refuterCannotRefute");
+        expect(subsumed.size).toBe(2);
     });
 });
 


### PR DESCRIPTION
Previously a single prior-suggestion row could show two warnings that
described the same impossibility from different angles. The screenshot
case: "Player 1 (you) refuted, but has none of these cards" stacked
with "You refuted this suggestion. What card did you show?" — if the
named refuter has none of the suggested cards, asking which one they
showed is downstream noise. The row now reads with one clear,
actionable warning.

The fix is targeted: `refuterCannotRefute` in the REFUTER slot silences
the SEENCARD slot (`shownCardNotInRefuterHand`,
`selfSuggesterMissingSeenCard`, `selfRefuterMissingSeenCard`) for
prior-log display. Other warning pairs are kept independent:

- W1 (passer could refute) + W2/W3/W4 describe different players, so
  both badges stay — the user still sees that a passer is misclassified
  alongside the refuter contradiction.
- W4 (refuter blank but someone could refute) is mutex with the SEENCARD
  warnings by construction (refuter-state requirements), so no rule is
  needed.

The form itself is untouched — each pill renders its own warning in
place, and the in-pill copy stays specific to that pill's context. The
subsumption applies only at the prior-log display layer where the row
reads one entry at a time.

Technical details:
- New `subsumePriorWarnings` export in `SuggestionForm.tsx`, applied to
  `validateFormSoft`'s output in `SuggestionLogPanel.tsx`'s
  `priorWarnings` memo.
- Existing `priorWarningTexts` dedupe-by-text loop stays as
  defense-in-depth.
- Unit tests in `SuggestionForm.subsumePriorWarnings.test.ts` cover each
  co-firing pair and the pass-through cases.
- Integration tests in `SuggestionLogPanel.warningBadge.test.tsx`
  reproduce the screenshot scenario through the full
  `validateFormSoft` → `subsumePriorWarnings` pipeline, and verify the
  W1 + W2 "two different players" case still emits both warnings.
- Test helper `warnsFor` return type narrowed from
  `ReadonlyMap<string, SoftWarning>` to `ReadonlyMap<PillId, SoftWarning>`
  to match the validator's actual return type (was an over-widened
  annotation).

https://claude.ai/code/session_0153rbBTvEEVHsLEUcBzQCFt