### PR TITLE
Pair reconcile by clientGeneratedId so cross-device renames don't pull

### DIFF
--- a/docs/card-pack-sync.md
+++ b/docs/card-pack-sync.md
@@ -220,8 +220,12 @@ Every successful settle triggers `applyServerSnapshot`:
    is in `tombstoneIds` is dropped. Any local pack whose `id` is in
    `tombstoneIds` is dropped (defensive — already gone from
    localStorage, but belt-and-braces).
-2. **Pair match (clientGeneratedId).** When a local pack's `id`
-   equals a server pack's `clientGeneratedId`:
+2. **Pair match (clientGeneratedId).** When a server pack's
+   `clientGeneratedId` equals a local pack's `clientGeneratedId` **or**
+   its `id` (pre-swap the local id *is* the cgid; post-swap only the
+   local `clientGeneratedId` still carries the original value, so a
+   cross-device rename of an already-synced pack pairs here rather than
+   looking like a fresh pull):
    - If content matches, merge with server's `id`, clear
      `unsyncedSince`, set `lastSyncedSnapshot` to the server view.
    - If content differs and `unsyncedSince` is set on the local

--- a/src/data/cardPacksSync.test.tsx
+++ b/src/data/cardPacksSync.test.tsx
@@ -106,6 +106,28 @@ describe("reconcileCardPacks", () => {
         expect(result.idMap.get("local-1")).toBe("server-1");
     });
 
+    test("cross-device rename of a fully-synced pack updates in place, no duplicate", () => {
+        // Device B is fully synced: its local id was already swapped to
+        // the server id, and the stable cgid is the original custom-…
+        // id. Device A renamed the pack on the server. Phase 1 must pair
+        // by cgid (local id no longer equals the server's cgid) so the
+        // rename lands without spawning a second pack.
+        const synced: CustomCardSet = {
+            ...localPack("server-1", "Office", "Rope"),
+            clientGeneratedId: "custom-abc",
+            lastSyncedSnapshot: { label: "Office", cardSet: makeCardSet("Rope") },
+        };
+        const result = reconcileCardPacks(
+            [synced],
+            [serverPack("server-1", "custom-abc", "Mansion", "Rope")],
+        );
+        expect(result.packs).toHaveLength(1);
+        expect(result.packs[0]?.id).toBe("server-1");
+        expect(result.packs[0]?.clientGeneratedId).toBe("custom-abc");
+        expect(result.packs[0]?.label).toBe("Mansion");
+        expect(result.countPulled).toBe(0);
+    });
+
     test("server-only packs land with lastSyncedSnapshot populated", () => {
         const result = reconcileCardPacks(
             [],

--- a/src/data/cardPacksSync.tsx
+++ b/src/data/cardPacksSync.tsx
@@ -141,8 +141,17 @@ export const reconcileCardPacks = (
 
     // Phase 1: client-id pair matches.
     for (const localPack of filteredLocal) {
+        // Pair the local pack to its server row by the stable
+        // clientGeneratedId. Match the server's cgid against the local
+        // pack's cgid OR its id: pre-swap the local id IS the cgid;
+        // post-swap the id is the server cuid2 and only the local cgid
+        // still carries the original value (so a cross-device rename of
+        // an already-synced pack pairs here instead of falling through
+        // to Phase 2 and looking like a fresh pull).
         const match = decodedServer.find(
-            s => s.clientGeneratedId === localPack.id,
+            s =>
+                s.clientGeneratedId === localPack.id ||
+                s.clientGeneratedId === localPack.clientGeneratedId,
         );
         if (match === undefined) continue;
         const matchingServer = match.pack;


### PR DESCRIPTION
## What this changes (user-facing)

Renaming a custom card pack on one device now lands cleanly on another device's already-synced copy — the receiving device updates the pack in place instead of momentarily treating it as a brand-new pull. Previously the rename still ended up correct, but only because a defensive dedupe step quietly collapsed a duplicate that reconcile had spawned; this removes that fragility.

This is a follow-up to PR #270 (merged), which fixed the same-device duplication on edit/rename by persisting the pack's stable `clientGeneratedId`. That field is what makes this reconcile fix possible.

## Why

Reconcile Phase 1 paired a local pack to its server row by matching the server's `client_generated_id` against the local pack's `id` only. That holds *pre-swap* (local id == cgid) but not *post-swap*, where the local id is the server's cuid2 and the original cgid now lives on the persisted `clientGeneratedId` field. A cross-device rename therefore missed Phase 1, fell through to the exact-content-duplicate check (which fails because the label changed), and got counted as a fresh pull — saved from a permanent duplicate only by the dedupe-by-id collapse, and incrementing `countPulled` spuriously.

## How

Phase 1 now matches the server cgid against the local pack's `clientGeneratedId` **or** its `id`, so an already-synced pack is paired in both states. Legacy packs whose cgid hasn't been backfilled yet still resolve via Phase 2 + the next reconcile.

## Commits

- `206eeb0` — broaden reconcile Phase 1 pairing to cgid-or-id; add a reconcile test for the fully-synced cross-device rename (one pack, new label, `countPulled` 0); document the broadened match in `docs/card-pack-sync.md`.

## Tests

Full gate green: typecheck, lint, knip, i18n:check, and all 1876 tests pass (including the new cross-device-rename reconcile case).

Note: cross-device behavior is covered at the reconcile unit layer; it was not exercised live with two signed-in sessions because sign-in goes through the real Google OAuth flow.

https://claude.ai/code/session_01CPx9RwfG4eRNQB3CjVnwLL

---
_Generated by [Claude Code](https://claude.ai/code/session_01CPx9RwfG4eRNQB3CjVnwLL)_