### PR TITLE
Fix card-pack duplication when editing or renaming a synced pack

### DIFF
--- a/docs/card-pack-sync.md
+++ b/docs/card-pack-sync.md
@@ -99,15 +99,17 @@ once signed in**:
 ## Per-pack metadata (the core data shape)
 
 Each `CustomCardSet` in `effect-clue.custom-presets.v1` carries
-three optional sync-related fields. They're **additive** to the
-schema — old payloads decode unchanged — and they're the foundation
-for every state machine in this doc.
+sync-related fields beyond the deck itself. The `unsyncedSince` /
+`lastSyncedSnapshot` pair is **additive** to the schema — old payloads
+decode unchanged — and they're the foundation for every state machine
+in this doc.
 
 | Field | Type | Meaning |
 |---|---|---|
 | `unsyncedSince` | `DateTime.Utc \| undefined` | Set on every local mutation while signed in. Cleared by a successful server roundtrip. Absent ⇒ pack is in sync (or pre-dates sync entirely). |
 | `lastSyncedSnapshot` | `{ label, cardSet } \| undefined` | The server's last-known view of this pack. Set by pulls and successful pushes. **Never mutated by local edits**, so it stays a stable diff baseline across multiple offline edits. Absent ⇒ the server has never acknowledged this pack. |
 | `id` | `string` | The canonical identifier the UI keys on. Equals the server's cuid2 once the pack has been pushed (or pulled); a `custom-…` ephemeral id otherwise. |
+| `clientGeneratedId` | `string` | The **cross-device-stable identity** — the server's `client_generated_id` column. Minted equal to `id` on a fresh local creation, then **preserved across the `markPackSynced` id-swap** (which moves `id` to the server's cuid2 but leaves this untouched). Every server-write site UPSERTs on this value so a re-save updates the existing `(owner_id, client_generated_id)` row instead of inserting a duplicate. Persisted as an optional schema field; legacy blobs lacking it decode with it **defaulted to `id`**, and the next reconcile backfills the real value from the server row (see below). |
 
 The discriminator that drives most decisions:
 
@@ -166,11 +168,18 @@ future pack-mutating UI use. They:
 
 - Always write to localStorage first (so the UI snaps).
 - Stamp `unsyncedSince` if signed in.
-- Fire the server action in parallel (idempotent on
-  `(owner_id, client_generated_id)`).
+- Fire the server action in parallel, keyed on the pack's
+  **`clientGeneratedId`** (not its `id`) so the UPSERT is idempotent on
+  `(owner_id, client_generated_id)`. `useCardPackActions` resolves this
+  via the pack's persisted `clientGeneratedId`, falling back to the
+  server cache's `client_generated_id` for a legacy pack whose local
+  cgid still defaults to the swapped server id. Sending the swapped
+  `id` here is exactly what used to insert a duplicate row on every
+  edit of an already-synced pack.
 - On success, swap the localStorage `id` for the server's cuid2
-  (when different), set `lastSyncedSnapshot`, clear `unsyncedSince`,
-  and remap usage entries via `remapCardPackUsageIds`.
+  (when different) **while preserving `clientGeneratedId`**, set
+  `lastSyncedSnapshot`, clear `unsyncedSince`, and remap usage entries
+  via `remapCardPackUsageIds`.
 - On failure, log via `Effect.logError` and leave local state alone.
   The next reconcile retries.
 
@@ -225,6 +234,14 @@ Every successful settle triggers `applyServerSnapshot`:
    clientGeneratedId pair-match BUT same label + cardSet as a local
    pack: server wins (already canonical), idMap remaps.
 4. **Server-only.** Pulled in. Increments `countPulled`.
+
+In every branch that emits a server-paired or server-pulled entry, the
+merged pack takes the **server's `client_generated_id`** as its
+`clientGeneratedId`. This is what backfills the stable cgid onto a
+legacy synced pack whose local cgid had defaulted to the swapped server
+id — once the next reconcile runs, that pack's saves UPSERT in place
+again. Phase-3 local-only passthrough keeps the pack's existing
+`clientGeneratedId` untouched.
 5. **Local-only.** Preserved with all metadata intact.
 
 ## The sign-in transition
@@ -295,15 +312,18 @@ T=0    Device A, signed in
 T+50ms Server returns row { id: "srv-xyz", clientGeneratedId:
        "custom-abc", label: "Office", cardSetData: ... }
        useSaveCardPack onSuccess:
