### PR TITLE
Add Next.js build cache to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,12 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      - uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('src/**/*.[jt]s', 'src/**/*.[jt]sx', 'app/**/*.[jt]s', 'app/**/*.[jt]sx') }}
+          restore-keys: |
+            ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
       - run: pnpm build
       # Catch a future Serwist / Next.js update that silently breaks
       # SW emission. Without `public/sw.js`, installed PWAs hit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,10 @@ All of these must pass green before every commit:
 
 If you amend or update a commit, re-run the full set — a previously-green commit can break after edits.
 
+## Static linting
+
+Whenever you introduce a new dependency, library, framework, or architectural pattern — or whenever you hit a bug that a static check could have caught — look for an ESLint plugin (or rule) that enforces correct usage and wire it into the flat config. The repo already does this: `eslint-plugin-i18next` guards against untranslated strings. Catching a whole class of mistake at lint time is cheaper than catching each instance in review or production, so reach for the plugin before relying on convention or code review.
+
 ## Manual verification in the preview
 
 For any change that's observable in the browser, exercise the change yourself before reporting the task done. In Claude, use the `next-dev` preview configured in `.claude/launch.json`; in Codex, follow the local database and dev server lifecycle above, then use the printed `Local:` URL in the in-app browser. Follow the active agent's browser verification workflow: start/reload the preview, check console/network/logs, take a screenshot or snapshot as proof. Don't ask the user to verify manually.


### PR DESCRIPTION
## Summary

Optimize CI build times by caching the Next.js build output (`.next/cache`) between workflow runs.

## Changes

- Added `actions/cache@v4` step to the CI workflow that caches `.next/cache` directory
- Cache key includes OS, dependency hash (`pnpm-lock.yaml`), and source file hashes to invalidate when dependencies or source code changes
- Fallback restore key allows partial cache hits when source files change but dependencies remain the same

## Implementation details

The cache strategy uses a three-part key:
1. `runner.os` — separate caches per OS
2. `hashFiles('pnpm-lock.yaml')` — invalidate on dependency changes
3. `hashFiles('src/**/*.[jt]s', 'src/**/*.[jt]sx', 'app/**/*.[jt]s', 'app/**/*.[jt]sx')` — invalidate on source code changes

The restore key allows reusing the dependency-level cache when only source files change, reducing cache misses and improving build performance across commits.

## Documentation

Added guidance to `AGENTS.md` on static linting best practices: when introducing new dependencies, libraries, frameworks, or architectural patterns, look for ESLint plugins that enforce correct usage rather than relying on convention or code review.

https://claude.ai/code/session_01DCfCb3hbZSASMmEosu6Gh4