### PR TITLE
chore: point renovate config at nunofyobiz/renovate-config

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,7 +1,7 @@
 {
     $schema: "https://docs.renovatebot.com/renovate-schema.json",
     extends: [
-        "github>StoryCut/renovate-config:js-app.json5",
-        "github>StoryCut/renovate-config:neon-local-postgres.json5",
+        "github>nunofyobiz/renovate-config:js-app.json5",
+        "github>nunofyobiz/renovate-config:neon-local-postgres.json5",
     ],
 }


### PR DESCRIPTION
The shared renovate-config preset repo moved from `StoryCut` to `nunofyobiz`. Update the preset references so Renovate can resolve them.

- `renovate.json5`: `js-app.json5` + `neon-local-postgres.json5` preset refs → `nunofyobiz/...`

---
_Generated by [Claude Code](https://claude.ai/code/session_014Qrbp9fDuoPUeJCMUnLRhd)_