-         1. markPackSynced("custom-abc", row) → swaps id to "srv-xyz",
+         1. markPackSynced("custom-abc", row) → swaps id to "srv-xyz"
+            BUT keeps clientGeneratedId: "custom-abc",
             sets lastSyncedSnapshot = { label: "Office", cardSet },
             clears unsyncedSince
          2. remapCardPackUsageIds("custom-abc" → "srv-xyz")
          3. clearTombstones(["custom-abc", "srv-xyz"])
        Device A's localStorage state:
-         { id: "srv-xyz", label: "Office",
-           unsyncedSince: undefined,
+         { id: "srv-xyz", clientGeneratedId: "custom-abc",
+           label: "Office", unsyncedSince: undefined,
            lastSyncedSnapshot: { label: "Office", cardSet } }
+       A later edit re-saves with clientGeneratedId "custom-abc", so
+       the server UPSERT updates srv-xyz in place — no duplicate row.
 
 T+5min User picks up Device B and signs in for the first time.
        <CardPacksSync /> mounts.

--- a/src/data/cardPacksFlush.test.tsx
+++ b/src/data/cardPacksFlush.test.tsx
@@ -58,6 +58,7 @@ const localPack = (
     overrides: Partial<CustomCardSet> = {},
 ): CustomCardSet => ({
     id,
+    clientGeneratedId: id,
     label,
     cardSet: makeCardSet(cardName),
     ...overrides,

--- a/src/data/cardPacksSync.test.tsx
+++ b/src/data/cardPacksSync.test.tsx
@@ -29,6 +29,7 @@ const localPack = (
     cardName: string,
 ): CustomCardSet => ({
     id,
+    clientGeneratedId: id,
     label,
     cardSet: makeCardSet(cardName),
 });
@@ -205,6 +206,47 @@ describe("reconcileCardPacks", () => {
         const result = reconcileCardPacks([local], []);
         expect(result.packs[0]?.unsyncedSince).toBeDefined();
         expect(result.packs[0]?.id).toBe("local-1");
+    });
+
+    describe("clientGeneratedId threading", () => {
+        test("Phase 1 paired match carries the server's clientGeneratedId", () => {
+            const result = reconcileCardPacks(
+                [localPack("local-1", "Office", "Rope")],
+                [serverPack("server-1", "local-1", "Office", "Rope")],
+            );
+            expect(result.packs[0]?.id).toBe("server-1");
+            expect(result.packs[0]?.clientGeneratedId).toBe("local-1");
+        });
+
+        test("Phase 2 server-only pull carries the server's clientGeneratedId", () => {
+            const result = reconcileCardPacks(
+                [],
+                [serverPack("server-1", "other-client", "Office", "Rope")],
+            );
+            expect(result.packs[0]?.clientGeneratedId).toBe("other-client");
+        });
+
+        test("backfills cgid for a legacy synced pack whose local cgid defaulted to the server id", () => {
+            // Pre-cgid-field state: local id was swapped to the server id
+            // and the cgid defaulted to it on load. Reconcile must correct
+            // it to the server's real client_generated_id so the next save
+            // UPSERTs in place instead of inserting a duplicate.
+            const legacy: CustomCardSet = {
+                ...localPack("server-1", "Office", "Rope"),
+                clientGeneratedId: "server-1",
+                lastSyncedSnapshot: {
+                    label: "Office",
+                    cardSet: makeCardSet("Rope"),
+                },
+            };
+            const result = reconcileCardPacks(
+                [legacy],
+                [serverPack("server-1", "custom-orig", "Office", "Rope")],
+            );
+            expect(result.packs).toHaveLength(1);
+            expect(result.packs[0]?.id).toBe("server-1");
+            expect(result.packs[0]?.clientGeneratedId).toBe("custom-orig");
+        });
     });
 
     // The dedupe pass at the end of `reconcileCardPacks` exists because

--- a/src/data/cardPacksSync.tsx
+++ b/src/data/cardPacksSync.tsx
@@ -156,6 +156,7 @@ export const reconcileCardPacks = (
         if (contentMatches) {
             merged.push({
                 id: matchingServer.id,
+                clientGeneratedId: match.clientGeneratedId,
                 label: localPack.label,
                 cardSet: localPack.cardSet,
                 unsyncedSince: undefined,
@@ -165,6 +166,7 @@ export const reconcileCardPacks = (
             // Local edit, conflict — local wins.
             merged.push({
                 id: matchingServer.id,
+                clientGeneratedId: match.clientGeneratedId,
                 label: localPack.label,
                 cardSet: localPack.cardSet,
                 unsyncedSince: localPack.unsyncedSince,
@@ -174,6 +176,7 @@ export const reconcileCardPacks = (
             // No local edit — server wins (rename, other-device update).
             merged.push({
                 id: matchingServer.id,
+                clientGeneratedId: match.clientGeneratedId,
                 label: matchingServer.label,
                 cardSet: matchingServer.cardSet,
                 unsyncedSince: undefined,
@@ -188,7 +191,7 @@ export const reconcileCardPacks = (
     }
 
     // Phase 2: remaining server packs — exact-content duplicate or fresh pull.
-    for (const { pack: serverPack } of decodedServer) {
+    for (const { pack: serverPack, clientGeneratedId } of decodedServer) {
         if (handledServerIds.has(serverPack.id)) continue;
         const exactDup = filteredLocal.find(
             local =>
@@ -201,6 +204,7 @@ export const reconcileCardPacks = (
         };
         merged.push({
             id: serverPack.id,
+            clientGeneratedId,
             label: serverPack.label,
             cardSet: serverPack.cardSet,
             unsyncedSince: undefined,
@@ -328,7 +332,7 @@ const signInPushEffect = Effect.fn("data.cardPacks.signInPush")(function* (
     }
     const promise = pushLocalPacksOnSignIn({
         packs: packs.map(p => ({
-            clientGeneratedId: p.id,
+            clientGeneratedId: p.clientGeneratedId,
             label: p.label,
             cardSetData: encodeCardSet(p.cardSet),
         })),
@@ -598,7 +602,7 @@ export const flushPendingChanges = async (): Promise<FlushResult> => {
         if (!needsPush) continue;
         try {
             const promise = saveCardPack({
-                clientGeneratedId: pack.id,
+                clientGeneratedId: pack.clientGeneratedId,
                 label: pack.label,
                 cardSetData: encodeCardSet(pack.cardSet),
             });

--- a/src/data/serverPackCodec.ts
+++ b/src/data/serverPackCodec.ts
@@ -99,9 +99,10 @@ export const decodeCardSet = (raw: string): CardSet | null => {
 
 /**
  * Decode a server-side `PersistedCardPack` into a domain
- * `CustomCardSet`. Drops the wire-format-only `clientGeneratedId` —
- * callers that need it pluck it from the original `PersistedCardPack`
- * they already had access to.
+ * `CustomCardSet`. Carries the server's `clientGeneratedId` through as
+ * the pack's cross-device-stable identity so the reconcile pipeline and
+ * the AccountModal preview don't have to re-pluck it from the original
+ * `PersistedCardPack`.
  */
 export const decodeServerPack = (
     pack: PersistedCardPack,
@@ -110,6 +111,7 @@ export const decodeServerPack = (
     if (cardSet === null) return null;
     return {
         id: pack.id,
+        clientGeneratedId: pack.clientGeneratedId,
         label: pack.label,
         cardSet,
     };

--- a/src/logic/CustomCardSets.test.ts
+++ b/src/logic/CustomCardSets.test.ts
@@ -110,6 +110,30 @@ describe("loadCustomCardSets", () => {
         expect(loaded).toHaveLength(1);
         expect(loaded[0]?.id).toBe("q7xao88qw0hobmp43aa5s0r8");
     });
+
+    test("defaults clientGeneratedId to id on a legacy blob lacking the field", () => {
+        window.localStorage.setItem(
+            STORAGE_KEY,
+            JSON.stringify({
+                version: 1,
+                presets: [
+                    {
+                        id: "legacy-1",
+                        label: "Legacy",
+                        categories: [
+                            {
+                                id: "cat-w",
+                                name: "Weapon",
+                                cards: [{ id: "card-knife", name: "Knife" }],
+                            },
+                        ],
+                    },
+                ],
+            }),
+        );
+        const loaded = loadCustomCardSets();
+        expect(loaded[0]?.clientGeneratedId).toBe("legacy-1");
+    });
 });
 
 describe("saveCustomCardSet + loadCustomCardSets", () => {
@@ -136,6 +160,13 @@ describe("saveCustomCardSet + loadCustomCardSets", () => {
         const pack = saveCustomCardSet("Label", makePack());
         expect(pack.id).toMatch(/^custom-/);
         expect(pack.label).toBe("Label");
+    });
+
+    test("a fresh creation mints clientGeneratedId equal to its id", () => {
+        const pack = saveCustomCardSet("Label", makePack());
+        expect(pack.clientGeneratedId).toBe(pack.id);
+        const loaded = loadCustomCardSets();
+        expect(loaded[0]!.clientGeneratedId).toBe(pack.id);
     });
 
     test("generated ids are unique across rapid successive calls", () => {
@@ -173,6 +204,24 @@ describe("saveCustomCardSet + loadCustomCardSets", () => {
         expect(all).toHaveLength(1);
         expect(all[0]!.id).toBe(original.id);
         expect(all[0]!.label).toBe("First — edited");
+    });
+
+    test("an in-place update preserves clientGeneratedId", () => {
+        // Simulate a previously-synced pack: id swapped to the server
+        // id, but the stable cgid retained.
+        replaceCustomCardSets([
+            {
+                id: "server-1",
+                clientGeneratedId: "custom-orig",
+                label: "Synced",
+                cardSet: makePack(),
+                lastSyncedSnapshot: { label: "Synced", cardSet: makePack() },
+            },
+        ]);
+        const updated = saveCustomCardSet("Synced — edited", makePack(), "server-1");
+        expect(updated.id).toBe("server-1");
+        expect(updated.clientGeneratedId).toBe("custom-orig");
+        expect(loadCustomCardSets()[0]!.clientGeneratedId).toBe("custom-orig");
     });
 
     test("with a stale existingId, falls back to insert", () => {
@@ -261,6 +310,21 @@ describe("markPackSynced", () => {
         expect(loaded[0]?.id).toBe("server-1");
     });
 
+    test("preserves clientGeneratedId across the id-swap", () => {
+        // The cgid must survive: the server keys its UPSERT on it, so
+        // losing it here is what made edits insert a duplicate row.
+        const saved = saveCustomCardSet("Office", makePack());
+        const cgid = saved.clientGeneratedId;
+        const result = markPackSynced(saved.id, {
+            id: "server-1",
+            label: "Office",
+            cardSet: makePack(),
+        });
+        expect(result?.id).toBe("server-1");
+        expect(result?.clientGeneratedId).toBe(cgid);
+        expect(loadCustomCardSets()[0]?.clientGeneratedId).toBe(cgid);
+    });
+
     test("returns undefined when the local id doesn't match", () => {
         saveCustomCardSet("A", makePack());
         const result = markPackSynced("nonexistent", {
@@ -290,6 +354,7 @@ describe("replaceCustomCardSets metadata round-trip", () => {
         replaceCustomCardSets([
             {
                 id: "server-1",
+                clientGeneratedId: "custom-1",
                 label: "Office",
                 cardSet: makePack(),
                 unsyncedSince: DateTime.makeUnsafe("2026-04-22T12:00:00Z"),
@@ -301,6 +366,7 @@ describe("replaceCustomCardSets metadata round-trip", () => {
         ]);
         const loaded = loadCustomCardSets();
         expect(loaded).toHaveLength(1);
+        expect(loaded[0]?.clientGeneratedId).toBe("custom-1");
         expect(DateTime.toEpochMillis(loaded[0]!.unsyncedSince!)).toBe(
             DateTime.toEpochMillis(
                 DateTime.makeUnsafe("2026-04-22T12:00:00Z"),
@@ -330,16 +396,19 @@ describe("writeAll dedupe — collapses ids on persist", () => {
             replaceCustomCardSets([
                 {
                     id: "server-1",
+                    clientGeneratedId: "custom-1",
                     label: "Office",
                     cardSet: makePack(),
                 },
                 {
                     id: "server-1",
+                    clientGeneratedId: "custom-1",
                     label: "Office (stale)",
                     cardSet: makePack(),
                 },
                 {
                     id: "server-1",
+                    clientGeneratedId: "custom-1",
                     label: "Office (stale 2)",
                     cardSet: makePack(),
                 },
@@ -352,9 +421,9 @@ describe("writeAll dedupe — collapses ids on persist", () => {
 
     test("non-colliding ids round-trip unchanged", () => {
         replaceCustomCardSets([
-            { id: "a", label: "A", cardSet: makePack() },
-            { id: "b", label: "B", cardSet: makePack() },
-            { id: "c", label: "C", cardSet: makePack() },
+            { id: "a", clientGeneratedId: "a", label: "A", cardSet: makePack() },
+            { id: "b", clientGeneratedId: "b", label: "B", cardSet: makePack() },
+            { id: "c", clientGeneratedId: "c", label: "C", cardSet: makePack() },
         ]);
         const loaded = loadCustomCardSets();
         expect(loaded.map(p => p.id)).toEqual(["a", "b", "c"]);

--- a/src/logic/CustomCardSets.ts
+++ b/src/logic/CustomCardSets.ts
@@ -55,6 +55,12 @@ const PersistedCustomCardSetSchema = Schema.Struct({
     id: Schema.String,
     label: Schema.String,
     categories: Schema.Array(PersistedCategorySchema),
+    /**
+     * Cross-device-stable identity (the server's `client_generated_id`).
+     * Optional on disk so pre-existing blobs decode; absent ⇒ defaulted
+     * to `id` on load (see `loadCustomCardSets`).
+     */
+    clientGeneratedId: Schema.optional(Schema.String),
     /** Epoch millis at the storage edge; `DateTime.Utc` in memory. */
     unsyncedSince: Schema.optional(Schema.Number),
     lastSyncedSnapshot: Schema.optional(PersistedSnapshotSchema),
@@ -93,6 +99,15 @@ export interface CardPackSnapshot {
  */
 export interface CustomCardSet {
     readonly id: string;
+    /**
+     * Cross-device-stable identity — the server's `client_generated_id`.
+     * Minted equal to `id` on a fresh local creation; preserved across
+     * the `markPackSynced` id-swap (which swaps `id` to the server's
+     * cuid2 but leaves this untouched) so every server-write site can
+     * UPSERT on the stable `(owner_id, client_generated_id)` key
+     * instead of accidentally inserting a duplicate row.
+     */
+    readonly clientGeneratedId: string;
     readonly label: string;
     readonly cardSet: CardSet;
     /**
@@ -217,6 +232,12 @@ export const loadCustomCardSets = (): ReadonlyArray<CustomCardSet> => {
         const decodedPacks: ReadonlyArray<CustomCardSet> =
             decoded.success.presets.map(p => ({
                 id: p.id,
+                // Legacy blobs predate this field; default to `id`. For a
+                // never-synced pack `id` IS the cgid, so that's exact. For
+                // a legacy synced pack `id` is the server id — wrong, but
+                // the next reconcile backfills the real cgid from the
+                // server row (see `reconcileCardPacks`).
+                clientGeneratedId: p.clientGeneratedId ?? p.id,
                 label: p.label,
                 cardSet: decodePersistedCategories(p.categories),
                 unsyncedSince: p.unsyncedSince !== undefined
@@ -245,6 +266,7 @@ const writeAll = (packs: ReadonlyArray<CustomCardSet>): void => {
             version: 1,
             presets: deduped.map(p => ({
                 id: p.id,
+                clientGeneratedId: p.clientGeneratedId,
                 label: p.label,
                 categories: encodePersistedCategories(p.cardSet),
                 unsyncedSince: p.unsyncedSince !== undefined
@@ -291,6 +313,7 @@ export const saveCustomCardSet = (
             const previous = packs[matchIdx]!;
             const updated: CustomCardSet = {
                 id: existingId,
+                clientGeneratedId: previous.clientGeneratedId,
                 label,
                 cardSet,
                 unsyncedSince: previous.unsyncedSince,
@@ -305,7 +328,9 @@ export const saveCustomCardSet = (
     const id = `custom-${Date.now().toString(36)}-${Math.random()
         .toString(36)
         .slice(2, 7)}`;
-    const newPack: CustomCardSet = { id, label, cardSet };
+    // Fresh creation: the cgid is the locally-minted id. It stays stable
+    // through the later server-sync id-swap so re-saves UPSERT cleanly.
+    const newPack: CustomCardSet = { id, clientGeneratedId: id, label, cardSet };
     writeAll([...packs, newPack]);
     return newPack;
 };
@@ -367,6 +392,10 @@ export const markPackSynced = (
     const previous = packs[idx]!;
     const updated: CustomCardSet = {
         id: serverRow.id,
+        // Preserve the cross-device-stable cgid across the id-swap. The
+        // server row's `client_generated_id` equals this value, so future
+        // saves UPSERT the same row instead of inserting a duplicate.
+        clientGeneratedId: previous.clientGeneratedId,
         label: previous.label,
         cardSet: previous.cardSet,
         unsyncedSince: undefined,

--- a/src/ui/account/AccountModal.test.tsx
+++ b/src/ui/account/AccountModal.test.tsx
@@ -525,6 +525,7 @@ describe("mergeCardPacks", () => {
             [
                 {
                     id: "custom-1",
+                    clientGeneratedId: "custom-1",
                     label: "Local name",
                     cardSet: { categories: [] } as never,
                 },
@@ -574,6 +575,7 @@ describe("mergeCardPacks", () => {
             [
                 {
                     id: "server-1",
+                    clientGeneratedId: "custom-mansion",
                     label: "Mansion",
                     cardSet: { categories: [] } as never,
                 },
@@ -601,6 +603,7 @@ describe("mergeCardPacks", () => {
             [
                 {
                     id: "server-1",
+                    clientGeneratedId: "custom-mansion",
                     label: "Mansion",
                     cardSet: { categories: [] } as never,
                     unsyncedSince: stamp,
@@ -629,6 +632,7 @@ describe("mergeCardPacks", () => {
             [
                 {
                     id: "custom-1",
+                    clientGeneratedId: "custom-1",
                     label: "Local",
                     cardSet: { categories: [] } as never,
                     unsyncedSince: stamp,
@@ -669,6 +673,7 @@ describe("mergeCardPacks", () => {
             [
                 {
                     id: "custom-local",
+                    clientGeneratedId: "custom-local",
                     label: "Local-only",
                     cardSet: { categories: [] } as never,
                     unsyncedSince: stamp,

--- a/src/ui/account/AccountModal.tsx
+++ b/src/ui/account/AccountModal.tsx
@@ -142,7 +142,7 @@ export const mergeCardPacks = (
         .filter((pack) => !serverIdentities.has(pack.id))
         .map((pack) => ({
             id: pack.id,
-            clientGeneratedId: pack.id,
+            clientGeneratedId: pack.clientGeneratedId,
             label: pack.label,
             cardSet: pack.cardSet,
             source: "local" as const,

--- a/src/ui/components/cardPackActions.test.tsx
+++ b/src/ui/components/cardPackActions.test.tsx
@@ -108,6 +108,7 @@ const localPackOf = (
     overrides: Partial<CustomCardSet> = {},
 ): CustomCardSet => ({
     id,
+    clientGeneratedId: id,
     label,
     cardSet: makeCardSet(label),
     ...overrides,
@@ -201,6 +202,56 @@ describe("useCardPackActions.savePack", () => {
             label: "Office",
         });
         expect(result.id).toBe("custom-1");
+    });
+
+    test("synced pack edit → saveServer keys on the original cgid, not the swapped server id", async () => {
+        // Post-sync: the local pack's id is the server's id; its
+        // clientGeneratedId is the original `custom-…`. Sending the
+        // server id as the cgid is exactly what duplicated the row.
+        signedInUserId = "alice";
+        const localPack = localPackOf("srv-1", "Office", {
+            clientGeneratedId: "custom-1",
+            lastSyncedSnapshot: {
+                label: "Office",
+                cardSet: makeCardSet("Office"),
+            },
+        });
+        saveLocalMutateAsync.mockResolvedValue(localPack);
+        renderWithSeed(
+            [localPack],
+            [serverPackOf("srv-1", "custom-1", "Office")],
+        );
+        await actionsRef!.savePack({
+            label: "Office",
+            cardSet: makeCardSet("Office"),
+            existingId: "srv-1",
+        });
+        expect(saveServerMutate).toHaveBeenCalledTimes(1);
+        expect(saveServerMutate.mock.calls[0]?.[0]).toMatchObject({
+            clientGeneratedId: "custom-1",
+        });
+    });
+
+    test("legacy synced pack (local cgid defaulted to server id) is corrected from the server cache", async () => {
+        // A pack synced before cgid was persisted loads with cgid === id
+        // (the server id). The server-cache lookup recovers the real cgid.
+        signedInUserId = "alice";
+        const localPack = localPackOf("srv-1", "Office", {
+            clientGeneratedId: "srv-1",
+        });
+        saveLocalMutateAsync.mockResolvedValue(localPack);
+        renderWithSeed(
+            [localPack],
+            [serverPackOf("srv-1", "custom-1", "Office")],
+        );
+        await actionsRef!.savePack({
+            label: "Office",
+            cardSet: makeCardSet("Office"),
+            existingId: "srv-1",
+        });
+        expect(saveServerMutate.mock.calls[0]?.[0]).toMatchObject({
+            clientGeneratedId: "custom-1",
+        });
     });
 });
 
@@ -296,6 +347,31 @@ describe("useCardPackActions.renamePack", () => {
             existingId: "srv-1",
         });
         // saveServer called with the cgid (the wire-format-stable id).
+        expect(saveServerMutate.mock.calls[0]?.[0]).toMatchObject({
+            clientGeneratedId: "custom-1",
+        });
+    });
+
+    test("synced pack rename falls back to the local pack's cgid when the server cache is empty", async () => {
+        // The persisted clientGeneratedId carries the stable identity
+        // even before the server query lands, so an offline-ish rename
+        // still keys the eventual UPSERT correctly.
+        signedInUserId = "alice";
+        promptAnswer = "Office Edition";
+        renderWithSeed(
+            [
+                localPackOf("srv-1", "Office", {
+                    clientGeneratedId: "custom-1",
+                }),
+            ],
+            [], // server cache not yet populated
+        );
+        await actionsRef!.renamePack({
+            // Caller passed the swapped server id as the target cgid.
+            clientGeneratedId: "srv-1",
+            label: "Office",
+            cardSet: makeCardSet("Office"),
+        });
         expect(saveServerMutate.mock.calls[0]?.[0]).toMatchObject({
             clientGeneratedId: "custom-1",
         });

--- a/src/ui/components/cardPackActions.ts
+++ b/src/ui/components/cardPackActions.ts
@@ -134,6 +134,33 @@ export function useCardPackActions(): CardPackActions {
         [queryClient, findServer],
     );
 
+    /**
+     * Resolve the cross-device-stable `clientGeneratedId` to send to the
+     * server's `(owner_id, client_generated_id)` UPSERT.
+     *
+     * The local pack carries its own `clientGeneratedId`, which is
+     * authoritative for packs created/synced under the current code. But
+     * a pack that was synced before the field existed loads with its cgid
+     * defaulted to `id` (= the server id) — wrong until the next reconcile
+     * backfills it. The server cache holds the real `client_generated_id`,
+     * so when a server row matches the local id (by either its `id` or its
+     * `clientGeneratedId`) we trust the server's value; otherwise we fall
+     * back to the local cgid (never-synced packs, or an unpopulated cache).
+     */
+    const resolveServerClientGeneratedId = useCallback(
+        (localId: string, fallbackCgid: string): string => {
+            const server =
+                queryClient.getQueryData<ReadonlyArray<PersistedCardPack>>(
+                    myCardPacksQueryKey(userId),
+                );
+            const match = server?.find(
+                (p) => p.id === localId || p.clientGeneratedId === localId,
+            );
+            return match?.clientGeneratedId ?? fallbackCgid;
+        },
+        [queryClient, userId],
+    );
+
     const sharePack = useCallback<CardPackActions["sharePack"]>(
         (pack) => {
             openShareCardPack({
@@ -149,14 +176,17 @@ export function useCardPackActions(): CardPackActions {
             const localPack = await saveLocal.mutateAsync(input);
             if (userId !== undefined) {
                 saveServer.mutate({
-                    clientGeneratedId: localPack.id,
+                    clientGeneratedId: resolveServerClientGeneratedId(
+                        localPack.id,
+                        localPack.clientGeneratedId,
+                    ),
                     label: localPack.label,
                     cardSet: localPack.cardSet,
                 });
             }
             return localPack;
         },
-        [saveLocal, saveServer, userId],
+        [saveLocal, saveServer, userId, resolveServerClientGeneratedId],
     );
 
     const renamePack = useCallback<CardPackActions["renamePack"]>(
@@ -182,12 +212,16 @@ export function useCardPackActions(): CardPackActions {
             // Always push to the server when signed in. The server
             // action is idempotent on `(owner_id,
             // client_generated_id)` — if the row already exists,
-            // it's an UPDATE; if not, an INSERT. Covers both the
-            // "synced pack rename" and "server-only pack rename"
-            // cases without a separate fallback branch.
+            // it's an UPDATE; if not, an INSERT. Resolve the stable
+            // cgid (a synced pack's local id is the swapped server id,
+            // so the caller's target id can't be trusted as the cgid)
+            // so the UPSERT updates in place instead of duplicating.
             if (userId !== undefined) {
                 saveServer.mutate({
-                    clientGeneratedId: pack.clientGeneratedId,
+                    clientGeneratedId: resolveServerClientGeneratedId(
+                        localMatch?.id ?? pack.clientGeneratedId,
+                        localMatch?.clientGeneratedId ?? pack.clientGeneratedId,
+                    ),
                     label: trimmed,
                     cardSet: pack.cardSet,
                 });
@@ -202,6 +236,7 @@ export function useCardPackActions(): CardPackActions {
             saveLocal,
             saveServer,
             userId,
+            resolveServerClientGeneratedId,
         ],
     );
 

--- a/src/ui/setup/steps/SetupStepCardPack.tsx
+++ b/src/ui/setup/steps/SetupStepCardPack.tsx
@@ -64,6 +64,14 @@ const LOCALE_COMPARE_OPTIONS = { sensitivity: "base" } as const;
 
 interface DisplayPack {
     readonly id: string;
+    /**
+     * Cross-device-stable cgid. For a custom pack this is the
+     * `CustomCardSet.clientGeneratedId` (survives the server-sync
+     * id-swap); for a built-in it's just the pack id. Used as the
+     * action-target id so rename/delete/save key the server UPSERT on
+     * the stable identity instead of the swapped local id.
+     */
+    readonly clientGeneratedId: string;
     readonly label: string;
     readonly cardSet: CardSet;
     readonly isCustom: boolean;
@@ -74,6 +82,8 @@ const toDisplayPack = (
     isCustom: boolean,
 ): DisplayPack => ({
     id: pack.id,
+    clientGeneratedId:
+        "clientGeneratedId" in pack ? pack.clientGeneratedId : pack.id,
     label: pack.label,
     cardSet: pack.cardSet,
     isCustom,
@@ -335,7 +345,7 @@ export function SetupStepCardPack({
     };
 
     const toActionTarget = (pack: DisplayPack) => ({
-        clientGeneratedId: pack.id,
+        clientGeneratedId: pack.clientGeneratedId,
         label: pack.label,
         cardSet: pack.cardSet,
     });

--- a/src/ui/share/resolveActivePackLabel.test.ts
+++ b/src/ui/share/resolveActivePackLabel.test.ts
@@ -35,8 +35,18 @@ const PACK_B = CardSet({
     ],
 });
 
-const customA: CustomCardSet = { id: "id-a", label: "Pack A", cardSet: PACK_A };
-const customB: CustomCardSet = { id: "id-b", label: "Pack B", cardSet: PACK_B };
+const customA: CustomCardSet = {
+    id: "id-a",
+    clientGeneratedId: "id-a",
+    label: "Pack A",
+    cardSet: PACK_A,
+};
+const customB: CustomCardSet = {
+    id: "id-b",
+    clientGeneratedId: "id-b",
+    label: "Pack B",
+    cardSet: PACK_B,
+};
 
 const usageOf = (
     entries: ReadonlyArray<readonly [string, string]>,


### PR DESCRIPTION
Updating a custom card pack that had already synced to the server
created a duplicate instead of updating in place: the copy showed up in
"My card packs" after the next reconcile. The same root cause affected
renaming a synced pack and the logout flush of an offline edit.

The pack's cross-device-stable identity (the server's
client_generated_id) was discarded once a pack synced: markPackSynced
swapped the local id to the server's cuid2 and the original id was lost.
Every server write then sent the swapped server id as the
clientGeneratedId, so the (owner_id, client_generated_id) UPSERT found
no match and inserted a new row.

Persist clientGeneratedId as a first-class field on CustomCardSet,
minted equal to id on creation and preserved across the markPackSynced
id-swap. Route every server-write site through it (save, rename, logout
flush, sign-in push, setup pill row). The orchestrator also resolves the
real cgid from the server cache as a fallback, and reconcile backfills it
onto packs that predate the field. The on-disk schema field is optional
and backwards-compatible; legacy blobs default it to id until the next
reconcile corrects it.

Share-import dedup is unchanged (recognises a custom pack on label +
contents, built-ins on contents).

Updates docs/card-pack-sync.md: the metadata table, the markPackSynced
id-swap, the reconcile cgid threading/backfill, and the life-of-a-pack
timeline.