### PR TITLE
Remove obsolete pnpm.onlyBuiltDependencies field

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,10 +116,5 @@
 		"typescript": "6.0.3",
 		"vercel": "54.1.0",
 		"vitest": "4.1.6"
-	},
-	"pnpm": {
-		"onlyBuiltDependencies": [
-			"sharp"
-		]
 	}
 }


### PR DESCRIPTION
## Summary
- `pnpm install` warned: `The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.onlyBuiltDependencies"`.
- That setting already lives in `pnpm-workspace.yaml` under `allowBuilds: { sharp: true }`, so the `package.json` entry was redundant.
- Removing the dead field silences the warning with no behavior change.

## Test plan
- [x] `pnpm install` — no longer prints the "pnpm field ignored" warning.

## Commits
- `Remove obsolete pnpm.onlyBuiltDependencies field from package.json` — deletes the `pnpm.onlyBuiltDependencies` block from `package.json`; build-script allow-listing continues to be governed by `pnpm-workspace.yaml`'s `allowBuilds`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)